### PR TITLE
fix(ci): restore PR title validation

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -33,14 +33,13 @@ jobs:
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          echo "$PR_TITLE" | pnpm run commitlint 2>&1 | tee /tmp/commitlint-output.txt
+          printf '%s\n' "$PR_TITLE" | pnpm exec commitlint 2>&1 | tee "$RUNNER_TEMP/commitlint-output.txt"
           exit_code=${PIPESTATUS[1]}
 
           {
-            echo 'error_message<<EOF'
-            cat /tmp/commitlint-output.txt
-            echo 'EOF'
-          } >> "$GITHUB_OUTPUT"
+            printf '## PR title validation failed\n\n'
+            sed 's/^/    /' "$RUNNER_TEMP/commitlint-output.txt"
+          } > "$RUNNER_TEMP/commitlint-comment.md"
 
           exit "$exit_code"
         continue-on-error: true
@@ -50,14 +49,7 @@ jobs:
         if: steps.commitlint.outcome == 'failure'
         with:
           header: pr-title-lint-error
-          message: |
-            ## ❌ PR Title Validation Failed
-
-            ```
-            ${{ steps.commitlint.outputs.error_message }}
-            ```
-
-            > 📖 See [CONTRIBUTING.md](https://github.com/ls1intum/Hephaestus/blob/main/CONTRIBUTING.md) for commit message guidelines.
+          path: ${{ runner.temp }}/commitlint-comment.md
 
       - name: "Remove error comment on success"
         uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4


### PR DESCRIPTION
## Description

Restore the required PR title check after the pnpm migration by invoking the repository-pinned commitlint executable directly. Validation failures are passed to the sticky-comment action through its file input, keeping diagnostics readable while avoiding delimiter collisions and Markdown injection from untrusted PR titles.

Fixes #1624

## How to test

- Run `pnpm run verify`.
- Confirm `docs(webapp): define accessibility audit evidence` passes `pnpm exec commitlint`.
- Confirm invalid titles, including `EOF` and triple backticks, fail and remain safely formatted as code in the generated comment.
- In GitHub, give a PR an invalid title and verify the **Validate title** check fails with one explanatory sticky comment; correct the title and verify the check passes and removes that comment.

## Checklist

- No changeset is required because this changes CI behavior only and does not affect shipped application code.
- No operator action or migration is required.
