### PR TITLE
refactor(server): enforce module-owned meter names

### DIFF
--- a/.changeset/quiet-metric-boundaries.md
+++ b/.changeset/quiet-metric-boundaries.md
@@ -1,0 +1,4 @@
+---
+---
+
+This internal metrics refactor does not change released application behavior or operator configuration.

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/activity/ActivityEventService.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/activity/ActivityEventService.java
@@ -1,5 +1,6 @@
 package de.tum.cit.aet.hephaestus.activity;
 
+import de.tum.cit.aet.hephaestus.activity.metrics.ActivityMetrics;
 import de.tum.cit.aet.hephaestus.activity.scoring.ExperiencePointProperties;
 import de.tum.cit.aet.hephaestus.activity.scoring.XpPrecision;
 import de.tum.cit.aet.hephaestus.activity.spi.ActivityRecorder;
@@ -72,16 +73,16 @@ public class ActivityEventService implements ActivityRecorder {
         this.workspaceRepository = workspaceRepository;
         this.xpProperties = xpProperties;
         this.eventPublisher = eventPublisher;
-        this.eventsRecordedCounter = Counter.builder("activity.events.recorded")
+        this.eventsRecordedCounter = Counter.builder(ActivityMetrics.ACTIVITY_EVENTS_RECORDED)
                 .description("Number of activity events recorded")
                 .register(meterRegistry);
-        this.eventsDuplicateCounter = Counter.builder("activity.events.duplicate")
+        this.eventsDuplicateCounter = Counter.builder(ActivityMetrics.ACTIVITY_EVENTS_DUPLICATE)
                 .description("Number of duplicate activity events skipped")
                 .register(meterRegistry);
-        this.eventsFailedCounter = Counter.builder("activity.events.failed")
+        this.eventsFailedCounter = Counter.builder(ActivityMetrics.ACTIVITY_EVENTS_FAILED)
                 .description("Number of activity events that failed to record after retries")
                 .register(meterRegistry);
-        this.xpDistribution = DistributionSummary.builder("activity.xp.distribution")
+        this.xpDistribution = DistributionSummary.builder(ActivityMetrics.ACTIVITY_XP_DISTRIBUTION)
                 .description("Distribution of XP values recorded")
                 .publishPercentiles(0.5, 0.95, 0.99)
                 .register(meterRegistry);
@@ -95,7 +96,7 @@ public class ActivityEventService implements ActivityRecorder {
     private Timer getTimerForEventType(ActivityEventType eventType) {
         return eventTypeTimers.computeIfAbsent(
                 eventType,
-                type -> Timer.builder("activity.events.record.duration.by_type")
+                type -> Timer.builder(ActivityMetrics.ACTIVITY_EVENTS_RECORD_DURATION_BY_TYPE)
                         .description("Time to persist activity event by type")
                         .tag("eventType", type.name())
                         .publishPercentiles(0.5, 0.95, 0.99)

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/activity/metrics/ActivityMetrics.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/activity/metrics/ActivityMetrics.java
@@ -1,0 +1,12 @@
+package de.tum.cit.aet.hephaestus.activity.metrics;
+
+public final class ActivityMetrics {
+
+    public static final String ACTIVITY_EVENTS_DUPLICATE = "activity.events.duplicate";
+    public static final String ACTIVITY_EVENTS_FAILED = "activity.events.failed";
+    public static final String ACTIVITY_EVENTS_RECORDED = "activity.events.recorded";
+    public static final String ACTIVITY_EVENTS_RECORD_DURATION_BY_TYPE = "activity.events.record.duration.by_type";
+    public static final String ACTIVITY_XP_DISTRIBUTION = "activity.xp.distribution";
+
+    private ActivityMetrics() {}
+}

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/activity/metrics/package-info.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/activity/metrics/package-info.java
@@ -1,0 +1,2 @@
+@org.jspecify.annotations.NullMarked
+package de.tum.cit.aet.hephaestus.activity.metrics;

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobExecutor.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobExecutor.java
@@ -9,6 +9,7 @@ import de.tum.cit.aet.hephaestus.agent.context.InsufficientEvidenceException;
 import de.tum.cit.aet.hephaestus.agent.handler.JobTypeHandlerRegistry;
 import de.tum.cit.aet.hephaestus.agent.handler.spi.JobTypeHandler;
 import de.tum.cit.aet.hephaestus.agent.handler.spi.PreparedJobInputs;
+import de.tum.cit.aet.hephaestus.agent.metrics.AgentMetrics;
 import de.tum.cit.aet.hephaestus.agent.practice.PracticeAgentRequest;
 import de.tum.cit.aet.hephaestus.agent.practice.PracticePiAdapter;
 import de.tum.cit.aet.hephaestus.agent.practice.PracticeSandboxSpec;
@@ -211,13 +212,13 @@ public class AgentJobExecutor {
         this.workerProperties = workerProperties;
         this.workerId = workerProperties.map(WorkerProperties::resolvedWorkerId).orElse(null);
 
-        this.concurrencyRejected = Counter.builder("agent.job.concurrency.rejected")
+        this.concurrencyRejected = Counter.builder(AgentMetrics.AGENT_JOB_CONCURRENCY_REJECTED)
                 .description("Jobs rejected due to concurrency limits")
                 .register(meterRegistry);
-        this.claimLatency = Timer.builder("agent.job.claim.latency")
+        this.claimLatency = Timer.builder(AgentMetrics.AGENT_JOB_CLAIM_LATENCY)
                 .description("Time between a job becoming available (available_at) and being claimed")
                 .register(meterRegistry);
-        this.infraRetryRequeued = Counter.builder("agent.job.infra.retry.requeued")
+        this.infraRetryRequeued = Counter.builder(AgentMetrics.AGENT_JOB_INFRA_RETRY_REQUEUED)
                 .description("Jobs requeued (not failed) after a classified sandbox-infrastructure failure")
                 .register(meterRegistry);
     }
@@ -640,7 +641,7 @@ public class AgentJobExecutor {
     }
 
     private void recordExecutionDuration(AgentJobType jobType, String outcome, Duration duration) {
-        Timer.builder("agent.job.execution.duration")
+        Timer.builder(AgentMetrics.AGENT_JOB_EXECUTION_DURATION)
                 .description("Total duration of agent job execution")
                 .tag("jobType", jobType != null ? jobType.name() : "unknown")
                 .tag("status", outcome)

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobRetentionService.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobRetentionService.java
@@ -1,5 +1,6 @@
 package de.tum.cit.aet.hephaestus.agent.job;
 
+import de.tum.cit.aet.hephaestus.agent.metrics.AgentMetrics;
 import de.tum.cit.aet.hephaestus.core.WorkspaceAgnostic;
 import de.tum.cit.aet.hephaestus.core.runtime.ConditionalOnServerRole;
 import io.micrometer.core.instrument.Counter;
@@ -49,10 +50,10 @@ public class AgentJobRetentionService {
         this.jobRepository = jobRepository;
         this.agentProperties = agentProperties;
         this.transactionTemplate = transactionTemplate;
-        this.stripped = Counter.builder("agent.job.retention.stripped")
+        this.stripped = Counter.builder(AgentMetrics.AGENT_JOB_RETENTION_STRIPPED)
                 .description("Terminal agent_job rows whose heavy payload columns were stripped to NULL")
                 .register(meterRegistry);
-        this.deleted = Counter.builder("agent.job.retention.deleted")
+        this.deleted = Counter.builder(AgentMetrics.AGENT_JOB_RETENTION_DELETED)
                 .description("Terminal agent_job rows deleted by the retention sweep")
                 .register(meterRegistry);
     }

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobZombieSweeper.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobZombieSweeper.java
@@ -1,6 +1,7 @@
 package de.tum.cit.aet.hephaestus.agent.job;
 
 import de.tum.cit.aet.hephaestus.agent.config.ConfigSnapshot;
+import de.tum.cit.aet.hephaestus.agent.metrics.AgentMetrics;
 import de.tum.cit.aet.hephaestus.agent.usage.LlmPriceSnapshot;
 import de.tum.cit.aet.hephaestus.agent.usage.LlmUsageRecorder;
 import de.tum.cit.aet.hephaestus.core.WorkspaceAgnostic;
@@ -91,19 +92,19 @@ public class AgentJobZombieSweeper {
         this.transactionTemplate = transactionTemplate;
         this.lifecycleService = lifecycleService;
         this.usageRecorder = usageRecorder;
-        this.zombieReaped = Counter.builder("agent.job.zombie.reaped")
+        this.zombieReaped = Counter.builder(AgentMetrics.AGENT_JOB_ZOMBIE_REAPED)
                 .description("Stale RUNNING jobs marked as TIMED_OUT")
                 .register(meterRegistry);
-        this.orphanRequeued = Counter.builder("agent.job.orphan.requeued")
+        this.orphanRequeued = Counter.builder(AgentMetrics.AGENT_JOB_ORPHAN_REQUEUED)
                 .description("RUNNING jobs whose owning worker was lost, requeued for another worker")
                 .register(meterRegistry);
-        this.orphanFailed = Counter.builder("agent.job.orphan.failed")
+        this.orphanFailed = Counter.builder(AgentMetrics.AGENT_JOB_ORPHAN_FAILED)
                 .description("Orphaned jobs that hit the retry cap and were failed")
                 .register(meterRegistry);
-        this.deliveryRecovered = Counter.builder("agent.job.delivery.recovered")
+        this.deliveryRecovered = Counter.builder(AgentMetrics.AGENT_JOB_DELIVERY_RECOVERED)
                 .description("Stuck PENDING deliveries successfully re-attempted by the recovery sweep")
                 .register(meterRegistry);
-        this.snapshotUnreadable = Counter.builder("agent.job.snapshot.unreadable")
+        this.snapshotUnreadable = Counter.builder(AgentMetrics.AGENT_JOB_SNAPSHOT_UNREADABLE)
                 .description("Terminal accounting events whose config snapshot could not be read; billed UNPRICED")
                 .register(meterRegistry);
     }

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/job/AgentQueueHealthSampler.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/job/AgentQueueHealthSampler.java
@@ -1,5 +1,6 @@
 package de.tum.cit.aet.hephaestus.agent.job;
 
+import de.tum.cit.aet.hephaestus.agent.metrics.AgentMetrics;
 import de.tum.cit.aet.hephaestus.core.WorkspaceAgnostic;
 import de.tum.cit.aet.hephaestus.core.runtime.ConditionalOnServerRole;
 import io.micrometer.core.instrument.Counter;
@@ -41,25 +42,25 @@ public class AgentQueueHealthSampler {
 
     public AgentQueueHealthSampler(AgentJobRepository jobRepository, MeterRegistry meterRegistry) {
         this.jobRepository = jobRepository;
-        Gauge.builder("agent.queue.depth", depth, AtomicLong::get)
+        Gauge.builder(AgentMetrics.AGENT_QUEUE_DEPTH, depth, AtomicLong::get)
                 .description(
                         "QUEUED jobs currently eligible to run (available_at <= now); last-good on sampler failure")
                 .register(meterRegistry);
-        Gauge.builder("agent.queue.oldest_age_seconds", oldestAgeSeconds, AtomicLong::get)
+        Gauge.builder(AgentMetrics.AGENT_QUEUE_OLDEST_AGE_SECONDS, oldestAgeSeconds, AtomicLong::get)
                 .description(
                         "Age in seconds of the oldest eligible QUEUED job; 0 when the queue is empty; last-good on sampler failure")
                 .register(meterRegistry);
         // Without this, a workspace over its monthly LLM cap is indistinguishable from an idle instance:
         // its whole backlog sits at available_at in the future, so agent.queue.depth reads 0 and the
         // "queue is backed up" alert stays silent while nothing runs. Alert on held > 0 sustained.
-        Gauge.builder("agent.queue.held", held, AtomicLong::get)
+        Gauge.builder(AgentMetrics.AGENT_QUEUE_HELD, held, AtomicLong::get)
                 .description(
                         "QUEUED jobs parked on an admin-undoable hold (monthly LLM cap); excluded from agent.queue.depth; last-good on sampler failure")
                 .register(meterRegistry);
-        Gauge.builder("agent.queue.running", running, AtomicLong::get)
+        Gauge.builder(AgentMetrics.AGENT_QUEUE_RUNNING, running, AtomicLong::get)
                 .description("Jobs currently RUNNING fleet-wide; last-good on sampler failure")
                 .register(meterRegistry);
-        this.samplerFailures = Counter.builder("agent.queue.health.sampler.failures")
+        this.samplerFailures = Counter.builder(AgentMetrics.AGENT_QUEUE_HEALTH_SAMPLER_FAILURES)
                 .description("Queue-health sample passes that failed (gauges kept their last-good value)")
                 .register(meterRegistry);
     }

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/job/WorkerLivenessReporter.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/job/WorkerLivenessReporter.java
@@ -1,5 +1,6 @@
 package de.tum.cit.aet.hephaestus.agent.job;
 
+import de.tum.cit.aet.hephaestus.agent.metrics.AgentMetrics;
 import de.tum.cit.aet.hephaestus.agent.runtime.worker.WorkerProperties;
 import de.tum.cit.aet.hephaestus.core.WorkspaceAgnostic;
 import de.tum.cit.aet.hephaestus.core.runtime.RuntimeRole;
@@ -58,7 +59,7 @@ public class WorkerLivenessReporter {
         this.transactionTemplate = transactionTemplate;
         this.interval = agentProperties.heartbeatInterval();
         this.workerId = workerProperties.resolvedWorkerId();
-        this.heartbeatFailures = Counter.builder("worker.liveness.heartbeat.failures")
+        this.heartbeatFailures = Counter.builder(AgentMetrics.WORKER_LIVENESS_HEARTBEAT_FAILURES)
                 .description("Failed worker_registry heartbeat writes (a stalled reporter risks false orphaning)")
                 .register(meterRegistry);
     }

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/mentor/chat/MentorChatMetrics.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/mentor/chat/MentorChatMetrics.java
@@ -1,5 +1,6 @@
 package de.tum.cit.aet.hephaestus.agent.mentor.chat;
 
+import de.tum.cit.aet.hephaestus.agent.metrics.AgentMetrics;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -59,15 +60,15 @@ public class MentorChatMetrics {
 
     public MentorChatMetrics(MeterRegistry registry) {
         this.registry = registry;
-        this.started = Counter.builder("mentor.turn.started")
+        this.started = Counter.builder(AgentMetrics.MENTOR_TURN_STARTED)
                 .description(
                         "Mentor chat turns observed at executor submit — increments on every dispatch, regardless of lock outcome.")
                 .register(registry);
-        this.duration = Timer.builder("mentor.turn.duration")
+        this.duration = Timer.builder(AgentMetrics.MENTOR_TURN_DURATION)
                 .description("Mentor chat turn wall-clock duration including sandbox attach + Pi RPC.")
                 .publishPercentileHistogram()
                 .register(registry);
-        this.costUsd = DistributionSummary.builder("mentor.turn.cost.usd")
+        this.costUsd = DistributionSummary.builder(AgentMetrics.MENTOR_TURN_COST_USD)
                 .description("Per-turn LLM cost in USD (skipped for turns where cost is unresolvable).")
                 .baseUnit("USD")
                 .register(registry);
@@ -78,7 +79,7 @@ public class MentorChatMetrics {
         for (Outcome o : Outcome.values()) {
             completedByOutcome.put(
                     o,
-                    Counter.builder("mentor.turn.completed")
+                    Counter.builder(AgentMetrics.MENTOR_TURN_COMPLETED)
                             .description("Mentor chat turns terminated, tagged by outcome.")
                             .tag("outcome", o.tag())
                             .register(registry));

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/metrics/AgentMetrics.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/metrics/AgentMetrics.java
@@ -1,0 +1,57 @@
+package de.tum.cit.aet.hephaestus.agent.metrics;
+
+public final class AgentMetrics {
+
+    public static final String AGENT_JOB_CLAIM_LATENCY = "agent.job.claim.latency";
+    public static final String AGENT_JOB_CONCURRENCY_REJECTED = "agent.job.concurrency.rejected";
+    public static final String AGENT_JOB_DELIVERY_RECOVERED = "agent.job.delivery.recovered";
+    public static final String AGENT_JOB_EXECUTION_DURATION = "agent.job.execution.duration";
+    public static final String AGENT_JOB_INFRA_RETRY_REQUEUED = "agent.job.infra.retry.requeued";
+    public static final String AGENT_JOB_ORPHAN_FAILED = "agent.job.orphan.failed";
+    public static final String AGENT_JOB_ORPHAN_REQUEUED = "agent.job.orphan.requeued";
+    public static final String AGENT_JOB_RETENTION_DELETED = "agent.job.retention.deleted";
+    public static final String AGENT_JOB_RETENTION_STRIPPED = "agent.job.retention.stripped";
+    public static final String AGENT_JOB_SNAPSHOT_UNREADABLE = "agent.job.snapshot.unreadable";
+    public static final String AGENT_JOB_ZOMBIE_REAPED = "agent.job.zombie.reaped";
+    public static final String AGENT_QUEUE_DEPTH = "agent.queue.depth";
+    public static final String AGENT_QUEUE_HEALTH_SAMPLER_FAILURES = "agent.queue.health.sampler.failures";
+    public static final String AGENT_QUEUE_HELD = "agent.queue.held";
+    public static final String AGENT_QUEUE_OLDEST_AGE_SECONDS = "agent.queue.oldest_age_seconds";
+    public static final String AGENT_QUEUE_RUNNING = "agent.queue.running";
+    public static final String AGENT_REVIEW_PRACTICE_COVERAGE_ELIGIBLE = "agent.review.practice.coverage.eligible";
+    public static final String AGENT_REVIEW_PRACTICE_COVERAGE_EVALUATED = "agent.review.practice.coverage.evaluated";
+    public static final String AGENT_REVIEW_PRACTICE_COVERAGE_RATIO = "agent.review.practice.coverage.ratio";
+    public static final String LLM_PROXY_DURATION = "llm.proxy.duration";
+    public static final String MENTOR_ATTACH_DURATION = "mentor.attach.duration";
+    public static final String MENTOR_ATTACH_FAILURE = "mentor.attach.failure";
+    public static final String MENTOR_FRAME_PARSE_ERROR = "mentor.frame.parse.error";
+    public static final String MENTOR_RING_BUFFER_DROPPED = "mentor.ring.buffer.dropped";
+    public static final String MENTOR_SEND_FRAME_BYTES = "mentor.send.frame.bytes";
+    public static final String MENTOR_SEND_REJECTED = "mentor.send.rejected";
+    public static final String MENTOR_SESSION_ACTIVE = "mentor.session.active";
+    public static final String MENTOR_SESSION_EVICTION = "mentor.session.eviction";
+    public static final String MENTOR_SESSION_LIFETIME = "mentor.session.lifetime";
+    public static final String MENTOR_SESSION_SUBSCRIBERS_AT_CLOSE = "mentor.session.subscribers.at.close";
+    public static final String MENTOR_SUBSCRIBER_DROPPED = "mentor.subscriber.dropped";
+    public static final String MENTOR_SUBSCRIBER_ERROR = "mentor.subscriber.error";
+    public static final String MENTOR_TURN_COMPLETED = "mentor.turn.completed";
+    public static final String MENTOR_TURN_COST_USD = "mentor.turn.cost.usd";
+    public static final String MENTOR_TURN_DURATION = "mentor.turn.duration";
+    public static final String MENTOR_TURN_STARTED = "mentor.turn.started";
+    public static final String SANDBOX_EXECUTIONS = "sandbox.executions";
+    public static final String SANDBOX_EXECUTION_DURATION = "sandbox.execution.duration";
+    public static final String SANDBOX_RECONCILER_DURATION = "sandbox.reconciler.duration";
+    public static final String SANDBOX_RECONCILER_ORPHANED = "sandbox.reconciler.orphaned";
+    public static final String SANDBOX_RECONCILER_SWEEPS = "sandbox.reconciler.sweeps";
+    public static final String WORKER_CONTROL_CHANNEL_CONNECTED = "worker.control.channel.connected";
+    public static final String WORKER_CONTROL_FRAMES_DROPPED = "worker.control.frames.dropped";
+    public static final String WORKER_CONTROL_FRAMES_RECEIVED = "worker.control.frames.received";
+    public static final String WORKER_CONTROL_FRAMES_SENT = "worker.control.frames.sent";
+    public static final String WORKER_CONTROL_RECONNECTS = "worker.control.reconnects";
+    public static final String WORKER_DRAIN_ACTIVE = "worker.drain.active";
+    public static final String WORKER_HEARTBEATS_FAILED = "worker.heartbeats.failed";
+    public static final String WORKER_HEARTBEATS_SENT = "worker.heartbeats.sent";
+    public static final String WORKER_LIVENESS_HEARTBEAT_FAILURES = "worker.liveness.heartbeat.failures";
+
+    private AgentMetrics() {}
+}

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/metrics/package-info.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/metrics/package-info.java
@@ -1,0 +1,2 @@
+@org.jspecify.annotations.NullMarked
+package de.tum.cit.aet.hephaestus.agent.metrics;

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/proxy/ProxyAccounting.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/proxy/ProxyAccounting.java
@@ -1,5 +1,6 @@
 package de.tum.cit.aet.hephaestus.agent.proxy;
 
+import de.tum.cit.aet.hephaestus.agent.metrics.AgentMetrics;
 import de.tum.cit.aet.hephaestus.core.runtime.RuntimeRole;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
@@ -99,7 +100,7 @@ public class ProxyAccounting {
     }
 
     public void stopTimer(Timer.Sample sample, String apiProtocol) {
-        sample.stop(Timer.builder("llm.proxy.duration")
+        sample.stop(Timer.builder(AgentMetrics.LLM_PROXY_DURATION)
                 .description("LLM proxy request duration")
                 .tag("apiProtocol", apiProtocol)
                 .register(meterRegistry));

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/runtime/PiResultParser.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/runtime/PiResultParser.java
@@ -1,5 +1,6 @@
 package de.tum.cit.aet.hephaestus.agent.runtime;
 
+import de.tum.cit.aet.hephaestus.agent.metrics.AgentMetrics;
 import de.tum.cit.aet.hephaestus.agent.sandbox.spi.SandboxResult;
 import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -43,13 +44,13 @@ public class PiResultParser {
     public PiResultParser(ObjectMapper objectMapper, MeterRegistry meterRegistry) {
         this.objectMapper = objectMapper;
         this.meterRegistry = meterRegistry;
-        this.eligiblePractices = DistributionSummary.builder("agent.review.practice.coverage.eligible")
+        this.eligiblePractices = DistributionSummary.builder(AgentMetrics.AGENT_REVIEW_PRACTICE_COVERAGE_ELIGIBLE)
                 .description("Eligible practices per review run.")
                 .register(meterRegistry);
-        this.evaluatedPractices = DistributionSummary.builder("agent.review.practice.coverage.evaluated")
+        this.evaluatedPractices = DistributionSummary.builder(AgentMetrics.AGENT_REVIEW_PRACTICE_COVERAGE_EVALUATED)
                 .description("Evaluated practices per review run.")
                 .register(meterRegistry);
-        this.practiceCoverageRatio = DistributionSummary.builder("agent.review.practice.coverage.ratio")
+        this.practiceCoverageRatio = DistributionSummary.builder(AgentMetrics.AGENT_REVIEW_PRACTICE_COVERAGE_RATIO)
                 .description("Fraction of eligible practices evaluated per review run.")
                 .maximumExpectedValue(1.0)
                 .register(meterRegistry);

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/runtime/worker/WorkerCapacityReporter.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/runtime/worker/WorkerCapacityReporter.java
@@ -1,5 +1,6 @@
 package de.tum.cit.aet.hephaestus.agent.runtime.worker;
 
+import de.tum.cit.aet.hephaestus.agent.metrics.AgentMetrics;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import jakarta.annotation.PreDestroy;
@@ -39,10 +40,10 @@ public class WorkerCapacityReporter {
         this.client = client;
         this.interval = properties.heartbeat().interval();
         this.scheduler = workerScheduler;
-        this.sent = Counter.builder("worker.heartbeats.sent")
+        this.sent = Counter.builder(AgentMetrics.WORKER_HEARTBEATS_SENT)
                 .description("Worker → hub CapacityReport frames sent")
                 .register(meterRegistry);
-        this.failed = Counter.builder("worker.heartbeats.failed")
+        this.failed = Counter.builder(AgentMetrics.WORKER_HEARTBEATS_FAILED)
                 .description("Worker → hub CapacityReport sends that threw")
                 .register(meterRegistry);
     }

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/runtime/worker/WorkerConfiguration.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/runtime/worker/WorkerConfiguration.java
@@ -1,6 +1,7 @@
 package de.tum.cit.aet.hephaestus.agent.runtime.worker;
 
 import de.tum.cit.aet.hephaestus.agent.job.AgentJobExecutor;
+import de.tum.cit.aet.hephaestus.agent.metrics.AgentMetrics;
 import de.tum.cit.aet.hephaestus.core.runtime.RuntimeRole;
 import de.tum.cit.aet.hephaestus.core.runtime.worker.protocol.FrameCodec;
 import io.micrometer.core.instrument.Gauge;
@@ -99,7 +100,7 @@ public class WorkerConfiguration {
             ObjectMapper objectMapper,
             MeterRegistry meterRegistry) {
         WorkerControlClient client = new WorkerControlClient(properties, frameCodec, objectMapper, meterRegistry);
-        Gauge.builder("worker.control.channel.connected", client, c -> c.isConnected() ? 1.0 : 0.0)
+        Gauge.builder(AgentMetrics.WORKER_CONTROL_CHANNEL_CONNECTED, client, c -> c.isConnected() ? 1.0 : 0.0)
                 .description("1 when the worker control channel is connected, 0 otherwise")
                 .strongReference(true)
                 .register(meterRegistry);

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/runtime/worker/WorkerControlClient.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/runtime/worker/WorkerControlClient.java
@@ -1,5 +1,6 @@
 package de.tum.cit.aet.hephaestus.agent.runtime.worker;
 
+import de.tum.cit.aet.hephaestus.agent.metrics.AgentMetrics;
 import de.tum.cit.aet.hephaestus.core.runtime.worker.protocol.CancelJob;
 import de.tum.cit.aet.hephaestus.core.runtime.worker.protocol.CapacityReport;
 import de.tum.cit.aet.hephaestus.core.runtime.worker.protocol.ForceReconnect;
@@ -93,16 +94,16 @@ public class WorkerControlClient {
         this.objectMapper = objectMapper;
         this.httpClient =
                 HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(10)).build();
-        this.framesSent = Counter.builder("worker.control.frames.sent")
+        this.framesSent = Counter.builder(AgentMetrics.WORKER_CONTROL_FRAMES_SENT)
                 .description("WSS frames written to the hub")
                 .register(meterRegistry);
-        this.framesReceived = Counter.builder("worker.control.frames.received")
+        this.framesReceived = Counter.builder(AgentMetrics.WORKER_CONTROL_FRAMES_RECEIVED)
                 .description("WSS frames decoded from the hub")
                 .register(meterRegistry);
-        this.sendDropped = Counter.builder("worker.control.frames.dropped")
+        this.sendDropped = Counter.builder(AgentMetrics.WORKER_CONTROL_FRAMES_DROPPED)
                 .description("Outbound frames dropped (queue full or transport closed)")
                 .register(meterRegistry);
-        this.reconnects = Counter.builder("worker.control.reconnects")
+        this.reconnects = Counter.builder(AgentMetrics.WORKER_CONTROL_RECONNECTS)
                 .description("Reconnection attempts after a connect/handshake failure")
                 .register(meterRegistry);
     }

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/runtime/worker/WorkerDrainCoordinator.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/runtime/worker/WorkerDrainCoordinator.java
@@ -2,6 +2,7 @@ package de.tum.cit.aet.hephaestus.agent.runtime.worker;
 
 import de.tum.cit.aet.hephaestus.agent.job.AgentJobCancellationReason;
 import de.tum.cit.aet.hephaestus.agent.job.AgentJobExecutor;
+import de.tum.cit.aet.hephaestus.agent.metrics.AgentMetrics;
 import de.tum.cit.aet.hephaestus.core.runtime.worker.protocol.CapacityReport;
 import de.tum.cit.aet.hephaestus.core.runtime.worker.protocol.Heartbeat;
 import de.tum.cit.aet.hephaestus.core.runtime.worker.protocol.WorkerControlFrame;
@@ -54,7 +55,7 @@ public class WorkerDrainCoordinator implements SmartLifecycle {
         this.properties = properties;
         this.executor = executor;
         this.events = events;
-        Gauge.builder("worker.drain.active", draining, b -> b.get() ? 1.0 : 0.0)
+        Gauge.builder(AgentMetrics.WORKER_DRAIN_ACTIVE, draining, b -> b.get() ? 1.0 : 0.0)
                 .description("1 while the worker is draining, 0 otherwise")
                 .register(meterRegistry);
     }

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/DockerSandboxAdapter.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/DockerSandboxAdapter.java
@@ -1,5 +1,6 @@
 package de.tum.cit.aet.hephaestus.agent.sandbox.docker;
 
+import de.tum.cit.aet.hephaestus.agent.metrics.AgentMetrics;
 import de.tum.cit.aet.hephaestus.agent.sandbox.SandboxProperties;
 import de.tum.cit.aet.hephaestus.agent.sandbox.spi.SandboxCancelledException;
 import de.tum.cit.aet.hephaestus.agent.sandbox.spi.SandboxException;
@@ -122,24 +123,24 @@ public class DockerSandboxAdapter implements SandboxManager {
         this.properties = properties;
         this.serverPort = serverPort;
 
-        this.executionsSuccess = Counter.builder("sandbox.executions")
+        this.executionsSuccess = Counter.builder(AgentMetrics.SANDBOX_EXECUTIONS)
                 .tag("outcome", "success")
                 .description("Successful sandbox executions")
                 .register(meterRegistry);
-        this.executionsFailed = Counter.builder("sandbox.executions")
+        this.executionsFailed = Counter.builder(AgentMetrics.SANDBOX_EXECUTIONS)
                 .tag("outcome", "failure")
                 .description("Failed sandbox executions")
                 .register(meterRegistry);
-        this.executionsTimedOut = Counter.builder("sandbox.executions")
+        this.executionsTimedOut = Counter.builder(AgentMetrics.SANDBOX_EXECUTIONS)
                 .tag("outcome", "timeout")
                 .description("Timed-out sandbox executions")
                 .register(meterRegistry);
-        this.executionsCancelled = Counter.builder("sandbox.executions")
+        this.executionsCancelled = Counter.builder(AgentMetrics.SANDBOX_EXECUTIONS)
                 .tag("outcome", "cancelled")
                 .description("Cancelled sandbox executions")
                 .register(meterRegistry);
         this.meterRegistry = meterRegistry;
-        this.executionDuration = Timer.builder("sandbox.execution.duration")
+        this.executionDuration = Timer.builder(AgentMetrics.SANDBOX_EXECUTION_DURATION)
                 .description("Duration of sandbox executions")
                 .register(meterRegistry);
 

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/SandboxReconciler.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/SandboxReconciler.java
@@ -3,6 +3,7 @@ package de.tum.cit.aet.hephaestus.agent.sandbox.docker;
 import de.tum.cit.aet.hephaestus.agent.job.AgentJob;
 import de.tum.cit.aet.hephaestus.agent.job.AgentJobRepository;
 import de.tum.cit.aet.hephaestus.agent.job.AgentJobStatus;
+import de.tum.cit.aet.hephaestus.agent.metrics.AgentMetrics;
 import de.tum.cit.aet.hephaestus.core.WorkspaceAgnostic;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -68,23 +69,23 @@ public class SandboxReconciler {
         this.containerManager = containerManager;
         this.networkManager = networkManager;
         this.clock = clock;
-        this.orphanedContainers = Counter.builder("sandbox.reconciler.orphaned")
+        this.orphanedContainers = Counter.builder(AgentMetrics.SANDBOX_RECONCILER_ORPHANED)
                 .tag("resource", "container")
                 .description("Orphaned containers removed")
                 .register(meterRegistry);
-        this.orphanedNetworks = Counter.builder("sandbox.reconciler.orphaned")
+        this.orphanedNetworks = Counter.builder(AgentMetrics.SANDBOX_RECONCILER_ORPHANED)
                 .tag("resource", "network")
                 .description("Orphaned networks removed")
                 .register(meterRegistry);
-        this.completedSweeps = Counter.builder("sandbox.reconciler.sweeps")
+        this.completedSweeps = Counter.builder(AgentMetrics.SANDBOX_RECONCILER_SWEEPS)
                 .tag("outcome", "completed")
                 .description("Reconciliation sweeps that ran to completion")
                 .register(meterRegistry);
-        this.skippedSweeps = Counter.builder("sandbox.reconciler.sweeps")
+        this.skippedSweeps = Counter.builder(AgentMetrics.SANDBOX_RECONCILER_SWEEPS)
                 .tag("outcome", "skipped")
                 .description("Reconciliation sweeps skipped because an inventory they depend on was unreadable")
                 .register(meterRegistry);
-        this.reconciliationDuration = Timer.builder("sandbox.reconciler.duration")
+        this.reconciliationDuration = Timer.builder(AgentMetrics.SANDBOX_RECONCILER_DURATION)
                 .description("Duration of periodic reconciliation sweeps")
                 .register(meterRegistry);
     }

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/interactive/InteractiveSandboxMetrics.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/interactive/InteractiveSandboxMetrics.java
@@ -1,5 +1,6 @@
 package de.tum.cit.aet.hephaestus.agent.sandbox.docker.interactive;
 
+import de.tum.cit.aet.hephaestus.agent.metrics.AgentMetrics;
 import de.tum.cit.aet.hephaestus.agent.sandbox.spi.EvictionReason;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.DistributionSummary;
@@ -55,15 +56,15 @@ public final class InteractiveSandboxMetrics {
         this.attachFailureMaxSessions = attachFailure(registry, "max_sessions");
         this.attachFailureOther = attachFailure(registry, "other");
 
-        this.attachDuration = Timer.builder("mentor.attach.duration")
+        this.attachDuration = Timer.builder(AgentMetrics.MENTOR_ATTACH_DURATION)
                 .description("Time from container spawn to first JSONL frame received from runner")
                 .register(registry);
 
-        this.sendBytes = Counter.builder("mentor.send.frame.bytes")
+        this.sendBytes = Counter.builder(AgentMetrics.MENTOR_SEND_FRAME_BYTES)
                 .tag("direction", "in")
                 .description("Bytes sent to runner stdin (UTF-8 encoded JSONL including the newline terminator)")
                 .register(registry);
-        this.recvBytes = Counter.builder("mentor.send.frame.bytes")
+        this.recvBytes = Counter.builder(AgentMetrics.MENTOR_SEND_FRAME_BYTES)
                 .tag("direction", "out")
                 .description("Bytes received from runner stdout (UTF-8 encoded JSONL line, no terminator)")
                 .register(registry);
@@ -73,28 +74,28 @@ public final class InteractiveSandboxMetrics {
         this.sendRejectedBrokenPipe = sendRejected(registry, "broken_pipe");
         this.sendRejectedClosed = sendRejected(registry, "closed");
 
-        this.ringBufferDropped = Counter.builder("mentor.ring.buffer.dropped")
+        this.ringBufferDropped = Counter.builder(AgentMetrics.MENTOR_RING_BUFFER_DROPPED)
                 .description("Frames evicted from the per-session ring buffer (drop-oldest on overflow)")
                 .register(registry);
 
-        this.subscriberDropped = Counter.builder("mentor.subscriber.dropped")
+        this.subscriberDropped = Counter.builder(AgentMetrics.MENTOR_SUBSCRIBER_DROPPED)
                 .tag("reason", "queue_full")
                 .description("Frames dropped from a subscriber's bounded queue due to slow listener")
                 .register(registry);
-        this.subscriberError = Counter.builder("mentor.subscriber.error")
+        this.subscriberError = Counter.builder(AgentMetrics.MENTOR_SUBSCRIBER_ERROR)
                 .description("Subscriber listener invocations that threw")
                 .register(registry);
 
-        this.frameParseError = Counter.builder("mentor.frame.parse.error")
+        this.frameParseError = Counter.builder(AgentMetrics.MENTOR_FRAME_PARSE_ERROR)
                 .description("JSONL frames that failed to parse (skipped, session continues)")
                 .register(registry);
 
         // Per-session counters / timers / gauges share the mentor.session.* stem.
-        this.lifetime = Timer.builder("mentor.session.lifetime")
+        this.lifetime = Timer.builder(AgentMetrics.MENTOR_SESSION_LIFETIME)
                 .description("End-to-end session lifetime (attach to close)")
                 .register(registry);
 
-        this.subscribersAtClose = DistributionSummary.builder("mentor.session.subscribers.at.close")
+        this.subscribersAtClose = DistributionSummary.builder(AgentMetrics.MENTOR_SESSION_SUBSCRIBERS_AT_CLOSE)
                 .description("Subscriber count observed at session close")
                 .register(registry);
 
@@ -102,7 +103,7 @@ public final class InteractiveSandboxMetrics {
         for (EvictionReason r : EvictionReason.values()) {
             evictionsByReason.put(
                     r,
-                    Counter.builder("mentor.session.eviction")
+                    Counter.builder(AgentMetrics.MENTOR_SESSION_EVICTION)
                             .tag("reason", r.tag())
                             .description("Session evictions by reason (covers all termination causes)")
                             .register(registry));
@@ -114,14 +115,14 @@ public final class InteractiveSandboxMetrics {
     }
 
     private static Counter attachFailure(MeterRegistry registry, String reason) {
-        return Counter.builder("mentor.attach.failure")
+        return Counter.builder(AgentMetrics.MENTOR_ATTACH_FAILURE)
                 .tag("reason", reason)
                 .description("attach() failures by reason")
                 .register(registry);
     }
 
     private static Counter sendRejected(MeterRegistry registry, String reason) {
-        return Counter.builder("mentor.send.rejected")
+        return Counter.builder(AgentMetrics.MENTOR_SEND_REJECTED)
                 .tag("reason", reason)
                 .description("send() rejections by reason")
                 .register(registry);

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/interactive/InteractiveSandboxRegistry.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/interactive/InteractiveSandboxRegistry.java
@@ -1,5 +1,6 @@
 package de.tum.cit.aet.hephaestus.agent.sandbox.docker.interactive;
 
+import de.tum.cit.aet.hephaestus.agent.metrics.AgentMetrics;
 import de.tum.cit.aet.hephaestus.agent.sandbox.InteractiveSandboxProperties;
 import de.tum.cit.aet.hephaestus.agent.sandbox.docker.DockerOperations;
 import de.tum.cit.aet.hephaestus.agent.sandbox.docker.SandboxContainerManager;
@@ -55,7 +56,7 @@ public class InteractiveSandboxRegistry {
         this.containerManager = containerManager;
         this.metrics = metrics;
         this.watchdog = watchdog;
-        Gauge.builder("mentor.session.active", sessions, ConcurrentHashMap::size)
+        Gauge.builder(AgentMetrics.MENTOR_SESSION_ACTIVE, sessions, ConcurrentHashMap::size)
                 .description("Currently attached mentor sandbox sessions on this replica")
                 .register(meterRegistry);
         meterRegistry.gauge("mentor.watchdog.targets", Tags.empty(), watchdog, StdinWriteWatchdog::activeTargets);

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/auth/jwt/IssuedJwtCleanupJob.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/auth/jwt/IssuedJwtCleanupJob.java
@@ -1,6 +1,7 @@
 package de.tum.cit.aet.hephaestus.core.auth.jwt;
 
 import de.tum.cit.aet.hephaestus.core.WorkspaceAgnostic;
+import de.tum.cit.aet.hephaestus.core.metrics.CoreMetrics;
 import de.tum.cit.aet.hephaestus.core.runtime.ConditionalOnServerRole;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -36,7 +37,7 @@ public class IssuedJwtCleanupJob {
     public IssuedJwtCleanupJob(IssuedJwtRepository repository, Clock clock, MeterRegistry meterRegistry) {
         this.repository = repository;
         this.clock = clock;
-        this.prunedCounter = Counter.builder("auth.issued_jwt.pruned")
+        this.prunedCounter = Counter.builder(CoreMetrics.AUTH_ISSUED_JWT_PRUNED)
                 .description("Expired issued_jwt revocation rows physically removed by the daily sweep")
                 .register(meterRegistry);
     }

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/auth/metrics/AuthMetrics.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/auth/metrics/AuthMetrics.java
@@ -1,5 +1,6 @@
 package de.tum.cit.aet.hephaestus.core.auth.metrics;
 
+import de.tum.cit.aet.hephaestus.core.metrics.CoreMetrics;
 import de.tum.cit.aet.hephaestus.core.runtime.ConditionalOnServerRole;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -35,7 +36,6 @@ import org.springframework.stereotype.Component;
 @Component
 public class AuthMetrics {
 
-    /** Outcome tagged on {@code auth.login}. Fixed set → bounded cardinality. */
     public enum LoginResult {
         SUCCESS("success"),
         FAILURE("failure");
@@ -59,13 +59,9 @@ public class AuthMetrics {
      * without inferring it from latency. Fixed set → bounded cardinality.
      */
     public enum RefreshResult {
-        /** A fresh access token was minted and set on the cookie. */
         SUCCESS("success"),
-        /** Conditional revoke affected 0 rows (a concurrent refresh/logout already rotated the jti). */
         NOOP("noop"),
-        /** Account was not ACTIVE (SUSPENDED / DELETING / DELETED / missing) — session ended, no re-mint. */
         SUSPENDED("suspended"),
-        /** The rotation threw after the presenting token was revoked (re-mint / cookie failure). */
         ERROR("error");
 
         private final String tag;
@@ -98,7 +94,7 @@ public class AuthMetrics {
         this.registry = registry;
         this.loginSuccess = login(registry, LoginResult.SUCCESS);
         this.loginFailure = login(registry, LoginResult.FAILURE);
-        this.tokenRefresh = Timer.builder("auth.token.refresh")
+        this.tokenRefresh = Timer.builder(CoreMetrics.AUTH_TOKEN_REFRESH)
                 .description("Wall-clock latency of the access-token rotation in AuthSessionService.refresh.")
                 .publishPercentileHistogram()
                 .register(registry);

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/metrics/CoreMetrics.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/metrics/CoreMetrics.java
@@ -1,0 +1,11 @@
+package de.tum.cit.aet.hephaestus.core.metrics;
+
+public final class CoreMetrics {
+
+    public static final String AUTH_ISSUED_JWT_PRUNED = "auth.issued_jwt.pruned";
+    public static final String AUTH_TOKEN_REFRESH = "auth.token.refresh";
+    public static final String TENANCY_PARSE_FAILURE_TOTAL = "tenancy.parse_failure.total";
+    public static final String WORKER_HUB_SESSIONS_ACTIVE = "worker.hub.sessions.active";
+
+    private CoreMetrics() {}
+}

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/metrics/package-info.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/metrics/package-info.java
@@ -1,0 +1,2 @@
+@org.jspecify.annotations.NullMarked
+package de.tum.cit.aet.hephaestus.core.metrics;

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/runtime/hub/WorkerSessionRegistry.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/runtime/hub/WorkerSessionRegistry.java
@@ -1,5 +1,6 @@
 package de.tum.cit.aet.hephaestus.core.runtime.hub;
 
+import de.tum.cit.aet.hephaestus.core.metrics.CoreMetrics;
 import de.tum.cit.aet.hephaestus.core.runtime.worker.protocol.ForceReconnect;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -32,7 +33,7 @@ public class WorkerSessionRegistry implements SmartLifecycle {
 
     public WorkerSessionRegistry(ApplicationEventPublisher events, MeterRegistry meterRegistry) {
         this.events = events;
-        Gauge.builder("worker.hub.sessions.active", byWorkerId, ConcurrentHashMap::size)
+        Gauge.builder(CoreMetrics.WORKER_HUB_SESSIONS_ACTIVE, byWorkerId, ConcurrentHashMap::size)
                 .description("Active worker WSS connections registered on this app-pod")
                 .register(meterRegistry);
     }

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/tenancy/TenancyConfiguration.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/tenancy/TenancyConfiguration.java
@@ -1,6 +1,7 @@
 package de.tum.cit.aet.hephaestus.core.tenancy;
 
 import de.tum.cit.aet.hephaestus.core.LoggingUtils;
+import de.tum.cit.aet.hephaestus.core.metrics.CoreMetrics;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.hibernate.cfg.AvailableSettings;
@@ -24,7 +25,7 @@ public class TenancyConfiguration {
 
     @Bean
     Counter tenancyParseFailureCounter(MeterRegistry registry) {
-        return Counter.builder("tenancy.parse_failure.total")
+        return Counter.builder(CoreMetrics.TENANCY_PARSE_FAILURE_TOTAL)
                 .description("SQL statements WorkspaceStatementInspector could not parse — fail-open.")
                 .tag("module", "tenancy")
                 .register(registry);

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/evidence/internal/ArtifactSourceGovernanceMetrics.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/evidence/internal/ArtifactSourceGovernanceMetrics.java
@@ -1,6 +1,7 @@
 package de.tum.cit.aet.hephaestus.evidence.internal;
 
 import de.tum.cit.aet.hephaestus.evidence.ArtifactSourceCatalogRegistry;
+import de.tum.cit.aet.hephaestus.evidence.metrics.EvidenceMetrics;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Clock;
@@ -13,7 +14,7 @@ final class ArtifactSourceGovernanceMetrics {
     ArtifactSourceGovernanceMetrics(
             ArtifactSourceCatalogRegistry sourceCatalogs, Clock clock, MeterRegistry meterRegistry) {
         Gauge.builder(
-                        "artifact.source.governance.expiry.seconds",
+                        EvidenceMetrics.ARTIFACT_SOURCE_GOVERNANCE_EXPIRY_SECONDS,
                         sourceCatalogs,
                         catalogs -> catalogs.earliestUseDecisionExpiry(null)
                                 .map(expiry -> (double) Duration.between(clock.instant(), expiry)

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/evidence/metrics/EvidenceMetrics.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/evidence/metrics/EvidenceMetrics.java
@@ -1,0 +1,8 @@
+package de.tum.cit.aet.hephaestus.evidence.metrics;
+
+public final class EvidenceMetrics {
+
+    public static final String ARTIFACT_SOURCE_GOVERNANCE_EXPIRY_SECONDS = "artifact.source.governance.expiry.seconds";
+
+    private EvidenceMetrics() {}
+}

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/evidence/metrics/package-info.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/evidence/metrics/package-info.java
@@ -1,0 +1,2 @@
+@org.jspecify.annotations.NullMarked
+package de.tum.cit.aet.hephaestus.evidence.metrics;

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/core/metrics/IntegrationCoreMetrics.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/core/metrics/IntegrationCoreMetrics.java
@@ -1,0 +1,17 @@
+package de.tum.cit.aet.hephaestus.integration.core.metrics;
+
+public final class IntegrationCoreMetrics {
+
+    public static final String INTEGRATION_SYNC_PUSH_MESSAGES = "integration.sync.push.messages";
+    public static final String INTEGRATION_SYNC_SSE_SUBSCRIBERS = "integration.sync.sse.subscribers";
+    public static final String OAUTH_STATE_NONCE_PRUNED = "oauth.state.nonce.pruned";
+    public static final String WEBHOOK_PUBLISH = "webhook.publish";
+    public static final String WEBHOOK_PUBLISH_RETRY = "webhook.publish.retry";
+    public static final String WEBHOOK_REJECTED = "webhook.rejected";
+    public static final String WEBHOOK_STREAM_OLDEST_MESSAGE_AGE = "webhook.stream.oldest.message.age";
+    public static final String WEBHOOK_STREAM_POLL_AGE = "webhook.stream.poll.age";
+    public static final String WEBHOOK_STREAM_UNACKNOWLEDGED_DELETIONS = "webhook.stream.unacknowledged.deletions";
+    public static final String WEBHOOK_STREAM_UNACKNOWLEDGED_GAP = "webhook.stream.unacknowledged.gap";
+
+    private IntegrationCoreMetrics() {}
+}

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/core/metrics/package-info.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/core/metrics/package-info.java
@@ -1,0 +1,2 @@
+@org.jspecify.annotations.NullMarked
+package de.tum.cit.aet.hephaestus.integration.core.metrics;

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/core/oauth/state/OAuthStateNonceCleanupJob.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/core/oauth/state/OAuthStateNonceCleanupJob.java
@@ -2,6 +2,7 @@ package de.tum.cit.aet.hephaestus.integration.core.oauth.state;
 
 import de.tum.cit.aet.hephaestus.core.WorkspaceAgnostic;
 import de.tum.cit.aet.hephaestus.core.runtime.ConditionalOnServerRole;
+import de.tum.cit.aet.hephaestus.integration.core.metrics.IntegrationCoreMetrics;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Duration;
@@ -46,7 +47,7 @@ public class OAuthStateNonceCleanupJob {
             OAuthStateNonceRepository repository, @Nullable Duration retention, MeterRegistry meterRegistry) {
         this.repository = repository;
         this.retention = retention == null ? Duration.ofDays(7) : retention;
-        this.prunedCounter = Counter.builder("oauth.state.nonce.pruned")
+        this.prunedCounter = Counter.builder(IntegrationCoreMetrics.OAUTH_STATE_NONCE_PRUNED)
                 .description("Number of OAuth state nonces pruned by the daily sweep")
                 .register(meterRegistry);
     }

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/core/sync/push/SyncEventHub.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/core/sync/push/SyncEventHub.java
@@ -2,6 +2,7 @@ package de.tum.cit.aet.hephaestus.integration.core.sync.push;
 
 import de.tum.cit.aet.hephaestus.core.WorkspaceAgnostic;
 import de.tum.cit.aet.hephaestus.core.runtime.ConditionalOnServerRole;
+import de.tum.cit.aet.hephaestus.integration.core.metrics.IntegrationCoreMetrics;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -92,7 +93,7 @@ public class SyncEventHub {
         this.eventsDelivered = counter(meterRegistry, "integration.sync.sse.events", "delivered");
         this.eventsDropped = counter(meterRegistry, "integration.sync.sse.events", "dropped");
         this.eventsFailed = counter(meterRegistry, "integration.sync.sse.events", "error");
-        Gauge.builder("integration.sync.sse.subscribers", this, SyncEventHub::totalSubscriberCount)
+        Gauge.builder(IntegrationCoreMetrics.INTEGRATION_SYNC_SSE_SUBSCRIBERS, this, SyncEventHub::totalSubscriberCount)
                 .description("Currently active sync-observability SSE subscribers on this server replica")
                 .register(meterRegistry);
     }

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/core/sync/push/SyncPushService.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/core/sync/push/SyncPushService.java
@@ -2,6 +2,7 @@ package de.tum.cit.aet.hephaestus.integration.core.sync.push;
 
 import de.tum.cit.aet.hephaestus.core.runtime.ConditionalOnServerRole;
 import de.tum.cit.aet.hephaestus.integration.core.events.ConnectionLifecycleEvent;
+import de.tum.cit.aet.hephaestus.integration.core.metrics.IntegrationCoreMetrics;
 import de.tum.cit.aet.hephaestus.integration.core.sync.SyncStateChangedEvent;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -155,7 +156,7 @@ public class SyncPushService {
     }
 
     private static Counter counter(MeterRegistry meterRegistry, String transport, String outcome) {
-        return Counter.builder("integration.sync.push.messages")
+        return Counter.builder(IntegrationCoreMetrics.INTEGRATION_SYNC_PUSH_MESSAGES)
                 .description("Sync invalidation messages by transport boundary and outcome")
                 .tag("transport", transport)
                 .tag("outcome", outcome)

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/core/webhook/JetStreamPublisher.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/core/webhook/JetStreamPublisher.java
@@ -1,6 +1,7 @@
 package de.tum.cit.aet.hephaestus.integration.core.webhook;
 
 import de.tum.cit.aet.hephaestus.core.webhook.WebhookProperties;
+import de.tum.cit.aet.hephaestus.integration.core.metrics.IntegrationCoreMetrics;
 import io.github.resilience4j.retry.Retry;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -42,11 +43,14 @@ public class JetStreamPublisher {
         this.jetStream = jetStream;
         this.retry = retry;
         this.properties = properties;
-        this.successCounter =
-                Counter.builder("webhook.publish").tag("outcome", "success").register(meterRegistry);
-        this.failureCounter =
-                Counter.builder("webhook.publish").tag("outcome", "failure").register(meterRegistry);
-        this.retryCounter = Counter.builder("webhook.publish.retry").register(meterRegistry);
+        this.successCounter = Counter.builder(IntegrationCoreMetrics.WEBHOOK_PUBLISH)
+                .tag("outcome", "success")
+                .register(meterRegistry);
+        this.failureCounter = Counter.builder(IntegrationCoreMetrics.WEBHOOK_PUBLISH)
+                .tag("outcome", "failure")
+                .register(meterRegistry);
+        this.retryCounter =
+                Counter.builder(IntegrationCoreMetrics.WEBHOOK_PUBLISH_RETRY).register(meterRegistry);
         retry.getEventPublisher().onRetry(event -> retryCounter.increment());
     }
 

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/core/webhook/WebhookPayloadSizeFilter.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/core/webhook/WebhookPayloadSizeFilter.java
@@ -1,6 +1,7 @@
 package de.tum.cit.aet.hephaestus.integration.core.webhook;
 
 import de.tum.cit.aet.hephaestus.core.webhook.WebhookProperties;
+import de.tum.cit.aet.hephaestus.integration.core.metrics.IntegrationCoreMetrics;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import jakarta.servlet.FilterChain;
@@ -75,7 +76,7 @@ public class WebhookPayloadSizeFilter extends OncePerRequestFilter {
         rejectionCounters
                 .computeIfAbsent(
                         provider + ":" + reason,
-                        key -> Counter.builder("webhook.rejected")
+                        key -> Counter.builder(IntegrationCoreMetrics.WEBHOOK_REJECTED)
                                 .tag("provider", provider)
                                 .tag("reason", reason)
                                 .register(meterRegistry))

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/core/webhook/WebhookStreamMonitor.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/core/webhook/WebhookStreamMonitor.java
@@ -2,6 +2,7 @@ package de.tum.cit.aet.hephaestus.integration.core.webhook;
 
 import de.tum.cit.aet.hephaestus.core.webhook.WebhookProperties;
 import de.tum.cit.aet.hephaestus.integration.core.consumer.ConsumerSubjectMath;
+import de.tum.cit.aet.hephaestus.integration.core.metrics.IntegrationCoreMetrics;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -95,7 +96,7 @@ class WebhookStreamMonitor {
             // Effective retention, measured rather than claimed: max-age is a ceiling and max-bytes is
             // the floor under it, so which one a deployment actually gets is a function of its volume.
             Gauge.builder(
-                            "webhook.stream.oldest.message.age",
+                            IntegrationCoreMetrics.WEBHOOK_STREAM_OLDEST_MESSAGE_AGE,
                             this,
                             monitor -> monitor.usage.getOrDefault(name, UNKNOWN).oldestMessageAgeSeconds())
                     .tags(tags)
@@ -106,18 +107,18 @@ class WebhookStreamMonitor {
 
             AtomicLong gap = new AtomicLong();
             unacknowledgedGap.put(name, gap);
-            Gauge.builder("webhook.stream.unacknowledged.gap", gap, AtomicLong::doubleValue)
+            Gauge.builder(IntegrationCoreMetrics.WEBHOOK_STREAM_UNACKNOWLEDGED_GAP, gap, AtomicLong::doubleValue)
                     .tags(tags)
                     .register(meterRegistry);
             dropped.put(
                     name,
-                    Counter.builder("webhook.stream.unacknowledged.deletions")
+                    Counter.builder(IntegrationCoreMetrics.WEBHOOK_STREAM_UNACKNOWLEDGED_DELETIONS)
                             .tags(tags)
                             .register(meterRegistry));
 
             AtomicLong polled = new AtomicLong();
             lastSuccessfulPollMillis.put(name, polled);
-            Gauge.builder("webhook.stream.poll.age", polled, WebhookStreamMonitor::secondsSince)
+            Gauge.builder(IntegrationCoreMetrics.WEBHOOK_STREAM_POLL_AGE, polled, WebhookStreamMonitor::secondsSince)
                     .tags(tags)
                     .baseUnit("seconds")
                     .register(meterRegistry);

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/github/common/GitHubExceptionClassifier.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/github/common/GitHubExceptionClassifier.java
@@ -1,6 +1,7 @@
 package de.tum.cit.aet.hephaestus.integration.scm.github.common;
 
 import de.tum.cit.aet.hephaestus.integration.scm.domain.common.exception.InstallationSuspendedException;
+import de.tum.cit.aet.hephaestus.integration.scm.github.metrics.GithubMetrics;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.io.IOException;
@@ -134,33 +135,32 @@ public class GitHubExceptionClassifier {
     private final Counter unknownCounter;
 
     public GitHubExceptionClassifier(MeterRegistry meterRegistry) {
-        // Register counters for each error category
-        this.retryableCounter = Counter.builder("github.sync.errors.total")
+        this.retryableCounter = Counter.builder(GithubMetrics.GITHUB_SYNC_ERRORS_TOTAL)
                 .description("Total GitHub sync errors by category")
                 .tag("category", "retryable")
                 .register(meterRegistry);
 
-        this.rateLimitedCounter = Counter.builder("github.sync.errors.total")
+        this.rateLimitedCounter = Counter.builder(GithubMetrics.GITHUB_SYNC_ERRORS_TOTAL)
                 .description("Total GitHub sync errors by category")
                 .tag("category", "rate_limited")
                 .register(meterRegistry);
 
-        this.notFoundCounter = Counter.builder("github.sync.errors.total")
+        this.notFoundCounter = Counter.builder(GithubMetrics.GITHUB_SYNC_ERRORS_TOTAL)
                 .description("Total GitHub sync errors by category")
                 .tag("category", "not_found")
                 .register(meterRegistry);
 
-        this.authErrorCounter = Counter.builder("github.sync.errors.total")
+        this.authErrorCounter = Counter.builder(GithubMetrics.GITHUB_SYNC_ERRORS_TOTAL)
                 .description("Total GitHub sync errors by category")
                 .tag("category", "auth_error")
                 .register(meterRegistry);
 
-        this.clientErrorCounter = Counter.builder("github.sync.errors.total")
+        this.clientErrorCounter = Counter.builder(GithubMetrics.GITHUB_SYNC_ERRORS_TOTAL)
                 .description("Total GitHub sync errors by category")
                 .tag("category", "client_error")
                 .register(meterRegistry);
 
-        this.unknownCounter = Counter.builder("github.sync.errors.total")
+        this.unknownCounter = Counter.builder(GithubMetrics.GITHUB_SYNC_ERRORS_TOTAL)
                 .description("Total GitHub sync errors by category")
                 .tag("category", "unknown")
                 .register(meterRegistry);

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/github/common/ScopedRateLimitTracker.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/github/common/ScopedRateLimitTracker.java
@@ -3,6 +3,7 @@ package de.tum.cit.aet.hephaestus.integration.scm.github.common;
 import de.tum.cit.aet.hephaestus.core.WorkspaceAgnostic;
 import de.tum.cit.aet.hephaestus.integration.core.spi.RateLimitSnapshot;
 import de.tum.cit.aet.hephaestus.integration.scm.github.graphql.model.GHRateLimit;
+import de.tum.cit.aet.hephaestus.integration.scm.github.metrics.GithubMetrics;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -396,27 +397,27 @@ public class ScopedRateLimitTracker implements RateLimitTracker, RateLimitObserv
         Tags tags = Tags.of("scope_id", String.valueOf(scopeId));
 
         // NaN, not 0, while unobserved: a gauge is a measurement too, and 0 would read as "exhausted".
-        Gauge.builder("github.graphql.ratelimit.points.remaining", state, s -> asDouble(s.remaining.get()))
+        Gauge.builder(GithubMetrics.GITHUB_GRAPHQL_RATELIMIT_POINTS_REMAINING, state, s -> asDouble(s.remaining.get()))
                 .tags(tags)
                 .description("GitHub GraphQL API rate limit points remaining")
                 .register(meterRegistry);
 
-        Gauge.builder("github.graphql.ratelimit.points.limit", state, s -> asDouble(s.limit.get()))
+        Gauge.builder(GithubMetrics.GITHUB_GRAPHQL_RATELIMIT_POINTS_LIMIT, state, s -> asDouble(s.limit.get()))
                 .tags(tags)
                 .description("GitHub GraphQL API rate limit total points per hour")
                 .register(meterRegistry);
 
-        Gauge.builder("github.graphql.ratelimit.points.used", state.used, AtomicInteger::get)
+        Gauge.builder(GithubMetrics.GITHUB_GRAPHQL_RATELIMIT_POINTS_USED, state.used, AtomicInteger::get)
                 .tags(tags)
                 .description("GitHub GraphQL API rate limit points used in current window")
                 .register(meterRegistry);
 
-        Gauge.builder("github.graphql.ratelimit.last_query_cost", state.lastQueryCost, AtomicInteger::get)
+        Gauge.builder(GithubMetrics.GITHUB_GRAPHQL_RATELIMIT_LAST_QUERY_COST, state.lastQueryCost, AtomicInteger::get)
                 .tags(tags)
                 .description("Cost of the last GitHub GraphQL query")
                 .register(meterRegistry);
 
-        Gauge.builder("github.graphql.ratelimit.seconds_until_reset", state, s -> {
+        Gauge.builder(GithubMetrics.GITHUB_GRAPHQL_RATELIMIT_SECONDS_UNTIL_RESET, state, s -> {
                     Instant reset = s.resetAt.get();
                     if (reset == null) {
                         return 0.0;

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/github/graphql/GitHubGraphQlConfig.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/github/graphql/GitHubGraphQlConfig.java
@@ -25,6 +25,7 @@ import de.tum.cit.aet.hephaestus.integration.scm.github.jackson.GitHubProjectV2O
 import de.tum.cit.aet.hephaestus.integration.scm.github.jackson.GitHubPullRequestMixin;
 import de.tum.cit.aet.hephaestus.integration.scm.github.jackson.GitHubRepositoryOwnerMixin;
 import de.tum.cit.aet.hephaestus.integration.scm.github.jackson.GitHubRequestedReviewerMixin;
+import de.tum.cit.aet.hephaestus.integration.scm.github.metrics.GithubMetrics;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.netty.resolver.DefaultAddressResolverGroup;
@@ -88,13 +89,13 @@ public class GitHubGraphQlConfig {
     private final AtomicInteger rateLimitUsed = new AtomicInteger(0);
 
     public GitHubGraphQlConfig(MeterRegistry meterRegistry) {
-        Gauge.builder("github.graphql.ratelimit.remaining", rateLimitRemaining, AtomicInteger::get)
+        Gauge.builder(GithubMetrics.GITHUB_GRAPHQL_RATELIMIT_REMAINING, rateLimitRemaining, AtomicInteger::get)
                 .description("GitHub GraphQL API rate limit points remaining")
                 .register(meterRegistry);
-        Gauge.builder("github.graphql.ratelimit.limit", rateLimitLimit, AtomicInteger::get)
+        Gauge.builder(GithubMetrics.GITHUB_GRAPHQL_RATELIMIT_LIMIT, rateLimitLimit, AtomicInteger::get)
                 .description("GitHub GraphQL API rate limit total points")
                 .register(meterRegistry);
-        Gauge.builder("github.graphql.ratelimit.used", rateLimitUsed, AtomicInteger::get)
+        Gauge.builder(GithubMetrics.GITHUB_GRAPHQL_RATELIMIT_USED, rateLimitUsed, AtomicInteger::get)
                 .description("GitHub GraphQL API rate limit points used")
                 .register(meterRegistry);
     }

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/github/metrics/GithubMetrics.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/github/metrics/GithubMetrics.java
@@ -1,0 +1,17 @@
+package de.tum.cit.aet.hephaestus.integration.scm.github.metrics;
+
+public final class GithubMetrics {
+
+    public static final String GITHUB_GRAPHQL_RATELIMIT_LAST_QUERY_COST = "github.graphql.ratelimit.last_query_cost";
+    public static final String GITHUB_GRAPHQL_RATELIMIT_LIMIT = "github.graphql.ratelimit.limit";
+    public static final String GITHUB_GRAPHQL_RATELIMIT_POINTS_LIMIT = "github.graphql.ratelimit.points.limit";
+    public static final String GITHUB_GRAPHQL_RATELIMIT_POINTS_REMAINING = "github.graphql.ratelimit.points.remaining";
+    public static final String GITHUB_GRAPHQL_RATELIMIT_POINTS_USED = "github.graphql.ratelimit.points.used";
+    public static final String GITHUB_GRAPHQL_RATELIMIT_REMAINING = "github.graphql.ratelimit.remaining";
+    public static final String GITHUB_GRAPHQL_RATELIMIT_SECONDS_UNTIL_RESET =
+            "github.graphql.ratelimit.seconds_until_reset";
+    public static final String GITHUB_GRAPHQL_RATELIMIT_USED = "github.graphql.ratelimit.used";
+    public static final String GITHUB_SYNC_ERRORS_TOTAL = "github.sync.errors.total";
+
+    private GithubMetrics() {}
+}

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/github/metrics/package-info.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/github/metrics/package-info.java
@@ -1,0 +1,2 @@
+@org.jspecify.annotations.NullMarked
+package de.tum.cit.aet.hephaestus.integration.scm.github.metrics;

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/gitlab/common/GitLabExceptionClassifier.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/gitlab/common/GitLabExceptionClassifier.java
@@ -1,5 +1,6 @@
 package de.tum.cit.aet.hephaestus.integration.scm.gitlab.common;
 
+import de.tum.cit.aet.hephaestus.integration.scm.gitlab.metrics.GitlabMetrics;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.io.IOException;
@@ -85,22 +86,22 @@ public class GitLabExceptionClassifier {
     private final Counter unknownCounter;
 
     public GitLabExceptionClassifier(MeterRegistry meterRegistry) {
-        this.retryableCounter = Counter.builder("gitlab.sync.errors.total")
+        this.retryableCounter = Counter.builder(GitlabMetrics.GITLAB_SYNC_ERRORS_TOTAL)
                 .tag("category", "retryable")
                 .register(meterRegistry);
-        this.rateLimitedCounter = Counter.builder("gitlab.sync.errors.total")
+        this.rateLimitedCounter = Counter.builder(GitlabMetrics.GITLAB_SYNC_ERRORS_TOTAL)
                 .tag("category", "rate_limited")
                 .register(meterRegistry);
-        this.notFoundCounter = Counter.builder("gitlab.sync.errors.total")
+        this.notFoundCounter = Counter.builder(GitlabMetrics.GITLAB_SYNC_ERRORS_TOTAL)
                 .tag("category", "not_found")
                 .register(meterRegistry);
-        this.authErrorCounter = Counter.builder("gitlab.sync.errors.total")
+        this.authErrorCounter = Counter.builder(GitlabMetrics.GITLAB_SYNC_ERRORS_TOTAL)
                 .tag("category", "auth_error")
                 .register(meterRegistry);
-        this.clientErrorCounter = Counter.builder("gitlab.sync.errors.total")
+        this.clientErrorCounter = Counter.builder(GitlabMetrics.GITLAB_SYNC_ERRORS_TOTAL)
                 .tag("category", "client_error")
                 .register(meterRegistry);
-        this.unknownCounter = Counter.builder("gitlab.sync.errors.total")
+        this.unknownCounter = Counter.builder(GitlabMetrics.GITLAB_SYNC_ERRORS_TOTAL)
                 .tag("category", "unknown")
                 .register(meterRegistry);
     }

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/gitlab/metrics/GitlabMetrics.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/gitlab/metrics/GitlabMetrics.java
@@ -1,0 +1,8 @@
+package de.tum.cit.aet.hephaestus.integration.scm.gitlab.metrics;
+
+public final class GitlabMetrics {
+
+    public static final String GITLAB_SYNC_ERRORS_TOTAL = "gitlab.sync.errors.total";
+
+    private GitlabMetrics() {}
+}

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/gitlab/metrics/package-info.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/gitlab/metrics/package-info.java
@@ -1,0 +1,2 @@
+@org.jspecify.annotations.NullMarked
+package de.tum.cit.aet.hephaestus.integration.scm.gitlab.metrics;

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/architecture/MetricOwnershipArchTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/architecture/MetricOwnershipArchTest.java
@@ -1,0 +1,60 @@
+package de.tum.cit.aet.hephaestus.architecture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("architecture")
+class MetricOwnershipArchTest {
+
+    private static final Path PRODUCTION_SOURCES = Path.of("src/main/java/de/tum/cit/aet/hephaestus");
+    private static final Pattern PACKAGE = Pattern.compile("package ([A-Za-z0-9_.]+);");
+    private static final Pattern LITERAL_BUILDER =
+            Pattern.compile("(?:Timer|Counter|Gauge|DistributionSummary)\\.builder\\(\\s*\\\"");
+    private static final Pattern METRICS_IMPORT =
+            Pattern.compile("import (de\\.tum\\.cit\\.aet\\.hephaestus\\.[A-Za-z0-9_.]+\\."
+                    + "(?:ActivityMetrics|AgentMetrics|CoreMetrics|EvidenceMetrics|GithubMetrics|"
+                    + "GitlabMetrics|IntegrationCoreMetrics));");
+
+    @Test
+    void meterNamesBelongToTheEmittingModule() throws IOException {
+        var modules = ModulithVerificationTest.applicationModules();
+        List<String> violations = new ArrayList<>();
+        try (var paths = Files.walk(PRODUCTION_SOURCES)) {
+            for (Path path : paths.filter(candidate -> candidate.toString().endsWith(".java"))
+                    .toList()) {
+                String source = Files.readString(path);
+                if (LITERAL_BUILDER.matcher(source).find()) {
+                    violations.add(path + " passes a string literal to a meter builder");
+                }
+
+                String sourcePackage = requiredMatch(PACKAGE, source, path);
+                Matcher imports = METRICS_IMPORT.matcher(source);
+                while (imports.find()) {
+                    String metricsType = imports.group(1);
+                    String metricsPackage = metricsType.substring(0, metricsType.lastIndexOf('.'));
+                    if (!modules.getModuleForPackage(sourcePackage)
+                            .equals(modules.getModuleForPackage(metricsPackage))) {
+                        violations.add(path + " imports meter names from another application module: " + metricsType);
+                    }
+                }
+            }
+        }
+
+        assertThat(violations).as("meter name ownership violations").isEmpty();
+    }
+
+    private static String requiredMatch(Pattern pattern, String source, Path path) {
+        Matcher matcher = pattern.matcher(source);
+        assertThat(matcher.find()).as("package declaration in %s", path).isTrue();
+        return matcher.group(1);
+    }
+}

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/architecture/ModulithVerificationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/architecture/ModulithVerificationTest.java
@@ -37,14 +37,19 @@ import org.springframework.modulith.core.ApplicationModules;
 @Tag("architecture")
 class ModulithVerificationTest {
 
+    private static final ApplicationModules MODULES = ApplicationModules.of(
+            Application.class,
+            resideInAnyPackage(
+                    "..integration.scm.github.graphql.model..",
+                    "..integration.scm.gitlab.graphql.model..",
+                    "..integration.outline.client.model.."));
+
     @Test
     void modulesAreCycleFreeAndRespectNamedInterfaces() {
-        ApplicationModules.of(
-                        Application.class,
-                        resideInAnyPackage(
-                                "..integration.scm.github.graphql.model..",
-                                "..integration.scm.gitlab.graphql.model..",
-                                "..integration.outline.client.model.."))
-                .verify();
+        MODULES.verify();
+    }
+
+    static ApplicationModules applicationModules() {
+        return MODULES;
     }
 }


### PR DESCRIPTION
## Description

Centralizes Micrometer meter names in internal catalogs owned by their Spring Modulith modules, then enforces that ownership with an architecture test. Existing meter names, tags, descriptions, and runtime behavior are unchanged.

The guard shares the production Modulith model used by `ModulithVerificationTest`, so it also detects cross-module catalog imports when a module is open. This closes the meter-builder literal scope of #1182 — its acceptance criteria cover `Timer`/`Counter`/`Gauge`/`DistributionSummary.builder(String)` calls, all of which now reference same-module constants — without creating public module APIs solely for constants.

Known gap, deliberately out of scope here: shorthand `MeterRegistry.counter("…")`/`.gauge("…")`-style registrations (about 35 call sites, mostly in `agent/` plus `core/runtime/hub/`) still pass literal names and are not covered by the guard. Extending the rule and migrating those call sites is follow-up work on the #1114 metric-hygiene line.

Closes #1182

Related to #1525 and #1152. This PR does not claim the broader practice-detection boundary work in #1525, and it intentionally does not move the feedback posters proposed in #1152 because those implementations now target provider-neutral delivery channels.

## How to test

- Run `pnpm run format`.
- Run `pnpm run check`.
- Run `pnpm run test:server:unit` (6,848 tests).
- Run `pnpm run verify` for the complete locally runnable CI mirror.
- To exercise the new guard, temporarily add either `Counter.builder("test.inline")` or a meter-catalog import from another application module; `MetricOwnershipArchTest` must reject it. (Verified: planting both an inline literal and a cross-module `GithubMetrics` import into `activity/ActivityEventService.java` fails the test with one violation per plant.)

## Checklist

- [x] The empty changeset explains why no changelog entry is needed: this refactor does not alter released behavior or operator configuration (all meter names verified byte-identical to `main`).
- [x] No operator action or migration is required.
