### PR TITLE
chore(release): assemble migration notes from fragments

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -23,11 +23,13 @@ format shown below. That is the one sanctioned hand-write; never touch `CHANGELO
 | --- | --- | --- |
 | `patch` | no action | bug fix, internal change, additive auto-applied migration |
 | `minor` | no action | new capability; note any new *optional* env var / flag in the summary |
-| `major` | must act first | required new env var, removed/renamed config, destructive/manual migration, dropped API — state the action + update `MIGRATION.md` |
+| `major` | must act first | required new env var, removed/renamed config, destructive/manual migration, dropped API — state the action + add a `.migration` fragment |
 
 **Pre-1.0 (now): never pick `major`** — it would cut 1.0.0; CI rejects it. Breaking changes ride in `minor`
 instead, so a pre-1.0 `minor` is *not* guaranteed zero-action: if the operator must act, say so
-(`**Operators:** …`) and update `MIGRATION.md` exactly as a `major` would.
+(`**Operators:** …`) and add `.migration/<changeset-slug>.md` exactly as a `major` would. The fragment
+contains the complete `#### 🔴 …` migration-guide entry. Never edit `MIGRATION.md`; versioning assembles
+and consumes fragments in filename order.
 
 Example (a migration-bearing fix):
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -39,7 +39,8 @@ Fixes # <!-- Link issue if applicable, or delete this line -->
 <!-- Only what CI can't check for you. Changeset presence is enforced by `verify-changesets`. -->
 
 - [ ] My changeset summary reads as an operator/user-facing note (it becomes the changelog entry) — see `.changeset/README.md`
-- [ ] If the operator must act on this change (new required env var, manual migration step), the changeset summary says how (`**Operators:** …`) and `MIGRATION.md` is updated
+- [ ] If operators must act, the changeset and migration entry give actionable upgrade instructions
+- [ ] I did not commit generated-artifact changes that this PR did not cause
 
 ## Screenshots
 

--- a/.github/workflows/verify-changesets.yml
+++ b/.github/workflows/verify-changesets.yml
@@ -44,6 +44,19 @@ jobs:
           mapfile -t changesets_added < <(git diff --diff-filter=A --name-only "$BASE_SHA"...HEAD -- '.changeset/*.md' | grep -v 'README\.md' || true)
           mapfile -t changesets_changed < <(git diff --diff-filter=AM --name-only "$BASE_SHA"...HEAD -- '.changeset/*.md' | grep -v 'README\.md' || true)
           mapfile -t changesets_removed < <(git diff --diff-filter=DR --name-only "$BASE_SHA"...HEAD -- '.changeset/*.md' | grep -v 'README\.md' || true)
+          mapfile -t migration_changed < <(git diff --diff-filter=AM --name-only "$BASE_SHA"...HEAD -- '.migration/*.md' | grep -v 'README\.md' || true)
+          mapfile -t migration_removed < <(git diff --diff-filter=DR --name-only "$BASE_SHA"...HEAD -- '.migration/*.md' | grep -v 'README\.md' || true)
+
+          if git diff --quiet "$BASE_SHA"...HEAD -- MIGRATION.md; then :; else
+            echo "::error::Do not edit MIGRATION.md in a feature PR; add a .migration/<changeset-slug>.md fragment instead."
+            exit 1
+          fi
+
+          if [ "${#migration_removed[@]}" -gt 0 ]; then
+            echo "::error::Pending migration fragments may be edited, but not deleted or renamed:"
+            printf '%s\n' "${migration_removed[@]}"
+            exit 1
+          fi
 
           if [ "${#changesets_removed[@]}" -gt 0 ]; then
             echo "::error::Pending changesets may be edited or converted to explained empty changesets, but not deleted or renamed:"
@@ -55,9 +68,13 @@ jobs:
             pnpm changeset status --since "$BASE_SHA" --output /tmp/changeset-status.json
             node scripts/verify-changesets.ts /tmp/changeset-status.json "${changesets_changed[@]}"
           fi
+          if [ "${#migration_changed[@]}" -gt 0 ]; then
+            pnpm changeset status --output /tmp/pending-changeset-status.json
+            node scripts/verify-changesets.ts /tmp/pending-changeset-status.json --migration "${migration_changed[@]}"
+          fi
 
           if git diff --name-only "$BASE_SHA"...HEAD -- server/application/src/main/resources/db/changelog/ | grep -q .; then
-            echo "::notice::This PR contains Liquibase changesets — the release notes will flag the migration automatically. If the operator must act, say so in your changeset and update MIGRATION.md."
+            echo "::notice::This PR contains Liquibase changesets — the release notes will flag the migration automatically. If the operator must act, add **Operators:** to its changeset and a matching .migration fragment."
           fi
 
           if [ -n "$shipped_changed" ] && [ "${#changesets_added[@]}" -eq 0 ]; then

--- a/.migration/README.md
+++ b/.migration/README.md
@@ -1,0 +1,7 @@
+# Migration fragments
+
+Add `.migration/<changeset-slug>.md` only when an upgrade requires operator action. The file is the
+complete migration-guide entry, begins with a `#### 🔴 …` heading, and has the same slug as the
+changeset whose summary contains `**Operators:**`. Never edit `MIGRATION.md`'s `### Next release`
+section. `pnpm run changeset:version` sorts fragments by filename, inserts them under a new version
+heading below the unchanged `### Next release` anchor, and then removes them.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,9 @@ own practice pages, or in conversation.
 too: the unit a review records is an **observation**, the unit a developer receives is **feedback**,
 and neither the application nor a review is an *agent*.
 
+Parallel contributions follow the hot-file lanes, generated-artifact, main-breakage, and merge-queue
+protocol in `docs/contributor/ai-agent-workflow.mdx` § Parallel delivery protocol.
+
 - `server/` — Spring Boot 4 + Java 21 + Spring Modulith 2. Liquibase-managed PostgreSQL, SQL-layer
   multi-tenancy (`core/tenancy/`), generated `openapi.yaml`. Three runtime roles (`server`, `worker`,
   `webhook`) selected by `hephaestus.runtime.*` — ADR 0005 and ADR 0008. See `server/AGENTS.md`.
@@ -181,11 +184,11 @@ as a Liquibase `<changeSet>` — a schema change needs both. Full flow:
   ✗ `Refactor LeaderboardService scoring hooks` → ✓ `Fixes duplicate leaderboard entries after a team rename.`
   One changeset per user-visible change.
 - **The bump is the operator's upgrade cost, not code semantics.** `patch` — no action needed.
-  `minor` — new capability; name any new *optional* env var. `major` — the operator must act, and
-  `MIGRATION.md` is updated. **Pre-1.0 (now): never pick `major`** — it would cut 1.0.0 and
+  `minor` — new capability; name any new *optional* env var. `major` — the operator must act, and a
+  matching `.migration/<changeset-slug>.md` is added. **Pre-1.0 (now): never pick `major`** — it would cut 1.0.0 and
   `verify-changesets` rejects it. Breaking changes ride in `minor`, so a pre-1.0 `minor` is not
-  guaranteed zero-action: say `**Operators:** …` in the summary and update `MIGRATION.md` exactly as a
-  `major` would.
+  guaranteed zero-action: say `**Operators:** …` in the summary and add a migration fragment exactly
+  as a `major` would.
 - **Automatic migrations are flagged by the release workflow** (it diffs `db/changelog/`), so the
   changeset does not mention them — keep it user-facing. Touching `db/changelog/` without touching
   `.changeset/` is always wrong.

--- a/docs/contributor/ai-agent-workflow.mdx
+++ b/docs/contributor/ai-agent-workflow.mdx
@@ -44,6 +44,36 @@ right.
 actually break: the test file that covers it rather than "run the tests", a request against the
 endpoint you added, a query confirming the row was written, the logs after the change.
 
+## Parallel delivery protocol
+
+Parallel work stays parallel only when contributors avoid manufacturing shared diffs:
+
+1. **Reserve hot-file lanes at assignment time.** Only one in-flight PR may write each lane:
+   `.github/workflows/**` and `.github/actions/**`; root `package.json` with `pnpm-lock.yaml`;
+   `CHANGELOG.md` and `MIGRATION.md` (release automation only); `webapp/src/api/**`; and
+   `server/application/src/main/resources/db/master.xml`. Migration fragments remove `MIGRATION.md`
+   from feature work, but release automation still owns it exclusively. Dependent changes use
+   `/gh-stack`; otherwise, do not make one PR wait for another.
+2. **Commit only regeneration caused by the change.** If OpenAPI, ERD, route-tree, or another generator
+   produces unrelated drift, stop and report it. One dedicated PR or the owning automation lands that
+   drift; feature branches do not each carry a copy.
+3. **Repair broken `main` once.** One queue-jumping hotfix owns the repair; feature branches neither
+   duplicate it nor absorb it.
+4. **Let the merge queue integrate.** Branch from a freshly fetched `origin/main`, rebase immediately
+   before requesting merge, then use `gh pr merge --squash --auto`. Do not repeatedly rebase behind
+   unrelated PRs or bypass the queue's final integration. A genuine dependency is a stack, not an
+   informal waiting chain.
+
+The assignee for a hot-file lane releases it when the PR merges or abandons the edit. If two tasks
+discover they need the same lane, split or sequence that part explicitly rather than resolving the
+same predictable conflict later.
+
+These rules follow observed failure modes: one merge day spent six rebases on lane collisions and
+none on disputed behavior; five sibling PRs carried the same generated API refresh; and one commitlint
+repair appeared in four branches plus duplicate PRs
+([#1632](https://github.com/ls1intum/Hephaestus/pull/1632),
+[#1634](https://github.com/ls1intum/Hephaestus/pull/1634)).
+
 ## Slash commands
 
 | Command | Does |

--- a/docs/contributor/release-management.mdx
+++ b/docs/contributor/release-management.mdx
@@ -54,7 +54,8 @@ sequenceDiagram
    rewrites the changelog. `GITHUB_TOKEN` updates do not trigger the required workflows, so release
    automation uses the ruleset bypass. Validation happens after the merge: `main` runs the full suite
    and a release is only cut if that run succeeds. Versioning also moves any
-   `### Next release` section in `MIGRATION.md` under the version being cut.
+   migration fragments at the existing `### Next release` anchor in `MIGRATION.md`, creates the
+   versioned section beneath it, and consumes the fragments.
 3. **Merging the Version PR cuts the release.** The workflow creates a draft release at the merge
    commit. After its evidence, seeded-upgrade, and supported-host gates pass, it promotes the CI-built images to
    `X.Y.Z`, `X.Y`, and `latest`, publishes the release, deploys staging, and requests production
@@ -118,21 +119,23 @@ A changeset summary becomes the `CHANGELOG.md` entry **verbatim** — write it i
 - **Don't mention automatic migrations** — the release notes get an automatic "back up before
   upgrading" banner whenever a release touches `server/application/src/main/resources/db/changelog/`, so the
   changeset stays user-facing. Only a migration that requires operator action belongs in the summary
-  (`**Operators:** …` + [`MIGRATION.md`](https://github.com/ls1intum/Hephaestus/blob/main/MIGRATION.md)).
+  (`**Operators:** …` plus a `.migration/<changeset-slug>.md` fragment).
 - **Bump = the operator's upgrade cost**, not code semantics:
   - `patch` — upgrade needs no action (bug fix, internal change, additive auto-applied migration).
   - `minor` — new capability, still zero-action; note any new *optional* env var / flag in the summary.
   - `major` — operator must act first (required new env var, removed/renamed config, destructive/manual
-    migration, dropped API); state the action and update [`MIGRATION.md`](https://github.com/ls1intum/Hephaestus/blob/main/MIGRATION.md).
+    migration, dropped API); state the action and add a `.migration` fragment.
 
 No TTY (agents, CI)? `pnpm changeset` is interactive — write the file by hand instead: create
 `.changeset/<slug>.md` with frontmatter `"hephaestus": <bump>` and the summary as the body (see
-`.changeset/README.md`). Never hand-edit `CHANGELOG.md`.
+`.changeset/README.md`). When action is required, add `.migration/<slug>.md` with the complete
+`#### 🔴 …` guide entry. CI requires the matching slug and `**Operators:**` marker. Never hand-edit
+`CHANGELOG.md` or `MIGRATION.md`; versioning generates both.
 
 :::caution Pre-1.0
 Never pick a `major` bump while the version is `0.x` — it would cut 1.0.0, and CI rejects it. Breaking
 changes ride in `minor` instead, so a pre-1.0 `minor` is **not** guaranteed zero-action: if the operator
-must act, say so in the summary and update `MIGRATION.md` exactly as a `major` would. The 1.0.0 release
+must act, say so in the summary and add a migration fragment exactly as a `major` would. The 1.0.0 release
 ships deliberately with the [1.0 milestone](https://github.com/ls1intum/Hephaestus/issues/1378) via a
 single sanctioned major changeset.
 :::

--- a/scripts/sync-release-version.test.ts
+++ b/scripts/sync-release-version.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { execFile } from "node:child_process";
-import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -11,6 +11,7 @@ const run = promisify(execFile);
 void test("synchronizes every release-owned version reference", async () => {
 	const cwd = await mkdtemp(join(tmpdir(), "sync-release-version-"));
 	await mkdir(join(cwd, "docs/admin"), { recursive: true });
+	await mkdir(join(cwd, ".migration"));
 	await writeFile(join(cwd, "package.json"), '{"version":"0.75.0"}');
 	await writeFile(
 		join(cwd, "docs/admin/install.mdx"),
@@ -20,7 +21,13 @@ void test("synchronizes every release-owned version reference", async () => {
 		join(cwd, "README.md"),
 		"```bash\n  VERSION=0.74.0 # the release you are installing\n```\n",
 	);
-	await writeFile(join(cwd, "MIGRATION.md"), "### Next release\n\nAction.\n");
+	await writeFile(
+		join(cwd, "MIGRATION.md"),
+		"### Next release\n\n#### 🔴 Existing action\n\nDo it.\n\n### v0.74.0\n\nOld.\n",
+	);
+	await writeFile(join(cwd, ".migration/z-last.md"), "#### 🔴 Z action\n\nDo Z.\n");
+	await writeFile(join(cwd, ".migration/a-first.md"), "#### 🔴 A action\n\nDo A.\n");
+	await writeFile(join(cwd, ".migration/README.md"), "instructions\n");
 
 	await run(process.execPath, [join(import.meta.dirname, "sync-release-version.ts")], { cwd });
 
@@ -32,8 +39,31 @@ void test("synchronizes every release-owned version reference", async () => {
 		await readFile(join(cwd, "README.md"), "utf8"),
 		"```bash\n  VERSION=0.75.0 # the release you are installing\n```\n",
 	);
-	assert.equal(await readFile(join(cwd, "MIGRATION.md"), "utf8"), "### v0.75.0\n\nAction.\n");
+	assert.equal(
+		await readFile(join(cwd, "MIGRATION.md"), "utf8"),
+		"### Next release\n\n### v0.75.0\n\n#### 🔴 Existing action\n\nDo it.\n\n#### 🔴 A action\n\nDo A.\n\n#### 🔴 Z action\n\nDo Z.\n\n### v0.74.0\n\nOld.\n",
+	);
+	assert.deepEqual(await readdir(join(cwd, ".migration")), ["README.md"]);
 
 	await run(process.execPath, [join(import.meta.dirname, "sync-release-version.ts")], { cwd });
-	assert.equal(await readFile(join(cwd, "MIGRATION.md"), "utf8"), "### v0.75.0\n\nAction.\n");
+	assert.equal(
+		await readFile(join(cwd, "MIGRATION.md"), "utf8"),
+		"### Next release\n\n### v0.75.0\n\n#### 🔴 Existing action\n\nDo it.\n\n#### 🔴 A action\n\nDo A.\n\n#### 🔴 Z action\n\nDo Z.\n\n### v0.74.0\n\nOld.\n",
+	);
+	assert.deepEqual(await readdir(join(cwd, ".migration")), ["README.md"]);
+
+	await writeFile(join(cwd, ".migration/late.md"), "#### 🔴 Late action\n");
+	await assert.rejects(
+		run(process.execPath, [join(import.meta.dirname, "sync-release-version.ts")], { cwd }),
+		/already contains ### v0\.75\.0/,
+	);
+	await rm(join(cwd, ".migration/late.md"));
+	await writeFile(
+		join(cwd, "MIGRATION.md"),
+		`### Next release\n\n${await readFile(join(cwd, "MIGRATION.md"), "utf8")}`,
+	);
+	await assert.rejects(
+		run(process.execPath, [join(import.meta.dirname, "sync-release-version.ts")], { cwd }),
+		/exactly one ### Next release/,
+	);
 });

--- a/scripts/sync-release-version.test.ts
+++ b/scripts/sync-release-version.test.ts
@@ -25,7 +25,10 @@ void test("synchronizes every release-owned version reference", async () => {
 		join(cwd, "MIGRATION.md"),
 		"### Next release\n\n#### 🔴 Existing action\n\nDo it.\n\n### v0.74.0\n\nOld.\n",
 	);
-	await writeFile(join(cwd, ".migration/z-last.md"), "#### 🔴 Z action\n\nDo Z.\n");
+	await writeFile(
+		join(cwd, ".migration/z-last.md"),
+		"#### 🔴 Z action\n\nDo Z: keep `$$VAR`, `$&`, and `$'` literal.\n",
+	);
 	await writeFile(join(cwd, ".migration/a-first.md"), "#### 🔴 A action\n\nDo A.\n");
 	await writeFile(join(cwd, ".migration/README.md"), "instructions\n");
 
@@ -41,14 +44,14 @@ void test("synchronizes every release-owned version reference", async () => {
 	);
 	assert.equal(
 		await readFile(join(cwd, "MIGRATION.md"), "utf8"),
-		"### Next release\n\n### v0.75.0\n\n#### 🔴 Existing action\n\nDo it.\n\n#### 🔴 A action\n\nDo A.\n\n#### 🔴 Z action\n\nDo Z.\n\n### v0.74.0\n\nOld.\n",
+		"### Next release\n\n### v0.75.0\n\n#### 🔴 Existing action\n\nDo it.\n\n#### 🔴 A action\n\nDo A.\n\n#### 🔴 Z action\n\nDo Z: keep `$$VAR`, `$&`, and `$'` literal.\n\n### v0.74.0\n\nOld.\n",
 	);
 	assert.deepEqual(await readdir(join(cwd, ".migration")), ["README.md"]);
 
 	await run(process.execPath, [join(import.meta.dirname, "sync-release-version.ts")], { cwd });
 	assert.equal(
 		await readFile(join(cwd, "MIGRATION.md"), "utf8"),
-		"### Next release\n\n### v0.75.0\n\n#### 🔴 Existing action\n\nDo it.\n\n#### 🔴 A action\n\nDo A.\n\n#### 🔴 Z action\n\nDo Z.\n\n### v0.74.0\n\nOld.\n",
+		"### Next release\n\n### v0.75.0\n\n#### 🔴 Existing action\n\nDo it.\n\n#### 🔴 A action\n\nDo A.\n\n#### 🔴 Z action\n\nDo Z: keep `$$VAR`, `$&`, and `$'` literal.\n\n### v0.74.0\n\nOld.\n",
 	);
 	assert.deepEqual(await readdir(join(cwd, ".migration")), ["README.md"]);
 

--- a/scripts/sync-release-version.ts
+++ b/scripts/sync-release-version.ts
@@ -1,4 +1,5 @@
-import { readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 
 import { asRecord, asString, parseJson } from "./lib/json.ts";
 
@@ -30,9 +31,32 @@ for (const { file, re, line } of edits) {
 
 const migrationFile = "MIGRATION.md";
 const migration = readFileSync(migrationFile, "utf8");
-const pendingHeading = /^### Next release$/m;
-if (pendingHeading.test(migration)) {
-	writeFileSync(migrationFile, migration.replace(pendingHeading, `### v${version}`));
+const pendingSections = [
+	...migration.matchAll(/^### Next release\n([\s\S]*?)(?=^### |(?![\s\S]))/gm),
+];
+if (pendingSections.length !== 1) {
+	throw new Error("sync-release-version: MIGRATION.md must contain exactly one ### Next release");
+}
+const pending = pendingSections[0]?.[1]?.trim() ?? "";
+const fragmentDirectory = ".migration";
+const fragmentFiles = existsSync(fragmentDirectory)
+	? readdirSync(fragmentDirectory)
+			.filter((file) => file.endsWith(".md") && file !== "README.md")
+			.toSorted()
+	: [];
+if (pending !== "" || fragmentFiles.length > 0) {
+	if (migration.split("\n").includes(`### v${version}`)) {
+		throw new Error(`sync-release-version: MIGRATION.md already contains ### v${version}`);
+	}
+	const fragments = fragmentFiles.map((file) =>
+		readFileSync(join(fragmentDirectory, file), "utf8").trim(),
+	);
+	const section = ["### Next release", `### v${version}`, pending, ...fragments].filter(Boolean);
+	writeFileSync(
+		migrationFile,
+		migration.replace(pendingSections[0]?.[0] ?? "", `${section.join("\n\n")}\n\n`),
+	);
+	for (const file of fragmentFiles) rmSync(join(fragmentDirectory, file));
 }
 
 console.log(`Synced release version references to ${version}`);

--- a/scripts/sync-release-version.ts
+++ b/scripts/sync-release-version.ts
@@ -54,7 +54,8 @@ if (pending !== "" || fragmentFiles.length > 0) {
 	const section = ["### Next release", `### v${version}`, pending, ...fragments].filter(Boolean);
 	writeFileSync(
 		migrationFile,
-		migration.replace(pendingSections[0]?.[0] ?? "", `${section.join("\n\n")}\n\n`),
+		// The replacer is a function so `$&`/`$$` in migration notes stay literal.
+		migration.replace(pendingSections[0]?.[0] ?? "", () => `${section.join("\n\n")}\n\n`),
 	);
 	for (const file of fragmentFiles) rmSync(join(fragmentDirectory, file));
 }

--- a/scripts/verify-changesets.test.ts
+++ b/scripts/verify-changesets.test.ts
@@ -75,6 +75,13 @@ void test("migration fragments require an operator marker and one entry", () => 
 			"#### 🔴 Do the thing\n\n**Migration**: act.\n",
 		),
 	);
+	assert.doesNotThrow(() =>
+		verifyMigrationFragment(
+			".migration/note.md",
+			"**Operators:** act.",
+			"#### 🔴 Pin the image\n\n```bash\n# either: remove the line entirely\n#### not a heading here\nVERSION=1\n```\n",
+		),
+	);
 	assert.throws(
 		() => verifyMigrationFragment(".migration/note.md", "Change.", "#### 🔴 Act\n"),
 		/must contain \*\*Operators:/,

--- a/scripts/verify-changesets.test.ts
+++ b/scripts/verify-changesets.test.ts
@@ -1,7 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { verifyChangesets } from "./verify-changesets.ts";
+import {
+	verifyChangesets,
+	verifyChangesetMigration,
+	verifyMigrationFragment,
+} from "./verify-changesets.ts";
 
 const status = (releases: unknown[], summary: string) => ({
 	changesets: [{ id: "note", releases, summary }],
@@ -16,7 +20,11 @@ void test("accepts root releases and explained opt-outs", () => {
 		verifyChangesets(status([], "No release note: CI only."), [".changeset/note.md"]),
 	);
 	assert.doesNotThrow(() =>
-		verifyChangesets(status(rootRelease("major"), "Stable API."), [".changeset/note.md"], false),
+		verifyChangesets(
+			status(rootRelease("major"), "Stable API. **Operators:** follow the migration guide."),
+			[".changeset/note.md"],
+			false,
+		),
 	);
 });
 
@@ -38,6 +46,11 @@ void test("rejects blank notes, non-root releases, and pre-1.0 majors", () => {
 		() => verifyChangesets(status(rootRelease("major"), "Breaks API."), [".changeset/note.md"]),
 		/pre-1.0 major/,
 	);
+	assert.throws(
+		() =>
+			verifyChangesets(status(rootRelease("major"), "Breaks API."), [".changeset/note.md"], false),
+		/must contain \*\*Operators:/,
+	);
 });
 
 void test("rejects files Changesets did not parse and release-note trailers", () => {
@@ -51,5 +64,48 @@ void test("rejects files Changesets did not parse and release-note trailers", ()
 				".changeset/note.md",
 			]),
 		/must not contain Co-authored-by/,
+	);
+});
+
+void test("migration fragments require an operator marker and one entry", () => {
+	assert.doesNotThrow(() =>
+		verifyMigrationFragment(
+			".migration/note.md",
+			"Change. **Operators:** act before upgrading.",
+			"#### 🔴 Do the thing\n\n**Migration**: act.\n",
+		),
+	);
+	assert.throws(
+		() => verifyMigrationFragment(".migration/note.md", "Change.", "#### 🔴 Act\n"),
+		/must contain \*\*Operators:/,
+	);
+	assert.throws(
+		() =>
+			verifyMigrationFragment(
+				".migration/note.md",
+				"**Operators:** act.",
+				"### Next release\n\n#### 🔴 Act\n",
+			),
+		/no level 1-3 headings/,
+	);
+	assert.throws(
+		() =>
+			verifyMigrationFragment(
+				".migration/note.md",
+				"**Operators:** act.",
+				"#### 🔴 First\n\n#### 🔴 Second\n",
+			),
+		/exactly one/,
+	);
+	assert.throws(
+		() => verifyChangesetMigration(".changeset/note.md", "**Operators:** act.", undefined),
+		/requires \.migration\/note\.md/,
+	);
+	assert.throws(
+		() => verifyChangesetMigration(".changeset/note.md", "No action.", "#### 🔴 Act\n"),
+		/must contain \*\*Operators:/,
+	);
+	assert.doesNotThrow(() =>
+		verifyChangesetMigration(".changeset/note.md", "No action.", undefined),
 	);
 });

--- a/scripts/verify-changesets.ts
+++ b/scripts/verify-changesets.ts
@@ -20,8 +20,11 @@ export const verifyMigrationFragment = (file: string, summary: string, content: 
 	if (!summary.includes("**Operators:**")) {
 		throw new Error(`${file}: matching changeset summary must contain **Operators:**`);
 	}
-	const entryHeadings = content.match(/^#### /gm) ?? [];
-	if (entryHeadings.length !== 1 || !/^#### 🔴 \S/m.test(content) || /^#{1,3} /m.test(content)) {
+	// Fenced code blocks may contain `# comment` lines (see MIGRATION.md v0.74.0); only prose
+	// outside them is subject to the heading rules.
+	const prose = content.replace(/^```[^\n]*\n[\s\S]*?^```[^\S\n]*$/gm, "");
+	const entryHeadings = prose.match(/^#### /gm) ?? [];
+	if (entryHeadings.length !== 1 || !/^#### 🔴 \S/m.test(prose) || /^#{1,3} /m.test(prose)) {
 		throw new Error(`${file}: must contain exactly one #### 🔴 entry and no level 1-3 headings`);
 	}
 };

--- a/scripts/verify-changesets.ts
+++ b/scripts/verify-changesets.ts
@@ -1,22 +1,49 @@
+import { existsSync, readFileSync } from "node:fs";
 import { basename } from "node:path";
 
 import { asArray, asRecord, asString, readJsonFile } from "./lib/json.ts";
+
+const changesetEntries = (status: unknown): Map<string, Record<string, unknown>> => {
+	const entries = asArray(
+		asRecord(status, "changeset status").changesets,
+		"changeset status.changesets",
+	);
+	return new Map(
+		entries.map((value, index) => {
+			const entry = asRecord(value, `changeset status.changesets[${index}]`);
+			return [asString(entry.id, `changeset status.changesets[${index}].id`), entry];
+		}),
+	);
+};
+
+export const verifyMigrationFragment = (file: string, summary: string, content: string): void => {
+	if (!summary.includes("**Operators:**")) {
+		throw new Error(`${file}: matching changeset summary must contain **Operators:**`);
+	}
+	const entryHeadings = content.match(/^#### /gm) ?? [];
+	if (entryHeadings.length !== 1 || !/^#### 🔴 \S/m.test(content) || /^#{1,3} /m.test(content)) {
+		throw new Error(`${file}: must contain exactly one #### 🔴 entry and no level 1-3 headings`);
+	}
+};
+
+export const verifyChangesetMigration = (
+	file: string,
+	summary: string,
+	fragment: string | undefined,
+): void => {
+	if (summary.includes("**Operators:**") && fragment === undefined) {
+		throw new Error(`${file}: **Operators:** requires .migration/${basename(file)}`);
+	}
+	if (fragment !== undefined)
+		verifyMigrationFragment(`.migration/${basename(file)}`, summary, fragment);
+};
 
 export const verifyChangesets = (
 	status: unknown,
 	files: readonly string[],
 	preOne = true,
 ): void => {
-	const entries = asArray(
-		asRecord(status, "changeset status").changesets,
-		"changeset status.changesets",
-	);
-	const byId = new Map(
-		entries.map((value, index) => {
-			const entry = asRecord(value, `changeset status.changesets[${index}]`);
-			return [asString(entry.id, `changeset status.changesets[${index}].id`), entry];
-		}),
-	);
+	const byId = changesetEntries(status);
 
 	for (const file of files) {
 		const entry = byId.get(basename(file, ".md"));
@@ -50,21 +77,47 @@ export const verifyChangesets = (
 				`${file}: pre-1.0 major changesets are reserved for the deliberate 1.0 release; use minor`,
 			);
 		}
+		if (bump === "major" && !summary.includes("**Operators:**")) {
+			throw new Error(`${file}: a major changeset must contain **Operators:**`);
+		}
 	}
 };
 
 if (import.meta.main) {
 	try {
-		const [statusJson, ...files] = process.argv.slice(2);
+		const [statusJson, ...arguments_] = process.argv.slice(2);
 		if (!statusJson)
 			throw new Error("usage: verify-changesets.ts <changeset-status-json> <files...>");
 		const status = await readJsonFile(statusJson);
-		const root = asRecord(await readJsonFile("package.json"), "package.json");
-		verifyChangesets(
-			status,
-			files,
-			asString(root.version, "package.json version").startsWith("0."),
-		);
+		if (arguments_[0] === "--migration") {
+			const entries = changesetEntries(status);
+			for (const file of arguments_.slice(1)) {
+				const entry = entries.get(basename(file, ".md"));
+				if (!entry) throw new Error(`${file}: requires a changeset with the same slug`);
+				const summary = asString(entry.summary, `${file} summary`);
+				verifyMigrationFragment(file, summary, readFileSync(file, "utf8"));
+			}
+		} else {
+			const root = asRecord(await readJsonFile("package.json"), "package.json");
+			verifyChangesets(
+				status,
+				arguments_,
+				asString(root.version, "package.json version").startsWith("0."),
+			);
+			const entries = changesetEntries(status);
+			for (const file of arguments_) {
+				const entry = entries.get(basename(file, ".md"));
+				if (entry) {
+					const summary = asString(entry.summary, `${file} summary`);
+					const fragmentFile = `.migration/${basename(file)}`;
+					verifyChangesetMigration(
+						file,
+						summary,
+						existsSync(fragmentFile) ? readFileSync(fragmentFile, "utf8") : undefined,
+					);
+				}
+			}
+		}
 	} catch (error) {
 		console.error(`::error::${error instanceof Error ? error.message : String(error)}`);
 		process.exitCode = 1;


### PR DESCRIPTION
## Description

Migration guidance now follows the same per-change fragment model as release notes: operator-facing PRs add a same-slug `.migration/*.md` entry, while release versioning assembles the pending entries deterministically under the existing `### Next release` anchor. CI validates both directions of the changeset/fragment relationship, rejects ambiguous release headings, and keeps pending fragments correctable until they are released.

This also documents the parallel-delivery protocol for hot-file ownership, generated artifacts, repairs to `main`, and merge-queue integration. Together, these changes remove `MIGRATION.md` from feature-branch edits without introducing a second release-heading convention or a one-time migration exception.

Fixes #1651
Fixes #1652

## How to test

- `pnpm run format`
- `pnpm run check`
- `pnpm run check:changesets`
- `pnpm run check:instructions`
- In a temporary fixture, verify release sync preserves existing pending guidance, sorts new fragments, consumes them only after assembly, and fails closed for missing or duplicate anchors and same-version ambiguity.

`pnpm run verify` completed the full webapp suite (998 tests), Storybook suite (1,634 tests), and server verification suite (7,113 tests). Its later Storybook build invocation did not start because the existing task graph generated the invalid command `vp exec -C webapp storybook build --stats-json`; this PR does not change that task or absorb an unrelated default-branch repair. The required local gate and pre-push gate both pass.

## Checklist

- [x] No release changeset is required: this PR changes repository release tooling and contributor documentation, not shipped application code.
- [x] No operator action or migration entry is required for this repository-only change.
- [x] I did not commit generated-artifact changes that this PR did not cause.
