### PR TITLE
fix(ci): restore PR title validation

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -33,7 +33,7 @@ jobs:
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          echo "$PR_TITLE" | pnpm run commitlint 2>&1 | tee /tmp/commitlint-output.txt
+          echo "$PR_TITLE" | pnpm exec commitlint 2>&1 | tee /tmp/commitlint-output.txt
           exit_code=${PIPESTATUS[1]}
 
           {


### PR DESCRIPTION
## Description

Restores pull-request title validation after the package-manager cleanup removed the `commitlint` package script. The trusted PR workflow now invokes the installed binary through `pnpm exec`, which is the direct pnpm mechanism and avoids reintroducing a one-line alias.

This currently blocks otherwise mergeable pull requests, including #1627 and #1630.

## How to test

```bash
printf '%s\n' 'fix(ci): restore PR title validation' | pnpm exec commitlint
pnpm run format
pnpm run check
```

After merge, re-run the `Validate title` check on an open pull request and confirm the job passes for a valid Conventional Commit title.

## Checklist

- [x] No changeset is required; this only repairs repository CI behavior
- [x] No operator action is required
