### PR TITLE
chore(db): qualify PostgreSQL 18

### DIFF
--- a/.changeset/qualify-postgresql-eighteen.md
+++ b/.changeset/qualify-postgresql-eighteen.md
@@ -1,0 +1,5 @@
+---
+"hephaestus": minor
+---
+
+**Operators:** PostgreSQL 18 is now the bundled and qualified database target. Before upgrading a stack whose volume was initialized by PostgreSQL 17, follow the documented dump-and-restore procedure; do not attach the old data directory to the new container.

--- a/.github/workflows/ci-quality-gates.yml
+++ b/.github/workflows/ci-quality-gates.yml
@@ -295,6 +295,8 @@ jobs:
             exit 1
           fi
 
+          pnpm run test:postgres-upgrade
+
           ISSUES_FOUND=()
 
           # draft-changelog first applies the full master.xml chain to the empty DB via

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -63,7 +63,7 @@ Before upgrading to any new `0.x.0` version:
 Entries exist only for releases that need operator action. Everything else is in the
 [release notes](https://github.com/ls1intum/Hephaestus/releases).
 
-### Next minor release
+### Next release
 
 #### 🔴 Integration credentials use a dedicated encryption key
 
@@ -95,6 +95,15 @@ for `docker compose logs` itself — the lines are still printed to the console,
 **Migration**: point existing parsers at the JSON fields instead of the plain-text layout. Filters
 that matched free text can key on `mdc."job.id"` and `mdc."workspace.id"`; see the log-correlation
 examples in the practice-review operations guide.
+
+#### 🔴 Restore PostgreSQL 17 data into PostgreSQL 18 before starting the stack
+
+**Affected**: operators upgrading a self-hosted deployment whose database volume was initialized by
+the bundled PostgreSQL 17 image.
+
+**Migration**: before starting this release, follow the
+[Backup & Restore](https://ls1intum.github.io/Hephaestus/admin/backup-restore#postgresql-17-to-18).
+Keep the PostgreSQL 17 volume until the upgraded deployment passes its acceptance checks.
 
 ### v0.76.0
 

--- a/docker/compose.app.yaml
+++ b/docker/compose.app.yaml
@@ -438,7 +438,7 @@ services:
           - postgres
     restart: unless-stopped
     volumes:
-      - postgresql-data:/var/lib/postgresql/data
+      - postgresql-data-v18:/var/lib/postgresql
     healthcheck:
       test:
         - CMD-SHELL
@@ -461,5 +461,5 @@ networks:
     driver: bridge
 
 volumes:
-  postgresql-data:
+  postgresql-data-v18:
   git-repos:

--- a/docker/postgres/Dockerfile
+++ b/docker/postgres/Dockerfile
@@ -1,11 +1,7 @@
-# ghcr.io/ls1intum/hephaestus/postgres — official PostgreSQL (Debian) + pg_partman, used in every
-# environment (Alpine has no partman package). No shared_preload_libraries: maintenance runs as plain
-# SQL from the app scheduler, so this stays stock Postgres + one extension. See ADR 0018.
-ARG PG_MAJOR=17
+ARG PG_MAJOR=18
 FROM postgres:${PG_MAJOR}-bookworm
-ARG PG_MAJOR=17
-# Pinned for reproducibility (PGDG bookworm pool). Bump deliberately.
-ARG PARTMAN_VERSION=5.4.3-1.pgdg12+1
+ARG PG_MAJOR=18
+ARG PARTMAN_VERSION=5.5.0-1.pgdg12+1
 RUN set -eux; \
     apt-get update; \
     apt-get install -y --no-install-recommends "postgresql-${PG_MAJOR}-partman=${PARTMAN_VERSION}"; \

--- a/docker/postgres/Dockerfile
+++ b/docker/postgres/Dockerfile
@@ -1,6 +1,10 @@
+# ghcr.io/ls1intum/hephaestus/postgres — official PostgreSQL (Debian) + pg_partman, used in every
+# environment (Alpine has no partman package). No shared_preload_libraries: maintenance runs as plain
+# SQL from the app scheduler, so this stays stock Postgres + one extension. See ADR 0018 and ADR 0038.
 ARG PG_MAJOR=18
 FROM postgres:${PG_MAJOR}-bookworm
 ARG PG_MAJOR=18
+# Pinned for reproducibility (PGDG bookworm pool). Bump deliberately.
 ARG PARTMAN_VERSION=5.5.0-1.pgdg12+1
 RUN set -eux; \
     apt-get update; \

--- a/docker/preview/compose.app.yaml
+++ b/docker/preview/compose.app.yaml
@@ -22,7 +22,7 @@ services:
       POSTGRES_USER: hephaestus
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
     volumes:
-      - postgres-data:/var/lib/postgresql/data
+      - postgres-data-v18:/var/lib/postgresql
     security_opt:
       - no-new-privileges:true
     cap_drop:
@@ -375,4 +375,4 @@ networks:
     name: shared-network
 
 volumes:
-  postgres-data:
+  postgres-data-v18:

--- a/docs/admin/backup-restore.mdx
+++ b/docs/admin/backup-restore.mdx
@@ -4,14 +4,14 @@ title: Backup & Restore
 description: What to back up on a self-hosted instance, and how to restore it.
 ---
 
-For the [self-host compose stack](./install). PostgreSQL holds the application state. The Context Fabric holds
-bounded evidence copies that may no longer be reproducible after upstream content changes or is erased.
+For the [self-host compose stack](./install). PostgreSQL holds application state. The Context Fabric
+holds bounded evidence copies that may become irreproducible after upstream content changes or erasure.
 
 ## What to back up
 
 | Data | Where | Priority |
 | --- | --- | --- |
-| PostgreSQL database | `postgresql-data` volume | **Everything.** Accounts, workspaces, observations, feedback, encrypted provider tokens, JWT signing keys. |
+| PostgreSQL volume | Compose-managed volume mounted by `postgres` | **Everything.** Accounts, workspaces, observations, feedback, encrypted provider tokens, JWT signing keys. |
 | `.env` | `/opt/hephaestus/docker/self-host/.env` | **Equal priority.** Its encryption keys protect values inside the database backup. Without them, provider credentials and signing material are unreadable. |
 | TLS certificates | `./letsencrypt/` | Optional — Let's Encrypt re-issues on first boot (rate limits permitting). |
 | Context Fabric | `git-repos` volume | Back up when replayable evidence is required. Skipping it discards repository clones and bounded replay/CAS content; durable job provenance remains in PostgreSQL, but the exact source bytes may be unrecoverable. |
@@ -23,7 +23,8 @@ Logical dump while everything runs (safe — Postgres MVCC gives a consistent sn
 
 ```bash
 cd /opt/hephaestus/docker/self-host
-docker compose exec -T postgres pg_dump -U root -Fc hephaestus \
+dc() { docker compose --env-file .env --env-file release-lock.env "$@"; }
+dc exec -T postgres pg_dump -U root -Fc hephaestus \
   > hephaestus-$(date +%F).dump
 cp .env hephaestus-$(date +%F).env
 ```
@@ -37,19 +38,79 @@ On a fresh host, complete install steps 1–2 first, restoring the saved `.env` 
 
 ```bash
 cd /opt/hephaestus/docker/self-host
-docker compose up -d postgres                      # database only
-docker compose stop application-server webhook-server 2>/dev/null || true
+dc() { docker compose --env-file .env --env-file release-lock.env "$@"; }
+dc up -d postgres
+dc stop application-server application-worker webhook-server 2>/dev/null || true
 
-docker compose exec -T postgres dropdb   -U root --if-exists hephaestus
-docker compose exec -T postgres createdb -U root hephaestus
-docker compose exec -T postgres pg_restore -U root -d hephaestus --no-owner \
+test -s hephaestus-YYYY-MM-DD.dump
+dc exec -T postgres pg_restore --list < hephaestus-YYYY-MM-DD.dump >/dev/null
+dc exec -T postgres dropdb -U root --if-exists hephaestus
+dc exec -T postgres createdb -U root hephaestus
+dc exec -T postgres pg_restore -U root -d hephaestus --no-owner --no-acl --single-transaction \
   < hephaestus-YYYY-MM-DD.dump
 
-docker compose up -d                               # full stack
+dc up -d --wait
 ```
 
 Verify: sign in, open a workspace, check recent activity is present up to the backup
 timestamp.
+
+## PostgreSQL 17 to 18
+
+PostgreSQL major-version data directories are not binary compatible. The PostgreSQL 18 image stores
+`PGDATA` under `/var/lib/postgresql/18/docker`.
+Do **not** point the PostgreSQL 18 container at the old PostgreSQL 17 volume and do not delete the
+old volume until the restored instance passes verification.
+
+From the PostgreSQL 17 release, stop application writes, make a logical dump, and record the exact
+Compose volume name:
+
+```bash
+cd /opt/hephaestus/docker/self-host
+dc() { docker compose --env-file .env --env-file release-lock.env "$@"; }
+dc stop application-server application-worker webhook-server
+dc exec -T postgres pg_dump -U root -Fc hephaestus > /var/tmp/hephaestus-pg17.dump
+test -s /var/tmp/hephaestus-pg17.dump
+dc exec -T postgres pg_restore --list < /var/tmp/hephaestus-pg17.dump >/dev/null
+sha256sum /var/tmp/hephaestus-pg17.dump > /var/tmp/hephaestus-pg17.dump.sha256
+PG17_VOLUME=$(docker inspect "$(dc ps -q postgres)" \
+  --format '{{range .Mounts}}{{if eq .Destination "/var/lib/postgresql/data"}}{{.Name}}{{end}}{{end}}')
+test -n "$PG17_VOLUME"
+dc down
+printf 'Preserved PostgreSQL 17 volume: %s\n' "$PG17_VOLUME"
+```
+
+Check out the new release and prepare its signed release lock as described in [Upgrades](./install#upgrades).
+The supported self-host stack creates no custom roles or tablespaces; operators who added either must
+migrate those cluster-global objects separately. Restore into the new PostgreSQL 18 volume:
+
+```bash
+dc() { docker compose --env-file .env --env-file release-lock.env "$@"; }
+dc up -d postgres
+until dc exec -T postgres pg_isready -U root -d hephaestus; do sleep 2; done
+test "$(dc exec -T postgres psql -U root -d hephaestus -Atc \
+  "SELECT current_setting('server_version_num')::int / 10000 || ':' || (to_regclass('public.databasechangelog') IS NULL)")" = "18:true"
+sha256sum -c /var/tmp/hephaestus-pg17.dump.sha256
+dc exec -T postgres dropdb -U root hephaestus
+dc exec -T postgres createdb -U root hephaestus
+dc exec -T postgres pg_restore -U root -d hephaestus --no-owner --no-acl \
+  --single-transaction < /var/tmp/hephaestus-pg17.dump
+dc exec -T postgres psql -U root -d hephaestus -v ON_ERROR_STOP=1 \
+  -c 'ALTER EXTENSION pg_partman UPDATE'
+dc up -d --wait
+```
+
+Verify application health, sign in, and inspect recent workspace activity. Then verify the database
+major, extension, and partition policy:
+
+```bash
+dc exec -T postgres psql -U root -d hephaestus -Atc \
+  "SELECT current_setting('server_version_num')::int / 10000 = 18; SELECT extversion = '5.5.0' FROM pg_extension WHERE extname = 'pg_partman'; SELECT count(*) = 1 FROM partman.part_config WHERE parent_table = 'public.auth_event';"
+```
+
+Keep the dump and PostgreSQL 17 volume until acceptance checks pass and backup policy permits their
+deletion. Rollback means stopping PostgreSQL 18 and starting the prior release against the preserved
+volume; never run the prior application against the PostgreSQL 18 database.
 
 ### After a point-in-time restore
 

--- a/docs/admin/install.mdx
+++ b/docs/admin/install.mdx
@@ -17,7 +17,7 @@ The stack you get:
 | `webapp` | React SPA served by nginx |
 | `application-server` | Spring Boot API + in-process job worker |
 | `webhook-server` | Same image, webhook profile — keeps receiving events while the app restarts |
-| `postgres` | PostgreSQL 17 + pg_partman (custom image — vanilla `postgres:17` is **not** a drop-in) |
+| `postgres` | PostgreSQL 18 + pg_partman (custom image — vanilla `postgres:18` is **not** a drop-in) |
 | `nats-server` | NATS JetStream event buffer |
 
 ## Requirements
@@ -219,9 +219,10 @@ node scripts/prepare-release-lock.ts "v$VERSION"
 cd docker/self-host && docker compose --env-file .env --env-file release-lock.env pull && docker compose --env-file .env --env-file release-lock.env up -d
 ```
 
-Compare your `.env` against the new release's `.env.example` for added variables. A release
-that changes the bundled PostgreSQL major version needs a dump and restore, not an in-place
-upgrade — such releases say so in their notes.
+Compare your `.env` against the new release's `.env.example` for added variables. When a release
+changes the PostgreSQL major version, follow its entry in
+[`MIGRATION.md`](https://github.com/ls1intum/Hephaestus/blob/main/MIGRATION.md) before starting the new
+stack.
 
 ## Rollback
 

--- a/docs/admin/production-setup.mdx
+++ b/docs/admin/production-setup.mdx
@@ -28,7 +28,9 @@ consists of:
 - **Application server** (Spring Boot, runs the Pi mentor agent in-process)
 - **Webhook server** (same Spring Boot artifact, `webhook` profile → NATS JetStream)
 - **React webapp** (served via nginx)
-- **PostgreSQL 17** (custom image with `pg_partman` — see [ADR 0018](https://github.com/ls1intum/Hephaestus/blob/main/docs/decisions/0018-pg-partman-for-auth-event-partitioning.md); vanilla `postgres:17` is not a drop-in)
+- **PostgreSQL 17–18** is supported; the release Compose stack qualifies and ships **PostgreSQL 18**
+  with `pg_partman` (see [ADR 0038](https://github.com/ls1intum/Hephaestus/blob/main/docs/decisions/0038-postgresql-18-release-baseline.md)).
+  Vanilla PostgreSQL is not a drop-in for the bundled stack. PostgreSQL 17 remains the minimum.
 - **Hephaestus-native auth** (Spring Security `oauth2Login` federating to GitHub + optional GitLab — gitlab.com or self-hosted — issuing cookie-session JWTs — [ADR 0017](https://github.com/ls1intum/Hephaestus/blob/main/docs/decisions/0017-replace-keycloak-with-spring-native-auth.md))
 
 ## Base environment variables

--- a/docs/decisions/0038-postgresql-18-release-baseline.md
+++ b/docs/decisions/0038-postgresql-18-release-baseline.md
@@ -1,0 +1,35 @@
+# ADR 0038: PostgreSQL 18 is the qualified release baseline
+
+## Status
+
+Accepted
+
+## Context
+
+[ADR 0018](0018-pg-partman-for-auth-event-partitioning.md) held PostgreSQL 17 while introducing
+pg_partman so the changes could be evaluated separately. The PostgreSQL 18 image persists its
+versioned `PGDATA` below `/var/lib/postgresql`; PostgreSQL 17 data directories are not binary
+compatible with PostgreSQL 18. pg_partman 5.5 includes the security fixes documented in its release
+notes. Maintenance remains application-scheduled as decided in ADR 0018.
+
+## Decision
+
+- Ship PostgreSQL 18 with pg_partman 5.5 as the release, local-development, preview, and CI target.
+- Continue to support PostgreSQL 17 as the minimum for externally operated installations. The
+  repository-managed Compose topology is qualified on PostgreSQL 18.
+- Mount PostgreSQL 18 persistence at `/var/lib/postgresql`, as required by the official image.
+- Use a new self-hosted Compose volume for PostgreSQL 18 so rollback retains the PostgreSQL 17 cluster.
+- Upgrade self-hosted installations by custom-format logical dump and transactional restore into an
+  empty PostgreSQL 18 cluster. Do not attempt an in-place container image swap.
+
+## Consequences
+
+Operators with PostgreSQL 17 volumes must complete the documented migration before starting
+PostgreSQL 18. Preview environments create a fresh PostgreSQL 18 cluster.
+
+## Sources
+
+- [PostgreSQL versioning policy](https://www.postgresql.org/support/versioning/)
+- [PostgreSQL major-upgrade documentation](https://www.postgresql.org/docs/18/upgrading.html)
+- [Official image `PGDATA` contract](https://github.com/docker-library/docs/blob/master/postgres/README.md#pgdata)
+- [pg_partman 5.5 release notes](https://github.com/pgpartman/pg_partman/releases/tag/v5.5.0)

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -76,5 +76,6 @@ do, its home is the Admin Guide (`docs/admin/`) and the runbook links to it.
 | [0035](0035-pull-request-previews-are-label-gated.md) | Pull request previews are label-gated and driven from the default branch | Accepted |
 | [0036](0036-agent-runtime-runs-on-node-24.md) | Agent runtime runs on Node.js 24 with bounded resources | Accepted |
 | [0037](0037-node-24-and-pnpm-12-are-the-javascript-toolchain.md) | Node.js 24 and pnpm 12 are the JavaScript toolchain | Accepted |
+| [0038](0038-postgresql-18-release-baseline.md) | PostgreSQL 18 is the qualified release baseline | Accepted |
 
 Template: [0000-template.md](0000-template.md).

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
 		"test:server:verification": "cd server && ./mvnw -pl application -am package -Dspring-boot.repackage.skip=true -Parchitecture-tests -Dsurefire.includedGroups=unit,architecture -DskipCoverage=false --batch-mode",
 		"test:server:integration": "cd server && ./mvnw -pl application -am package -Dspring-boot.repackage.skip=true -Dsurefire.includedGroups=integration -Dparallel=none --batch-mode",
 		"test:server:mutation": "node scripts/run-security-mutations.ts",
+		"test:postgres-upgrade": "node scripts/postgres-major-upgrade-test.ts",
 		"test:load:syntax": "docker run --rm -v \"$PWD/load-tests:/tests:ro\" grafana/k6:1.2.3@sha256:4f82892217f3110cb233e2b2622bcc97fabc70f14bd241fbfbfe7305105c68aa inspect -e BASE_URL=http://example.test -e WEBHOOK_SECRET=abcdefghijklmnopqrstuvwxyz123456 /tests/webhook-burst.js >/dev/null && docker run --rm -v \"$PWD/load-tests:/tests:ro\" grafana/k6:1.2.3@sha256:4f82892217f3110cb233e2b2622bcc97fabc70f14bd241fbfbfe7305105c68aa inspect -e API_BASE_URL=http://example.test/api -e AUTH_TOKEN=test -e WORKSPACE_SLUG=test -e ARTIFACT_IDS=1,2 /tests/detection-mentor.js >/dev/null",
 		"summarize:test-results": "node scripts/summarize-test-results.ts",
 		"build:webapp": "pnpm --filter webapp run build",

--- a/scripts/postgres-major-upgrade-test.ts
+++ b/scripts/postgres-major-upgrade-test.ts
@@ -192,4 +192,5 @@ try {
 	for (const container of [source, target]) spawnSync("docker", ["rm", "-f", container]);
 	for (const volume of [sourceVolume, targetVolume])
 		spawnSync("docker", ["volume", "rm", "-f", volume]);
+	for (const image of [`${id}:17`, `${id}:18`]) spawnSync("docker", ["rmi", "-f", image]);
 }

--- a/scripts/postgres-major-upgrade-test.ts
+++ b/scripts/postgres-major-upgrade-test.ts
@@ -103,6 +103,17 @@ try {
 	if (sql(source, "SHOW server_version_num").slice(0, 2) !== "17")
 		throw new Error("source is not PostgreSQL 17");
 
+	// liquibase:update is a single-module invocation, so the reactor sibling the application
+	// depends on must be installed to the local repository first — a warm CI cache is not a given.
+	run("node", [
+		"scripts/run-mvnw.ts",
+		"-pl",
+		"generated-clients",
+		"-am",
+		"install",
+		"-DskipTests",
+		"--quiet",
+	]);
 	run("node", [
 		"scripts/run-mvnw.ts",
 		"-f",

--- a/scripts/postgres-major-upgrade-test.ts
+++ b/scripts/postgres-major-upgrade-test.ts
@@ -1,0 +1,195 @@
+import { spawnSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+
+const id = `postgres-upgrade-${randomUUID().slice(0, 8)}`;
+const source = `${id}-17`;
+const target = `${id}-18`;
+const sourceVolume = `${source}-data`;
+const targetVolume = `${target}-data`;
+
+function run(command: string, args: string[], input?: Buffer): string {
+	const result = spawnSync(command, args, { encoding: "utf8", input, maxBuffer: 64 * 1024 * 1024 });
+	if (result.status !== 0) {
+		throw new Error(`${command} ${args.join(" ")} failed:\n${result.stdout}${result.stderr}`);
+	}
+	return result.stdout.trim();
+}
+
+function docker(...args: string[]): string {
+	return run("docker", args);
+}
+
+function sql(container: string, query: string): string {
+	return docker(
+		"exec",
+		container,
+		"psql",
+		"-U",
+		"root",
+		"-d",
+		"hephaestus",
+		"-v",
+		"ON_ERROR_STOP=1",
+		"-Atc",
+		query,
+	);
+}
+
+function wait(container: string): void {
+	for (let attempt = 0; attempt < 60; attempt++) {
+		const result = spawnSync("docker", [
+			"exec",
+			container,
+			"psql",
+			"-U",
+			"root",
+			"-d",
+			"hephaestus",
+			"-c",
+			"SELECT 1",
+		]);
+		if (result.status === 0) return;
+		Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 1_000);
+	}
+	throw new Error(`${container} did not become ready`);
+}
+
+function start(container: string, volume: string, mount: string, image: string): number {
+	docker(
+		"run",
+		"-d",
+		"--name",
+		container,
+		"-p",
+		"127.0.0.1::5432",
+		"-v",
+		`${volume}:${mount}`,
+		"-e",
+		"POSTGRES_DB=hephaestus",
+		"-e",
+		"POSTGRES_USER=root",
+		"-e",
+		"POSTGRES_PASSWORD=root",
+		image,
+	);
+	wait(container);
+	const mapping = docker("port", container, "5432/tcp");
+	return Number(mapping.slice(mapping.lastIndexOf(":") + 1));
+}
+
+function fingerprint(container: string): string {
+	return sql(
+		container,
+		"SELECT count(*) || ':' || md5(string_agg(id || ':' || author || ':' || filename, '|' ORDER BY orderexecuted)) FROM databasechangelog",
+	);
+}
+
+try {
+	run("docker", [
+		"build",
+		"--build-arg",
+		"PG_MAJOR=17",
+		"--build-arg",
+		"PARTMAN_VERSION=5.4.3-1.pgdg12+1",
+		"-t",
+		`${id}:17`,
+		"docker/postgres",
+	]);
+	run("docker", ["build", "-t", `${id}:18`, "docker/postgres"]);
+	docker("volume", "create", sourceVolume);
+	docker("volume", "create", targetVolume);
+
+	const sourcePort = start(source, sourceVolume, "/var/lib/postgresql/data", `${id}:17`);
+	if (sql(source, "SHOW server_version_num").slice(0, 2) !== "17")
+		throw new Error("source is not PostgreSQL 17");
+
+	run("node", [
+		"scripts/run-mvnw.ts",
+		"-f",
+		"application/pom.xml",
+		"liquibase:update",
+		`-Dpostgres.port=${sourcePort}`,
+		"--quiet",
+	]);
+	if (sql(source, "SELECT extversion FROM pg_extension WHERE extname='pg_partman'") !== "5.4.3") {
+		throw new Error("source pg_partman is not 5.4.3");
+	}
+	sql(
+		source,
+		"CREATE TABLE upgrade_qualification(id bigint PRIMARY KEY, value text NOT NULL); INSERT INTO upgrade_qualification VALUES (1, 'preserved')",
+	);
+	sql(source, "CALL partman.run_maintenance_proc()");
+	const sourceFingerprint = fingerprint(source);
+	const partmanConfig = sql(
+		source,
+		"SELECT parent_table || ':' || partition_interval || ':' || premake || ':' || retention FROM partman.part_config WHERE parent_table='public.auth_event'",
+	);
+	if (!partmanConfig) throw new Error("auth_event is not registered with pg_partman");
+
+	const dump = spawnSync("docker", ["exec", source, "pg_dump", "-U", "root", "-Fc", "hephaestus"], {
+		maxBuffer: 64 * 1024 * 1024,
+	}).stdout;
+	if (!(dump instanceof Buffer) || dump.length === 0) throw new Error("source dump is empty");
+	const listing = spawnSync("docker", ["exec", "-i", source, "pg_restore", "--list"], {
+		input: dump,
+	});
+	if (listing.status !== 0) throw new Error("source dump is unreadable");
+	docker("stop", source);
+
+	start(target, targetVolume, "/var/lib/postgresql", `${id}:18`);
+	docker("exec", target, "dropdb", "-U", "root", "hephaestus");
+	docker("exec", target, "createdb", "-U", "root", "hephaestus");
+	const restore = spawnSync(
+		"docker",
+		[
+			"exec",
+			"-i",
+			target,
+			"pg_restore",
+			"-U",
+			"root",
+			"-d",
+			"hephaestus",
+			"--no-owner",
+			"--no-acl",
+			"--single-transaction",
+		],
+		{ input: dump, encoding: "utf8", maxBuffer: 64 * 1024 * 1024 },
+	);
+	if (restore.status !== 0) throw new Error(`restore failed:\n${restore.stdout}${restore.stderr}`);
+	sql(target, "ALTER EXTENSION pg_partman UPDATE");
+
+	if (sql(target, "SHOW server_version_num").slice(0, 2) !== "18")
+		throw new Error("target is not PostgreSQL 18");
+	if (sql(target, "SELECT extversion FROM pg_extension WHERE extname='pg_partman'") !== "5.5.0")
+		throw new Error("target pg_partman is not 5.5.0");
+	if (sql(target, "SELECT value FROM upgrade_qualification WHERE id=1") !== "preserved")
+		throw new Error("qualification row was not restored");
+	if (fingerprint(target) !== sourceFingerprint)
+		throw new Error("Liquibase history changed during restore");
+	if (
+		sql(
+			target,
+			"SELECT parent_table || ':' || partition_interval || ':' || premake || ':' || retention FROM partman.part_config WHERE parent_table='public.auth_event'",
+		) !== partmanConfig
+	)
+		throw new Error("pg_partman configuration changed during restore");
+	sql(target, "CALL partman.run_maintenance_proc()");
+	if (
+		sql(
+			target,
+			"SELECT count(*) > 0 FROM pg_inherits WHERE inhparent = 'public.auth_event'::regclass",
+		) !== "t"
+	)
+		throw new Error("auth_event partitions were not restored");
+
+	docker("stop", target);
+	docker("start", source);
+	wait(source);
+	if (sql(source, "SELECT value FROM upgrade_qualification WHERE id=1") !== "preserved")
+		throw new Error("PostgreSQL 17 rollback volume is unreadable");
+} finally {
+	for (const container of [source, target]) spawnSync("docker", ["rm", "-f", container]);
+	for (const volume of [sourceVolume, targetVolume])
+		spawnSync("docker", ["volume", "rm", "-f", volume]);
+}

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/auth/oauth/IdentityLinkUniquenessLiquibaseTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/auth/oauth/IdentityLinkUniquenessLiquibaseTest.java
@@ -32,8 +32,7 @@ import org.junit.jupiter.api.Test;
  * <p>That difference is load-bearing: it is the index violation that makes
  * {@link AccountProvisioningService}'s concurrent-first-login loser read-after-conflict and return
  * the winner instead of minting a duplicate account. A unit/ddl-auto test cannot see it, so this
- * raw-JDBC test runs the real {@code db/master.xml} on a stock {@code postgres:16} and asserts the
- * index semantics directly.
+ * raw-JDBC test runs {@code db/master.xml} and asserts the index semantics directly.
  */
 @Tag("database")
 class IdentityLinkUniquenessLiquibaseTest {

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/testconfig/PostgreSQLTestContainer.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/testconfig/PostgreSQLTestContainer.java
@@ -115,7 +115,7 @@ public final class PostgreSQLTestContainer {
 
     @SuppressWarnings("resource") // Closed by the JVM shutdown hook.
     private static PostgreSQLContainer<?> createContainer() {
-        PostgreSQLContainer<?> newContainer = new PostgreSQLContainer<>("postgres:16")
+        PostgreSQLContainer<?> newContainer = new PostgreSQLContainer<>("postgres:18")
                 .withDatabaseName(DEFAULT_TEST_DB)
                 .withUsername(DEFAULT_TEST_USER)
                 .withPassword(DEFAULT_TEST_PASSWORD);

--- a/server/compose.yaml
+++ b/server/compose.yaml
@@ -21,7 +21,7 @@ services:
     networks:
       - app-network
     volumes:
-      - ./postgres-data:/var/lib/postgresql/data
+      - ./postgres-data:/var/lib/postgresql
     healthcheck:
       test: ['CMD-SHELL', 'pg_isready -U root -d hephaestus']
       interval: 5s


### PR DESCRIPTION
## Description

Qualifies PostgreSQL 18 as the bundled database target for the 1.0 release without silently dropping PostgreSQL 17 support. This is not an image-tag-only update: the shipped Compose stacks, pg_partman image, Testcontainers baseline, Liquibase migration chain, backup and restore procedure, operator upgrade path, rollback boundary, documentation, and CI database qualification are reviewed as one production contract.

Existing PostgreSQL 17 data directories are never mounted into PostgreSQL 18. Preview and self-hosted stacks move to new PG18 volume identities, and operators upgrading an existing installation use the documented logical dump-and-restore path while retaining the source volume for rollback.

This is the database-only half of #1583. Dependency retirement remains isolated in [#1630](https://github.com/ls1intum/Hephaestus/pull/1630), so each operational risk can be reviewed and merged independently.

Fixes the PostgreSQL qualification scope of #1583

## Outcome at a glance

| Surface | Before | This PR | Qualification |
| --- | --- | --- | --- |
| Bundled PostgreSQL | 17 | **18** | Local, preview, and self-hosted Compose |
| Supported range | Implicit | **17–18** | Recorded in ADR 0038 and operator docs |
| pg_partman | 5.4.3 | **5.5.0** | Image build, extension upgrade, maintenance, and partition state |
| Testcontainers | PostgreSQL 17 | **PostgreSQL 18** | Shared server integration baseline |
| Major-upgrade evidence | Version assertions | **Full PG17→PG18 restore drill** | Liquibase, data, pg_partman, partitions, and rollback source |
| Existing data volume | Could be reused accidentally | **New PG18 named volumes** | Prevents incompatible in-place attachment |

## Compatibility and safety review

| Area | Decision | Evidence / invariant |
| --- | --- | --- |
| Minimum supported version | Keep PostgreSQL 17 | The issue explicitly forbids silently changing the minimum; ADR 0038 records PostgreSQL 17–18. |
| Container storage layout | Mount PostgreSQL 18 at `/var/lib/postgresql` | Follows the official image's PostgreSQL 18 `PGDATA` layout rather than preserving the old parent mount by accident. |
| Existing named volumes | Introduce versioned PG18 volume names | PostgreSQL 18 cannot initialize over or consume a PostgreSQL 17 data directory through the new stack. |
| Local development data | Preserve the existing bind-mount identity | Local reset/database helpers continue to own the same path; only the container-side PostgreSQL 18 layout changes. |
| Schema migration | Run the complete immutable Liquibase master changelog on PostgreSQL 17 before export | Proves the released migration chain, not a synthetic subset. |
| Backup format | PostgreSQL custom archive | `pg_restore --list` validates the archive before source shutdown is treated as complete. |
| Restore semantics | `--no-owner --no-acl --single-transaction` | Avoids restoring source ownership and leaves no partially restored target database. |
| Extension migration | Restore, then `ALTER EXTENSION pg_partman UPDATE` | Proves the target image can advance the restored extension to 5.5.0. |
| Rollback | Preserve and restart the PostgreSQL 17 source volume | Rollback does not depend on reverse-restoring data from PostgreSQL 18. |
| Application restart | Start with Compose `--wait` after database validation | Server and worker writes remain stopped until the restored target has passed explicit checks. |

## Automated upgrade drill

`pnpm run test:postgres-upgrade` exercises the actual release path in disposable Docker resources:

1. Build the source PostgreSQL 17/pg_partman 5.4.3 image and the target PostgreSQL 18/pg_partman 5.5.0 image.
2. Apply the complete Liquibase changelog to PostgreSQL 17.
3. Seed sentinel application data and run pg_partman maintenance.
4. Capture deterministic Liquibase history and pg_partman configuration fingerprints.
5. Produce a custom-format dump and validate it with `pg_restore --list`.
6. Stop PostgreSQL 17 while preserving its volume.
7. Restore into a fresh PostgreSQL 18 database in one transaction and update pg_partman.
8. Assert the exact server and extension versions, sentinel data, unchanged migration/configuration fingerprints, and expected partition children.
9. Run pg_partman maintenance on the restored target.
10. Restart the preserved PostgreSQL 17 source volume and recheck its sentinel data.

Containers and volumes use unique names and are removed in a `finally` path, so local and hosted runs do not leak reusable database state.

## Operator impact

**Action is required only when an existing stack moves from PostgreSQL 17 to the bundled PostgreSQL 18 image.** Follow the PostgreSQL 17→18 procedure in `docs/admin/backup-restore.mdx`; do not point PostgreSQL 18 at the old data directory.

The runbook now covers:

- loading the same Compose and release-lock environment used by the deployment;
- stopping every application write path, including the worker;
- archive validation and SHA-256 verification;
- capturing the old volume identity before teardown;
- asserting an empty PostgreSQL 18 target before restore;
- transactionally restoring without source ownership or ACLs;
- updating and checking pg_partman;
- health-gated service restart and partition verification;
- retaining the PostgreSQL 17 volume as the rollback boundary.

New installations require no additional configuration and start on PostgreSQL 18 directly.

## Deliberate exclusions

| Excluded work | Why |
| --- | --- |
| In-place `pg_upgrade` automation | The shipped deployment does not control both server binary trees in one supported image; logical backup/restore is simpler to inspect and recover. |
| Dropping PostgreSQL 17 | Explicitly outside the issue contract; the supported range remains 17–18. |
| Reverse migration from PostgreSQL 18 to 17 | PostgreSQL major downgrades are not supported. Rollback means restarting the preserved, quiesced PostgreSQL 17 source volume. |
| Dependency retirement | Reviewed separately in [#1630](https://github.com/ls1intum/Hephaestus/pull/1630). |
| Application schema changes | None are needed to qualify PostgreSQL 18; no Liquibase changelog or ERD regeneration is introduced. |

## Honest limitations

| Limitation | Assessment |
| --- | --- |
| Logical restore duration depends on database size | The runbook requires a maintenance window; this PR does not claim zero-downtime major upgrades. |
| The automated drill uses representative sentinel and partition state | It validates the complete schema and migration history, but cannot reproduce every production dataset size or distribution. Operators still validate backups and rehearse against representative data. |
| PostgreSQL 17 support is source-compatible, not a promise that new bundled stacks remain on 17 | New bundled deployments move to 18; 17 remains an explicitly supported external/operator baseline during the 1.0 window. |
| Hosted CI is the final clean-environment authority | Local Docker qualification passed. Required GitHub checks must also pass before merge. |

## Verification

### Local evidence

| Gate | Result |
| --- | --- |
| `pnpm run format` | **Pass** |
| `pnpm run check` | **Pass** |
| `pnpm run test:postgres-upgrade` | **Pass** |
| `pnpm --filter docs run build` | **Pass** |
| `git diff --check` | **Pass** |
| Webapp unit suite during full verification | **998 passed** |

One local `pnpm run verify` attempt reached the Storybook browser suite after all static checks and 998 webapp tests passed, then the browser connection closed while `ReviewArtifact.stories.tsx` was running. No Storybook assertion failed. This is recorded rather than presented as a clean full verification run; GitHub's Storybook job is the clean-environment authority.

### GitHub evidence

The documentation preview and Compose rendering pass on the isolated database branch. Remaining required jobs are allowed to finish before merge.

The repository's trusted title workflow currently invokes a package script removed from `main`, so otherwise valid titles fail before commitlint evaluates them. [#1632](https://github.com/ls1intum/Hephaestus/pull/1632) is the focused one-line repair; after it merges, the title check on this PR must be re-run. This PR does not claim green CI until that baseline failure and every queued required job are resolved.

## How to test manually

1. Start a disposable PostgreSQL 17 stack containing representative application and partition data.
2. Follow `docs/admin/backup-restore.mdx` exactly, including archive validation and checksum verification.
3. Confirm the target reports PostgreSQL 18 and pg_partman 5.5.0.
4. Confirm the application and worker become healthy only after the restore checks pass.
5. Compare Liquibase history and pg_partman configuration with the captured source values.
6. Confirm expected partition children exist and pg_partman maintenance succeeds.
7. Before removing the source volume, stop the target and restart the captured PostgreSQL 17 volume; confirm the pre-upgrade sentinel data remains readable.

## Checklist

- [x] My changeset summary reads as an operator-facing note and states the required upgrade action.
- [x] `MIGRATION.md` and the backup/restore runbook describe the PostgreSQL 17→18 operator path.
- [x] PostgreSQL 17 remains explicitly supported; the minimum version is not changed silently.
- [x] The database and dependency scopes are separate PRs.
- [x] No compatibility shim, reverse-migration claim, or unverified zero-downtime promise is introduced.
- [ ] Every required GitHub check passes after the repository-wide title-workflow repair in #1632.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - PostgreSQL 18 is now the standard bundled and qualified database version.
  - PostgreSQL 17 remains supported for externally managed installations.
  - Updated database persistence handling provides a separate PostgreSQL 18 data volume.

- **Documentation**
  - Added detailed PostgreSQL 17-to-18 migration, backup, restore, upgrade, and rollback guidance.
  - Installation and production setup documentation now reflects supported versions and upgrade requirements.

- **Bug Fixes**
  - Improved validation of PostgreSQL upgrades, data preservation, extensions, and rollback readiness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->