### PR TITLE
fix(ci): make the release upgrade gate reach readiness

### DIFF
--- a/scripts/release-deployment-policy.test.ts
+++ b/scripts/release-deployment-policy.test.ts
@@ -4,6 +4,7 @@ import { test } from "node:test";
 
 const release = readFileSync(".github/workflows/release.yml", "utf8");
 const deployment = readFileSync(".github/workflows/deploy-locked-compose.yml", "utf8");
+const upgradeDrill = readFileSync("scripts/release-upgrade-test.ts", "utf8");
 
 await test("release promotion deploys the complete topology by signed tag", () => {
 	assert.match(release, /image-tag: \$\{\{ needs\.release\.outputs\.tag_name \}\}/);
@@ -42,6 +43,13 @@ await test("release publication requires the seeded upgrade gate", () => {
 	const upgradeGate =
 		release.match(/ {2}upgrade-test:[\s\S]*?\n {2}supported-host-smoke:/)?.[0] ?? "";
 	assert.doesNotMatch(upgradeGate, /secrets: inherit/);
+});
+
+await test("release upgrade runs the server topology without optional infrastructure", () => {
+	assert.match(upgradeDrill, /"HEPHAESTUS_RUNTIME_WORKER_ENABLED=false"/);
+	assert.match(upgradeDrill, /"HEPHAESTUS_RUNTIME_WEBHOOK_ENABLED=false"/);
+	assert.match(upgradeDrill, /"HEPHAESTUS_SYNC_NATS_ENABLED=false"/);
+	assert.doesNotMatch(upgradeDrill, /"NATS_ENABLED=false"/);
 });
 
 await test("release publication requires native smoke tests for every supported host", () => {

--- a/scripts/release-upgrade-test.ts
+++ b/scripts/release-upgrade-test.ts
@@ -43,7 +43,12 @@ function startApplication(name: string, image: string): number {
 		"--env",
 		"SPRING_DATASOURCE_PASSWORD=root",
 		"--env",
-		"NATS_ENABLED=false",
+		"HEPHAESTUS_SYNC_NATS_ENABLED=false",
+		"--env",
+		// Exercise the server/database upgrade without optional worker infrastructure.
+		"HEPHAESTUS_RUNTIME_WORKER_ENABLED=false",
+		"--env",
+		"HEPHAESTUS_RUNTIME_WEBHOOK_ENABLED=false",
 		"--env",
 		"AGENT_ENABLED=false",
 		"--env",


### PR DESCRIPTION
## Description

Run the seeded release-upgrade drill with only the server role and its database dependencies enabled. This keeps the N-1 → N gate focused on Liquibase and core reads instead of requiring the previous release to reach an unavailable Docker or NATS service.

The drill now disables the optional worker and webhook roles through their canonical Spring properties. A focused policy test protects that topology and rejects the obsolete, profile-specific NATS override that allowed the candidate image to attempt a localhost connection.

Fixes #1646

## How to test

- `pnpm run format`
- `pnpm run check`
- Run `scripts/release-upgrade-test.ts` with the immutable v0.74.0 application, current candidate application, and release PostgreSQL image digests; the complete seeded upgrade passes locally.
- Manually dispatch the **Seeded Release Upgrade** workflow after merge, then confirm the next scheduled run remains green.

`pnpm run verify` completed the tooling, webapp, Storybook, and server suites except for one local startup-budget timing assertion while the machine was under sustained verification load (`achievementController` took 7.48 s against a 6 s budget). The same `StartupBudgetIntegrationTest` passed immediately when rerun in isolation. No startup code is changed by this PR.

## Checklist

- [x] Changeset not required: this changes CI-only test orchestration, not shipped code.
- [x] No operator action or migration is required.