### PR TITLE
docs(server): define evidence storage ownership

### DIFF
--- a/docs/admin/practice-review-operations.mdx
+++ b/docs/admin/practice-review-operations.mdx
@@ -30,9 +30,12 @@ See the
 and [reference Compose files](https://github.com/ls1intum/Hephaestus/tree/main/docker) before changing an
 environment variable. Unknown or unforwarded variables do not configure the application.
 
-Repository checkouts, replay metadata, and content-addressed evidence share the fabric root. A split or
-multi-host deployment must mount the same durable read-write filesystem on every server and worker, with
+Repository checkouts, replay metadata, and content-addressed evidence share the fabric root. A split
+or multi-host deployment must mount the same durable read-write filesystem on every server and worker, with
 cross-process locks, atomic rename, and access controls suitable for source content.
+
+[ADR 0039](https://github.com/ls1intum/Hephaestus/blob/main/docs/decisions/0039-git-and-postgresql-own-evidence.md)
+defines the accepted 1.0 replacement; current releases still require this mount.
 
 Source authorization is not a deployment toggle. The shipped artifact-source contract fixes which governed
 sources each purpose may use; integrations only determine which authorized sources are available. See

--- a/docs/decisions/0020-context-fabric-everything-is-an-integration.md
+++ b/docs/decisions/0020-context-fabric-everything-is-an-integration.md
@@ -387,3 +387,7 @@ materializations remain disposable projections.
 There is no filesystem content-addressed evidence store in the 1.0 target. ADR 0039 supersedes the
 `cas/sha256/**` and `jobs/**` replay layout, manifest-walking garbage collection, independent CAS
 retention clock, and shared-fabric deployment contract above.
+
+The 2026-08-04 update's "bounded residual windows" consequence for the CAS and replay cache remains
+accurate for pre-cutover releases only; in the 1.0 target ADR 0039's SQL-root-set collection replaces
+it, and selective erasure stops being a deployment-approval consideration tied to a filesystem cache.

--- a/docs/decisions/0020-context-fabric-everything-is-an-integration.md
+++ b/docs/decisions/0020-context-fabric-everything-is-an-integration.md
@@ -374,3 +374,16 @@ limitation and protection by default.
 Triggers §3 and §8 have fired and are answered. Still live: a cross-context link that needs to be
 *asserted* rather than hinted (`entity_node`/`entity_edge`, §5), and ADR 0004's counter reading clean
 for a calendar week so prod can flip to `throw` and fold RLS in (§9).
+
+## Update — 2026-08-30 (issue #1636)
+
+[ADR 0039](0039-git-and-postgresql-own-evidence.md) supersedes §1/§2's realised filesystem CAS and
+the “Filesystem layout” subsection of the 2026-08-04 update. The statement that SQL is authoritative
+still holds for manifests, references, captured API payloads, liveness, retention and erasure. Its
+application to repository bytes is now more precise: Git owns the commit/tree/blob object closure
+pinned by a live job keep-ref, while PostgreSQL owns the root set. Temporary worktrees and payload
+materializations remain disposable projections.
+
+There is no filesystem content-addressed evidence store in the 1.0 target. ADR 0039 supersedes the
+`cas/sha256/**` and `jobs/**` replay layout, manifest-walking garbage collection, independent CAS
+retention clock, and shared-fabric deployment contract above.

--- a/docs/decisions/0039-git-and-postgresql-own-evidence.md
+++ b/docs/decisions/0039-git-and-postgresql-own-evidence.md
@@ -1,0 +1,161 @@
+# ADR 0039: Git owns repository evidence; PostgreSQL owns captured payloads and references
+
+**Status:** Accepted
+**Date:** 2026-08-30
+**Authors:** Hephaestus maintainers
+**Builds on:** [ADR 0020](0020-context-fabric-everything-is-an-integration.md),
+[ADR 0025](0025-agent-job-queue-on-postgresql.md)
+
+## Context
+
+Practice-review evidence currently crosses three authorities. PostgreSQL retains a job manifest for
+90 days, while a filesystem CAS retains cited bytes for 30 days. Delivery requires those bytes, so
+the CAS is not a disposable cache. Its collector derives liveness by parsing filesystem manifests;
+one unreadable manifest stops collection. Split roles consequently require a shared POSIX filesystem.
+
+This contradicts ADR 0020's SQL-authority rule, gives one capture independent retention clocks, and
+makes erasure depend on a filesystem scan. Issue
+[#1427](https://github.com/ls1intum/Hephaestus/issues/1427) defined the required evidence invariants
+without selecting storage; this ADR selects it for 1.0.
+
+## Decision drivers
+
+- A retained citation resolves to the captured bytes or a typed unreplayable outcome, never to
+  substitute bytes or a malformed-evidence error caused by cache expiry.
+- PostgreSQL is the queryable authority for tenancy, liveness, retention, and erasure.
+- Server and worker roles share PostgreSQL, not an evidence volume.
+- The design uses Git's object graph for repositories and avoids a third store or dual-read migration.
+
+## Considered options
+
+1. **Repair the filesystem CAS.** Rejected: it remains a third authority and shared-filesystem
+   prerequisite, with liveness outside PostgreSQL.
+2. **Store every byte in PostgreSQL.** Rejected for repository history: it duplicates Git's packing,
+   reachability, and worktree model. PostgreSQL remains suitable for bounded API captures.
+3. **Adopt S3-compatible storage.** Rejected until measurements justify another credential,
+   availability boundary, lifecycle policy, and erasure reconciliation loop.
+4. **Git for repository evidence and PostgreSQL for everything else (chosen).**
+
+## Decision
+
+### Authority and identity
+
+- Each worker maintains a full local clone of every repository it captures. A capture pins its commit
+  closure at `refs/hephaestus/keep/<jobId>`. Job IDs are globally unique. Git owns the reachable
+  commit, tree, and blob objects; PostgreSQL owns the object-ID reference and its liveness.
+- PostgreSQL owns manifests, evidence references, retention and erasure state, and bounded bytes
+  captured through APIs, including pull-request data, comments, Slack threads, and Outline documents.
+  Payloads use inline `bytea`, extending [#1103](https://github.com/ls1intum/Hephaestus/issues/1103).
+- Commit object IDs and SHA-256 payload digests are the only evidence identities. Paths, URLs,
+  repository IDs, source kinds, and provider types cannot participate in identity. Typed provenance
+  and sandbox-relative locations may accompany a digest only as tenant-scoped metadata required to
+  authorize retrieval and verify a citation; host paths and upstream URLs never cross the worker
+  protocol. A digest proves integrity, not authorization.
+
+There is no filesystem blob store, object-store SPI, S3 deployment, or compatibility reader. A clone
+with a live keep-ref is evidence storage, not an evictable cache. Worktrees and job directories are
+disposable projections.
+
+The 1.0 topology has one worker storage node; multiple worker processes on that node share its clones
+and locks. Adding independent worker storage nodes requires explicit placement and routing and is a
+revisit, not an implicit capability of this decision.
+
+### Publication, erasure, and collection
+
+Git and PostgreSQL cannot share a transaction. Every process that mutates or prunes refs in one local
+clone therefore uses the same inter-process clone lock:
+
+1. under the lock, fetch the complete closure and create the previously absent keep-ref atomically;
+   retry may confirm the same object ID but never move the ref;
+2. in one PostgreSQL transaction, insert payloads, references, manifest, and the capture state that
+   makes them visible;
+3. release the lock and acknowledge only after commit.
+
+A keep-ref without a live SQL job is SQL-orphaned and eligible for removal. Collection takes a
+consistent PostgreSQL root set under the clone lock; it never infers liveness from disk. Publication
+and erasure lock or conditionally update the same job state, so erasure either follows publication or
+prevents it; a late writer cannot resurrect evidence.
+
+SQL deletion revokes access to the job, manifest, references, and payloads transactionally. Payload
+deduplication is workspace-local; bytes remain while another authorized job references them. Digest
+lookup cannot reveal cross-workspace existence. Cleanup then removes job worktrees and temporary
+files before its keep-ref, and Git reclaims unreferenced objects under its normal prune policy.
+Keep-refs have no reflog. Cleanup is idempotent, retried, and measured; physical reclamation in Git,
+PostgreSQL, WAL, replicas, and backups follows their documented retention rather than pretending to
+be immediate secure deletion.
+
+### Durability contract
+
+Captured API payloads are durable for the job lifetime. Repository evidence is best-effort within
+that window because local clones are not replicated. A lost clone may recover the commit only when an
+ordinary authenticated upstream fetch can reach it. Otherwise replay and delivery use the existing
+**unreplayable-legacy** outcome, never malformed evidence, and never current upstream content.
+
+### Failure matrix
+
+| Failure | Required outcome |
+|---|---|
+| Crash after ref creation, before SQL commit | No visible capture; collection may remove the SQL-orphaned ref. |
+| SQL rollback after payload insertion | Payloads, references, and manifest roll back together; the ref is SQL-orphaned. |
+| Crash after SQL commit, before acknowledgement | Retry observes the capture without duplicating payloads or moving the ref. |
+| Clone lost while job is live | Recover only from the exact upstream object; otherwise unreplayable-legacy. |
+| Upstream force-push or branch deletion | A live keep-ref preserves the closure; without it, loss is unreplayable-legacy. |
+| Publish races with erasure | Publish then erase, or erase prevents visibility; evidence is never resurrected. |
+| Collection races with publication | The clone lock and SQL root set preserve every published ref. |
+| Cleanup fails at any step | Revoke access, retain excess bytes, report lag, and retry; never remove a live ref. |
+
+### Materialization and limits
+
+Each execution gets a disposable full Git worktree for every captured repository plus declared
+PostgreSQL payloads in its temporary input directory. Worktrees are read-only to the network-isolated
+sandbox and their cleanup does not affect keep-refs.
+
+Repository evidence is not truncated by `GIT_TREE_MAX_*`. Those repository-tree limits are retired;
+any API-payload limits use source-specific names, reject oversize input before publication, and expose
+rejected-size and stored-size measurements. TOAST does not relax those limits.
+
+For 1.0, a full clone has no promisor dependency for retained evidence. This supersedes
+[#1102](https://github.com/ls1intum/Hephaestus/issues/1102)'s locked `--filter=blob:none` choice for the
+evidence path. Partial clone may return in v2 only after an offline test proves every object reachable
+from every live keep-ref remains locally available after restart and eviction consults SQL liveness.
+
+### Completion criterion
+
+The implementation is complete when isolated server and worker filesystems, sharing only one
+PostgreSQL instance, capture, publish, deliver with exact-quote verification, erase, and collect one
+case end to end. Automated tests verify no SQL-visible dangling evidence, no resurrection, idempotent
+retry, conservative cleanup failure, and exact-byte delivery. Disposable
+remotes cover lost-clone and force-push behavior; cleanup crash tests cover every ordered step.
+
+Every surviving or replacement setting used by a runtime role must be represented in `ROLE_SCOPES`,
+as required by ADR 0005's 2026-08-22 amendment.
+
+## Consequences
+
+- PostgreSQL backups cover all non-repository evidence and lifecycle metadata. Repository replay can
+  end early after worker-disk loss, which is observable separately from corruption and insufficient
+  evidence.
+- Implementations maintain publication and cleanup across the Git/SQL boundary. Conservative cleanup
+  failure consumes storage rather than deleting live evidence.
+- Implementing this decision removes the CAS, filesystem manifests, shared evidence-volume contract,
+  and compatibility reads in one cutover.
+
+## Revisit trigger
+
+Consider object storage when captured-payload p99 exceeds 100 MB or measured PostgreSQL payload growth
+or backup/restore time breaches its documented service objective. A proposal must address tenancy,
+encryption, transactional publication, retention, erasure, recovery, cost, and migration while
+preserving one authority per object. Scale speculation is not a trigger.
+
+Adding a second worker storage node requires measured demand plus a placement and routing design that
+preserves the same failure matrix without shared evidence storage.
+
+## Sources
+
+- [Git partial clone](https://git-scm.com/docs/partial-clone)
+- [Git `update-ref`](https://git-scm.com/docs/git-update-ref)
+- [Git `worktree`](https://git-scm.com/docs/git-worktree)
+- [Git garbage collection](https://git-scm.com/docs/git-gc)
+- [PostgreSQL binary data types](https://www.postgresql.org/docs/18/datatype-binary.html)
+- [PostgreSQL TOAST](https://www.postgresql.org/docs/18/storage-toast.html)
+- [PostgreSQL transaction isolation](https://www.postgresql.org/docs/18/transaction-iso.html)

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -58,7 +58,7 @@ do, its home is the Admin Guide (`docs/admin/`) and the runbook links to it.
 | [0017](0017-replace-keycloak-with-spring-native-auth.md) | Replace Keycloak with Spring-native auth (BFF cookie-JWT + `Connection`-backed workspace IdPs) | Accepted |
 | [0018](0018-pg-partman-for-auth-event-partitioning.md) | `pg_partman` for `auth_event` partitioning | Accepted |
 | [0019](0019-workspace-membership-keyed-on-account.md) | Workspace membership is keyed on `Account`, not the SCM `User` | Proposed |
-| [0020](0020-context-fabric-everything-is-an-integration.md) | Context Fabric: everything is an integration | Accepted (amended 2026-08-04 #1430) |
+| [0020](0020-context-fabric-everything-is-an-integration.md) | Context Fabric: everything is an integration | Accepted (amended 2026-08-04 #1430, 2026-08-30 #1636 — evidence storage superseded by [0039](0039-git-and-postgresql-own-evidence.md)) |
 | [0021](0021-observations-feedback-synthesis-seam.md) | Findings vs feedback — evidence and delivered feedback are separate records | Accepted (amended 2026-07-31 #1423, 2026-08-16 #1430) |
 | [0022](0022-observation-presence-assessment-and-schema-cleanup.md) | Observation = presence × assessment (drop `Practice.kind`); reaction anchors on feedback; ruthless column cleanup | Accepted |
 | [0023](0023-outline-documentation-integration.md) | Outline documentation integration — a content source, not a detection surface | Accepted |

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -77,5 +77,6 @@ do, its home is the Admin Guide (`docs/admin/`) and the runbook links to it.
 | [0036](0036-agent-runtime-runs-on-node-24.md) | Agent runtime runs on Node.js 24 with bounded resources | Accepted |
 | [0037](0037-node-24-and-pnpm-12-are-the-javascript-toolchain.md) | Node.js 24 and pnpm 12 are the JavaScript toolchain | Accepted |
 | [0038](0038-postgresql-18-release-baseline.md) | PostgreSQL 18 is the qualified release baseline | Accepted |
+| [0039](0039-git-and-postgresql-own-evidence.md) | Git owns repository evidence; PostgreSQL owns captured payloads and references | Accepted |
 
 Template: [0000-template.md](0000-template.md).


### PR DESCRIPTION
## Description

Records the 1.0 evidence-storage authority model in ADR 0039: Git retains repository evidence, while PostgreSQL owns captured API payloads, references, liveness, retention, and erasure state. The ADR defines publication and cleanup failure semantics, the full-clone disposition, the single-node worker-storage boundary, and the no-shared-volume completion test.

ADR 0020 is amended append-only, the decision index is updated, and the operator guide links the accepted replacement without claiming it is already deployed. ADR number 0039 is used because 0038 is already assigned to the PostgreSQL 18 baseline.

Fixes #1636

## How to test

- `pnpm run format`
- `pnpm run check`
- `pnpm run verify`

## Checklist

- [x] No changeset is required because this PR changes documentation only.
- [x] No operator action is required by this PR; current releases still require the existing fabric mount.


The ADR supersedes #1102's locked `--filter=blob:none` choice for the evidence path (full clones for 1.0, partial clone revalidated for v2) — this mention carries the required notification to #1102.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added accepted ADR 0039, defining Git and PostgreSQL ownership for repository evidence, payloads, references, retention, and erasure.
  - Documented transactional publication, retention, cleanup, failure handling, and workspace behavior.
  - Updated ADR 0020 and the ADR index to reflect the new evidence-storage decision.
  - Clarified deployment guidance and the transition away from the shared fabric-root mount.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->