### PR TITLE
refactor(ci): centralize setup and release evidence checks

### DIFF
--- a/.github/actions/ghcr-login/action.yml
+++ b/.github/actions/ghcr-login/action.yml
@@ -1,0 +1,17 @@
+name: Log in to GHCR
+description: Authenticate Docker to ghcr.io
+inputs:
+  username:
+    description: GitHub actor or registry username
+    required: true
+  password:
+    description: Token passed to Docker login
+    required: true
+runs:
+  using: composite
+  steps:
+    - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+      with:
+        registry: ghcr.io
+        username: ${{ inputs.username }}
+        password: ${{ inputs.password }}

--- a/.github/actions/setup-browsers/action.yml
+++ b/.github/actions/setup-browsers/action.yml
@@ -1,0 +1,16 @@
+name: Setup Playwright browsers
+description: Prepare Playwright for webapp tests
+runs:
+  using: composite
+  steps:
+    - name: Read Playwright version
+      id: playwright
+      shell: bash
+      run: node -e "const v=require('./webapp/package.json').devDependencies.playwright; if(!/^\\d+\\.\\d+\\.\\d+(?:-[0-9A-Za-z.-]+)?$/.test(v)) throw Error('Playwright must use an exact version'); console.log('version='+v)" >> "$GITHUB_OUTPUT"
+    - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ~/.cache/ms-playwright
+        key: ${{ runner.os }}-playwright-${{ steps.playwright.outputs.version }}
+    - name: Install Chromium
+      shell: bash
+      run: pnpm --filter webapp exec playwright install chromium --with-deps

--- a/.github/actions/setup-caches/action.yml
+++ b/.github/actions/setup-caches/action.yml
@@ -1,5 +1,5 @@
 name: "Setup CI caches"
-description: "Caches Maven dependencies, generated-client build outputs, and Playwright browsers."
+description: "Set up the JDK and cache Maven dependencies and generated clients."
 inputs:
   cache-type:
     description: "Type of cache to setup"
@@ -18,7 +18,7 @@ runs:
         CACHE_TYPE: ${{ inputs.cache-type }}
       run: |
         case "$CACHE_TYPE" in
-          application-server-quality|application-server-verification|application-server-integration|server-contracts|webapp-e2e|webapp-storybook) ;;
+          application-server-quality|application-server-verification|application-server-integration|server-contracts|webapp-e2e) ;;
           *) echo "::error::Unknown cache type '$CACHE_TYPE'."; exit 1 ;;
         esac
 
@@ -31,19 +31,6 @@ runs:
       run: |
         if [[ -z "$DEPENDENCY_HASH" ]]; then
           echo "::error::Cannot compute the generated-client cache identity from the checked-out repository."
-          exit 1
-        fi
-        echo "hash=$DEPENDENCY_HASH" >> "$GITHUB_OUTPUT"
-
-    - name: Compute Playwright cache identity
-      id: playwright-identity
-      if: contains(fromJSON('["webapp-storybook", "webapp-e2e"]'), inputs.cache-type)
-      shell: bash
-      env:
-        DEPENDENCY_HASH: ${{ hashFiles('pnpm-lock.yaml') }}
-      run: |
-        if [[ -z "$DEPENDENCY_HASH" ]]; then
-          echo "::error::Cannot compute the Playwright cache identity from the checked-out repository."
           exit 1
         fi
         echo "hash=$DEPENDENCY_HASH" >> "$GITHUB_OUTPUT"
@@ -76,12 +63,3 @@ runs:
       with:
         path: ~/.m2/build-cache
         key: ${{ inputs.os }}-${{ steps.java.outputs.distribution }}-${{ steps.java.outputs.version }}-generated-clients-${{ steps.generated-clients-identity.outputs.hash }}
-
-    - name: Cache Playwright browsers
-      if: contains(fromJSON('["webapp-storybook", "webapp-e2e"]'), inputs.cache-type)
-      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-      with:
-        path: ~/.cache/ms-playwright
-        key: ${{ inputs.os }}-playwright-${{ steps.playwright-identity.outputs.hash }}
-        restore-keys: |
-          ${{ inputs.os }}-playwright-

--- a/.github/actions/setup-node-pnpm/action.yml
+++ b/.github/actions/setup-node-pnpm/action.yml
@@ -1,5 +1,10 @@
 name: "Setup Node.js and pnpm"
 description: "Installs the versions declared by package.json and restores the pnpm store cache."
+inputs:
+  install:
+    description: "Install mode: none skips, frozen requires the lockfile, hardened also disables lifecycle scripts."
+    required: false
+    default: "none"
 runs:
   using: "composite"
   steps:
@@ -11,4 +16,18 @@ runs:
       with:
         cache: true
         cache-dependency-path: pnpm-lock.yaml
-        install: false
+        install: ${{ inputs.install == 'frozen' }}
+        require-lockfile: ${{ inputs.install == 'frozen' }}
+    - name: Validate install mode
+      shell: bash
+      env:
+        INSTALL_MODE: ${{ inputs.install }}
+      run: |
+        case "$INSTALL_MODE" in
+          none|frozen|hardened) ;;
+          *) echo "::error::Unknown install mode '$INSTALL_MODE'. Expected none, frozen, or hardened."; exit 1 ;;
+        esac
+    - name: Install hardened dependencies
+      if: inputs.install == 'hardened'
+      shell: bash
+      run: pnpm install --frozen-lockfile --ignore-scripts

--- a/.github/actions/setup-release-security-tools/action.yml
+++ b/.github/actions/setup-release-security-tools/action.yml
@@ -1,13 +1,25 @@
 name: Setup release security tools
-description: Install checksum-verified Syft and Trivy binaries used by release evidence workflows
+description: Install release security tools
 inputs:
   install-syft:
-    description: Install Syft in addition to Trivy
+    description: Install Syft; Cosign and Trivy are always installed
     default: "true"
 runs:
   using: composite
   steps:
-    - shell: bash
+    - name: Validate options
+      shell: bash
+      env:
+        INSTALL_SYFT: ${{ inputs.install-syft }}
+      run: |
+        case "$INSTALL_SYFT" in
+          true|false) ;;
+          *) echo "::error::install-syft must be true or false"; exit 1 ;;
+        esac
+    - name: Install Cosign
+      uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+    - name: Install Syft and Trivy
+      shell: bash
       env:
         INSTALL_SYFT: ${{ inputs.install-syft }}
         # renovate: datasource=github-releases depName=anchore/syft

--- a/.github/workflows/cd-docs-teardown.yml
+++ b/.github/workflows/cd-docs-teardown.yml
@@ -21,8 +21,8 @@ jobs:
 
       - name: Setup Node.js and pnpm
         uses: ./.github/actions/setup-node-pnpm
-
-      - run: pnpm install --frozen-lockfile --ignore-scripts
+        with:
+          install: "hardened"
 
       - name: Teardown Surge.sh preview
         env:

--- a/.github/workflows/cd-docs.yml
+++ b/.github/workflows/cd-docs.yml
@@ -30,6 +30,8 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/setup-node-pnpm
+        with:
+          install: "frozen"
       - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
@@ -39,7 +41,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-docusaurus-preview-${{ hashFiles('pnpm-lock.yaml') }}-
             ${{ runner.os }}-docusaurus-preview-
-      - run: pnpm install --frozen-lockfile
       - run: pnpm --filter docs run build
         env:
           DOCUSAURUS_BASE_URL: "/"
@@ -59,6 +60,8 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/setup-node-pnpm
+        with:
+          install: "frozen"
       - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
@@ -68,7 +71,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-docusaurus-production-${{ hashFiles('pnpm-lock.yaml') }}-
             ${{ runner.os }}-docusaurus-production-
-      - run: pnpm install --frozen-lockfile
       - run: pnpm --filter docs run build
         env:
           DOCUSAURUS_BASE_URL: "/Hephaestus/"
@@ -97,7 +99,8 @@ jobs:
           name: docs-build-preview
           path: docs-build
       - uses: ./.github/actions/setup-node-pnpm
-      - run: pnpm install --frozen-lockfile --ignore-scripts
+        with:
+          install: "hardened"
       - name: Deploy to Surge.sh
         env:
           SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}

--- a/.github/workflows/ci-compose-validate.yml
+++ b/.github/workflows/ci-compose-validate.yml
@@ -97,6 +97,8 @@ jobs:
 
       - name: Set up the repository's Node.js and pnpm versions
         uses: ./.github/actions/setup-node-pnpm
+        with:
+          install: "none"
 
       - name: Render the preview stack and assert it stays sandboxed
         run: pnpm run check:preview-stack

--- a/.github/workflows/ci-docker-build.yml
+++ b/.github/workflows/ci-docker-build.yml
@@ -196,15 +196,15 @@ jobs:
       attestations: read
       contents: read
     steps:
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
       - name: Log in to Container Registry
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Install cosign
-        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Verify and tag unchanged images
         id: tag

--- a/.github/workflows/ci-profile.yml
+++ b/.github/workflows/ci-profile.yml
@@ -22,6 +22,8 @@ jobs:
           persist-credentials: false
 
       - uses: ./.github/actions/setup-node-pnpm
+        with:
+          install: "none"
 
       - uses: ./.github/actions/setup-caches
         with:

--- a/.github/workflows/ci-quality-gates.yml
+++ b/.github/workflows/ci-quality-gates.yml
@@ -106,6 +106,8 @@ jobs:
       - name: Setup Node.js and pnpm
         if: steps.should_run.outputs.run == 'true'
         uses: ./.github/actions/setup-node-pnpm
+        with:
+          install: "frozen"
 
       - name: Setup application-server caches
         if: steps.should_run.outputs.run == 'true' && matrix.check == 'application-server-quality'
@@ -124,7 +126,6 @@ jobs:
       - name: Application-server quality
         if: steps.should_run.outputs.run == 'true' && matrix.check == 'application-server-quality'
         run: |
-          pnpm install --frozen-lockfile
           ISSUES_FOUND=()
           SERVER_OK=true; PMD_CANARY_OK=true; NULLNESS_OK=true; CONTRACTS_OK=true; ENV_OK=true
 
@@ -164,7 +165,6 @@ jobs:
       - name: Tooling and docs quality
         if: steps.should_run.outputs.run == 'true' && matrix.check == 'tooling-quality'
         run: |
-          pnpm install --frozen-lockfile
           pnpm run check:package-manager
           pnpm run check:agent-runtime-pins
           pnpm run check:agents
@@ -180,7 +180,6 @@ jobs:
         working-directory: ./webapp
         run: |
           cd ..
-          pnpm install --frozen-lockfile
           cd webapp
 
           ISSUES_FOUND=()
@@ -258,7 +257,6 @@ jobs:
           DATABASE_URL: postgresql://fake:fake@localhost:5432/fake
           MODEL_NAME: fake:model
         run: |
-          pnpm install --frozen-lockfile
           pnpm run generate:api
           git add .
           if ! git diff --cached --quiet; then

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -53,6 +53,8 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup-node-pnpm
+        with:
+          install: "none"
       - uses: ./.github/actions/setup-caches
         with:
           cache-type: application-server-verification
@@ -117,6 +119,8 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup-node-pnpm
+        with:
+          install: "none"
       - uses: ./.github/actions/setup-caches
         with:
           cache-type: application-server-integration
@@ -170,14 +174,9 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - uses: ./.github/actions/setup-node-pnpm
-      - uses: ./.github/actions/setup-caches
         with:
-          cache-type: webapp-storybook
-          os: ${{ runner.os }}
-      - name: Install dependencies and browser
-        run: |
-          pnpm install --frozen-lockfile
-          pnpm --filter webapp exec playwright install chromium --with-deps
+          install: "frozen"
+      - uses: ./.github/actions/setup-browsers
       - name: Run story tests and generated-asset check
         id: tests
         continue-on-error: true
@@ -295,10 +294,13 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup-node-pnpm
+        with:
+          install: "frozen"
       - uses: ./.github/actions/setup-caches
         with:
           cache-type: webapp-e2e
           os: ${{ runner.os }}
+      - uses: ./.github/actions/setup-browsers
       - name: Download built reactor
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -306,8 +308,6 @@ jobs:
           path: server
       - name: Run end-to-end tests against the built server
         run: |
-          pnpm install --frozen-lockfile
-          pnpm --filter webapp exec playwright install chromium --with-deps
           # The base image may still be publishing; build the same Dockerfile as fallback.
           if [[ "${INPUTS_POSTGRES_IMAGE_CHANGED}" == "true" ]] ||
             ! docker pull ghcr.io/ls1intum/hephaestus/postgres:${{ github.event.pull_request.base.sha || github.sha }}; then

--- a/.github/workflows/cleanup-preview.yml
+++ b/.github/workflows/cleanup-preview.yml
@@ -54,6 +54,8 @@ jobs:
 
       - name: Set up the repository's Node.js and pnpm versions
         uses: ./.github/actions/setup-node-pnpm
+        with:
+          install: "none"
 
       - name: Request Coolify cleanup through the signed close event
         id: close

--- a/.github/workflows/deploy-locked-compose.yml
+++ b/.github/workflows/deploy-locked-compose.yml
@@ -55,6 +55,8 @@ jobs:
           persist-credentials: false
 
       - uses: ./.github/actions/setup-node-pnpm
+        with:
+          install: "none"
 
       - name: Validate and render release topology
         env:

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -49,6 +49,8 @@ jobs:
 
       - name: Set up the repository's Node.js and pnpm versions
         uses: ./.github/actions/setup-node-pnpm
+        with:
+          install: "none"
 
       - name: Resolve the pull request head
         id: context

--- a/.github/workflows/openapi-autocommit.yml
+++ b/.github/workflows/openapi-autocommit.yml
@@ -29,13 +29,13 @@ jobs:
           persist-credentials: false
       - name: Setup Node.js and pnpm
         uses: ./.github/actions/setup-node-pnpm
+        with:
+          install: "hardened"
       - name: Setup Java
         uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:
           distribution: temurin
           java-version: 21
-      - name: Install dependencies without lifecycle scripts
-        run: pnpm install --frozen-lockfile --ignore-scripts
       # This executes PR-controlled Maven plugins, so this job must remain read-only and secretless.
       - name: Generate OpenAPI spec and client
         run: pnpm run generate:api

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -29,9 +29,8 @@ jobs:
 
       - name: Setup Node.js and pnpm
         uses: ./.github/actions/setup-node-pnpm
-
-      - name: "Install dependencies"
-        run: pnpm install --frozen-lockfile
+        with:
+          install: "frozen"
 
       - name: "Validate PR title with commitlint"
         id: commitlint

--- a/.github/workflows/reconcile-previews.yml
+++ b/.github/workflows/reconcile-previews.yml
@@ -37,6 +37,8 @@ jobs:
 
       - name: Set up the repository's Node.js and pnpm versions
         uses: ./.github/actions/setup-node-pnpm
+        with:
+          install: "none"
 
       - name: Find the previews that still hold a slot
         id: candidates
@@ -84,6 +86,8 @@ jobs:
 
       - name: Set up the repository's Node.js and pnpm versions
         uses: ./.github/actions/setup-node-pnpm
+        with:
+          install: "none"
 
       - name: Recheck pull request state
         id: pull

--- a/.github/workflows/release-upgrade.yml
+++ b/.github/workflows/release-upgrade.yml
@@ -45,11 +45,12 @@ jobs:
           persist-credentials: false
 
       - uses: ./.github/actions/setup-node-pnpm
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
-          registry: ghcr.io
+          install: "none"
+
+      - name: Log in to GitHub Container Registry
+        uses: ./.github/actions/ghcr-login
+        with:
           username: ${{ github.actor }}
           password: ${{ github.token }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,15 +105,10 @@ jobs:
               echo ""
             } >> "$NOTES"
           fi
-          # Slice the `## <version>` section: stop at the next release header or
-          # the footer's `---` fence. Exact-string header compare is regex-safe
-          # against the dots in the version. (A literal `---` inside a changeset
-          # body would truncate notes — our entries are short prose, so this is
-          # accepted over more fragile parsing.)
           git show "$SHA:CHANGELOG.md" \
             | awk -v ver="## $VERSION" '
                 $0 == ver { on=1; next }
-                on && (/^## / || /^---$/) { exit }
+                on && /^## / { exit }
                 on { print }
               ' >> "$NOTES"
           echo "----- release notes -----"; cat "$NOTES"; echo "-------------------------"
@@ -163,10 +158,9 @@ jobs:
           ref: ${{ needs.release.outputs.sha }}
           fetch-depth: 1
 
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+      - name: Log in to GitHub Container Registry
+        uses: ./.github/actions/ghcr-login
         with:
-          registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
@@ -237,9 +231,8 @@ jobs:
       - uses: ./.github/actions/setup-release-security-tools
 
       - uses: ./.github/actions/setup-node-pnpm
-
-      - name: Install cosign
-        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          install: "none"
 
       - name: Generate and enforce release evidence
         env:
@@ -283,22 +276,8 @@ jobs:
                 -o "syft-json=evidence/$image-$suffix.syft.json" \
                 -o "spdx-json=evidence/$image-$suffix.spdx.json" \
                 -o "cyclonedx-json=evidence/$image-$suffix.cdx.json"
-              node scripts/check-release-sbom.ts \
-                "evidence/$image-$suffix.syft.json" \
-                "evidence/$image-$suffix.spdx.json" \
-                "evidence/$image-$suffix.cdx.json" \
-                "$platform_digest" "$platform" "evidence/$image-$suffix.sbom-validation.json"
               trivy image --skip-db-update --scanners vuln --format json --output "evidence/$image-$suffix.trivy.json" "$platform_ref"
               trivy image --skip-db-update --scanners license --format json --output "evidence/$image-$suffix.license.json" "$platform_ref"
-              jq -e --arg ref "$platform_ref" \
-                '.ArtifactName == $ref and (.Results | type == "array")' \
-                "evidence/$image-$suffix.license.json" >/dev/null
-              node scripts/check-release-vulnerabilities.ts "$image" "$platform" "$platform_digest" "$repository" \
-                "evidence/$image-$suffix.trivy.json" security/vulnerability-policy.json \
-                "evidence/$image-$suffix.policy.json"
-              if [ "$provenance" = first-party ]; then
-                cosign attest --yes --type spdxjson --predicate "evidence/$image-$suffix.spdx.json" "$platform_ref"
-              fi
             done
           }
           while IFS=$'\t' read -r image digest; do
@@ -323,35 +302,18 @@ jobs:
             > evidence/manifest.json
           cp security/vulnerability-policy.json evidence/vulnerability-policy.json
           cp security/release-images.json evidence/release-images.json
+          node scripts/verify-release-evidence.ts evidence --write-validation
+          jq -er '.subjects[] | select(.provenance == "first-party") | [.repository, .digest, .image, .platform] | @tsv' evidence/manifest.json |
+          while IFS=$'\t' read -r repository digest image platform; do
+            suffix=${platform//\//-}
+            cosign attest --yes --type spdxjson --predicate "evidence/$image-$suffix.spdx.json" "$repository@$digest"
+          done
           (cd evidence && sha256sum -- * > SHA256SUMS)
 
       - name: Verify evidence from registry subjects
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          while IFS=$'\t' read -r image platform _ digest repository provenance; do
-            [ "$provenance" = first-party ] || continue
-            ref="$repository@$digest"
-            suffix=${platform//\//-}
-            cosign verify-attestation \
-              --type spdxjson \
-              --certificate-identity 'https://github.com/${{ github.repository }}/.github/workflows/release.yml@refs/heads/main' \
-              --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
-              "$ref" > verified-attestations.json
-            jq -e --slurpfile sbom "evidence/$image-$suffix.spdx.json" \
-              'any(.[]; (.payload | @base64d | fromjson | .predicate) == $sbom[0])' \
-              verified-attestations.json >/dev/null
-          done < release-platforms.tsv
-          while IFS=$'\t' read -r image digest; do
-            ref="ghcr.io/ls1intum/hephaestus/$image@$digest"
-            cosign verify "$ref" \
-              --certificate-identity 'https://github.com/${{ github.repository }}/.github/workflows/reusable-docker-build.yml@refs/heads/main' \
-              --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
-              --certificate-github-workflow-repository '${{ github.repository }}' >/dev/null
-            gh attestation verify "oci://$ref" --owner "${{ github.repository_owner }}" \
-              --signer-workflow '${{ github.repository }}/.github/workflows/reusable-docker-build.yml' >/dev/null
-          done < release-images.tsv
+        run: node scripts/verify-release-evidence.ts evidence --verify-signatures
 
       - name: Write release image lock
         id: pin
@@ -461,14 +423,15 @@ jobs:
           persist-credentials: false
 
       - uses: ./.github/actions/setup-node-pnpm
+        with:
+          install: "none"
 
-      - name: Install cosign
+      - name: Install Cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+      - name: Log in to GitHub Container Registry
+        uses: ./.github/actions/ghcr-login
         with:
-          registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
@@ -556,14 +519,15 @@ jobs:
           persist-credentials: false
 
       - uses: ./.github/actions/setup-node-pnpm
+        with:
+          install: "none"
 
-      - name: Install cosign
+      - name: Install Cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+      - name: Log in to GitHub Container Registry
+        uses: ./.github/actions/ghcr-login
         with:
-          registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
@@ -604,9 +568,6 @@ jobs:
           mkdir evidence
           gh release download "$TAG_NAME" --repo "${{ github.repository }}" --dir evidence
           (cd evidence && sha256sum -c SHA256SUMS)
-          for file in manifest.json release-images.json tool-versions.json trivy-db.json vulnerability-policy.json; do
-            test -s "evidence/$file"
-          done
           lock="release-${TAG_NAME}.json"
           cosign verify-blob \
             --bundle "evidence/$lock.sigstore.json" \
@@ -615,57 +576,7 @@ jobs:
             "evidence/$lock"
           node scripts/release-image-lock.ts "evidence/$lock" evidence/manifest.json \
             "$TAG_NAME" /tmp/release-lock.env
-          jq -e --slurpfile inventory evidence/release-images.json \
-            '.schemaVersion == 1 and
-             ([.subjects[].image] | unique == (($inventory[0].images + [$inventory[0].upstream[].name]) | sort)) and
-             (group_by(.image) | all(.[]; [.[].platform] == ["linux/amd64", "linux/arm64"])) and
-             all(.subjects[]; (.digest | test("^sha256:[a-f0-9]{64}$")) and (.indexDigest | test("^sha256:[a-f0-9]{64}$")))' \
-            evidence/manifest.json >/dev/null
-          jq -er '.subjects[] | [.image, .platform, .digest, .repository, .provenance] | @tsv' evidence/manifest.json |
-          while IFS=$'\t' read -r image platform digest repository provenance; do
-            suffix=${platform//\//-}
-            node scripts/check-release-sbom.ts \
-              "evidence/$image-$suffix.syft.json" \
-              "evidence/$image-$suffix.spdx.json" \
-              "evidence/$image-$suffix.cdx.json" \
-              "$digest" "$platform" /tmp/sbom-validation.json
-            cmp "evidence/$image-$suffix.sbom-validation.json" /tmp/sbom-validation.json
-            for kind in trivy policy; do
-              test -s "evidence/$image-$suffix.$kind.json"
-            done
-            jq -e --arg ref "$repository@$digest" \
-              '.ArtifactName == $ref and (.Results | type == "array")' \
-              "evidence/$image-$suffix.license.json" >/dev/null
-            node scripts/check-release-vulnerabilities.ts "$image" "$platform" "$digest" "$repository" \
-              "evidence/$image-$suffix.trivy.json" evidence/vulnerability-policy.json \
-              /tmp/policy.json
-            cmp "evidence/$image-$suffix.policy.json" /tmp/policy.json
-            if [ "$provenance" = first-party ]; then
-              cosign verify-attestation --type spdxjson \
-                --certificate-identity 'https://github.com/${{ github.repository }}/.github/workflows/release.yml@refs/heads/main' \
-                --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
-                "$repository@$digest" > verified-attestations.json
-              jq -e --slurpfile sbom "evidence/$image-$suffix.spdx.json" \
-                'any(.[]; (.payload | @base64d | fromjson | .predicate) == $sbom[0])' \
-                verified-attestations.json >/dev/null
-            fi
-            index_digest=$(jq -er --arg image "$image" --arg platform "$platform" \
-              '.subjects[] | select(.image == $image and .platform == $platform) | .indexDigest' evidence/manifest.json)
-            architecture=${platform#*/}
-            docker buildx imagetools inspect "$repository@$index_digest" --raw |
-              jq -e --arg architecture "$architecture" --arg digest "$digest" \
-                'any(.manifests[]; .platform.os == "linux" and .platform.architecture == $architecture and .digest == $digest)' >/dev/null
-          done
-          jq -er '[.subjects[] | select(.provenance == "first-party") | [.repository, .indexDigest]] | unique[] | @tsv' evidence/manifest.json |
-          while IFS=$'\t' read -r repository digest; do
-            ref="$repository@$digest"
-            cosign verify "$ref" \
-              --certificate-identity 'https://github.com/${{ github.repository }}/.github/workflows/reusable-docker-build.yml@refs/heads/main' \
-              --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
-              --certificate-github-workflow-repository '${{ github.repository }}' >/dev/null
-            gh attestation verify "oci://$ref" --owner "${{ github.repository_owner }}" \
-              --signer-workflow '${{ github.repository }}/.github/workflows/reusable-docker-build.yml' >/dev/null
-          done
+          node scripts/verify-release-evidence.ts evidence --verify-signatures
           asset="evidence/release-${TAG_NAME}.json"
           cosign verify-blob --bundle "${asset}.sigstore.json" \
             --certificate-identity 'https://github.com/ls1intum/Hephaestus/.github/workflows/release.yml@refs/heads/main' \

--- a/.github/workflows/rescan-release-images.yml
+++ b/.github/workflows/rescan-release-images.yml
@@ -19,11 +19,11 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup-node-pnpm
+        with:
+          install: "none"
       - uses: ./.github/actions/setup-release-security-tools
         with:
           install-syft: "false"
-      - name: Install cosign
-        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
       - name: Download and verify latest supported release evidence
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -33,39 +33,6 @@ jobs:
           mkdir release-evidence
           gh release download "$tag" --repo "${{ github.repository }}" --dir release-evidence
           (cd release-evidence && sha256sum -c SHA256SUMS)
-          for file in manifest.json release-images.json tool-versions.json trivy-db.json vulnerability-policy.json; do
-            test -s "release-evidence/$file"
-          done
-          jq -e --slurpfile inventory release-evidence/release-images.json \
-            '.schemaVersion == 1 and
-             ([.subjects[].image] | unique == (($inventory[0].images + [$inventory[0].upstream[].name]) | sort)) and
-             (group_by(.image) | all(.[]; [.[].platform] == ["linux/amd64", "linux/arm64"])) and
-             all(.subjects[]; (.digest | test("^sha256:[a-f0-9]{64}$")) and (.indexDigest | test("^sha256:[a-f0-9]{64}$")))' \
-            release-evidence/manifest.json >/dev/null
-          jq -er '.subjects[] | [.image, .platform, .indexDigest, .digest, .repository] | @tsv' release-evidence/manifest.json |
-          while IFS=$'\t' read -r image platform index_digest digest repository; do
-            suffix=${platform//\//-}
-            node scripts/check-release-sbom.ts \
-              "release-evidence/$image-$suffix.syft.json" \
-              "release-evidence/$image-$suffix.spdx.json" \
-              "release-evidence/$image-$suffix.cdx.json" \
-              "$digest" "$platform" /tmp/sbom-validation.json
-            cmp "release-evidence/$image-$suffix.sbom-validation.json" /tmp/sbom-validation.json
-            for kind in trivy policy; do
-              test -s "release-evidence/$image-$suffix.$kind.json"
-            done
-            jq -e --arg ref "$repository@$digest" \
-              '.ArtifactName == $ref and (.Results | type == "array")' \
-              "release-evidence/$image-$suffix.license.json" >/dev/null
-            node scripts/check-release-vulnerabilities.ts "$image" "$platform" "$digest" "$repository" \
-              "release-evidence/$image-$suffix.trivy.json" \
-              release-evidence/vulnerability-policy.json /tmp/policy.json
-            cmp "release-evidence/$image-$suffix.policy.json" /tmp/policy.json
-            architecture=${platform#*/}
-            docker buildx imagetools inspect "$repository@$index_digest" --raw |
-              jq -e --arg architecture "$architecture" --arg digest "$digest" \
-                'any(.manifests[]; .platform.os == "linux" and .platform.architecture == $architecture and .digest == $digest)' >/dev/null
-          done
           lock="release-$tag.json"
           cosign verify-blob \
             --bundle "release-evidence/$lock.sigstore.json" \
@@ -74,6 +41,7 @@ jobs:
             "release-evidence/$lock"
           node scripts/release-image-lock.ts "release-evidence/$lock" \
             release-evidence/manifest.json "$tag" /tmp/release-lock.env
+          node scripts/verify-release-evidence.ts release-evidence
       - name: Rescan immutable subjects
         env:
           TRIVY_USERNAME: ${{ github.actor }}

--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -283,7 +283,7 @@ jobs:
           subject-digest: ${{ steps.single-digest.outputs.manifest-digest }}
           push-to-registry: true
 
-      - name: Install cosign
+      - name: Install Cosign
         if: inputs.single-arch
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
@@ -428,7 +428,7 @@ jobs:
           subject-digest: ${{ steps.digest.outputs.manifest-digest }}
           push-to-registry: true
 
-      - name: Install cosign
+      - name: Install Cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       # --recursive: sign each child manifest so per-platform verify works.

--- a/.github/workflows/security-mutation.yml
+++ b/.github/workflows/security-mutation.yml
@@ -47,9 +47,8 @@ jobs:
           cache-dependency-path: "server/**/pom.xml"
 
       - uses: ./.github/actions/setup-node-pnpm
-
-      - name: Install repository tooling
-        run: pnpm install --frozen-lockfile
+        with:
+          install: "frozen"
 
       - name: Run security mutation suite
         run: timeout --kill-after=30s 8m pnpm run test:server:mutation

--- a/.github/workflows/verify-changesets.yml
+++ b/.github/workflows/verify-changesets.yml
@@ -19,9 +19,8 @@ jobs:
 
       - name: Setup Node.js and pnpm
         uses: ./.github/actions/setup-node-pnpm
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile --ignore-scripts
+        with:
+          install: "hardened"
 
       - name: Test changeset and version-sync policies
         run: pnpm run check:changesets

--- a/.github/workflows/version-pr.yml
+++ b/.github/workflows/version-pr.yml
@@ -30,9 +30,8 @@ jobs:
 
       - name: Setup Node.js and pnpm
         uses: ./.github/actions/setup-node-pnpm
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        with:
+          install: "frozen"
 
       - name: Maintain Version PR
         uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0

--- a/docs/contributor/ci-cd.mdx
+++ b/docs/contributor/ci-cd.mdx
@@ -211,9 +211,22 @@ why the label is the authority, and which alternatives were priced and declined,
 | `cleanup-preview.yml` | Label removed, PR closed or drafted | Removes and verifies resources, then retains a cleanup tombstone |
 | `reconcile-previews.yml` | Nightly, manual | Re-sends teardown for any preview environment whose pull request is closed, drafted or unlabelled |
 | `version-pr.yml`       | Push to main          | Maintains the accumulating Version PR (changesets) |
-| `release.yml`          | On CI/CD Success      | Cuts a release when the Version PR merged: tag + GitHub Release, gates production |
+| `release.yml`          | Successful CI/CD push on `main` | Publishes the release and promotes it through the Staging and Production environment gates |
 | `deploy-staging.yml`   | Called by `release.yml` or manual dispatch | Deploys a verified release lock to staging |
-| `deploy-prod.yml`      | workflow_dispatch     | Deploys to production (manual trigger)             |
+| `deploy-prod.yml`      | Called by `release.yml` or manual dispatch | Deploys the staging-verified release to production |
+
+### Shared setup actions
+
+| Action | Contract |
+| --- | --- |
+| `setup-node-pnpm` | Installs the versions pinned in `package.json`; `install` must be `none`, `frozen`, or `hardened` |
+| `setup-caches` | Restores Maven and generated-client caches for one validated `cache-type` |
+| `setup-browsers` | Restores the exact Playwright browser version and installs Chromium system dependencies |
+| `setup-release-security-tools` | Installs Cosign, Trivy, and optionally Syft for release-evidence jobs |
+| `ghcr-login` | Authenticates Docker to GHCR |
+
+Repository-local actions require checkout first. Jobs without checkout use the external SHA-pinned
+action directly rather than checking out the repository only to reach a wrapper.
 
 ### Workflow Architecture
 
@@ -349,7 +362,7 @@ pnpm run test:webapp           # Unit tests
 
 # Application Server (Java) — includes the integration.core.webhook receiver
 pnpm run format:java:check     # Check formatting
-cd server && ./mvnw test       # Unit tests, including required reactor dependencies
+pnpm run test:server:unit      # Unit tests
 
 # Agent runtime (Node) — the Pi runner and the practice precompute scripts
 pnpm run test:agents           # Runner + precompute specs
@@ -405,123 +418,20 @@ This helps identify bottlenecks and optimization opportunities.
 
 ## 🆕 Adding a New Service
 
-When adding a new service to the monorepo, update CI configuration in this order:
+Extend the pipeline at the ownership boundary that changed; do not copy an existing job wholesale.
 
-### Step 1: Path Detection (`cicd.yml`)
+1. Add the service's paths to `detect-changes` in `cicd.yml`, including the shared files that can
+   affect it. Expose the result as a reusable-workflow input.
+2. Add purpose-named jobs to `ci-quality-gates.yml` and `ci-tests.yml`. Declare `needs` only when a
+   job consumes another job's artifact, and give every runnable job a timeout and least-privilege
+   permissions.
+3. Use `setup-node-pnpm` with an explicit install mode. Java jobs use a validated `setup-caches`
+   type; browser jobs use `setup-browsers`.
+4. Add image builds through `reusable-docker-build.yml`. Keep image metadata, immutable tags,
+   attestations, and signing in that workflow rather than reproducing them in the caller.
+5. Pass the change-detection output from `cicd.yml` to every reusable workflow that needs it.
 
-Add a path filter and output for the new service:
-
-```yaml
-# In detect-changes job outputs:
-outputs:
-  new-service: ${{ steps.filter.outputs.new-service }}
-
-# In paths-filter step:
-filters: |
-  new-service:
-    - 'server/new-service/**'
-    - 'package.json'
-    - 'pnpm-lock.yaml'
-    - 'pnpm-workspace.yaml'
-```
-
-Update the `any-code` aggregate output to include the new service.
-
-### Step 2: Quality Gates (`ci-quality-gates.yml`)
-
-1. **Add to matrix:**
-
-```yaml
-matrix:
-  check: [
-      # ... existing checks
-      new-service-quality,
-    ]
-```
-
-1. **Add case statement** in "Determine if check should run":
-
-```yaml
-"new-service-quality")
-  echo "run=${{ inputs.new_service_changed }}" >> $GITHUB_OUTPUT
-  ;;
-```
-
-1. **Add quality check step** with the appropriate linting/type checking commands.
-
-### Step 3: Tests (`ci-tests.yml`)
-
-Add a purpose-named job and gate it directly from the reusable workflow input:
-
-```yaml
-new-service-unit:
-  name: "New Service: Unit"
-  if: inputs.should_skip != 'true' && inputs.new_service_changed == 'true'
-  runs-on: ubuntu-latest
-  timeout-minutes: 15
-  permissions:
-    contents: read
-    checks: write
-  steps:
-    - uses: actions/checkout@<full-commit-sha> # vX.Y.Z
-      with:
-        persist-credentials: false
-    - uses: ./.github/actions/setup-node-pnpm
-    - name: Run unit tests
-      run: pnpm run test:new-service:unit
-    - name: Upload test results
-      if: always()
-      uses: dorny/test-reporter@<full-commit-sha> # vX.Y.Z
-      with:
-        path: new-service/test-results/*.xml
-        reporter: java-junit
-```
-
-Declare `needs` only when the job consumes an artifact from another job. Upload JUnit results or
-failure diagnostics when the test runner produces them.
-
-### Step 4: Docker Build (`ci-docker-build.yml`)
-
-Add a new build job:
-
-```yaml
-new-service-build:
-  name: "Docker: new-service"
-  if: inputs.should_skip != 'true' && inputs.new_service_changed == 'true'
-  uses: ls1intum/.github/.github/workflows/build-and-push-docker-image.yml@main
-  with:
-    image-name: "ls1intum/hephaestus/new-service"
-    docker-file: "./server/new-service/Dockerfile"
-    docker-context: "./server/new-service"
-    # ... rest of config
-```
-
-### Step 5: Caching (`setup-caches/action.yml`)
-
-Add the new service's cache-types to the appropriate conditions:
-
-```yaml
-# For Java services:
-- name: Cache Maven dependencies
-  if: contains(fromJSON('["...", "new-service-unit"]'), inputs.cache-type)
-```
-
-### Step 6: Update Workflow Inputs
-
-In `cicd.yml`, add the new input to workflow calls:
-
-```yaml
-with:
-  new_service_changed: ${{ (needs.detect-changes.outputs.new-service == 'true' || ...) && 'true' || 'false' }}
-```
-
-### Verification Checklist
-
-After adding a new service, verify:
-
-- [ ] Path filter correctly detects changes to new service
-- [ ] Quality gates run only when new service changes
-- [ ] Tests run only when new service changes
-- [ ] Docker build runs only when new service changes
-- [ ] CI config changes trigger all jobs (safety net)
-- [ ] JUnit reports appear in Test Results tab
+Before opening the pull request, verify that tooling-only changes skip the service, shared inputs
+select it, its JUnit or diagnostic artifacts are uploaded, and CI configuration changes exercise its
+safety-net path. `scripts/ci-contract.test.ts` owns the repository-wide workflow invariants; extend it
+when the new service introduces another invariant rather than relying on prose.

--- a/scripts/check-package-manager.ts
+++ b/scripts/check-package-manager.ts
@@ -105,8 +105,13 @@ const setup = readFileSync(".github/actions/setup-node-pnpm/action.yml", "utf8")
 if (!/^\s*uses: pnpm\/setup@[a-f0-9]{40} # v\d+\.\d+\.\d+$/m.test(setup)) {
 	throw new Error("setup-node-pnpm must pin pnpm/setup to a full commit SHA");
 }
-if (!/^\s*cache: true$/m.test(setup) || !/^\s*install: false$/m.test(setup)) {
-	throw new Error("setup-node-pnpm must cache the store and leave installs to each workflow");
+if (
+	!/^\s*cache: true$/m.test(setup) ||
+	!/^\s*install: \${{ inputs\.install == 'frozen' }}$/m.test(setup) ||
+	!/^\s*require-lockfile: \${{ inputs\.install == 'frozen' }}$/m.test(setup) ||
+	!setup.includes("pnpm install --frozen-lockfile --ignore-scripts")
+) {
+	throw new Error("setup-node-pnpm must own frozen and hardened dependency installation");
 }
 if (/^\s*(?:version|runtime):/m.test(setup)) {
 	throw new Error("setup-node-pnpm must read tool versions from package.json");

--- a/scripts/ci-cache-policy.test.ts
+++ b/scripts/ci-cache-policy.test.ts
@@ -3,6 +3,7 @@ import { readFile } from "node:fs/promises";
 import { describe, test } from "node:test";
 
 const cacheAction = await readFile(".github/actions/setup-caches/action.yml", "utf8");
+const browserAction = await readFile(".github/actions/setup-browsers/action.yml", "utf8");
 
 function actionStep(name: string): string {
 	const marker = `    - name: ${name}\n`;
@@ -33,13 +34,14 @@ await describe("CI cache policy", async () => {
 		assert.ok(actionStep("Cache generated clients").includes('"webapp-e2e"'));
 	});
 
-	await test("browser consumers share one Playwright cache predicate", () => {
-		const identity = actionStep("Compute Playwright cache identity");
-		const cache = actionStep("Cache Playwright browsers");
-		const predicate = identity.match(/^\s+if: (.+)$/m)?.[1];
-		assert.ok(predicate);
-		assert.equal(cache.match(/^\s+if: (.+)$/m)?.[1], predicate);
-		assert.ok(predicate.includes("webapp-e2e"));
-		assert.ok(predicate.includes("webapp-storybook"));
+	await test("browser consumers share one cache-and-install action", async () => {
+		assert.match(
+			browserAction,
+			/key: \${{ runner\.os }}-playwright-\${{ steps\.playwright\.outputs\.version }}/,
+		);
+		assert.doesNotMatch(browserAction, /restore-keys:/);
+		assert.match(browserAction, /playwright install chromium --with-deps/);
+		const workflow = await readFile(".github/workflows/ci-tests.yml", "utf8");
+		assert.equal((workflow.match(/uses: \.\/\.github\/actions\/setup-browsers/g) ?? []).length, 2);
 	});
 });

--- a/scripts/ci-contract.test.ts
+++ b/scripts/ci-contract.test.ts
@@ -193,4 +193,51 @@ void describe("CI contract", () => {
 		}
 		assert.deepEqual(invalid, [], "External uses must match @<40 lowercase hex> # v...");
 	});
+
+	void test("centralises dependency installation and browser setup", async () => {
+		const sources = await workflowSources();
+		for (const [file, source] of sources) {
+			assert.doesNotMatch(
+				source,
+				/pnpm install --frozen-lockfile/,
+				`${file} must install through setup-node-pnpm`,
+			);
+			const setupCalls = source.match(/uses: \.\/\.github\/actions\/setup-node-pnpm/g) ?? [];
+			const explicitModes =
+				source.match(
+					/uses: \.\/\.github\/actions\/setup-node-pnpm\n\s+with:\n\s+install: "(?:none|frozen|hardened)"/g,
+				) ?? [];
+			assert.equal(
+				explicitModes.length,
+				setupCalls.length,
+				`${file} must select an explicit setup-node-pnpm install mode`,
+			);
+		}
+		const tests = await readFile(".github/workflows/ci-tests.yml", "utf8");
+		assert.equal((tests.match(/uses: \.\/\.github\/actions\/setup-browsers/g) ?? []).length, 2);
+		assert.doesNotMatch(tests, /playwright install chromium/);
+	});
+
+	void test("runs release evidence verification through tested TypeScript", async () => {
+		const release = await readFile(".github/workflows/release.yml", "utf8");
+		const rescan = await readFile(".github/workflows/rescan-release-images.yml", "utf8");
+		assert.match(rescan, /node scripts\/verify-release-evidence\.ts release-evidence/);
+		assert.doesNotMatch(rescan, /node scripts\/check-release-sbom\.ts/);
+		assert.equal((release.match(/node scripts\/verify-release-evidence\.ts/g) ?? []).length, 3);
+		assert.doesNotMatch(release, /node scripts\/check-release-(?:sbom|vulnerabilities)\.ts/);
+	});
+
+	void test("never invokes a repository-local action before checkout", async () => {
+		for (const [file, source] of await workflowSources()) {
+			for (const jobSource of source.split(/^ {2}(?=[A-Za-z][\w-]*:\s*$)/m).slice(1)) {
+				const firstLocalAction = jobSource.indexOf("uses: ./.github/actions/");
+				if (firstLocalAction < 0) continue;
+				const checkout = jobSource.indexOf("uses: actions/checkout@");
+				assert.ok(
+					checkout >= 0 && checkout < firstLocalAction,
+					`${file} invokes a local action before checking it out`,
+				);
+			}
+		}
+	});
 });

--- a/scripts/verify-release-evidence.test.ts
+++ b/scripts/verify-release-evidence.test.ts
@@ -1,0 +1,184 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+	attestationContainsSbom,
+	indexContainsSubject,
+	validateLicenseReport,
+	validateManifest,
+} from "./verify-release-evidence.ts";
+
+const digest = `sha256:${"a".repeat(64)}`;
+const inventory = { schemaVersion: 1, images: ["server"], upstream: [] };
+const subject = (platform: "linux/amd64" | "linux/arm64") => ({
+	digest,
+	image: "server",
+	indexDigest: digest,
+	platform,
+	provenance: "first-party" as const,
+	repository: "ghcr.io/ls1intum/hephaestus/server",
+});
+
+void describe("release evidence manifest", () => {
+	void it("accepts exactly one canonical subject for each supported platform", () => {
+		const result = validateManifest(
+			{ schemaVersion: 1, subjects: [subject("linux/amd64"), subject("linux/arm64")] },
+			inventory,
+		);
+		assert.equal(result.subjects.length, 2);
+	});
+
+	void it("fails closed on missing, reordered, and duplicate platforms", () => {
+		assert.throws(
+			() => validateManifest({ schemaVersion: 1, subjects: [subject("linux/amd64")] }, inventory),
+			/canonical order/,
+		);
+		assert.throws(
+			() =>
+				validateManifest(
+					{ schemaVersion: 1, subjects: [subject("linux/arm64"), subject("linux/amd64")] },
+					inventory,
+				),
+			/canonical order/,
+		);
+		assert.throws(
+			() =>
+				validateManifest(
+					{ schemaVersion: 1, subjects: [subject("linux/amd64"), subject("linux/amd64")] },
+					inventory,
+				),
+			/duplicate image platforms/,
+		);
+	});
+
+	void it("rejects path traversal, mutable identities, wrong repositories, and invalid provenance", () => {
+		const valid = subject("linux/amd64");
+		for (const invalid of [
+			{ ...valid, image: "../manifest" },
+			{ ...valid, digest: "latest" },
+			{ ...valid, repository: "ghcr.io/attacker/server" },
+			{ ...valid, provenance: "upstream" },
+			{ ...valid, provenance: "unknown" },
+		]) {
+			assert.throws(
+				() =>
+					validateManifest(
+						{ schemaVersion: 1, subjects: [invalid, subject("linux/arm64")] },
+						inventory,
+					),
+				/malformed|does not match/,
+			);
+		}
+	});
+
+	void it("rejects duplicate or malformed inventory entries", () => {
+		const subjects = [subject("linux/amd64"), subject("linux/arm64")];
+		assert.throws(
+			() =>
+				validateManifest(
+					{ schemaVersion: 1, subjects },
+					{ schemaVersion: 1, images: ["server", "server"], upstream: [] },
+				),
+			/duplicate release image/,
+		);
+		assert.throws(
+			() =>
+				validateManifest(
+					{ schemaVersion: 1, subjects },
+					{ schemaVersion: 1, images: ["../server"], upstream: [] },
+				),
+			/invalid image/,
+		);
+	});
+
+	void it("derives provenance and index identity from the inventory", () => {
+		const upstreamDigest = `sha256:${"b".repeat(64)}`;
+		const upstreamInventory = {
+			schemaVersion: 1,
+			images: [],
+			upstream: [
+				{
+					digest: upstreamDigest,
+					name: "postgres",
+					repository: "docker.io/library/postgres",
+				},
+			],
+		};
+		const upstreamSubject = (platform: "linux/amd64" | "linux/arm64") => ({
+			digest,
+			image: "postgres",
+			indexDigest: upstreamDigest,
+			platform,
+			provenance: "upstream" as const,
+			repository: "docker.io/library/postgres",
+		});
+		const valid = [upstreamSubject("linux/amd64"), upstreamSubject("linux/arm64")];
+		assert.doesNotThrow(() =>
+			validateManifest({ schemaVersion: 1, subjects: valid }, upstreamInventory),
+		);
+		assert.throws(
+			() =>
+				validateManifest(
+					{ schemaVersion: 1, subjects: [{ ...valid[0], provenance: "first-party" }, valid[1]] },
+					upstreamInventory,
+				),
+			/does not match its inventory/,
+		);
+		assert.throws(
+			() =>
+				validateManifest(
+					{ schemaVersion: 1, subjects: [{ ...valid[0], indexDigest: digest }, valid[1]] },
+					upstreamInventory,
+				),
+			/does not match its inventory/,
+		);
+		assert.throws(
+			() =>
+				validateManifest(
+					{
+						schemaVersion: 1,
+						subjects: [
+							subject("linux/amd64"),
+							{ ...subject("linux/arm64"), indexDigest: upstreamDigest },
+						],
+					},
+					inventory,
+				),
+			/one index digest/,
+		);
+	});
+});
+
+void describe("release evidence bindings", () => {
+	void it("binds license and OCI index evidence to the immutable subject", () => {
+		const amd64 = subject("linux/amd64");
+		const reference = `${amd64.repository}@${amd64.digest}`;
+		assert.doesNotThrow(() =>
+			validateLicenseReport({ ArtifactName: reference, Results: [] }, reference),
+		);
+		assert.throws(() => validateLicenseReport({ ArtifactName: "wrong", Results: [] }, reference));
+		assert.equal(
+			indexContainsSubject(
+				{ manifests: [{ digest, platform: { os: "linux", architecture: "amd64" } }] },
+				amd64,
+			),
+			true,
+		);
+		assert.equal(
+			indexContainsSubject(
+				{ manifests: [{ digest, platform: { os: "linux", architecture: "arm64" } }] },
+				amd64,
+			),
+			false,
+		);
+	});
+
+	void it("requires a Cosign payload whose predicate exactly matches the durable SBOM", () => {
+		const sbom = { packages: [{ name: "example", version: "1" }] };
+		const payload = (predicate: unknown): string =>
+			Buffer.from(JSON.stringify({ predicate })).toString("base64");
+		assert.equal(attestationContainsSbom([{ payload: payload(sbom) }], sbom), true);
+		assert.equal(attestationContainsSbom([{ payload: payload({ packages: [] }) }], sbom), false);
+		assert.equal(attestationContainsSbom([{ payload: "not-base64-json" }], sbom), false);
+	});
+});

--- a/scripts/verify-release-evidence.ts
+++ b/scripts/verify-release-evidence.ts
@@ -1,0 +1,326 @@
+import { spawnSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { isDeepStrictEqual } from "node:util";
+
+import { validateReleaseSbom } from "./check-release-sbom.ts";
+import { evaluate } from "./check-release-vulnerabilities.ts";
+
+type Subject = {
+	digest: string;
+	image: string;
+	indexDigest: string;
+	platform: "linux/amd64" | "linux/arm64";
+	provenance: "first-party" | "upstream";
+	repository: string;
+};
+
+type Manifest = { schemaVersion: 1; subjects: Subject[] };
+type JsonObject = Record<string, unknown>;
+type ExpectedImage = {
+	indexDigest?: string;
+	provenance: Subject["provenance"];
+	repository: string;
+};
+type VerificationMode = "verify" | "verify-signatures" | "write-validation";
+
+const digestPattern = /^sha256:[a-f0-9]{64}$/;
+const imagePattern = /^[a-z0-9-]+$/;
+
+function record(value: unknown): value is JsonObject {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readJson(path: string): unknown {
+	return JSON.parse(readFileSync(path, "utf8")) as unknown;
+}
+
+function serialized(value: unknown): string {
+	return `${JSON.stringify(value, null, 2)}\n`;
+}
+
+function persistOrVerify(path: string, value: unknown, writeValidation: boolean): void {
+	if (writeValidation) {
+		writeFileSync(path, serialized(value));
+		return;
+	}
+	if (readFileSync(path, "utf8") !== serialized(value))
+		throw new Error(`${path} changed when re-derived`);
+}
+
+export function validateLicenseReport(value: unknown, reference: string): void {
+	if (!record(value) || value.ArtifactName !== reference || !Array.isArray(value.Results))
+		throw new Error(`license report is not bound to ${reference}`);
+}
+
+export function indexContainsSubject(value: unknown, subject: Subject): boolean {
+	if (!record(value) || !Array.isArray(value.manifests)) throw new Error("OCI index is malformed");
+	const architecture = subject.platform.slice("linux/".length);
+	return value.manifests.some((entry) => {
+		if (!record(entry) || !record(entry.platform)) return false;
+		return (
+			entry.digest === subject.digest &&
+			entry.platform.os === "linux" &&
+			entry.platform.architecture === architecture
+		);
+	});
+}
+
+export function attestationContainsSbom(value: unknown, sbom: unknown): boolean {
+	if (!Array.isArray(value)) throw new Error("Cosign attestation result is malformed");
+	return value.some((entry) => {
+		if (!record(entry) || typeof entry.payload !== "string") return false;
+		try {
+			const envelope: unknown = JSON.parse(Buffer.from(entry.payload, "base64").toString("utf8"));
+			return record(envelope) && isDeepStrictEqual(envelope.predicate, sbom);
+		} catch {
+			return false;
+		}
+	});
+}
+
+export function validateManifest(value: unknown, inventoryValue: unknown): Manifest {
+	if (!record(value) || value.schemaVersion !== 1 || !Array.isArray(value.subjects))
+		throw new Error("release manifest must use schema version 1 and contain subjects");
+	if (
+		!record(inventoryValue) ||
+		inventoryValue.schemaVersion !== 1 ||
+		!Array.isArray(inventoryValue.images) ||
+		!Array.isArray(inventoryValue.upstream)
+	)
+		throw new Error("release image inventory is malformed");
+	if (
+		!inventoryValue.images.every((image) => typeof image === "string" && imagePattern.test(image))
+	)
+		throw new Error("release image inventory contains an invalid image");
+	const images = inventoryValue.images.filter(
+		(image): image is string => typeof image === "string",
+	);
+	if (new Set(images).size !== images.length) throw new Error("duplicate release image");
+	const expectedImages = new Map<string, ExpectedImage>();
+	for (const image of images)
+		expectedImages.set(image, {
+			provenance: "first-party",
+			repository: `ghcr.io/ls1intum/hephaestus/${image}`,
+		});
+	for (const item of inventoryValue.upstream) {
+		if (
+			!record(item) ||
+			typeof item.name !== "string" ||
+			!imagePattern.test(item.name) ||
+			typeof item.repository !== "string" ||
+			!item.repository ||
+			typeof item.digest !== "string" ||
+			!digestPattern.test(item.digest)
+		)
+			throw new Error("release image inventory contains an invalid upstream image");
+		if (expectedImages.has(item.name)) throw new Error(`duplicate release image: ${item.name}`);
+		expectedImages.set(item.name, {
+			indexDigest: item.digest,
+			provenance: "upstream",
+			repository: item.repository,
+		});
+	}
+	const subjects: Subject[] = value.subjects.map((item, index) => {
+		if (
+			!record(item) ||
+			typeof item.image !== "string" ||
+			!imagePattern.test(item.image) ||
+			(item.platform !== "linux/amd64" && item.platform !== "linux/arm64") ||
+			typeof item.digest !== "string" ||
+			!digestPattern.test(item.digest) ||
+			typeof item.indexDigest !== "string" ||
+			!digestPattern.test(item.indexDigest) ||
+			typeof item.repository !== "string" ||
+			(item.provenance !== "first-party" && item.provenance !== "upstream")
+		)
+			throw new Error(`release manifest subject ${index} is malformed`);
+		const expected = expectedImages.get(item.image);
+		if (
+			!expected ||
+			expected.repository !== item.repository ||
+			expected.provenance !== item.provenance ||
+			(expected.indexDigest && expected.indexDigest !== item.indexDigest)
+		)
+			throw new Error(`release manifest subject ${item.image} does not match its inventory`);
+		return {
+			digest: item.digest,
+			image: item.image,
+			indexDigest: item.indexDigest,
+			platform: item.platform,
+			provenance: item.provenance,
+			repository: item.repository,
+		};
+	});
+	if (
+		new Set(subjects.map(({ image, platform }) => `${image}\0${platform}`)).size !== subjects.length
+	)
+		throw new Error("release manifest contains duplicate image platforms");
+	if (new Set(subjects.map(({ image }) => image)).size !== expectedImages.size)
+		throw new Error("release manifest does not match the image inventory");
+	for (const image of expectedImages.keys()) {
+		const imageSubjects = subjects.filter((subject) => subject.image === image);
+		const platforms = imageSubjects.map(({ platform }) => platform);
+		if (!isDeepStrictEqual(platforms, ["linux/amd64", "linux/arm64"]))
+			throw new Error(`${image} must have exactly amd64 and arm64 evidence in canonical order`);
+		if (new Set(imageSubjects.map(({ indexDigest }) => indexDigest)).size !== 1)
+			throw new Error(`${image} subjects must share one index digest`);
+	}
+	return { schemaVersion: 1, subjects };
+}
+
+function command(commandName: string, args: string[], capture = false): string {
+	const result = spawnSync(commandName, args, {
+		encoding: "utf8",
+		stdio: capture ? "pipe" : "inherit",
+	});
+	if (result.error) throw result.error;
+	if (result.status !== 0) {
+		const detail = capture && result.stderr.trim() ? `: ${result.stderr.trim()}` : "";
+		throw new Error(`${commandName} failed with exit code ${result.status ?? "unknown"}${detail}`);
+	}
+	return result.stdout;
+}
+
+export function verifyReleaseEvidence(
+	directory: string,
+	mode: VerificationMode = "verify",
+): Manifest {
+	const manifest = validateManifest(
+		readJson(join(directory, "manifest.json")),
+		readJson(join(directory, "release-images.json")),
+	);
+	const policy = readJson(join(directory, "vulnerability-policy.json"));
+	for (const subject of manifest.subjects) {
+		const suffix = subject.platform.replace("/", "-");
+		const prefix = join(directory, `${subject.image}-${suffix}`);
+		const sbom = validateReleaseSbom(
+			readJson(`${prefix}.syft.json`),
+			readJson(`${prefix}.spdx.json`),
+			readJson(`${prefix}.cdx.json`),
+			subject.digest,
+			subject.platform,
+		);
+		persistOrVerify(`${prefix}.sbom-validation.json`, sbom, mode === "write-validation");
+		const reference = `${subject.repository}@${subject.digest}`;
+		validateLicenseReport(readJson(`${prefix}.license.json`), reference);
+		const result = evaluate(subject.image, readJson(`${prefix}.trivy.json`), policy, new Date(), {
+			digest: subject.digest,
+			platform: subject.platform,
+			reference,
+		});
+		const policyResult = {
+			image: subject.image,
+			platform: subject.platform,
+			digest: subject.digest,
+			status: result.errors.length === 0 && result.rejected.length === 0 ? "pass" : "fail",
+			...result,
+		};
+		persistOrVerify(`${prefix}.policy.json`, policyResult, mode === "write-validation");
+		if (result.errors.length > 0 || result.rejected.length > 0)
+			throw new Error(`${subject.image} does not satisfy vulnerability policy`);
+		const index = readJsonFromCommand("docker", [
+			"buildx",
+			"imagetools",
+			"inspect",
+			`${subject.repository}@${subject.indexDigest}`,
+			"--raw",
+		]);
+		if (!indexContainsSubject(index, subject))
+			throw new Error(`${subject.image} index does not contain ${subject.platform} digest`);
+		if (mode === "verify-signatures" && subject.provenance === "first-party") {
+			const repository = requiredEnvironment("GITHUB_REPOSITORY");
+			const attestations = readJsonFromCommand("cosign", [
+				"verify-attestation",
+				"--type",
+				"spdxjson",
+				"--certificate-identity",
+				`https://github.com/${repository}/.github/workflows/release.yml@refs/heads/main`,
+				"--certificate-oidc-issuer",
+				"https://token.actions.githubusercontent.com",
+				reference,
+			]);
+			if (!attestationContainsSbom(attestations, readJson(`${prefix}.spdx.json`)))
+				throw new Error(`${subject.image} SBOM attestation does not match its durable evidence`);
+		}
+	}
+	if (mode === "verify-signatures") verifyIndexSignatures(manifest);
+	return manifest;
+}
+
+function readJsonFromCommand(name: string, args: string[]): unknown {
+	return JSON.parse(command(name, args, true)) as unknown;
+}
+
+function requiredEnvironment(name: string): string {
+	const value = process.env[name];
+	if (!value) throw new Error(`${name} is required`);
+	return value;
+}
+
+function verifyIndexSignatures(manifest: Manifest): void {
+	const repository = requiredEnvironment("GITHUB_REPOSITORY");
+	const owner = requiredEnvironment("GITHUB_REPOSITORY_OWNER");
+	const indexes = new Map(
+		manifest.subjects
+			.filter(({ provenance }) => provenance === "first-party")
+			.map(({ repository: imageRepository, indexDigest }) => [
+				`${imageRepository}@${indexDigest}`,
+				true,
+			]),
+	);
+	for (const reference of indexes.keys()) {
+		command(
+			"cosign",
+			[
+				"verify",
+				reference,
+				"--certificate-identity",
+				`https://github.com/${repository}/.github/workflows/reusable-docker-build.yml@refs/heads/main`,
+				"--certificate-oidc-issuer",
+				"https://token.actions.githubusercontent.com",
+				"--certificate-github-workflow-repository",
+				repository,
+			],
+			true,
+		);
+		command(
+			"gh",
+			[
+				"attestation",
+				"verify",
+				`oci://${reference}`,
+				"--owner",
+				owner,
+				"--signer-workflow",
+				`${repository}/.github/workflows/reusable-docker-build.yml`,
+			],
+			true,
+		);
+	}
+}
+
+if (import.meta.main) {
+	const [directory, option] = process.argv.slice(2);
+	if (!directory)
+		throw new Error(
+			"usage: verify-release-evidence <evidence-directory> [--verify-signatures|--write-validation]",
+		);
+	let mode: VerificationMode;
+	switch (option) {
+		case undefined:
+			mode = "verify";
+			break;
+		case "--verify-signatures":
+			mode = "verify-signatures";
+			break;
+		case "--write-validation":
+			mode = "write-validation";
+			break;
+		default:
+			throw new Error(
+				"usage: verify-release-evidence <evidence-directory> [--verify-signatures|--write-validation]",
+			);
+	}
+	verifyReleaseEvidence(directory, mode);
+}


### PR DESCRIPTION
## Description

Centralize repeated Node/pnpm, browser, GHCR, and release-security setup while moving release-evidence verification out of workflow shell into tested TypeScript. This reduces workflow drift, gives install and verification paths explicit fail-closed contracts, and strengthens release provenance by binding repository, provenance, subject, and index-digest evidence to the signed inventory.

This PR also updates the contributor CI/CD guide to describe ownership and extension points instead of encouraging copy-pasted workflow fragments.

Part of #1591. It deliberately does **not** close the issue: the remaining `setup-java-maven`, `sign-and-attest`, CI summary, generated-file checks, and Docker workflow-shape work still needs implementation or the issue's documented deferral process.

### What changed

- Roll out explicit `none`, `frozen`, or `hardened` install modes to every `setup-node-pnpm` caller.
- Share exact-version Playwright browser setup between Storybook and E2E jobs.
- Consolidate repository-backed GHCR and release-security setup without forcing checkout into jobs that otherwise do not need it.
- Replace three release-evidence shell implementations with `scripts/verify-release-evidence.ts` and adversarial `node:test` coverage.
- Add CI contract tests for action pinning, checkout order, install ownership, browser setup, and release verifier adoption.
- Remove stale contributor examples and document the current shared-action boundaries.

### Security posture

The verifier fails closed on malformed inventories, mutable image references, repository or provenance mismatches, divergent subject digests, inventory/manifest disagreement, and incorrect SBOM, license, Cosign, or GitHub attestation evidence. External actions remain pinned to full commit SHAs.

## How to test

```bash
pnpm run format
pnpm run check
pnpm run verify
```

`pnpm run verify` completed every webapp, Storybook, tooling, documentation, build, and server verification leg. Its first server run reported a transient startup-budget miss (`accountController` at 6.67s against a 6s budget); an immediate isolated rerun of `StartupBudgetIntegrationTest` passed. No changed file is on that application startup path.

Focused release and CI contracts can also be run with:

```bash
node --test \
  scripts/verify-release-evidence.test.ts \
  scripts/ci-contract.test.ts \
  scripts/ci-cache-policy.test.ts
```

## Checklist

- [x] No changeset is required because this PR changes repository CI, tooling, tests, and contributor documentation only; it does not change shipped application code.
- [x] No operator action or migration is required.
