### PR TITLE
perf(ci): restore parallel server test execution

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -107,7 +107,6 @@ jobs:
 
   server-integration:
     name: "App Server: Integration"
-    needs: server-build
     if: inputs.should_skip != 'true' && inputs.application_server_changed == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -125,30 +124,10 @@ jobs:
         with:
           cache-type: application-server-integration
           os: ${{ runner.os }}
-      - name: Download built reactor
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: ${{ env.SERVER_REACTOR_ARTIFACT }}
-          path: server
-      - name: Install downloaded reactor dependencies
-        run: |
-          # Surefire resolves the generated-clients JAR from the local repository, which is only
-          # warm when the dependency cache hits — and its key hashes every server POM, so the PR
-          # that edits one starts cold. Install the downloaded reactor artifacts explicitly instead
-          # of relying on that cache.
-          cd server
-          CLIENT_JAR="$(find generated-clients/target -maxdepth 1 -name 'hephaestus-generated-clients-*.jar' ! -name '*-sources.jar' ! -name '*-javadoc.jar' -print -quit)"
-          test -n "$CLIENT_JAR"
-          ./mvnw --batch-mode --non-recursive org.apache.maven.plugins:maven-install-plugin:3.1.4:install-file \
-            -Dfile=pom.xml -DpomFile=pom.xml
-          ./mvnw --batch-mode --non-recursive org.apache.maven.plugins:maven-install-plugin:3.1.4:install-file \
-            -Dfile="$CLIENT_JAR" -DpomFile=generated-clients/pom.xml
-      - name: Run integration tests from the built reactor
+      - name: Run integration tests
         run: |
           rm -rf server/application/target/surefire-reports/*
-          cd server
-          ./mvnw -pl application -am initialize surefire:test \
-            -Dsurefire.includedGroups=integration -Dparallel=none --batch-mode
+          pnpm run test:server:integration
       - name: Upload test results
         if: always()
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0

--- a/scripts/ci-contract.test.ts
+++ b/scripts/ci-contract.test.ts
@@ -137,18 +137,19 @@ void describe("CI contract", () => {
 		assert.deepEqual(rejected, [], "Workflows may only request recognised cache types");
 	});
 
-	void test("shares one server build with integration and E2E", async () => {
+	void test("runs server integration independently and reuses the server build for E2E", async () => {
 		const source = await readFile(".github/workflows/ci-tests.yml", "utf8");
 		const build = job(source, "server-build");
 		const integration = job(source, "server-integration");
 		const e2e = job(source, "webapp-e2e");
 		assert.equal((build.match(/actions\/upload-artifact@/g) ?? []).length, 1);
-		for (const consumer of [integration, e2e]) {
-			assert.match(consumer, /needs: server-build/);
-			assert.equal((consumer.match(/actions\/download-artifact@/g) ?? []).length, 1);
-			assert.match(consumer, /name: \${{ env\.SERVER_REACTOR_ARTIFACT }}/);
-		}
-		assert.match(integration, /\.\/mvnw -pl application -am initialize surefire:test/);
+		assert.match(build, /name: \${{ env\.SERVER_REACTOR_ARTIFACT }}/);
+		assert.doesNotMatch(integration, /^ {4}needs:/m);
+		assert.doesNotMatch(integration, /actions\/download-artifact@/);
+		assert.match(integration, /pnpm run test:server:integration/);
+		assert.match(e2e, /needs: server-build/);
+		assert.equal((e2e.match(/actions\/download-artifact@/g) ?? []).length, 1);
+		assert.match(e2e, /name: \${{ env\.SERVER_REACTOR_ARTIFACT }}/);
 	});
 
 	void test("builds Storybook once and gives its TurboSnap stats to Chromatic", async () => {


### PR DESCRIPTION
## Description

Run the server integration suite independently from the reactor/unit job so GitHub Actions can schedule both long-running test legs at the same time. The previous artifact dependency reduced duplicate compilation, but production measurements showed that it serialized two roughly six-minute jobs and increased the PR verdict path to about 13 minutes.

Integration now uses the repository's canonical `pnpm run test:server:integration` command. E2E continues to consume the executable reactor artifact, and the CI contract test protects both scheduling independence and the producer/consumer artifact name.

This is deliberately a latency-first correction: integration compiles its own reactor again. It therefore does **not** satisfy #1590's single-build acceptance criterion by itself, and this PR does not close the issue. The issue should remain open until the required post-merge sample reaches p50 ≤7 minutes and a faster single-build fan-out is either proven or the criterion is explicitly revised.

Relates to #1590.

## How to test

- `pnpm run format`
- `pnpm run check`
- `pnpm run test:webapp`
- `pnpm --filter webapp run test:storybook`
- In GitHub Actions, verify that **App Server: Reactor** and **App Server: Integration** have no dependency edge, while **Webapp: E2E** still consumes the reactor artifact.
- After merge, measure at least 10 comparable PR runs and report the verdict p50 on #1590.

Local `pnpm run verify` completed the quality and webapp unit gates, then hit a transient Storybook browser-module fetch failure affecting all stories. Re-running the Storybook command immediately passed all 274 files and 1,634 tests. Hosted CI remains the authoritative clean-run validation.

## Checklist

- [x] No changeset is required because this changes CI behavior only; it does not change shipped code.
- [x] No operator action or migration is required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI Improvements**
  * Server integration tests now run independently without requiring a server build artifact.
  * Integration testing uses the standardized project test command for more direct execution.
  * End-to-end web application tests continue to use the server build artifact as expected.
* **Tests**
  * Updated CI validation checks to reflect the revised integration test workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->