### PR TITLE
feat(ci): add merge queue and harden workflow reliability

### DIFF
--- a/.github/actions/setup-release-security-tools/action.yml
+++ b/.github/actions/setup-release-security-tools/action.yml
@@ -16,19 +16,20 @@ runs:
         TRIVY_VERSION: 0.74.0
       run: |
         set -euo pipefail
+        curl_args=(-fsSL --proto =https --retry 5 --retry-all-errors --retry-delay 2 --retry-max-time 300 --connect-timeout 15 --max-time 120)
         if [ "$INSTALL_SYFT" = true ]; then
           syft_archive="syft_${SYFT_VERSION}_linux_amd64.tar.gz"
           syft_base="https://github.com/anchore/syft/releases/download/v${SYFT_VERSION}"
-          curl -fsSL --proto =https -o "/tmp/$syft_archive" "$syft_base/$syft_archive"
-          curl -fsSL --proto =https -o /tmp/syft-checksums "$syft_base/syft_${SYFT_VERSION}_checksums.txt"
+          curl "${curl_args[@]}" -o "/tmp/$syft_archive" "$syft_base/$syft_archive"
+          curl "${curl_args[@]}" -o /tmp/syft-checksums "$syft_base/syft_${SYFT_VERSION}_checksums.txt"
           (cd /tmp && grep " $syft_archive$" syft-checksums | sha256sum -c -)
           tar -xzf "/tmp/$syft_archive" -C /usr/local/bin syft
           syft version
         fi
         trivy_archive="trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz"
         trivy_base="https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}"
-        curl -fsSL --proto =https -o "/tmp/$trivy_archive" "$trivy_base/$trivy_archive"
-        curl -fsSL --proto =https -o /tmp/trivy-checksums "$trivy_base/trivy_${TRIVY_VERSION}_checksums.txt"
+        curl "${curl_args[@]}" -o "/tmp/$trivy_archive" "$trivy_base/$trivy_archive"
+        curl "${curl_args[@]}" -o /tmp/trivy-checksums "$trivy_base/trivy_${TRIVY_VERSION}_checksums.txt"
         (cd /tmp && grep " $trivy_archive$" trivy-checksums | sha256sum -c -)
         tar -xzf "/tmp/$trivy_archive" -C /usr/local/bin trivy
         trivy --version

--- a/.github/workflows/cd-docs.yml
+++ b/.github/workflows/cd-docs.yml
@@ -17,12 +17,7 @@ concurrency:
   group: docs-deploy-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.number) || github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-  pull-requests: write
-  statuses: write
+permissions: {}
 
 jobs:
   build-preview:
@@ -30,6 +25,8 @@ jobs:
     if: github.event_name == 'pull_request'
     timeout-minutes: 15
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/setup-node-pnpm
@@ -57,6 +54,8 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     timeout-minutes: 15
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/setup-node-pnpm
@@ -85,6 +84,10 @@ jobs:
     if: github.event_name == 'pull_request'
     timeout-minutes: 10
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      statuses: write
     env:
       PREVIEW_URL: ls1intum-hephaestus-docs-pr-${{ github.event.number }}.surge.sh
     steps:
@@ -111,6 +114,8 @@ jobs:
 
             <sub>Preview for commit ${{ github.event.pull_request.head.sha }}. Updates automatically on new commits.</sub>
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          TARGET_URL: https://${{ env.PREVIEW_URL }}
         with:
           script: |
             const sha = context.payload.pull_request?.head?.sha || context.sha;
@@ -119,7 +124,7 @@ jobs:
               repo: context.repo.repo,
               sha: sha,
               state: 'success',
-              target_url: 'https://${{ env.PREVIEW_URL }}',
+              target_url: process.env.TARGET_URL,
               description: 'Click Details to view Docs Preview',
               context: 'Preview / Docs'
             });
@@ -130,6 +135,9 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     timeout-minutes: 10
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      pages: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/ci-compose-validate.yml
+++ b/.github/workflows/ci-compose-validate.yml
@@ -19,6 +19,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: validate-compose-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   validate:
     name: "Render compose stacks"

--- a/.github/workflows/ci-quality-gates.yml
+++ b/.github/workflows/ci-quality-gates.yml
@@ -66,16 +66,16 @@ jobs:
         run: |
           case "${{ matrix.check }}" in
             "webapp-quality")
-              echo "run=${{ inputs.webapp_changed }}" >> $GITHUB_OUTPUT
+              echo "run=${INPUTS_WEBAPP_CHANGED}" >> $GITHUB_OUTPUT
               ;;
             "application-server-quality")
-              echo "run=${{ inputs.application_server_changed }}" >> $GITHUB_OUTPUT
+              echo "run=${INPUTS_APPLICATION_SERVER_CHANGED}" >> $GITHUB_OUTPUT
               ;;
             "server-contracts")
-              echo "run=${{ inputs.contracts_changed }}" >> $GITHUB_OUTPUT
+              echo "run=${INPUTS_CONTRACTS_CHANGED}" >> $GITHUB_OUTPUT
               ;;
             "tooling-quality")
-              echo "run=${{ inputs.tooling_changed }}" >> $GITHUB_OUTPUT
+              echo "run=${INPUTS_TOOLING_CHANGED}" >> $GITHUB_OUTPUT
               ;;
             *)
               echo "::error::Unknown check type '${{ matrix.check }}' in ci-quality-gates.yml matrix."
@@ -84,6 +84,11 @@ jobs:
               exit 1
               ;;
           esac
+        env:
+          INPUTS_WEBAPP_CHANGED: ${{ inputs.webapp_changed }}
+          INPUTS_APPLICATION_SERVER_CHANGED: ${{ inputs.application_server_changed }}
+          INPUTS_CONTRACTS_CHANGED: ${{ inputs.contracts_changed }}
+          INPUTS_TOOLING_CHANGED: ${{ inputs.tooling_changed }}
 
       - name: Skip notification
         if: steps.should_run.outputs.run != 'true'
@@ -126,7 +131,7 @@ jobs:
           pnpm run check:server || { SERVER_OK=false; ISSUES_FOUND+=("Server formatting or PMD failed. Run: pnpm run check:server"); }
           pnpm run check:java-nullness \
             || { NULLNESS_OK=false; ISSUES_FOUND+=("Java nullness policy failed. Run: pnpm run check:java-nullness"); }
-          if [ "$SERVER_OK" = "true" ] && [ "${{ inputs.pmd_canary }}" = "true" ]; then
+          if [ "$SERVER_OK" = "true" ] && [ "${INPUTS_PMD_CANARY}" = "true" ]; then
             PMD_CANARY=server/application/src/main/java/de/tum/cit/aet/hephaestus/Application.java
             cp "$PMD_CANARY" "$RUNNER_TEMP/Application.java"
             trap 'cp "$RUNNER_TEMP/Application.java" "$PMD_CANARY"' EXIT
@@ -153,6 +158,8 @@ jobs:
             for issue in "${ISSUES_FOUND[@]}"; do echo "::error::$issue"; done
             exit 1
           fi
+        env:
+          INPUTS_PMD_CANARY: ${{ inputs.pmd_canary }}
 
       - name: Tooling and docs quality
         if: steps.should_run.outputs.run == 'true' && matrix.check == 'tooling-quality'
@@ -268,9 +275,8 @@ jobs:
         continue-on-error: true
         if: steps.should_run.outputs.run == 'true' && matrix.check == 'server-contracts' && always()
         run: |
-          # The base-sha tag is published by that commit's own main run, which can still be in
-          # flight when the base just advanced — fall back to building the identical Dockerfile.
-          if [[ "${{ inputs.postgres_image_changed }}" == "true" ]] ||
+          # The base image may still be publishing; build the same Dockerfile as fallback.
+          if [[ "${INPUTS_POSTGRES_IMAGE_CHANGED}" == "true" ]] ||
             ! docker pull ghcr.io/ls1intum/hephaestus/postgres:${{ github.event.pull_request.base.sha || github.sha }}; then
             docker build -t hephaestus-postgres:ci docker/postgres
           else
@@ -328,6 +334,8 @@ jobs:
             done
             exit 1
           fi
+        env:
+          INPUTS_POSTGRES_IMAGE_CHANGED: ${{ inputs.postgres_image_changed }}
 
       - name: Evaluate API and database contracts
         if: steps.should_run.outputs.run == 'true' && matrix.check == 'server-contracts' && always()

--- a/.github/workflows/ci-security-scan.yml
+++ b/.github/workflows/ci-security-scan.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Upload Trivy results
         if: always()
         continue-on-error: true
-        uses: github/codeql-action/upload-sarif@89a39a4e59826350b863aa6b6252a07ad50cf83e # v4
+        uses: github/codeql-action/upload-sarif@89a39a4e59826350b863aa6b6252a07ad50cf83e # v4.32.4
         with:
           sarif_file: "trivy-results.sarif"
 

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -28,6 +28,11 @@ on:
         required: false
         type: string
         default: "false"
+    secrets:
+      CHROMATIC_PROJECT_TOKEN:
+        required: false
+      SURGE_TOKEN:
+        required: false
 
 permissions: {}
 
@@ -56,12 +61,14 @@ jobs:
         run: |
           rm -rf server/application/target/surefire-reports/*
           cd server
-          if [[ "${{ inputs.application_server_changed }}" == "true" ]]; then
+          if [[ "${INPUTS_APPLICATION_SERVER_CHANGED}" == "true" ]]; then
             ./mvnw -pl application -am package -Parchitecture-tests \
               -Dsurefire.includedGroups=unit,architecture -DskipCoverage=false --batch-mode
           else
             ./mvnw -pl application -am package -DskipTests --batch-mode
           fi
+        env:
+          INPUTS_APPLICATION_SERVER_CHANGED: ${{ inputs.application_server_changed }}
       - name: Validate built reactor
         run: |
           test -d server/application/target/classes
@@ -301,9 +308,8 @@ jobs:
         run: |
           pnpm install --frozen-lockfile
           pnpm --filter webapp exec playwright install chromium --with-deps
-          # The base-sha tag is published by that commit's own main run, which can still be in
-          # flight when the base just advanced — fall back to building the identical Dockerfile.
-          if [[ "${{ inputs.postgres_image_changed }}" == "true" ]] ||
+          # The base image may still be publishing; build the same Dockerfile as fallback.
+          if [[ "${INPUTS_POSTGRES_IMAGE_CHANGED}" == "true" ]] ||
             ! docker pull ghcr.io/ls1intum/hephaestus/postgres:${{ github.event.pull_request.base.sha || github.sha }}; then
             docker build -t ghcr.io/ls1intum/hephaestus/postgres:dev docker/postgres
           else
@@ -311,7 +317,18 @@ jobs:
           fi
           docker compose -f server/compose.yaml up -d --wait --no-build postgres
           cleanup() {
-            if [[ -n "${SERVER_PID:-}" ]]; then kill "${SERVER_PID}" 2>/dev/null || true; fi
+            if [[ -n "${SERVER_PID:-}" ]]; then
+              kill -TERM -- "-$SERVER_PID" 2>/dev/null || true
+              (sleep 10; kill -KILL -- "-$SERVER_PID" 2>/dev/null || true) &
+              KILL_WATCHDOG=$!
+              wait "$SERVER_PID" 2>/dev/null || true
+              if kill -0 -- "-$SERVER_PID" 2>/dev/null; then
+                wait "$KILL_WATCHDOG" 2>/dev/null || true
+              else
+                kill "$KILL_WATCHDOG" 2>/dev/null || true
+                wait "$KILL_WATCHDOG" 2>/dev/null || true
+              fi
+            fi
             docker compose -f server/compose.yaml down -v
           }
           trap cleanup EXIT
@@ -320,7 +337,7 @@ jobs:
           SERVER_JAR=${SERVER_JARS[0]}
           SERVER_PORT=8080 MANAGEMENT_PORT=8080 POSTGRES_PORT=5432 \
             SPRING_DOCKER_COMPOSE_ENABLED=false APPLICATION_HOST_URL=http://localhost:4200 \
-            java -jar "$SERVER_JAR" --spring.profiles.active=e2e,playwright > e2e-server.log 2>&1 &
+            setsid java -jar "$SERVER_JAR" --spring.profiles.active=e2e,playwright > e2e-server.log 2>&1 &
           SERVER_PID=$!
           timeout 5m bash -c 'until curl --fail --silent http://localhost:8080/actuator/health/liveness >/dev/null; do kill -0 '"${SERVER_PID}"' || exit 1; sleep 2; done'
           curl --fail --silent --show-error -X POST http://localhost:8080/auth/dev-login \
@@ -328,6 +345,8 @@ jobs:
           docker compose -f server/compose.yaml exec -T postgres \
             psql -v ON_ERROR_STOP=1 -U root -d hephaestus < webapp/e2e/seed.sql
           timeout --kill-after=30s 10m pnpm --filter webapp run test:e2e
+        env:
+          INPUTS_POSTGRES_IMAGE_CHANGED: ${{ inputs.postgres_image_changed }}
       - name: Upload diagnostics
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -6,6 +6,7 @@ on:
     branches: ["main"]
   pull_request:
     branches: ["**"]
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -176,7 +177,7 @@ jobs:
               - '!webapp/src/test/**'
 
   workflow-lint:
-    name: "Workflow syntax"
+    name: "Actionlint"
     timeout-minutes: 10
     runs-on: ubuntu-latest
     needs: [detect-changes]
@@ -194,11 +195,35 @@ jobs:
           persist-credentials: false
 
       - uses: reviewdog/action-actionlint@dbe5299849118fd6f099ba563d263d770955a64a # v1.73.2
+        env:
+          SHELLCHECK_OPTS: --severity=warning
         with:
-          actionlint_flags: -shellcheck=
           fail_level: error
           filter_mode: nofilter
           reporter: github-check
+
+  zizmor:
+    name: "Zizmor"
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - id: zizmor
+        uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2
+        with:
+          min-confidence: medium
+          # renovate: datasource=github-releases depName=zizmorcore/zizmor
+          version: 1.29.0
+
+      - name: Enforce Zizmor findings
+        env:
+          ZIZMOR_SARIF: ${{ steps.zizmor.outputs.output-file }}
+        run: jq -e '[.runs[]?.results[]?] | length == 0' "$ZIZMOR_SARIF"
 
   Quality:
     uses: ./.github/workflows/ci-quality-gates.yml
@@ -209,7 +234,6 @@ jobs:
         needs.detect-changes.outputs.ci-config == 'true' ||
         github.event_name != 'pull_request'
       )
-    secrets: inherit
     permissions:
       checks: write
       contents: read
@@ -231,7 +255,6 @@ jobs:
         needs.detect-changes.outputs.ci-config == 'true' ||
         github.event_name != 'pull_request'
       )
-    secrets: inherit
     permissions:
       contents: read
       security-events: write
@@ -247,7 +270,9 @@ jobs:
         needs.detect-changes.outputs.ci-config == 'true' ||
         github.event_name != 'pull_request'
       )
-    secrets: inherit
+    secrets:
+      CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+      SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
     permissions:
       contents: read
       checks: write
@@ -282,7 +307,6 @@ jobs:
         needs.detect-changes.outputs.any-code == 'true' ||
         needs.detect-changes.outputs.ci-config == 'true'
       )
-    secrets: inherit
     permissions:
       contents: read
       packages: write
@@ -302,7 +326,7 @@ jobs:
     permissions:
       actions: read
       statuses: write
-    needs: [detect-changes, workflow-lint, Quality, Security, Test, Changesets, Docker]
+    needs: [detect-changes, workflow-lint, zizmor, Quality, Security, Test, Changesets, Docker]
     if: always()
     steps:
       - name: Generate workflow timeline
@@ -354,6 +378,7 @@ jobs:
         run: |
           echo "detect-changes: ${{ needs.detect-changes.result }}"
           echo "workflow-lint: ${{ needs.workflow-lint.result }}"
+          echo "zizmor:        ${{ needs.zizmor.result }}"
           echo "Quality:        ${{ needs.Quality.result }}"
           echo "Security:       ${{ needs.Security.result }}"
           echo "Test:           ${{ needs.Test.result }}"
@@ -402,7 +427,8 @@ jobs:
             esac
           }
 
-          echo "| Workflow syntax | $(result_to_emoji '${{ needs.workflow-lint.result }}') |" >> $GITHUB_STEP_SUMMARY
+          echo "| Actionlint | $(result_to_emoji '${{ needs.workflow-lint.result }}') |" >> $GITHUB_STEP_SUMMARY
+          echo "| Zizmor | $(result_to_emoji '${{ needs.zizmor.result }}') |" >> $GITHUB_STEP_SUMMARY
           echo "| Quality | $(result_to_emoji '${{ needs.Quality.result }}') |" >> $GITHUB_STEP_SUMMARY
           echo "| Test | $(result_to_emoji '${{ needs.Test.result }}') |" >> $GITHUB_STEP_SUMMARY
           echo "| Changesets | $(result_to_emoji '${{ needs.Changesets.result }}') |" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/cleanup-preview.yml
+++ b/.github/workflows/cleanup-preview.yml
@@ -1,9 +1,8 @@
 name: Preview cleanup
 
-# Since 2025-12-08 `pull_request_target` always takes the workflow file and the checked-out commit from
-# the default branch, so no fork code runs beside the secrets here.
 on:
-  pull_request_target:
+  pull_request_target: # zizmor: ignore[dangerous-triggers] No pull-request code is checked out or executed.
+    branches: [main]
     types: [closed, unlabeled, converted_to_draft]
 
 permissions: {}

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,10 +1,8 @@
 name: Preview deployment
 
-# Since 2025-12-08 `pull_request_target` always takes the workflow file and the checked-out commit
-# from the default branch, whatever the pull request targets. Pull-request code therefore never runs
-# on this runner, which holds the Coolify webhook secret.
 on:
-  pull_request_target:
+  pull_request_target: # zizmor: ignore[dangerous-triggers] No pull-request code is checked out or executed.
+    branches: [main]
     types: [labeled, synchronize, reopened, ready_for_review]
 
 permissions: {}

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -27,4 +27,3 @@ jobs:
     with:
       environment: Production
       release: ${{ inputs.image-tag }}
-    secrets: inherit

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -27,3 +27,6 @@ jobs:
     with:
       environment: Production
       release: ${{ inputs.image-tag }}
+    # Deploy credentials include organization secrets, which reach the locked-compose
+    # workflow only through inheritance — environment secrets alone do not cover them.
+    secrets: inherit # zizmor: ignore[secrets-inherit]

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -27,3 +27,6 @@ jobs:
     with:
       environment: Staging
       release: ${{ inputs.image-tag }}
+    # Deploy credentials include organization secrets, which reach the locked-compose
+    # workflow only through inheritance — environment secrets alone do not cover them.
+    secrets: inherit # zizmor: ignore[secrets-inherit]

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -27,4 +27,3 @@ jobs:
     with:
       environment: Staging
       release: ${{ inputs.image-tag }}
-    secrets: inherit

--- a/.github/workflows/openapi-autocommit.yml
+++ b/.github/workflows/openapi-autocommit.yml
@@ -2,6 +2,7 @@ name: API
 
 on:
   pull_request_target: # zizmor: ignore[dangerous-triggers] PR code runs only in the read-only generate job.
+    branches: [main]
     types: [labeled]
 
 permissions: {}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,13 +1,18 @@
 name: "PR"
 
 on:
-  pull_request_target:
+  pull_request_target: # zizmor: ignore[dangerous-triggers] No pull-request code is checked out or executed.
+    branches: [main]
     types:
       - opened
       - edited
       - synchronize
       - reopened
       - ready_for_review
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   validate-title:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ name: Release
 # Versioning contract: docs/admin/compatibility-policy.mdx
 
 on:
-  workflow_run:
+  workflow_run: # zizmor: ignore[dangerous-triggers] The guard authenticates the completed run before privileged jobs start.
     workflows: ["CI/CD"]
     types: [completed]
     branches: [main]
@@ -177,22 +177,22 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Authoritative registry-side digest of the manifest list.
-          manifest_digest() {
-            docker buildx imagetools inspect "$1" --format '{{json .Manifest}}' | jq -r '.digest'
-          }
-
           mapfile -t IMAGES < <(jq -er '.images[]' security/release-images.json)
           [ "${#IMAGES[@]}" -gt 0 ] || { echo "::error::Release image inventory is empty"; exit 1; }
+          declare -A DIGESTS=()
           : > release-images.tsv
 
-          # Probe all images first; refuse to partial-publish if any is missing.
+          # Resolve every source digest before publishing any release tag.
           for img in "${IMAGES[@]}"; do
             FULL_IMAGE="ghcr.io/ls1intum/hephaestus/$img"
             for i in $(seq 1 24); do
-              if docker buildx imagetools inspect "$FULL_IMAGE:$SHA" > /dev/null 2>&1; then break; fi
+              digest=$(docker buildx imagetools inspect "$FULL_IMAGE:$SHA" --format '{{json .Manifest}}' 2>/dev/null | jq -er '.digest' 2>/dev/null) || true
+              if [[ "$digest" =~ ^sha256:[a-f0-9]{64}$ ]]; then
+                DIGESTS[$img]=$digest
+                break
+              fi
               if [ "$i" -ge 24 ]; then
-                echo "::error::Image $FULL_IMAGE:$SHA not found after 120 s"
+                echo "::error::Could not resolve a valid digest for $FULL_IMAGE:$SHA after 120 s"
                 exit 1
               fi
               sleep 5
@@ -203,9 +203,7 @@ jobs:
             FULL_IMAGE="ghcr.io/ls1intum/hephaestus/$img"
             echo "::group::$img"
 
-            SRC_DIGEST=$(manifest_digest "$FULL_IMAGE:$SHA")
-            [[ "$SRC_DIGEST" =~ ^sha256:[a-f0-9]{64}$ ]] || {
-              echo "::error::$img source digest is malformed: ${SRC_DIGEST:-<empty>}"; exit 1; }
+            SRC_DIGEST=${DIGESTS[$img]}
             echo "$img source digest: $SRC_DIGEST"
             printf '%s\t%s\n' "$img" "$SRC_DIGEST" >> release-images.tsv
 
@@ -252,7 +250,14 @@ jobs:
           mkdir -p evidence
           : > release-platforms.tsv
           started=$SECONDS
-          trivy image --download-db-only
+          for attempt in 1 2 3; do
+            trivy image --timeout 90s --download-db-only && break
+            if [ "$attempt" -eq 3 ]; then
+              echo "::error::Trivy database download failed after $attempt attempts"
+              exit 1
+            fi
+            sleep $((attempt * 5))
+          done
           db_metadata="${TRIVY_CACHE_DIR:-$HOME/.cache/trivy}/db/metadata.json"
           jq -e '(.UpdatedAt | sub("\\.[0-9]+Z$"; "Z") | fromdateiso8601) as $updated |
             ((now - $updated) >= 0) and ((now - $updated) <= 86400)' \
@@ -283,8 +288,8 @@ jobs:
                 "evidence/$image-$suffix.spdx.json" \
                 "evidence/$image-$suffix.cdx.json" \
                 "$platform_digest" "$platform" "evidence/$image-$suffix.sbom-validation.json"
-              trivy image --scanners vuln --format json --output "evidence/$image-$suffix.trivy.json" "$platform_ref"
-              trivy image --scanners license --format json --output "evidence/$image-$suffix.license.json" "$platform_ref"
+              trivy image --skip-db-update --scanners vuln --format json --output "evidence/$image-$suffix.trivy.json" "$platform_ref"
+              trivy image --skip-db-update --scanners license --format json --output "evidence/$image-$suffix.license.json" "$platform_ref"
               jq -e --arg ref "$platform_ref" \
                 '.ArtifactName == $ref and (.Results | type == "array")' \
                 "evidence/$image-$suffix.license.json" >/dev/null
@@ -707,7 +712,6 @@ jobs:
       packages: read
     with:
       image-tag: ${{ needs.release.outputs.tag_name }}
-    secrets: inherit
 
   deploy-production:
     needs: [release, deploy-staging]
@@ -717,4 +721,3 @@ jobs:
       contents: read
     with:
       image-tag: ${{ needs.release.outputs.tag_name }}
-    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -712,6 +712,9 @@ jobs:
       packages: read
     with:
       image-tag: ${{ needs.release.outputs.tag_name }}
+    # Deploy credentials include organization secrets, which reach nested reusable
+    # workflows only through inheritance — environment secrets alone do not cover them.
+    secrets: inherit # zizmor: ignore[secrets-inherit]
 
   deploy-production:
     needs: [release, deploy-staging]
@@ -721,3 +724,6 @@ jobs:
       contents: read
     with:
       image-tag: ${{ needs.release.outputs.tag_name }}
+    # Deploy credentials include organization secrets, which reach nested reusable
+    # workflows only through inheritance — environment secrets alone do not cover them.
+    secrets: inherit # zizmor: ignore[secrets-inherit]

--- a/.github/workflows/rescan-release-images.yml
+++ b/.github/workflows/rescan-release-images.yml
@@ -81,7 +81,14 @@ jobs:
         run: |
           set -euo pipefail
           mkdir reports
-          trivy image --download-db-only
+          for attempt in 1 2 3; do
+            trivy image --timeout 90s --download-db-only && break
+            if [ "$attempt" -eq 3 ]; then
+              echo "::error::Trivy database download failed after $attempt attempts"
+              exit 1
+            fi
+            sleep $((attempt * 5))
+          done
           db_metadata="${TRIVY_CACHE_DIR:-$HOME/.cache/trivy}/db/metadata.json"
           jq -e '(.UpdatedAt | sub("\\.[0-9]+Z$"; "Z") | fromdateiso8601) as $updated |
             ((now - $updated) >= 0) and ((now - $updated) <= 86400)' \
@@ -90,7 +97,7 @@ jobs:
           jq -er '.subjects[] | [.image, .platform, .digest, .repository] | @tsv' release-evidence/manifest.json |
           while IFS=$'\t' read -r image platform digest repository; do
             suffix=${platform//\//-}
-            trivy image --scanners vuln --format json --output "reports/$image-$suffix.json" "$repository@$digest"
+            trivy image --skip-db-update --scanners vuln --format json --output "reports/$image-$suffix.json" "$repository@$digest"
             node scripts/check-release-vulnerabilities.ts "$image" "$platform" "$digest" "$repository" \
               "reports/$image-$suffix.json" security/vulnerability-policy.json \
               "reports/$image-$suffix.policy.json"

--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -122,9 +122,11 @@ jobs:
                   [ -n "$value" ] && echo "type=raw,value=$value"
                 done
               fi
-            done <<< "${{ inputs.tags }}"
+            done <<< "$INPUT_TAGS"
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
+        env:
+          INPUT_TAGS: ${{ inputs.tags }}
 
       - name: Extract metadata
         id: meta
@@ -137,10 +139,13 @@ jobs:
       - name: Prepare platform pair
         id: prep
         run: |
-          platform=${{ matrix.platform }}
+          platform=$MATRIX_PLATFORM
           echo "platform_pair=${platform//\//-}" >> $GITHUB_OUTPUT
-          image="${{ inputs.image-name }}"
+          image="$INPUT_IMAGE_NAME"
           echo "image_name=${image//\//-}" >> $GITHUB_OUTPUT
+        env:
+          INPUT_IMAGE_NAME: ${{ inputs.image-name }}
+          MATRIX_PLATFORM: ${{ matrix.platform }}
 
       # Only main may write the shared registry cache.
       - name: Build and push (Dockerfile)
@@ -162,9 +167,6 @@ jobs:
             type=registry,ref=${{ inputs.registry }}/${{ inputs.image-name }}:cache-main-${{ steps.prep.outputs.platform_pair }}
           cache-to: ${{ github.ref == 'refs/heads/main' && format('type=registry,ref={0}/{1}:cache-main-{2},mode=max', inputs.registry, inputs.image-name, steps.prep.outputs.platform_pair) || '' }}
 
-      # Buildpacks path: spring-boot:build-image publishes an OCI image (Application CDS enabled),
-      # then we capture the per-arch digest so the merge job builds the multi-arch manifest exactly
-      # like the Dockerfile path.
       - name: Set up JDK 21
         if: inputs.use-buildpacks
         uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
@@ -181,15 +183,15 @@ jobs:
           restore-keys: |
             m2-${{ runner.os }}-${{ runner.arch }}-
 
-      # Fail fast if a downstream caller flips use-buildpacks=true without supplying maven-module.
-      # `working-directory: ""` would silently run from the repo root, where there is no ./mvnw.
       - name: Validate buildpacks inputs
         if: inputs.use-buildpacks
         run: |
-          if [ -z "${{ inputs.maven-module }}" ]; then
+          if [ -z "$INPUT_MAVEN_MODULE" ]; then
             echo "::error::use-buildpacks=true requires maven-module (e.g. server/application)"
             exit 1
           fi
+        env:
+          INPUT_MAVEN_MODULE: ${{ inputs.maven-module }}
 
       - name: Build and push (Paketo Buildpacks + CDS)
         id: build-buildpacks
@@ -199,23 +201,25 @@ jobs:
           DOCKER_PUBLISH_REGISTRY_URL: https://${{ inputs.registry }}
           DOCKER_PUBLISH_REGISTRY_USERNAME: ${{ github.actor }}
           DOCKER_PUBLISH_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_IMAGE_NAME: ${{ inputs.image-name }}
+          INPUT_REGISTRY: ${{ inputs.registry }}
+          MATRIX_PLATFORM: ${{ matrix.platform }}
+          PLATFORM_PAIR: ${{ steps.prep.outputs.platform_pair }}
         run: |
           set -euo pipefail
-          PER_ARCH_TAG="${{ inputs.registry }}/${{ inputs.image-name }}:ci-${{ github.run_id }}-${{ steps.prep.outputs.platform_pair }}"
+          PER_ARCH_TAG="$INPUT_REGISTRY/$INPUT_IMAGE_NAME:ci-$GITHUB_RUN_ID-$PLATFORM_PAIR"
           ../mvnw -B -ntp -f ../pom.xml -pl generated-clients -am install -DskipTests=true
           ../mvnw -B -ntp spring-boot:build-image -DskipTests=true \
             -Dspring-boot.build-image.imageName="$PER_ARCH_TAG" \
-            -Dspring-boot.build-image.imagePlatform="${{ matrix.platform }}" \
+            -Dspring-boot.build-image.imagePlatform="$MATRIX_PLATFORM" \
             -Dspring-boot.build-image.publish=true \
             -Ddocker.publishRegistry.url="$DOCKER_PUBLISH_REGISTRY_URL" \
             -Ddocker.publishRegistry.username="$DOCKER_PUBLISH_REGISTRY_USERNAME" \
             -Ddocker.publishRegistry.password="$DOCKER_PUBLISH_REGISTRY_PASSWORD"
-          # Capture the platform-specific manifest digest. Newer Paketo lifecycle versions may
-          # publish per-arch tags as a single-entry image index; descend to the matching arch when
-          # that happens so the merge job pins the platform manifest, not the index wrapper.
+          # Buildpacks may wrap one platform in an index; capture its manifest, not the wrapper.
           RAW=$(docker buildx imagetools inspect "$PER_ARCH_TAG" --format '{{json .Manifest}}')
           if echo "$RAW" | jq -e '.manifests' >/dev/null 2>&1; then
-            ARCH=$(echo "${{ matrix.platform }}" | awk -F/ '{print $2}')
+            ARCH=$(echo "$MATRIX_PLATFORM" | awk -F/ '{print $2}')
             DIGEST=$(echo "$RAW" | jq -r --arg arch "$ARCH" \
               '.manifests[] | select(.platform.architecture == $arch and .platform.os == "linux") | .digest')
           else
@@ -322,8 +326,10 @@ jobs:
       - name: Prepare
         id: prep
         run: |
-          image="${{ inputs.image-name }}"
+          image="${INPUTS_IMAGE_NAME}"
           echo "image_name=${image//\//-}" >> $GITHUB_OUTPUT
+        env:
+          INPUTS_IMAGE_NAME: ${{ inputs.image-name }}
 
       - name: Download digests
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -353,9 +359,8 @@ jobs:
             echo "type=ref,event=branch"
             echo "type=ref,event=pr"
             echo "type=sha,prefix="
-            # Custom tags from input
-            if [ -n "${{ inputs.tags }}" ]; then
-              echo "${{ inputs.tags }}" | while IFS= read -r line || [[ -n "$line" ]]; do
+            if [ -n "${INPUTS_TAGS}" ]; then
+              echo "${INPUTS_TAGS}" | while IFS= read -r line || [[ -n "$line" ]]; do
                 line=$(echo "$line" | xargs)
                 if [ -n "$line" ]; then
                   if [[ "$line" == *"type="* ]]; then
@@ -374,6 +379,8 @@ jobs:
             fi
             echo "EOF"
           } >> $GITHUB_OUTPUT
+        env:
+          INPUTS_TAGS: ${{ inputs.tags }}
 
       - name: Extract metadata
         id: meta
@@ -386,12 +393,19 @@ jobs:
       - name: Create manifest and push
         working-directory: ${{ runner.temp }}/digests
         run: |
-          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ inputs.registry }}/${{ inputs.image-name }}@sha256:%s ' *)
+          mapfile -t tags < <(jq -er '.tags[]' <<< "$DOCKER_METADATA_OUTPUT_JSON")
+          args=()
+          for tag in "${tags[@]}"; do args+=(-t "$tag"); done
+          for digest in *; do args+=("$INPUTS_REGISTRY/$INPUTS_IMAGE_NAME@sha256:$digest"); done
+          docker buildx imagetools create "${args[@]}"
+        env:
+          INPUTS_REGISTRY: ${{ inputs.registry }}
+          INPUTS_IMAGE_NAME: ${{ inputs.image-name }}
 
       - name: Inspect image
-        run: |
-          docker buildx imagetools inspect ${{ inputs.registry }}/${{ inputs.image-name }}:${{ steps.meta.outputs.version }}
+        run: docker buildx imagetools inspect "$IMAGE_REF"
+        env:
+          IMAGE_REF: ${{ inputs.registry }}/${{ inputs.image-name }}:${{ steps.meta.outputs.version }}
 
       - name: Capture manifest digest
         id: digest

--- a/.github/workflows/review-policy.yml
+++ b/.github/workflows/review-policy.yml
@@ -37,6 +37,12 @@ jobs:
               ...context.repo,
               pull_number: context.payload.pull_request.number,
             });
+            // pull_request_review supports no base-branch filter, so guard here: the
+            // policy applies to pull requests that target main only.
+            if (pull.base.ref !== 'main') {
+              core.info(`The review policy does not apply to base branch ${pull.base.ref}.`);
+              return;
+            }
             const author = pull.user.login.toLowerCase();
             const maintainers = new Set(
               (process.env.MAINTAINERS || '')

--- a/.github/workflows/review-policy.yml
+++ b/.github/workflows/review-policy.yml
@@ -1,0 +1,82 @@
+name: Review policy
+
+on:
+  pull_request_target: # zizmor: ignore[dangerous-triggers] API reads only; no pull-request code is executed.
+    branches: [main]
+    types: [opened, reopened, synchronize, ready_for_review]
+  pull_request_review:
+    types: [submitted, dismissed]
+  merge_group:
+
+permissions: {}
+
+concurrency:
+  group: review-policy-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  review-policy:
+    name: review-policy
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Enforce review policy
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          MAINTAINERS: ${{ vars.REVIEW_POLICY_MAINTAINERS }}
+        with:
+          script: |
+            if (context.eventName === 'merge_group') {
+              return;
+            }
+
+            const { data: pull } = await github.rest.pulls.get({
+              ...context.repo,
+              pull_number: context.payload.pull_request.number,
+            });
+            const author = pull.user.login.toLowerCase();
+            const maintainers = new Set(
+              (process.env.MAINTAINERS || '')
+                .split(',')
+                .map((login) => login.trim().toLowerCase())
+                .filter(Boolean),
+            );
+            if (maintainers.has(author)) {
+              core.info(`${pull.user.login} is in REVIEW_POLICY_MAINTAINERS.`);
+              return;
+            }
+
+            const reviews = await github.paginate(github.rest.pulls.listReviews, {
+              ...context.repo,
+              pull_number: pull.number,
+              per_page: 100,
+            });
+            const latestByReviewer = new Map();
+            for (const review of reviews.sort((left, right) => left.id - right.id)) {
+              if (
+                review.user &&
+                review.user.login.toLowerCase() !== author &&
+                ['APPROVED', 'CHANGES_REQUESTED', 'DISMISSED'].includes(review.state)
+              ) {
+                latestByReviewer.set(review.user.login.toLowerCase(), review);
+              }
+            }
+
+            for (const [login, review] of latestByReviewer) {
+              if (review.state !== 'APPROVED' || review.commit_id !== pull.head.sha) continue;
+              const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+                ...context.repo,
+                username: login,
+              });
+              if (['admin', 'maintain', 'write'].includes(data.permission)) {
+                core.info(`Approved by ${login}, who has ${data.permission} access.`);
+                return;
+              }
+            }
+
+            core.setFailed(
+              'This contributor pull request needs an approving review from a non-author with write access.',
+            );

--- a/.github/workflows/version-pr.yml
+++ b/.github/workflows/version-pr.yml
@@ -1,21 +1,8 @@
 name: Version PR
 
-# Maintains the accumulating "Version PR" (changesets). On every push to main
-# it folds pending .changeset/*.md files into a PR that bumps the root
-# `hephaestus` package version and rewrites CHANGELOG.md. Merging that PR is
-# the deliberate act that cuts a release — release.yml takes over from there.
-#
-# This workflow only ever opens/updates the PR; it never tags or deploys.
-#
-# The PR is opened with GITHUB_TOKEN, so it is authored by github-actions[bot]
-# and carries no CI: events created with that token don't trigger workflows.
-# That is deliberate — the PR only bumps a version string and rewrites
-# CHANGELOG.md, and it is re-pushed on every merge to main, so running the full
-# matrix (Docker builds included) on it would burn CI on every merge without
-# validating anything. The real validation happens after the merge: main runs
-# the full suite and release.yml only cuts a release if that run succeeded.
-# `ls1intum/hephaestus-maintainers` bypasses the branch ruleset, so the missing
-# required checks do not block merging the Version PR.
+# Maintains the changesets Version PR; release.yml handles merged version bumps.
+# GITHUB_TOKEN-authored updates do not trigger CI, so release automation uses the
+# ruleset bypass. A release still requires successful main CI.
 #
 # Contributor guide: docs/contributor/release-management.mdx
 

--- a/docs/contributor/ci-cd.mdx
+++ b/docs/contributor/ci-cd.mdx
@@ -14,9 +14,11 @@ Hephaestus uses trunk-based delivery powered by GitHub Actions. Every merge to `
 ```mermaid
 flowchart TD
     accTitle: Pull request delivery pipeline
-    accDescr: An approved change passes CI, enters a Version PR, and becomes a signed release that deploys to staging before production approval.
-    PR[Pull Request] --> Review{Code Review}
-    Review -->|Approved| Merge[Merge to main]
+    accDescr: A pull request satisfies review policy, passes projected-main CI in the merge queue, and becomes a signed release that deploys to staging before production approval.
+    PR[Pull Request] --> Policy{Review policy}
+    Policy --> Queue[Merge queue]
+    Queue --> MG[Projected-main CI]
+    MG --> Merge[Merge to main]
     Merge --> CI[CI/CD Pipeline]
 
     subgraph CI/CD
@@ -59,6 +61,26 @@ Before any release, code must pass:
 | Agent and repository-tooling files | oxlint + oxfmt + tsc | Lint, format, and typecheck where applicable |
 | Docs code and configuration | oxfmt | Format JavaScript, TypeScript, JSON/JSONC, and CSS |
 | Agent runtime   | Node         | Runner and precompute specs on the version pinned by `package.json`; the package-manager contract rejects Docker image drift |
+| Workflow syntax and shell correctness | Actionlint + ShellCheck | Rejects invalid Actions configuration and warning-level shell defects |
+| Workflow security | Zizmor | Uploads SARIF and rejects medium-or-higher-confidence findings |
+
+### Merge policy
+
+Pull requests targeting `main` merge through GitHub's merge queue after these GitHub
+Actions contexts pass: `CI Status Gate`, `Actionlint`, `Zizmor`, and `review-policy`. The queue runs
+the same checks against the projected `main` commit through the `merge_group` event. Each required
+context is bound to the GitHub Actions integration rather than accepting a same-named external status.
+
+`review-policy` accepts an author listed in the comma-separated repository variable
+`REVIEW_POLICY_MAINTAINERS`. Every other author needs an approval from a non-author who currently
+has write access; the approval must cover the current head commit. Repository administrators own the
+allow-list. Native required approvals remain zero because GitHub cannot combine an author's
+self-authored change, a mandatory approval, and the merge queue without bypassing the queue.
+
+The changesets Version PR is the temporary exception: updates made with `GITHUB_TOKEN` do not trigger
+the required workflows, so release automation uses the ruleset bypass. The release workflow still
+requires successful CI on the resulting `main` commit before it publishes anything. Move the Version
+PR to a machine identity that triggers workflows before removing this exception.
 
 ## 🔒 Security
 
@@ -137,10 +159,9 @@ Each stack keeps its own PostgreSQL, preview-only credentials, and signed commit
 No container holds the Docker socket: the seed loader reads staging over the network as a role that
 can only read.
 
-Stacked pull requests work. A layer based on the layer below gets its own preview of the whole stack
-up to that layer, and each labelled layer takes its own slot. Deployment policy is checked against
-`main`, not against the layer below, so a layer cannot inherit a workflow or `docker/preview/` edit
-from underneath it.
+Preview controllers run only for pull requests targeting `main`; this keeps privileged
+`pull_request_target` workflows anchored to the protected branch. A stacked layer becomes eligible
+after it is retargeted to `main`.
 
 ### When the comment says nothing deployed
 
@@ -176,7 +197,8 @@ why the label is the authority, and which alternatives were priced and declined,
 
 | Workflow               | Trigger               | Purpose                                            |
 | ---------------------- | --------------------- | -------------------------------------------------- |
-| `cicd.yml`             | Push to main, PRs     | Orchestrator: change detection + workflow dispatch |
+| `cicd.yml`             | Push to main, PRs, merge queue | Orchestrator: change detection + workflow dispatch |
+| `review-policy.yml`    | PR and review events, merge queue | Enforces author allow-list or current-head write-access approval |
 | `ci-quality-gates.yml` | Called by cicd.yml    | Code quality, formatting, schema validation        |
 | `ci-tests.yml`         | Called by cicd.yml    | Unit, integration, visual tests                    |
 | `ci-docker-build.yml`  | Called by cicd.yml    | Docker image builds per component                  |

--- a/docs/contributor/release-management.mdx
+++ b/docs/contributor/release-management.mdx
@@ -51,10 +51,9 @@ sequenceDiagram
    titled `chore(release): version packages` that previews the next version and the assembled
    `CHANGELOG.md` section. It is safe to leave open — it updates itself. It is opened by
    `github-actions[bot]` and deliberately runs **no CI**: it only bumps a version string and
-   rewrites the changelog, and it is re-pushed on every merge to `main`, so running the full matrix
-   on it would burn CI without validating anything. Validation happens after the merge — `main` runs
-   the full suite and a release is only cut if that run succeeds. Maintainers bypass the branch
-   ruleset, so the absent required checks don't block the merge. Versioning also moves any
+   rewrites the changelog. `GITHUB_TOKEN` updates do not trigger the required workflows, so release
+   automation uses the ruleset bypass. Validation happens after the merge: `main` runs the full suite
+   and a release is only cut if that run succeeds. Versioning also moves any
    `### Next release` section in `MIGRATION.md` under the version being cut.
 3. **Merging the Version PR cuts the release.** The workflow creates a draft release at the merge
    commit. After its evidence, seeded-upgrade, and supported-host gates pass, it promotes the CI-built images to

--- a/renovate.json
+++ b/renovate.json
@@ -127,6 +127,15 @@
 			"versioningTemplate": "semver"
 		},
 		{
+			"description": "Track the Zizmor CLI version",
+			"customType": "regex",
+			"managerFilePatterns": ["/^\\.github/workflows/cicd\\.yml$/"],
+			"matchStrings": [
+				"# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\s+version: (?<currentValue>\\S+)"
+			],
+			"versioningTemplate": "semver"
+		},
+		{
 			"description": "Track release image tags and digests",
 			"customType": "regex",
 			"managerFilePatterns": ["/^security/release-images\\.json$/"],


### PR DESCRIPTION
## Description

Adds merge-queue-aware CI and closes the workflow-security and reliability gaps tracked in #1592.

This change:

- runs the complete required pipeline for `merge_group` commits;
- adds required Actionlint/ShellCheck and Zizmor checks, with SARIF upload and finding enforcement;
- introduces a base-branch-authoritative `review-policy` check that allows configured maintainers or requires a current-head approval from a write-capable non-author;
- bounds release downloads, Trivy database updates, registry propagation, and E2E process cleanup;
- scopes privileged pull-request controllers to PRs targeting `main`, tightens secret and permission boundaries, and adds missing concurrency controls;
- documents the merge policy and release-automation exception.

Fixes #1592

### Rollout note

The repository ruleset is intentionally not changed before this PR lands: requiring contexts that do not yet exist on `main` would deadlock this PR and the merge queue. After merge, update the ruleset to require `CI Status Gate`, `Actionlint`, `Zizmor`, and `review-policy`, bind them to GitHub Actions, and then enable the queue.

The existing base-branch `Validate title` workflow currently calls a missing package script, so that required check fails before it can evaluate this PR title. This PR fixes the workflow to invoke the installed CLI directly. Because `pull_request_target` correctly uses the base-branch workflow definition, landing this bootstrap fix requires a maintainer to use the existing ruleset bypass once; subsequent PRs will run the repaired check normally.

The Changesets Version PR still needs the existing release-automation bypass because pushes made with `GITHUB_TOKEN` do not trigger required workflows. Removing that exception depends on moving Version PR authorship to a machine identity, as tracked by #1599.

## How to test

- `pnpm run format`
- `pnpm run check`
- `pnpm run verify` (the first Storybook launch hit a transient Vite dynamic-import failure; an immediate isolated rerun passed all 1,634 stories)
- Actionlint with ShellCheck at warning severity
- authenticated Zizmor 1.29.0 audit at medium confidence
- adversarial TERM-resistant process-group cleanup smoke test

After merge, enqueue a test PR and verify that all four required contexts report on its `merge_group` commit.

## Checklist

- [x] No changeset is required: this changes CI, repository policy, and contributor documentation only.
- [x] No operator migration or runtime configuration change is required.
