### PR TITLE
feat(server): add structured JSON logging with credential redaction

### DIFF
--- a/.changeset/structured-safe-logs.md
+++ b/.changeset/structured-safe-logs.md
@@ -1,0 +1,5 @@
+---
+"hephaestus": minor
+---
+
+Operators can now ingest application logs as structured JSON, correlate agent-job logs by job or workspace, and scrape application metrics from the Prometheus actuator endpoint. Bearer, GitLab, GitHub, and token-query-string credentials are masked before console output.

--- a/.changeset/structured-safe-logs.md
+++ b/.changeset/structured-safe-logs.md
@@ -3,3 +3,5 @@
 ---
 
 Operators can now ingest application logs as structured JSON, correlate agent-job logs by job or workspace, and scrape application metrics from the Prometheus actuator endpoint. Bearer, GitLab, GitHub, and token-query-string credentials are masked before console output.
+
+**Operators:** the server now writes one JSON object per log line instead of plain text, by default and in every profile. Anything that parses the previous plain-text format — log shippers, alerts, grep-based tooling — must be updated to read JSON; see `MIGRATION.md`.

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -119,6 +119,19 @@ jobs:
         with:
           name: ${{ env.SERVER_REACTOR_ARTIFACT }}
           path: server
+      - name: Install downloaded reactor dependencies
+        run: |
+          # Surefire resolves the generated-clients JAR from the local repository, which is only
+          # warm when the dependency cache hits — and its key hashes every server POM, so the PR
+          # that edits one starts cold. Install the downloaded reactor artifacts explicitly instead
+          # of relying on that cache.
+          cd server
+          CLIENT_JAR="$(find generated-clients/target -maxdepth 1 -name 'hephaestus-generated-clients-*.jar' ! -name '*-sources.jar' ! -name '*-javadoc.jar' -print -quit)"
+          test -n "$CLIENT_JAR"
+          ./mvnw --batch-mode --non-recursive org.apache.maven.plugins:maven-install-plugin:3.1.4:install-file \
+            -Dfile=pom.xml -DpomFile=pom.xml
+          ./mvnw --batch-mode --non-recursive org.apache.maven.plugins:maven-install-plugin:3.1.4:install-file \
+            -Dfile="$CLIENT_JAR" -DpomFile=generated-clients/pom.xml
       - name: Run integration tests from the built reactor
         run: |
           rm -rf server/application/target/surefire-reports/*

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -81,6 +81,21 @@ value of `HEPHAESTUS_SECURITY_ENCRYPTION_KEY`. After every runtime is upgraded, 
 to replace it with an independent key. Self-hosted installations using `docker/self-host/setup.sh`
 receive the initial value automatically.
 
+#### 🔴 Server logs are now structured JSON
+
+**Affected**: deployments that parse the application server or worker console output — log shippers,
+alerting rules, or grep-based tooling built for the previous plain-text lines.
+
+**Before**: the server and worker wrote human-readable plain-text log lines.
+
+**After**: every log line is a single JSON object (`timestamp`, `level`, `logger`, `message`, `mdc`,
+`stacktrace`), in every profile, with known credential formats masked before output. Nothing changes
+for `docker compose logs` itself — the lines are still printed to the console, just as JSON.
+
+**Migration**: point existing parsers at the JSON fields instead of the plain-text layout. Filters
+that matched free text can key on `mdc."job.id"` and `mdc."workspace.id"`; see the log-correlation
+examples in the practice-review operations guide.
+
 ### v0.76.0
 
 #### 🔴 Upgrade the server and agent image together

--- a/docs/admin/practice-review-operations.mdx
+++ b/docs/admin/practice-review-operations.mdx
@@ -79,16 +79,21 @@ Metric names in the instrumented code are the source of truth for dashboards and
 
 ### Log correlation
 
-Collector labels are deployment-specific. In these examples, replace the stream selector with one that
-selects the worker logs in your deployment:
+The application emits one JSON object per log line, so worker logs filter by the correlation keys
+under `mdc` with the tools already in the shipped Compose stack. From the directory you deploy from:
 
-```logql
-{container="application-worker"} | json job_id=`mdc["job.id"]` | job_id="<job-uuid>"
+```bash
+# All log lines for one agent job
+docker compose logs --no-log-prefix application-worker \
+  | jq -cR 'fromjson? | select(.mdc."job.id" == "<job-uuid>")'
+
+# All errors for one workspace
+docker compose logs --no-log-prefix application-worker \
+  | jq -cR 'fromjson? | select(.mdc."workspace.id" == "<workspace-id>" and .level == "ERROR")'
 ```
 
-```logql
-{container="application-worker"} | json workspace_id=`mdc["workspace.id"]` | workspace_id="<workspace-id>" | level="ERROR"
-```
+A deployment that ships logs to its own collector can key dashboards and alerts on the same `mdc`
+fields; label names there are deployment-specific.
 
 **Retention.** Terminal job payloads are stripped before their rows are deleted, so row retention shorter
 than payload retention is incoherent — the application refuses to start rather than accept it. Treat the

--- a/docs/admin/practice-review-operations.mdx
+++ b/docs/admin/practice-review-operations.mdx
@@ -77,6 +77,19 @@ visible in **Review activity** and the refusal counter; they do not remove the w
 Gauges are sampled periodically; timers and counters are recorded when the corresponding event occurs.
 Metric names in the instrumented code are the source of truth for dashboards and alerts.
 
+### Log correlation
+
+Collector labels are deployment-specific. In these examples, replace the stream selector with one that
+selects the worker logs in your deployment:
+
+```logql
+{container="application-worker"} | json job_id=`mdc["job.id"]` | job_id="<job-uuid>"
+```
+
+```logql
+{container="application-worker"} | json workspace_id=`mdc["workspace.id"]` | workspace_id="<workspace-id>" | level="ERROR"
+```
+
 **Retention.** Terminal job payloads are stripped before their rows are deleted, so row retention shorter
 than payload retention is incoherent — the application refuses to start rather than accept it. Treat the
 fabric root as sensitive storage. Delivery-policy evaluations and dispatch intents follow their owning

--- a/server/application/pom.xml
+++ b/server/application/pom.xml
@@ -52,6 +52,7 @@
         <springdoc.version>3.1.0</springdoc.version>
         <springdoc-maven-plugin.version>1.5</springdoc-maven-plugin.version>
         <sentry.version>8.53.0</sentry.version>
+        <logstash-logback-encoder.version>9.0</logstash-logback-encoder.version>
         <slack-bolt.version>1.50.0</slack-bolt.version>
         <jnats.version>2.26.2</jnats.version>
         <jgit.version>7.7.1.202607240634-r</jgit.version>
@@ -78,6 +79,19 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>net.logstash.logback</groupId>
+            <artifactId>logstash-logback-encoder</artifactId>
+            <version>${logstash-logback-encoder.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>context-propagation</artifactId>
         </dependency>
         <dependency>
             <groupId>com.github.ben-manes.caffeine</groupId>

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobExecutor.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobExecutor.java
@@ -35,6 +35,7 @@ import de.tum.cit.aet.hephaestus.agent.usage.LlmUsageRecorder;
 import de.tum.cit.aet.hephaestus.core.WorkspaceAgnostic;
 import de.tum.cit.aet.hephaestus.core.runtime.RuntimeRole;
 import de.tum.cit.aet.hephaestus.evidence.AutomatedReviewReadinessReport;
+import de.tum.cit.aet.hephaestus.observability.StructuredLogKeys;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
@@ -103,7 +104,7 @@ public class AgentJobExecutor {
 
     private static final Logger log = LoggerFactory.getLogger(AgentJobExecutor.class);
 
-    private static final String MDC_JOB_ID = "agent.jobId";
+    private static final String MDC_JOB_ID = StructuredLogKeys.JOB_ID;
     private static final String MDC_JOB_TYPE = "agent.jobType";
     private static final int MAX_ERROR_MESSAGE_LENGTH = 4000;
     private static final int MAX_CONTAINER_LOGS_CHARS = 65536; // 64KB
@@ -564,6 +565,7 @@ public class AgentJobExecutor {
     private void runClaimedJob(UUID jobId, ClaimResult claim) {
         MDC.put(MDC_JOB_ID, jobId.toString());
         AgentJob job = claim.job;
+        MDC.put(StructuredLogKeys.WORKSPACE_ID, job.getWorkspace().getId().toString());
         MDC.put(MDC_JOB_TYPE, job.getJobType().name());
         Instant startTime = Instant.now();
         String metricOutcome = "unknown";
@@ -630,6 +632,7 @@ public class AgentJobExecutor {
             releaseCapacity();
             localRunningJobs.remove(jobId);
             MDC.remove(MDC_JOB_ID);
+            MDC.remove(StructuredLogKeys.WORKSPACE_ID);
             MDC.remove(MDC_JOB_TYPE);
         }
     }

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/config/SpringAsyncConfig.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/config/SpringAsyncConfig.java
@@ -9,6 +9,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.core.Ordered;
 import org.springframework.core.task.AsyncTaskExecutor;
+import org.springframework.core.task.support.ContextPropagatingTaskDecorator;
 import org.springframework.core.task.support.TaskExecutorAdapter;
 import org.springframework.scheduling.annotation.AsyncConfigurer;
 import org.springframework.scheduling.annotation.EnableAsync;
@@ -40,6 +41,7 @@ public class SpringAsyncConfig implements AsyncConfigurer {
         executor.setMaxPoolSize(16);
         executor.setQueueCapacity(500);
         executor.setThreadNamePrefix("async-");
+        executor.setTaskDecorator(new ContextPropagatingTaskDecorator());
         // Let in-flight async DB work finish before the EntityManagerFactory closes on shutdown.
         executor.setWaitForTasksToCompleteOnShutdown(true);
         executor.setAwaitTerminationSeconds(30);
@@ -67,6 +69,7 @@ public class SpringAsyncConfig implements AsyncConfigurer {
         executor.setMaxPoolSize(4);
         executor.setQueueCapacity(1000);
         executor.setThreadNamePrefix("feedback-lane-");
+        executor.setTaskDecorator(new ContextPropagatingTaskDecorator());
         // Same reason as applicationTaskExecutor: let in-flight DB work finish before the
         // EntityManagerFactory closes.
         executor.setWaitForTasksToCompleteOnShutdown(true);
@@ -82,6 +85,7 @@ public class SpringAsyncConfig implements AsyncConfigurer {
         executor.setMaxPoolSize(4);
         executor.setQueueCapacity(0);
         executor.setThreadNamePrefix("sync-job-");
+        executor.setTaskDecorator(new ContextPropagatingTaskDecorator());
         // SyncJobService (a lifecycle phase above) records cooperative cancellation first; runners
         // observe it and unwind on their own. shutdownNow is the backstop that bounds context close
         // rather than leaking this non-daemon pool — it must never be the primary mechanism, since an
@@ -101,6 +105,8 @@ public class SpringAsyncConfig implements AsyncConfigurer {
     @Bean(name = "monitoringExecutor")
     @ConditionalOnMissingBean(name = "monitoringExecutor")
     public AsyncTaskExecutor monitoringExecutor() {
-        return new TaskExecutorAdapter(Executors.newVirtualThreadPerTaskExecutor());
+        TaskExecutorAdapter executor = new TaskExecutorAdapter(Executors.newVirtualThreadPerTaskExecutor());
+        executor.setTaskDecorator(new ContextPropagatingTaskDecorator());
+        return executor;
     }
 }

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/observability/MdcContextConfiguration.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/observability/MdcContextConfiguration.java
@@ -1,0 +1,15 @@
+package de.tum.cit.aet.hephaestus.observability;
+
+import io.micrometer.context.ContextRegistry;
+import io.micrometer.context.integration.Slf4jThreadLocalAccessor;
+import jakarta.annotation.PostConstruct;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class MdcContextConfiguration {
+
+    @PostConstruct
+    void register() {
+        ContextRegistry.getInstance().registerThreadLocalAccessor(new Slf4jThreadLocalAccessor());
+    }
+}

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/observability/StructuredLogKeys.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/observability/StructuredLogKeys.java
@@ -1,0 +1,9 @@
+package de.tum.cit.aet.hephaestus.observability;
+
+public final class StructuredLogKeys {
+
+    public static final String JOB_ID = "job.id";
+    public static final String WORKSPACE_ID = "workspace.id";
+
+    private StructuredLogKeys() {}
+}

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/workspace/context/WorkspaceContextHolder.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/workspace/context/WorkspaceContextHolder.java
@@ -1,5 +1,6 @@
 package de.tum.cit.aet.hephaestus.workspace.context;
 
+import de.tum.cit.aet.hephaestus.observability.StructuredLogKeys;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -13,7 +14,7 @@ public final class WorkspaceContextHolder {
 
     private static final Logger log = LoggerFactory.getLogger(WorkspaceContextHolder.class);
 
-    private static final String MDC_WORKSPACE_ID = "workspace_id";
+    private static final String MDC_WORKSPACE_ID = StructuredLogKeys.WORKSPACE_ID;
     private static final String MDC_WORKSPACE_SLUG = "workspace_slug";
     private static final String MDC_INSTALLATION_ID = "installation_id";
 

--- a/server/application/src/main/resources/application.yml
+++ b/server/application/src/main/resources/application.yml
@@ -18,6 +18,9 @@ spring:
         virtual:
             enabled: true
 
+    reactor:
+        context-propagation: auto
+
     # Virtual threads are always daemons. With virtual threads enabled, both the request executor
     # and the @Scheduled TaskScheduler use them — so no non-daemon thread remains after main().
     # keep-alive registers one to hold the JVM open between cron firings.

--- a/server/application/src/main/resources/logback-spring.xml
+++ b/server/application/src/main/resources/logback-spring.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml" />
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <fieldNames>
+                <timestamp>timestamp</timestamp>
+                <version>[ignore]</version>
+                <logger>logger</logger>
+                <mdc>mdc</mdc>
+                <stackTrace>stacktrace</stackTrace>
+            </fieldNames>
+            <timestampPattern>[ISO_INSTANT]</timestampPattern>
+            <includeMdc>true</includeMdc>
+            <decorator class="net.logstash.logback.mask.MaskingJsonGeneratorDecorator">
+                <pathMask>
+                    <paths>password,secret,token,access_token,accessToken,refresh_token,refreshToken,authorization</paths>
+                    <mask>***</mask>
+                </pathMask>
+                <valueMask>
+                    <value>(?i)Bearer\s+[A-Za-z0-9._~+/=-]+</value>
+                    <mask>Bearer ***</mask>
+                </valueMask>
+                <valueMask>
+                    <value>glpat-[A-Za-z0-9_-]+</value>
+                    <mask>glpat-***</mask>
+                </valueMask>
+                <valueMask>
+                    <value>github_pat_[A-Za-z0-9_]+</value>
+                    <mask>github_pat_***</mask>
+                </valueMask>
+                <valueMask>
+                    <value>([?&amp;]token=)[^&amp;\s"']+</value>
+                    <mask>$1***</mask>
+                </valueMask>
+            </decorator>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE" />
+    </root>
+</configuration>

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/observability/MdcPropagationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/observability/MdcPropagationTest.java
@@ -1,0 +1,59 @@
+package de.tum.cit.aet.hephaestus.observability;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.slf4j.MDC;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.core.io.buffer.DefaultDataBufferFactory;
+import org.springframework.core.task.support.ContextPropagatingTaskDecorator;
+import org.springframework.core.task.support.TaskExecutorAdapter;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Hooks;
+import reactor.core.scheduler.Schedulers;
+
+@Tag("unit")
+class MdcPropagationTest {
+
+    @BeforeAll
+    static void enableContextPropagation() {
+        new MdcContextConfiguration().register();
+        Hooks.enableAutomaticContextPropagation();
+    }
+
+    @AfterAll
+    static void clearMdc() {
+        MDC.clear();
+    }
+
+    @Test
+    void shouldPropagateMdcAcrossVirtualThreadTask() throws Exception {
+        try (ExecutorService executorService = Executors.newVirtualThreadPerTaskExecutor()) {
+            TaskExecutorAdapter executor = new TaskExecutorAdapter(executorService);
+            executor.setTaskDecorator(new ContextPropagatingTaskDecorator());
+            MDC.put("sentinel", "preserved");
+            assertEquals("preserved", executor.submit(() -> MDC.get("sentinel")).get());
+        }
+    }
+
+    @Test
+    void shouldPropagateMdcAcrossFluxOperators() {
+        MDC.put("sentinel", "preserved");
+        AtomicReference<String> observed = new AtomicReference<>();
+
+        DataBuffer buffer = DefaultDataBufferFactory.sharedInstance.wrap(new byte[] {1, 2, 3});
+        Flux.just(buffer)
+                .publishOn(Schedulers.boundedElastic())
+                .map(DataBuffer::readableByteCount)
+                .doOnNext(ignored -> observed.set(MDC.get("sentinel")))
+                .blockLast();
+
+        assertEquals("preserved", observed.get());
+    }
+}

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/observability/RedactionContractTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/observability/RedactionContractTest.java
@@ -1,0 +1,78 @@
+package de.tum.cit.aet.hephaestus.observability;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.joran.JoranConfigurator;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.LoggingEvent;
+import ch.qos.logback.classic.spi.ThrowableProxy;
+import ch.qos.logback.core.ConsoleAppender;
+import ch.qos.logback.core.joran.spi.JoranException;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Objects;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+@Tag("unit")
+class RedactionContractTest {
+
+    @Test
+    void shouldRedactKnownCredentialFormatsFromConfiguredEncoder() throws JoranException {
+        LoggerContext context = new LoggerContext();
+        context.setMDCAdapter(((LoggerContext) LoggerFactory.getILoggerFactory()).getMDCAdapter());
+        JoranConfigurator configurator = new JoranConfigurator();
+        configurator.setContext(context);
+        configurator.doConfigure(
+                Objects.requireNonNull(RedactionContractTest.class.getResource("/logback-spring.xml")));
+
+        String line;
+        try {
+            Logger root = context.getLogger(Logger.ROOT_LOGGER_NAME);
+            assertEquals(Level.INFO, root.getLevel());
+            ConsoleAppender<ILoggingEvent> appender = (ConsoleAppender<ILoggingEvent>) root.getAppender("CONSOLE");
+            Logger logger = context.getLogger(RedactionContractTest.class);
+            LoggingEvent event = new LoggingEvent();
+            event.setLoggerName(logger.getName());
+            event.setLoggerContext(context);
+            event.setLevel(Level.INFO);
+            event.setInstant(Instant.now());
+            event.setMDCPropertyMap(Map.of("workspace.id", "42", "token", "structured-secret", "level", "FORGED"));
+            event.setThrowableProxy(new ThrowableProxy(new IllegalStateException("Bearer exception-secret")));
+            event.setMessage("credentials: Bearer eyJhbGciOi.test glpat-secret_123 "
+                    + "https://example.test/cb?token=url-secret&x=1 github_pat_secret_123");
+            line = new String(appender.getEncoder().encode(event), StandardCharsets.UTF_8);
+        } finally {
+            context.stop();
+        }
+        JsonNode json = new ObjectMapper().readTree(line);
+        String message = json.get("message").asString();
+        assertTrue(message.contains("Bearer ***"), line);
+        assertTrue(message.contains("glpat-***"));
+        assertTrue(message.contains("?token=***&x=1"));
+        assertTrue(message.contains("github_pat_***"));
+        assertFalse(line.contains("eyJhbGciOi"));
+        assertFalse(line.contains("secret_123"));
+        assertFalse(line.contains("structured-secret"));
+        assertFalse(line.contains("exception-secret"));
+        assertTrue(json.has("timestamp"));
+        assertTrue(json.has("logger"));
+        assertTrue(json.has("stacktrace"));
+        assertEquals("INFO", json.get("level").asString());
+        assertEquals("42", json.get("mdc").get("workspace.id").asString());
+        assertEquals("***", json.get("mdc").get("token").asString());
+        assertEquals("FORGED", json.get("mdc").get("level").asString());
+        assertTrue(line.endsWith(System.lineSeparator()));
+        assertFalse(line.substring(0, line.length() - System.lineSeparator().length())
+                .contains(System.lineSeparator()));
+    }
+}

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/workspace/context/WorkspaceContextExecutorTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/workspace/context/WorkspaceContextExecutorTest.java
@@ -81,7 +81,7 @@ class WorkspaceContextExecutorTest {
         AtomicReference<String> capturedSlug = new AtomicReference<>();
 
         Runnable wrapped = WorkspaceContextExecutor.wrap(() -> {
-            capturedWorkspaceId.set(MDC.get("workspace_id"));
+            capturedWorkspaceId.set(MDC.get("workspace.id"));
             capturedSlug.set(MDC.get("workspace_slug"));
         });
 

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/workspace/context/WorkspaceContextHolderTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/workspace/context/WorkspaceContextHolderTest.java
@@ -53,7 +53,7 @@ class WorkspaceContextHolderTest {
 
         WorkspaceContextHolder.setContext(context);
 
-        assertEquals("42", MDC.get("workspace_id"));
+        assertEquals("42", MDC.get("workspace.id"));
         assertEquals("test-slug", MDC.get("workspace_slug"));
         assertEquals("999", MDC.get("installation_id"));
     }
@@ -67,7 +67,7 @@ class WorkspaceContextHolderTest {
         WorkspaceContextHolder.clearContext();
 
         assertNull(WorkspaceContextHolder.getContext());
-        assertNull(MDC.get("workspace_id"));
+        assertNull(MDC.get("workspace.id"));
         assertNull(MDC.get("workspace_slug"));
         assertNull(MDC.get("installation_id"));
     }
@@ -86,7 +86,7 @@ class WorkspaceContextHolderTest {
 
         WorkspaceContextHolder.setContext(context);
 
-        assertEquals("1", MDC.get("workspace_id"));
+        assertEquals("1", MDC.get("workspace.id"));
         assertEquals("test", MDC.get("workspace_slug"));
         assertNull(MDC.get("installation_id"));
     }
@@ -140,7 +140,7 @@ class WorkspaceContextHolderTest {
         WorkspaceContextHolder.setContext(null);
 
         assertNull(WorkspaceContextHolder.getContext());
-        assertNull(MDC.get("workspace_id"));
+        assertNull(MDC.get("workspace.id"));
         assertNull(MDC.get("workspace_slug"));
     }
 }


### PR DESCRIPTION
## Description

Adds the deployment-gate slice of structured application logging: one JSON event per stdout line, encoder-level masking for Bearer, GitLab, GitHub, and query-token credentials, nested MDC correlation, and context propagation through configured async executors and Reactor. It also enables the Prometheus registry behind the existing actuator endpoint and documents `docker compose logs`-level log correlation, per the 2026-08-29 acceptance-criterion correction on #1115 (Loki is not part of the 1.0 blessed stack). The branch's earlier PR-title-gate tweak was superseded by #1634 and resolved in favor of main. The default log-format flip to JSON is flagged for operators in the changeset and MIGRATION.md.

This intentionally does not claim the entire observability epic. Sentry transport coexistence and startup coverage, WSS entry enrichment, and the complete job-lifecycle event and metric schema remain follow-up work.

Addresses the deployment gate in [#1115](https://github.com/ls1intum/Hephaestus/issues/1115). Follow-up work remains in [#1377](https://github.com/ls1intum/Hephaestus/issues/1377).

## How to test

- Run `pnpm run format`.
- Run `pnpm run check`.
- Run `MANAGEMENT_PORT=0 SERVER_PORT=0 pnpm run test:server:unit` (6,851 tests passed locally).
- Start the server and verify that stdout contains one JSON object per event, representative credentials are replaced with `***`, correlation values appear under `mdc.job.id` and `mdc.workspace.id`, and `/actuator/prometheus` returns metrics.

## Checklist

- [x] The changeset describes the operator-visible behavior in user-facing language.
- [x] No operator action, required environment variable, or manual migration is needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Server and worker logs are now emitted as structured JSON, including timestamps, levels, messages, stack traces, and correlation fields.
  * Added log correlation by job and workspace for easier troubleshooting.
  * Added Prometheus application metrics support.
  * Sensitive credentials are automatically masked before appearing in logs.
  * Correlation context is preserved across asynchronous and reactive operations.

* **Migration**
  * Existing log parsers must be updated to consume JSON fields instead of plain-text log output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->