### PR TITLE
ci(release): gate releases on seeded N-1 upgrades

### DIFF
--- a/.github/workflows/release-upgrade.yml
+++ b/.github/workflows/release-upgrade.yml
@@ -64,11 +64,11 @@ jobs:
           REQUESTED_CANDIDATE: ${{ inputs.candidate-sha }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_SHA: ${{ github.sha }}
-        run: bun scripts/resolve-release-upgrade-images.ts
+        run: node scripts/resolve-release-upgrade-images.ts
 
       - name: Test seeded previous-release upgrade
         env:
           PREVIOUS_APP: ${{ steps.images.outputs.previous-app }}
           CANDIDATE_APP: ${{ steps.images.outputs.candidate-app }}
           POSTGRES_IMAGE: ${{ steps.images.outputs.postgres }}
-        run: bun scripts/release-upgrade-test.ts "$PREVIOUS_APP" "$CANDIDATE_APP" "$POSTGRES_IMAGE"
+        run: node scripts/release-upgrade-test.ts "$PREVIOUS_APP" "$CANDIDATE_APP" "$POSTGRES_IMAGE"

--- a/.github/workflows/release-upgrade.yml
+++ b/.github/workflows/release-upgrade.yml
@@ -1,0 +1,74 @@
+name: Seeded Release Upgrade
+
+on:
+  workflow_call:
+    inputs:
+      previous-application-image:
+        type: string
+        required: true
+      candidate-application-image:
+        type: string
+        required: true
+      postgres-image:
+        type: string
+        required: true
+      candidate-source-sha:
+        type: string
+        required: true
+  workflow_dispatch:
+    inputs:
+      previous-tag:
+        description: Previous stable release tag (defaults to latest)
+        required: false
+      candidate-sha:
+        description: Candidate commit SHA (defaults to this workflow commit)
+        required: false
+  schedule:
+    - cron: "37 4 * * 3"
+
+permissions:
+  contents: read
+  packages: read
+
+concurrency:
+  group: release-upgrade-${{ inputs.candidate-application-image || inputs.candidate-sha || github.sha }}
+  cancel-in-progress: false
+
+jobs:
+  upgrade:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.candidate-source-sha || inputs.candidate-sha || github.sha }}
+          persist-credentials: false
+
+      - uses: ./.github/actions/setup-bun
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Resolve immutable image references
+        id: images
+        env:
+          GH_TOKEN: ${{ github.token }}
+          INPUT_PREVIOUS_APP: ${{ inputs.previous-application-image }}
+          INPUT_CANDIDATE_APP: ${{ inputs.candidate-application-image }}
+          INPUT_POSTGRES: ${{ inputs.postgres-image }}
+          REQUESTED_PREVIOUS: ${{ inputs.previous-tag }}
+          REQUESTED_CANDIDATE: ${{ inputs.candidate-sha }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_SHA: ${{ github.sha }}
+        run: bun scripts/resolve-release-upgrade-images.ts
+
+      - name: Test seeded previous-release upgrade
+        env:
+          PREVIOUS_APP: ${{ steps.images.outputs.previous-app }}
+          CANDIDATE_APP: ${{ steps.images.outputs.candidate-app }}
+          POSTGRES_IMAGE: ${{ steps.images.outputs.postgres }}
+        run: bun scripts/release-upgrade-test.ts "$PREVIOUS_APP" "$CANDIDATE_APP" "$POSTGRES_IMAGE"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,9 +5,9 @@ name: Release
 # after CI/CD succeeds so the Docker images for the commit already exist.
 #
 # A release: tags vX.Y.Z at the version-bump commit, creates the GitHub Release
-# from that version's CHANGELOG.md section (flagging schema migrations), retags
-# the CI-built images (X.Y.Z, X.Y, latest), verifies a seeded previous-release
-# upgrade before publication, and starts the deploy chain
+# from that version's CHANGELOG.md section (flagging schema migrations), verifies
+# a seeded previous-release upgrade before publication, retags the CI-built
+# images (X.Y.Z, X.Y, latest), and starts the deploy chain
 # (staging automatically, production after environment approval).
 #
 # Versioning contract: docs/admin/compatibility-policy.mdx

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,8 @@ name: Release
 #
 # A release: tags vX.Y.Z at the version-bump commit, creates the GitHub Release
 # from that version's CHANGELOG.md section (flagging schema migrations), retags
-# the CI-built images (X.Y.Z, X.Y, latest), and starts the deploy chain
+# the CI-built images (X.Y.Z, X.Y, latest), verifies a seeded previous-release
+# upgrade before publication, and starts the deploy chain
 # (staging automatically, production after environment approval).
 #
 # Versioning contract: docs/admin/compatibility-policy.mdx
@@ -43,6 +44,7 @@ jobs:
       major: ${{ steps.cut.outputs.major }}
       minor: ${{ steps.cut.outputs.minor }}
       tag_name: ${{ steps.cut.outputs.tag_name }}
+      previous_version: ${{ steps.cut.outputs.previous_version }}
       sha: ${{ steps.cut.outputs.sha }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -86,7 +88,11 @@ jobs:
           fi
           echo "Cutting $TAG at $SHA (was $PARENT_VERSION)"
 
-          PREV_TAG=$(git tag --list 'v*' --sort=-v:refname | head -1)
+          PREV_TAG="v$PARENT_VERSION"
+          previous=$(gh release view "$PREV_TAG" --repo "${{ github.repository }}" --json isDraft,isPrerelease 2>/dev/null) || {
+            echo "::error::Previous package version $PARENT_VERSION is not a published release"; exit 1; }
+          jq -e '.isDraft == false and .isPrerelease == false' <<< "$previous" >/dev/null || {
+            echo "::error::$PREV_TAG is not a stable published release"; exit 1; }
 
           # Release notes = this version's CHANGELOG.md section (the assembled
           # changeset entries), with a first-class migration warning when the
@@ -127,6 +133,7 @@ jobs:
             MINOR="${VERSION#*.}"; echo "minor=${MINOR%%.*}"
             echo "tag_name=$TAG"
             echo "sha=$SHA"
+            echo "previous_version=$PARENT_VERSION"
           } >> "$GITHUB_OUTPUT"
 
       - name: Summary
@@ -148,6 +155,7 @@ jobs:
     outputs:
       agent-pi-digest: ${{ steps.retag.outputs.agent-pi-digest }}
       application-server-digest: ${{ steps.retag.outputs.application-server-digest }}
+      postgres-digest: ${{ steps.retag.outputs.postgres-digest }}
     steps:
       - name: Check out the released tree
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -204,6 +212,7 @@ jobs:
             case "$img" in
               agent-pi)            echo "agent-pi-digest=$SRC_DIGEST" >> "$GITHUB_OUTPUT" ;;
               application-server)  echo "application-server-digest=$SRC_DIGEST" >> "$GITHUB_OUTPUT" ;;
+              postgres)            echo "postgres-digest=$SRC_DIGEST" >> "$GITHUB_OUTPUT" ;;
             esac
             echo "::endgroup::"
           done
@@ -410,8 +419,20 @@ jobs:
             "$ASSET" "${ASSET}.sigstore.json" evidence/* \
             --repo "${{ github.repository }}"
 
-  publish-release:
+  upgrade-test:
     needs: [release, tag-images]
+    if: needs.release.outputs.released == 'true'
+    uses: ./.github/workflows/release-upgrade.yml
+    permissions:
+      contents: read
+      packages: read
+    with:
+      previous-application-image: ghcr.io/ls1intum/hephaestus/application-server:${{ needs.release.outputs.previous_version }}
+      candidate-application-image: ghcr.io/ls1intum/hephaestus/application-server@${{ needs.tag-images.outputs.application-server-digest }}
+      postgres-image: ghcr.io/ls1intum/hephaestus/postgres@${{ needs.tag-images.outputs.postgres-digest }}
+      candidate-source-sha: ${{ needs.release.outputs.sha }}
+  publish-release:
+    needs: [release, tag-images, upgrade-test]
     if: needs.release.outputs.released == 'true'
     timeout-minutes: 20
     runs-on: ubuntu-latest

--- a/docs/contributor/database-migration.mdx
+++ b/docs/contributor/database-migration.mdx
@@ -86,7 +86,7 @@ CI enforces 1 and 2 mechanically (see below); 3 is a review responsibility.
 
 ## CI validation
 
-Three GitHub Actions checks guard the database (all in `ci-quality-gates.yml`):
+CI uses complementary database checks:
 
 1. **Migration-chain replay** (`Database` gate) – Applies the full `master.xml` chain via
    `liquibase:update` to an empty pg_partman PostgreSQL (the production image). A changelog that
@@ -100,8 +100,15 @@ Three GitHub Actions checks guard the database (all in `ci-quality-gates.yml`):
    renamed, or deleted, or if an existing `master.xml` `<include>` line was removed, reordered,
    or edited. This catches exactly the edits Liquibase checksums miss (preconditions, contexts,
    labels, comments, and deleted changesets).
+4. **Seeded release upgrade** (`release-upgrade.yml`) – Boots the previous stable release, creates
+   representative account and workspace data, then boots the candidate against the same database. The gate
+   verifies that Liquibase reaches application readiness, seeded relationships and the practice catalog
+   survive, and authenticated core reads succeed. Release publication depends on this gate, and the same test
+   runs weekly.
 
-The replay applies **every** changeset (the Maven plugin sets no context filter), so it validates
+Baseline changes must update the fixture without breaking the supported previous-release upgrade.
+
+The empty-database replay applies **every** changeset (the Maven plugin sets no context filter), so it validates
 that the whole chain is well-formed — it does **not** reproduce a specific instance's boot (a real
 `dev`/`prod` boot filters by `spring.liquibase.contexts`) and, running against an empty database,
 does **not** catch data-incompatible migrations (a `NOT NULL` add or a `CHECK` that existing rows
@@ -146,7 +153,7 @@ flowchart TD
     A[Entity changes] --> B[Migrations]
     B --> C[ERD docs]
 
-    subgraph CI [CI quality gates]
+    subgraph CI [Pull request gates]
         D[Schema validation]
         E[ERD validation]
         F[Changelog immutability]

--- a/docs/contributor/release-management.mdx
+++ b/docs/contributor/release-management.mdx
@@ -33,9 +33,9 @@ sequenceDiagram
     Note over VP: CHANGELOG.md + version bump preview
     VP->>M: Maintainer merges when the release is ready
     M->>R: Create draft vX.Y.Z release
-    R->>R: Promote X.Y.Z / X.Y / latest image tags
     R->>R: Generate and verify digest-bound evidence
     R->>R: Upgrade seeded data from the previous stable release
+    R->>R: Promote X.Y.Z / X.Y / latest image tags
     R->>R: Publish release and deploy staging
     Note over R: Production still requires approval
 ```
@@ -56,8 +56,8 @@ sequenceDiagram
    ruleset, so the absent required checks don't block the merge. Versioning also moves any
    `### Next release` section in `MIGRATION.md` under the version being cut.
 3. **Merging the Version PR cuts the release.** The workflow creates a draft release at the merge
-   commit and promotes the CI-built images to `X.Y.Z`, `X.Y`, and `latest`. After its evidence and
-   seeded-upgrade gates pass, it publishes the release, deploys staging, and requests production
+   commit. After its evidence and seeded-upgrade gates pass, it promotes the CI-built images to
+   `X.Y.Z`, `X.Y`, and `latest`, publishes the release, deploys staging, and requests production
    approval.
 
 ## Supply-chain evidence

--- a/docs/contributor/release-management.mdx
+++ b/docs/contributor/release-management.mdx
@@ -33,8 +33,9 @@ sequenceDiagram
     Note over VP: CHANGELOG.md + version bump preview
     VP->>M: Maintainer merges when the release is ready
     M->>R: Create draft vX.Y.Z release
-    R->>R: Generate and verify digest-bound evidence
     R->>R: Promote X.Y.Z / X.Y / latest image tags
+    R->>R: Generate and verify digest-bound evidence
+    R->>R: Upgrade seeded data from the previous stable release
     R->>R: Publish release and deploy staging
     Note over R: Production still requires approval
 ```
@@ -55,8 +56,9 @@ sequenceDiagram
    ruleset, so the absent required checks don't block the merge. Versioning also moves any
    `### Next release` section in `MIGRATION.md` under the version being cut.
 3. **Merging the Version PR cuts the release.** The workflow creates a draft release at the merge
-   commit. After its evidence gate passes, it promotes the CI-built images to `X.Y.Z`, `X.Y`, and
-   `latest`, publishes the release, deploys staging, and requests production approval.
+   commit and promotes the CI-built images to `X.Y.Z`, `X.Y`, and `latest`. After its evidence and
+   seeded-upgrade gates pass, it publishes the release, deploys staging, and requests production
+   approval.
 
 ## Supply-chain evidence
 

--- a/scripts/release-deployment-policy.test.ts
+++ b/scripts/release-deployment-policy.test.ts
@@ -17,3 +17,25 @@ await test("deployment uses Compose metadata, waits for readiness, and preserves
 	assert.match(deployment, /--wait --wait-timeout 600/);
 	assert.doesNotMatch(deployment, /docker image prune/);
 });
+
+await test("release publication requires the seeded upgrade gate", () => {
+	const upgrade = readFileSync(".github/workflows/release-upgrade.yml", "utf8");
+
+	assert.match(release, /publish-release:\n\s+needs: \[release, tag-images, upgrade-test\]/);
+	assert.match(
+		release,
+		/candidate-application-image: .*@\$\{\{ needs\.tag-images\.outputs\.application-server-digest \}\}/,
+	);
+	assert.match(
+		release,
+		/postgres-image: .*@\$\{\{ needs\.tag-images\.outputs\.postgres-digest \}\}/,
+	);
+	assert.match(release, /candidate-source-sha: \$\{\{ needs\.release\.outputs\.sha \}\}/);
+	assert.match(upgrade, /schedule:/);
+	assert.match(
+		upgrade,
+		/ref: \$\{\{ inputs\.candidate-source-sha \|\| inputs\.candidate-sha \|\| github\.sha \}\}/,
+	);
+	const upgradeGate = release.match(/ {2}upgrade-test:[\s\S]*?\n {2}publish-release:/)?.[0] ?? "";
+	assert.doesNotMatch(upgradeGate, /secrets: inherit/);
+});

--- a/scripts/release-upgrade-test.ts
+++ b/scripts/release-upgrade-test.ts
@@ -1,12 +1,13 @@
 import { spawnSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import process from "node:process";
+import { setTimeout as sleep } from "node:timers/promises";
 
 const [previousImage, candidateImage, postgresImage] = process.argv.slice(2);
 
 if (!previousImage || !candidateImage || !postgresImage) {
 	throw new Error(
-		"Usage: bun scripts/release-upgrade-test.ts <previous-app-image> <candidate-app-image> <postgres-image>",
+		"Usage: node scripts/release-upgrade-test.ts <previous-app-image> <candidate-app-image> <postgres-image>",
 	);
 }
 
@@ -70,7 +71,7 @@ async function waitUntilReady(name: string, port: number): Promise<void> {
 		} catch {
 			// The endpoint is unavailable while the container starts.
 		}
-		await Bun.sleep(2_000);
+		await sleep(2_000);
 	}
 	throw new Error(`${name} did not become ready within 180 seconds`);
 }
@@ -246,7 +247,7 @@ async function waitForSeededCatalog(): Promise<number> {
 	for (let attempt = 0; attempt < 60; attempt++) {
 		const catalogSize = seededCatalogSize();
 		if (catalogSize > 0) return catalogSize;
-		await Bun.sleep(1_000);
+		await sleep(1_000);
 	}
 	throw new Error("Previous release did not seed the practice catalog within 60 seconds");
 }
@@ -277,7 +278,7 @@ try {
 			break;
 		} catch {
 			if (attempt === 59) throw new Error("PostgreSQL did not become ready");
-			await Bun.sleep(1_000);
+			await sleep(1_000);
 		}
 	}
 

--- a/scripts/release-upgrade-test.ts
+++ b/scripts/release-upgrade-test.ts
@@ -1,0 +1,333 @@
+import { spawnSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import process from "node:process";
+
+const [previousImage, candidateImage, postgresImage] = process.argv.slice(2);
+
+if (!previousImage || !candidateImage || !postgresImage) {
+	throw new Error(
+		"Usage: bun scripts/release-upgrade-test.ts <previous-app-image> <candidate-app-image> <postgres-image>",
+	);
+}
+
+const runId = `upgrade-${randomUUID().slice(0, 8)}`;
+const network = runId;
+const postgres = `${runId}-postgres`;
+let application = `${runId}-previous`;
+
+function docker(...args: string[]): string {
+	const result = spawnSync("docker", args, { encoding: "utf8" });
+	if (result.status !== 0) {
+		throw new Error(`docker ${args.join(" ")} failed:\n${result.stdout}${result.stderr}`);
+	}
+	return result.stdout.trim();
+}
+
+function startApplication(name: string, image: string): number {
+	docker(
+		"run",
+		"--detach",
+		"--name",
+		name,
+		"--network",
+		network,
+		"--publish",
+		"127.0.0.1::8080",
+		"--env",
+		"SPRING_PROFILES_ACTIVE=e2e",
+		"--env",
+		"SPRING_DATASOURCE_URL=jdbc:postgresql://postgres:5432/hephaestus",
+		"--env",
+		"SPRING_DATASOURCE_USERNAME=root",
+		"--env",
+		"SPRING_DATASOURCE_PASSWORD=root",
+		"--env",
+		"NATS_ENABLED=false",
+		"--env",
+		"AGENT_ENABLED=false",
+		"--env",
+		"HEPHAESTUS_WORKSPACE_INIT_DEFAULT=false",
+		"--env",
+		"HEPHAESTUS_SYNC_RUN_ON_STARTUP=false",
+		"--env",
+		"HEPHAESTUS_SECURITY_ENCRYPTION_KEY=upgradeTestEncryptionKey01234567",
+		image,
+	);
+	const mapping = docker("port", name, "8080/tcp");
+	const port = Number(mapping.slice(mapping.lastIndexOf(":") + 1));
+	if (!Number.isInteger(port)) throw new Error(`Could not parse application port from ${mapping}`);
+	return port;
+}
+
+async function waitUntilReady(name: string, port: number): Promise<void> {
+	const deadline = Date.now() + 180_000;
+	while (Date.now() < deadline) {
+		const state = docker("inspect", "--format", "{{.State.Status}}", name);
+		if (state !== "running") throw new Error(`${name} stopped during startup`);
+		try {
+			const response = await fetch(`http://127.0.0.1:${port}/actuator/health/readiness`);
+			if (response.ok) return;
+		} catch {
+			// The endpoint is unavailable while the container starts.
+		}
+		await Bun.sleep(2_000);
+	}
+	throw new Error(`${name} did not become ready within 180 seconds`);
+}
+
+async function login(port: number, username: string): Promise<string> {
+	const response = await fetch(`http://127.0.0.1:${port}/auth/dev-login`, {
+		method: "POST",
+		headers: { "content-type": "application/json" },
+		body: JSON.stringify({
+			username,
+			displayName: `Upgrade ${username}`,
+			admin: username === "root",
+		}),
+	});
+	if (response.status !== 204)
+		throw new Error(`Dev login returned ${response.status}: ${await response.text()}`);
+	const cookie = response.headers
+		.getSetCookie()
+		.find((value) => value.slice(0, value.indexOf("=")).endsWith("HEPHAESTUS_AT"))
+		?.split(";", 1)[0];
+	if (!cookie) throw new Error("Dev login did not return an authentication cookie");
+	return cookie;
+}
+
+async function assertCoreReads(port: number, cookie: string): Promise<void> {
+	const user = await fetch(`http://127.0.0.1:${port}/user`, { headers: { cookie } });
+	if (!user.ok) throw new Error(`Core read /user returned ${user.status}: ${await user.text()}`);
+	const userBody: unknown = await user.json();
+	if (
+		typeof userBody !== "object" ||
+		userBody === null ||
+		!("displayName" in userBody) ||
+		userBody.displayName !== "Upgrade alice"
+	)
+		throw new Error("Core read /user did not return the seeded account");
+
+	const providers = await fetch(`http://127.0.0.1:${port}/identity-providers`);
+	if (!providers.ok)
+		throw new Error(
+			`Core read /identity-providers returned ${providers.status}: ${await providers.text()}`,
+		);
+	const providerBody: unknown = await providers.json();
+	if (!Array.isArray(providerBody) || providerBody.length === 0)
+		throw new Error("Core read /identity-providers returned no providers");
+	const workspaces = await fetch(`http://127.0.0.1:${port}/workspaces`, { headers: { cookie } });
+	if (!workspaces.ok)
+		throw new Error(
+			`Core read /workspaces returned ${workspaces.status}: ${await workspaces.text()}`,
+		);
+	const body: unknown = await workspaces.json();
+	if (
+		!Array.isArray(body) ||
+		!body.some(
+			(workspace: unknown) =>
+				typeof workspace === "object" &&
+				workspace !== null &&
+				"workspaceSlug" in workspace &&
+				workspace.workspaceSlug === "upgrade-fixture",
+		)
+	)
+		throw new Error("Core read /workspaces did not return the seeded workspace");
+}
+
+async function seedWorkspace(port: number, cookie: string): Promise<void> {
+	const response = await fetch(`http://127.0.0.1:${port}/workspaces`, {
+		method: "POST",
+		headers: { "content-type": "application/json", cookie },
+		body: JSON.stringify({
+			workspaceSlug: "upgrade-fixture",
+			displayName: "Upgrade Fixture",
+			accountLogin: "upgrade-fixture",
+			accountType: "ORG",
+			kind: "GITHUB",
+			personalAccessToken: "upgrade-fixture-token",
+		}),
+	});
+	if (response.status !== 201)
+		throw new Error(`Workspace seed returned ${response.status}: ${await response.text()}`);
+}
+
+function linkWorkspaceIdentity(): void {
+	docker(
+		"exec",
+		postgres,
+		"psql",
+		"--username=root",
+		"--dbname=hephaestus",
+		"--set=ON_ERROR_STOP=1",
+		"--command",
+		`WITH fixture AS (
+		   SELECT account.id AS account_id, identity_provider.id AS provider_id
+		   FROM account CROSS JOIN identity_provider
+		   WHERE account.primary_email = 'alice@dev.invalid'
+		   ORDER BY identity_provider.id LIMIT 1
+		 ), created AS (
+		   INSERT INTO "user" (provider_id, native_id, login, avatar_url, html_url, type)
+		   SELECT provider_id, 424242, 'account:' || account_id, 'https://example.invalid/avatar',
+		          'https://example.invalid/user', 'USER'
+		   FROM fixture
+		   RETURNING id, provider_id
+		 )
+		 INSERT INTO identity_link
+		   (account_id, provider_id, subject, external_actor_id, username_at_signup, linked_via)
+		 SELECT fixture.account_id, created.provider_id, 'upgrade-fixture', created.id,
+		        'account:' || fixture.account_id, 'MANUAL_LINK'
+		 FROM fixture CROSS JOIN created;`,
+	);
+}
+
+function dataFingerprint(): string {
+	return docker(
+		"exec",
+		postgres,
+		"psql",
+		"--username=root",
+		"--dbname=hephaestus",
+		"--tuples-only",
+		"--no-align",
+		"--command",
+		`SELECT kind || '|' || value
+		 FROM (
+		   SELECT 'account' AS kind,
+		          concat_ws('|', id, display_name, app_role, status) AS value
+		   FROM account
+		   UNION ALL
+		   SELECT 'identity', concat_ws('|', id, account_id, subject, username_at_signup, linked_via)
+		   FROM identity_link
+		   UNION ALL
+		   SELECT 'user', concat_ws('|', id, provider_id, native_id, login, type)
+		   FROM "user"
+		   UNION ALL
+		   SELECT 'workspace', concat_ws('|', w.id,
+		          coalesce(to_jsonb(w)->>'workspace_slug', to_jsonb(w)->>'slug'),
+		          w.display_name, w.account_login, w.account_type, w.status)
+		   FROM workspace w
+		   UNION ALL
+		   SELECT 'membership', concat_ws('|', workspace_id, user_id, role)
+		   FROM workspace_membership
+		   UNION ALL
+		   SELECT 'connection', concat_ws('|', id, workspace_id, kind, state)
+		   FROM connection
+		 ) fixture
+		 ORDER BY kind, value;`,
+	);
+}
+
+function count(sql: string): number {
+	const value = docker(
+		"exec",
+		postgres,
+		"psql",
+		"--username=root",
+		"--dbname=hephaestus",
+		"--tuples-only",
+		"--no-align",
+		"--command",
+		sql,
+	);
+	if (!/^[0-9]+$/.test(value))
+		throw new Error(`Expected an integer query result, received: ${value}`);
+	return Number(value);
+}
+
+function seededCatalogSize(): number {
+	return count("SELECT count(*) FROM practice;");
+}
+
+function appliedChangeCount(): number {
+	return count("SELECT count(*) FROM databasechangelog;");
+}
+
+async function waitForSeededCatalog(): Promise<number> {
+	for (let attempt = 0; attempt < 60; attempt++) {
+		const catalogSize = seededCatalogSize();
+		if (catalogSize > 0) return catalogSize;
+		await Bun.sleep(1_000);
+	}
+	throw new Error("Previous release did not seed the practice catalog within 60 seconds");
+}
+
+try {
+	docker("network", "create", network);
+	docker(
+		"run",
+		"--detach",
+		"--name",
+		postgres,
+		"--network",
+		network,
+		"--network-alias",
+		"postgres",
+		"--env",
+		"POSTGRES_DB=hephaestus",
+		"--env",
+		"POSTGRES_USER=root",
+		"--env",
+		"POSTGRES_PASSWORD=root",
+		postgresImage,
+	);
+
+	for (let attempt = 0; attempt < 60; attempt++) {
+		try {
+			docker("exec", postgres, "pg_isready", "--username=root", "--dbname=hephaestus");
+			break;
+		} catch {
+			if (attempt === 59) throw new Error("PostgreSQL did not become ready");
+			await Bun.sleep(1_000);
+		}
+	}
+
+	let port = startApplication(application, previousImage);
+	await waitUntilReady(application, port);
+	const previousCookie = await login(port, "alice");
+	await login(port, "root");
+	linkWorkspaceIdentity();
+	await seedWorkspace(port, previousCookie);
+	await assertCoreReads(port, previousCookie);
+	const seededData = dataFingerprint();
+	for (const kind of ["account", "identity", "user", "workspace", "membership", "connection"]) {
+		if (!seededData.includes(`${kind}|`))
+			throw new Error(`Previous release did not seed ${kind} data`);
+	}
+	const seededPractices = await waitForSeededCatalog();
+	const previousChanges = appliedChangeCount();
+
+	docker("stop", "--time", "30", application);
+	docker("rm", application);
+	application = `${runId}-candidate`;
+	port = startApplication(application, candidateImage);
+	await waitUntilReady(application, port);
+	const upgradedData = dataFingerprint();
+	if (upgradedData !== seededData)
+		throw new Error("Seeded application data changed during upgrade");
+	const upgradedPractices = seededCatalogSize();
+	if (upgradedPractices < seededPractices)
+		throw new Error(
+			`Practice catalog shrank during upgrade: before=${seededPractices}, after=${upgradedPractices}`,
+		);
+	const candidateChanges = appliedChangeCount();
+	if (candidateChanges < previousChanges)
+		throw new Error(
+			`Liquibase history shrank during upgrade: before=${previousChanges}, after=${candidateChanges}`,
+		);
+	const candidateCookie = await login(port, "alice");
+	await assertCoreReads(port, candidateCookie);
+
+	console.log("Seeded previous-release upgrade passed.");
+} catch (error) {
+	for (const name of [application, postgres]) {
+		try {
+			console.error(`\n--- ${name} logs ---\n${docker("logs", name)}`);
+		} catch {
+			// Containers created after the failure point have no logs.
+		}
+	}
+	throw error;
+} finally {
+	spawnSync("docker", ["rm", "--force", application, postgres], { stdio: "ignore" });
+	spawnSync("docker", ["network", "rm", network], { stdio: "ignore" });
+}

--- a/scripts/resolve-release-upgrade-images.ts
+++ b/scripts/resolve-release-upgrade-images.ts
@@ -1,0 +1,87 @@
+import { spawnSync } from "node:child_process";
+import { appendFileSync } from "node:fs";
+import process from "node:process";
+
+const applicationRepository = "ghcr.io/ls1intum/hephaestus/application-server";
+const postgresRepository = "ghcr.io/ls1intum/hephaestus/postgres";
+
+function command(executable: string, args: string[]): string {
+	const result = spawnSync(executable, args, { encoding: "utf8" });
+	if (result.status !== 0)
+		throw new Error(`${executable} ${args.join(" ")} failed:\n${result.stdout}${result.stderr}`);
+	return result.stdout.trim();
+}
+
+function nonEmpty(value: string | undefined): string | undefined {
+	return value === undefined || value === "" ? undefined : value;
+}
+
+function immutable(reference: string, repository: string): string {
+	if (!reference.startsWith(`${repository}:`) && !reference.startsWith(`${repository}@sha256:`))
+		throw new Error(`Unexpected image repository: ${reference}`);
+	const manifest = command("docker", [
+		"buildx",
+		"imagetools",
+		"inspect",
+		reference,
+		"--format",
+		"{{json .Manifest}}",
+	]);
+	const parsed: unknown = JSON.parse(manifest);
+	if (
+		typeof parsed !== "object" ||
+		parsed === null ||
+		!("digest" in parsed) ||
+		typeof parsed.digest !== "string" ||
+		!/^sha256:[a-f0-9]{64}$/.test(parsed.digest)
+	)
+		throw new Error(`Registry returned an invalid digest for ${reference}`);
+	return `${repository}@${parsed.digest}`;
+}
+
+const supplied = [
+	process.env.INPUT_PREVIOUS_APP,
+	process.env.INPUT_CANDIDATE_APP,
+	process.env.INPUT_POSTGRES,
+];
+if (supplied.some(Boolean) && !supplied.every(Boolean))
+	throw new Error("Reusable workflow callers must provide all three image references");
+
+let [previousApplication, candidateApplication, postgres] = supplied;
+if (!previousApplication || !candidateApplication || !postgres) {
+	const repository = process.env.GITHUB_REPOSITORY;
+	if (!repository) throw new Error("GITHUB_REPOSITORY is required");
+	const requestedPrevious = nonEmpty(process.env.REQUESTED_PREVIOUS);
+	const previous =
+		requestedPrevious ??
+		command("gh", [
+			"release",
+			"view",
+			"--repo",
+			repository,
+			"--json",
+			"tagName",
+			"--jq",
+			".tagName",
+		]);
+	if (!/^v[0-9]+\.[0-9]+\.[0-9]+$/.test(previous))
+		throw new Error("Previous release must be a stable vX.Y.Z tag");
+	const candidate = nonEmpty(process.env.REQUESTED_CANDIDATE) ?? process.env.GITHUB_SHA;
+	if (!candidate || !/^[a-f0-9]{40}$/.test(candidate))
+		throw new Error("Candidate must be a full commit SHA");
+	previousApplication = `${applicationRepository}:${previous.slice(1)}`;
+	candidateApplication = `${applicationRepository}:${candidate}`;
+	postgres = `${postgresRepository}:${candidate}`;
+}
+
+const output = process.env.GITHUB_OUTPUT;
+if (!output) throw new Error("GITHUB_OUTPUT is required");
+appendFileSync(
+	output,
+	[
+		`previous-app=${immutable(previousApplication, applicationRepository)}`,
+		`candidate-app=${immutable(candidateApplication, applicationRepository)}`,
+		`postgres=${immutable(postgres, postgresRepository)}`,
+		"",
+	].join("\n"),
+);


### PR DESCRIPTION
## Description

Adds a release-gating upgrade test that starts the previous stable application image, seeds representative account and workspace data, and then starts the candidate against the same PostgreSQL database. Release publication now waits for that upgrade to reach readiness, preserve the seeded relationships and practice catalog, and complete authenticated core reads.

The workflow also runs weekly and on demand. It checks out the exact candidate commit, resolves container images to immutable digests, uses read-only permissions, and keeps the fixture orchestration in typed Bun scripts. The release and database-migration guides document the new gate and its baseline-maintenance contract.

Fixes #1604

## How to test

- Run `bun run verify` for the complete local CI mirror.
- Run `bun test scripts/release-deployment-policy.test.ts` to verify that publication depends on the seeded upgrade gate and that candidate source and image inputs remain coupled.
- Manually dispatch **Seeded Release Upgrade** with a stable previous release and a full candidate commit SHA to exercise registry resolution and the containerized upgrade path.

A local smoke test successfully upgraded real `0.74.0` application data to the current candidate image while preserving the seeded fixture and 37 catalog practices.

## Checklist

- [x] No changeset is required: this changes release CI, repository tooling, and contributor documentation, not shipped application code.
- [x] No operator action, environment variable, or manual migration step is introduced.
