### PR TITLE
fix(webapp): confirm automatic feedback promotion

### DIFF
--- a/.changeset/safe-automatic-feedback-promotion.md
+++ b/.changeset/safe-automatic-feedback-promotion.md
@@ -1,0 +1,5 @@
+---
+"hephaestus": patch
+---
+
+Workspace administrators now confirm before setting practices, groups, or the workspace default to Send automatically. Feedback already awaiting approval remains unchanged.

--- a/webapp/src/components/admin/practices/practice-autonomy/PracticeAutonomyPage.stories.tsx
+++ b/webapp/src/components/admin/practices/practice-autonomy/PracticeAutonomyPage.stories.tsx
@@ -100,7 +100,6 @@ const oneUnreviewablePractice = buildAutonomyFixture({
 	],
 });
 
-/** Built once and shared: resolving the whole inheritance chain over this many rows is not free. */
 const atScale = scaleFixture();
 
 const idle = {
@@ -136,12 +135,6 @@ const meta = {
 	},
 	decorators: [withWidePage],
 	tags: ["autodocs"],
-	/**
-	 * Only the scope filter is held in state; the autonomy setters stay spies. {@link buildAutonomyFixture}
-	 * resolves the three-level inheritance chain the way the server does, so applying an autonomy locally
-	 * would mean resolving it a second time by hand — and the page would show a rollup its own rows
-	 * contradict the first time the two disagreed.
-	 */
 	render: (args) => (
 		<Stateful initial={args.overridesOnly}>
 			{(overridesOnly, setOverridesOnly) => (
@@ -170,8 +163,6 @@ export const WorkspaceDefaultUnset: Story = {
 		await expect(
 			canvas.getByRole("radiogroup", { name: "How far reviews go without you" }),
 		).toBeVisible();
-		// The workspace makes one decision, not two: how far a review goes is the only axis, and
-		// Review before sending means a person decides whether the composed feedback is released.
 		await expect(canvas.queryByText(/feedback may go/i)).not.toBeInTheDocument();
 		await expect(canvas.queryByText(/mentor conversation/i)).not.toBeInTheDocument();
 		await expectNoPageOverflow();
@@ -202,6 +193,9 @@ export const GroupOverride: Story = {
 		});
 		await expect(within(testing).getByRole("radio", { name: "Off" })).toBeChecked();
 		await userEvent.click(within(testing).getByRole("radio", { name: "Send automatically" }));
+		const dialog = within(await screen.findByRole("alertdialog"));
+		await expect(args.onSetGroupAutonomy).not.toHaveBeenCalled();
+		await userEvent.click(dialog.getByRole("button", { name: "Start sending automatically" }));
 		await expect(args.onSetGroupAutonomy).toHaveBeenCalledWith("testing", "AUTOMATIC");
 
 		const unassigned = canvas.getByText("Unassigned").closest('[data-slot="accordion-item"]');
@@ -213,14 +207,40 @@ export const GroupOverride: Story = {
 	},
 };
 
+export const WorkspaceAutomaticCanBeCancelled: Story = {
+	play: async ({ args, canvas, userEvent }) => {
+		const workspace = canvas.getByRole("radiogroup", {
+			name: "How far reviews go without you",
+		});
+		await userEvent.click(within(workspace).getByRole("radio", { name: "Send automatically" }));
+		const dialog = within(await screen.findByRole("alertdialog"));
+		await userEvent.click(dialog.getByRole("button", { name: "Cancel" }));
+		await expect(args.onSetWorkspaceDefault).not.toHaveBeenCalled();
+	},
+};
+
+export const PracticeAutomaticRequiresConfirmation: Story = {
+	play: async ({ args, canvas, userEvent }) => {
+		await userEvent.click(canvas.getByRole("button", { name: /Pull request hygiene/ }));
+		const row = canvas.getByText("States the motivation").closest("li");
+		if (!(row instanceof HTMLElement)) throw new Error("Practice row not rendered");
+		await userEvent.click(within(row).getByRole("radio", { name: "Send automatically" }));
+		const dialog = within(await screen.findByRole("alertdialog"));
+		await expect(args.onSetPracticeAutonomy).not.toHaveBeenCalled();
+		await userEvent.click(dialog.getByRole("button", { name: "Start sending automatically" }));
+		await expect(args.onSetPracticeAutonomy).toHaveBeenCalledWith(
+			"pull-request-hygiene-states-the-motivation",
+			"AUTOMATIC",
+		);
+	},
+};
+
 export const PracticeOverrideWithReset: Story = {
 	play: async ({ args, canvas, userEvent }) => {
 		await userEvent.click(canvas.getByRole("button", { name: /Pull request hygiene/ }));
 		const row = canvas.getByText("Links the issue it closes").closest("li");
 		if (!(row instanceof HTMLElement)) throw new Error("Practice row not rendered");
 
-		// `getByText` matches an element's own text nodes, so this is the paragraph and not the button
-		// inside it; the button is asserted by role below.
 		await expect(within(row).getByText("Set here.")).toBeVisible();
 		await expect(
 			within(row).getByRole("radiogroup", {
@@ -241,11 +261,6 @@ export const PracticeOverrideWithReset: Story = {
 	},
 };
 
-/**
- * A practice carrying no prose gets no preview card at all, rather than an empty popup appearing
- * under the pointer. Locally written practices usually carry none, so this is a state production
- * reaches routinely.
- */
 export const PracticeContext: Story = {
 	args: from(oneDescribedAndOneBare),
 	play: async ({ canvas, userEvent }) => {
@@ -258,7 +273,6 @@ export const PracticeContext: Story = {
 			within(described).queryByText(/reads as arbitrary six months later/),
 		).not.toBeInTheDocument();
 
-		// The card is portalled, so it is found on the screen and not in the row.
 		await userEvent.hover(
 			within(described).getByRole("link", { name: "Explains the trade-off it chose" }),
 		);
@@ -267,9 +281,6 @@ export const PracticeContext: Story = {
 		const bare = canvas.getByText("Written by hand, and says nothing more").closest("li");
 		if (!(bare instanceof HTMLElement)) throw new Error("Bare row not rendered");
 		await expect(within(bare).getByText("Pull or merge request")).toBeVisible();
-		// A practice with neither field renders its link bare rather than wrapped in a card that
-		// would open on hover with nothing in it. Asserted on the element, not by hovering and
-		// waiting for nothing, which passes just as well when the card is merely slow.
 		await expect(
 			within(bare).getByRole("link", { name: "Written by hand, and says nothing more" }),
 		).not.toHaveAttribute("data-slot", "hover-card-trigger");
@@ -277,11 +288,6 @@ export const PracticeContext: Story = {
 	},
 };
 
-/**
- * The card hangs off the practice's own link rather than a help icon, so the tab stop the row already
- * has is the keyboard path and no row grows a second one. This story is what keeps that a fact rather
- * than a claim: Base UI's hover card opens on focus-visible, Radix's does not.
- */
 export const PracticeDetailOnKeyboardFocus: Story = {
 	parameters: { chromatic: { disableSnapshot: true } },
 	args: from(oneDescribedPractice),
@@ -290,8 +296,6 @@ export const PracticeDetailOnKeyboardFocus: Story = {
 		const link = canvas.getByRole("link", { name: "Explains the trade-off it chose" });
 
 		await expect(screen.queryByText(/reads as arbitrary six months later/)).not.toBeInTheDocument();
-		// `link.focus()` would not do: the card opens on focus-*visible*, so focus has to arrive by
-		// keyboard. Bounded, so a DOM change ahead of the link fails the story instead of hanging it.
 		for (let step = 0; step < 12 && document.activeElement !== link; step++) {
 			await userEvent.tab();
 		}
@@ -340,7 +344,7 @@ export const BulkSet: Story = {
 	},
 };
 
-export const BulkAutomaticShowsBlastRadius: Story = {
+export const BulkAutomaticRequiresConfirmation: Story = {
 	play: async ({ args, canvas, userEvent }) => {
 		await userEvent.click(canvas.getByRole("button", { name: /Pull request hygiene/ }));
 		await userEvent.click(
@@ -354,11 +358,9 @@ export const BulkAutomaticShowsBlastRadius: Story = {
 		);
 
 		const dialog = within(await screen.findByRole("alertdialog"));
-		await expectSettledVisible(dialog.getByText(/2 selected practices/));
-		await expectSettledVisible(dialog.getByText(/42 review jobs entered/));
 		await expect(args.onBulkSetAutonomy).not.toHaveBeenCalled();
 
-		await userEvent.click(dialog.getByRole("button", { name: "Send automatically" }));
+		await userEvent.click(dialog.getByRole("button", { name: "Start sending automatically" }));
 		await expect(args.onBulkSetAutonomy).toHaveBeenCalledWith(
 			[
 				"pull-request-hygiene-states-the-motivation",
@@ -409,18 +411,12 @@ export const AtScale: Story = {
 	},
 };
 
-/**
- * A geometry assertion, because a ladder laid out after a content-width header takes its left edge
- * from the length of the group's name — and nothing about the DOM, the roles or the text changes when
- * that happens, so no other kind of assertion catches it.
- */
+/** Text and role assertions cannot detect column drift, so this story verifies geometry. */
 export const DecisionsShareOneColumn: Story = {
 	args: from(atScale),
 	globals: { viewport: { value: "desktop" } },
 	parameters: { chromatic: { disableSnapshot: true } },
 	play: async ({ canvas, userEvent }) => {
-		// Below `sm` every ladder is full width and shares a left edge regardless, so a runner that
-		// ignored the viewport would pass this story for the wrong reason.
 		await expect(window.innerWidth).toBeGreaterThanOrEqual(640);
 
 		await userEvent.click(canvas.getByRole("button", { name: /^Pull request hygiene/ }));
@@ -430,7 +426,6 @@ export const DecisionsShareOneColumn: Story = {
 			.map((group) => Math.round(group.getBoundingClientRect().left));
 
 		await expect(lefts.length).toBeGreaterThan(25);
-		// One column, to within the sub-pixel rounding of a grid track inside a grid track.
 		await expect(Math.max(...lefts) - Math.min(...lefts)).toBeLessThanOrEqual(2);
 	},
 };

--- a/webapp/src/components/admin/practices/practice-autonomy/PracticeAutonomyPage.stories.tsx
+++ b/webapp/src/components/admin/practices/practice-autonomy/PracticeAutonomyPage.stories.tsx
@@ -100,6 +100,7 @@ const oneUnreviewablePractice = buildAutonomyFixture({
 	],
 });
 
+/** Built once and shared: resolving the whole inheritance chain over this many rows is not free. */
 const atScale = scaleFixture();
 
 const idle = {
@@ -135,6 +136,12 @@ const meta = {
 	},
 	decorators: [withWidePage],
 	tags: ["autodocs"],
+	/**
+	 * Only the scope filter is held in state; the autonomy setters stay spies. {@link buildAutonomyFixture}
+	 * resolves the three-level inheritance chain the way the server does, so applying an autonomy locally
+	 * would mean resolving it a second time by hand — and the page would show a rollup its own rows
+	 * contradict the first time the two disagreed.
+	 */
 	render: (args) => (
 		<Stateful initial={args.overridesOnly}>
 			{(overridesOnly, setOverridesOnly) => (
@@ -163,6 +170,8 @@ export const WorkspaceDefaultUnset: Story = {
 		await expect(
 			canvas.getByRole("radiogroup", { name: "How far reviews go without you" }),
 		).toBeVisible();
+		// The workspace makes one decision, not two: how far a review goes is the only axis, and
+		// Review before sending means a person decides whether the composed feedback is released.
 		await expect(canvas.queryByText(/feedback may go/i)).not.toBeInTheDocument();
 		await expect(canvas.queryByText(/mentor conversation/i)).not.toBeInTheDocument();
 		await expectNoPageOverflow();
@@ -241,6 +250,8 @@ export const PracticeOverrideWithReset: Story = {
 		const row = canvas.getByText("Links the issue it closes").closest("li");
 		if (!(row instanceof HTMLElement)) throw new Error("Practice row not rendered");
 
+		// `getByText` matches an element's own text nodes, so this is the paragraph and not the button
+		// inside it; the button is asserted by role below.
 		await expect(within(row).getByText("Set here.")).toBeVisible();
 		await expect(
 			within(row).getByRole("radiogroup", {
@@ -261,6 +272,11 @@ export const PracticeOverrideWithReset: Story = {
 	},
 };
 
+/**
+ * A practice carrying no prose gets no preview card at all, rather than an empty popup appearing
+ * under the pointer. Locally written practices usually carry none, so this is a state production
+ * reaches routinely.
+ */
 export const PracticeContext: Story = {
 	args: from(oneDescribedAndOneBare),
 	play: async ({ canvas, userEvent }) => {
@@ -273,6 +289,7 @@ export const PracticeContext: Story = {
 			within(described).queryByText(/reads as arbitrary six months later/),
 		).not.toBeInTheDocument();
 
+		// The card is portalled, so it is found on the screen and not in the row.
 		await userEvent.hover(
 			within(described).getByRole("link", { name: "Explains the trade-off it chose" }),
 		);
@@ -281,6 +298,9 @@ export const PracticeContext: Story = {
 		const bare = canvas.getByText("Written by hand, and says nothing more").closest("li");
 		if (!(bare instanceof HTMLElement)) throw new Error("Bare row not rendered");
 		await expect(within(bare).getByText("Pull or merge request")).toBeVisible();
+		// A practice with neither field renders its link bare rather than wrapped in a card that
+		// would open on hover with nothing in it. Asserted on the element, not by hovering and
+		// waiting for nothing, which passes just as well when the card is merely slow.
 		await expect(
 			within(bare).getByRole("link", { name: "Written by hand, and says nothing more" }),
 		).not.toHaveAttribute("data-slot", "hover-card-trigger");
@@ -288,6 +308,11 @@ export const PracticeContext: Story = {
 	},
 };
 
+/**
+ * The card hangs off the practice's own link rather than a help icon, so the tab stop the row already
+ * has is the keyboard path and no row grows a second one. This story is what keeps that a fact rather
+ * than a claim: Base UI's hover card opens on focus-visible, Radix's does not.
+ */
 export const PracticeDetailOnKeyboardFocus: Story = {
 	parameters: { chromatic: { disableSnapshot: true } },
 	args: from(oneDescribedPractice),
@@ -296,6 +321,8 @@ export const PracticeDetailOnKeyboardFocus: Story = {
 		const link = canvas.getByRole("link", { name: "Explains the trade-off it chose" });
 
 		await expect(screen.queryByText(/reads as arbitrary six months later/)).not.toBeInTheDocument();
+		// `link.focus()` would not do: the card opens on focus-*visible*, so focus has to arrive by
+		// keyboard. Bounded, so a DOM change ahead of the link fails the story instead of hanging it.
 		for (let step = 0; step < 12 && document.activeElement !== link; step++) {
 			await userEvent.tab();
 		}
@@ -411,12 +438,18 @@ export const AtScale: Story = {
 	},
 };
 
-/** Text and role assertions cannot detect column drift, so this story verifies geometry. */
+/**
+ * A geometry assertion, because a ladder laid out after a content-width header takes its left edge
+ * from the length of the group's name — and nothing about the DOM, the roles or the text changes when
+ * that happens, so no other kind of assertion catches it.
+ */
 export const DecisionsShareOneColumn: Story = {
 	args: from(atScale),
 	globals: { viewport: { value: "desktop" } },
 	parameters: { chromatic: { disableSnapshot: true } },
 	play: async ({ canvas, userEvent }) => {
+		// Below `sm` every ladder is full width and shares a left edge regardless, so a runner that
+		// ignored the viewport would pass this story for the wrong reason.
 		await expect(window.innerWidth).toBeGreaterThanOrEqual(640);
 
 		await userEvent.click(canvas.getByRole("button", { name: /^Pull request hygiene/ }));
@@ -426,6 +459,7 @@ export const DecisionsShareOneColumn: Story = {
 			.map((group) => Math.round(group.getBoundingClientRect().left));
 
 		await expect(lefts.length).toBeGreaterThan(25);
+		// One column, to within the sub-pixel rounding of a grid track inside a grid track.
 		await expect(Math.max(...lefts) - Math.min(...lefts)).toBeLessThanOrEqual(2);
 	},
 };

--- a/webapp/src/components/admin/practices/practice-autonomy/PracticeAutonomyPage.tsx
+++ b/webapp/src/components/admin/practices/practice-autonomy/PracticeAutonomyPage.tsx
@@ -668,6 +668,7 @@ export interface DecisionNoteProps {
 	onClear: () => void;
 }
 
+/** `DecisionNote` reads `null` as "chosen here, so offer the reset" — narrowed once, not per site. */
 function inheritedSentenceOrNull(
 	assignment: Parameters<typeof autonomySourceOf>[0],
 	inheritedFrom: string,

--- a/webapp/src/components/admin/practices/practice-autonomy/PracticeAutonomyPage.tsx
+++ b/webapp/src/components/admin/practices/practice-autonomy/PracticeAutonomyPage.tsx
@@ -71,6 +71,12 @@ const GROUP_GRID = "sm:grid-cols-[minmax(0,1fr)_20rem]";
 
 const ROW_GRID = "grid-cols-[auto_minmax(0,1fr)] sm:grid-cols-[auto_minmax(0,1fr)_20rem]";
 
+type AutomaticPromotion =
+	| { scope: "workspace" }
+	| { scope: "group"; slug: string; name: string }
+	| { scope: "practice"; slug: string; name: string }
+	| { scope: "bulk"; slugs: string[] };
+
 export interface PracticeAutonomyPendingState {
 	workspace: boolean;
 	groupSlugs: ReadonlySet<string>;
@@ -113,7 +119,7 @@ export function PracticeAutonomyPage({
 }: PracticeAutonomyPageProps) {
 	const [selected, setSelected] = useState<ReadonlySet<string>>(new Set());
 	const [openGroups, setOpenGroups] = useState<string[]>([]);
-	const [automaticPromotion, setAutomaticPromotion] = useState<string[] | null>(null);
+	const [automaticPromotion, setAutomaticPromotion] = useState<AutomaticPromotion | null>(null);
 
 	const groups = groupPracticesByGroup(rollup, practices, { overridesOnly });
 	const overrides = countOverrides(rollup);
@@ -145,30 +151,29 @@ export function PracticeAutonomyPage({
 			>
 				<AlertDialogContent>
 					<AlertDialogHeader>
-						<AlertDialogTitle>Send feedback automatically?</AlertDialogTitle>
+						<AlertDialogTitle>Start sending automatically?</AlertDialogTitle>
 						<AlertDialogDescription>
-							Set {automaticPromotion?.length ?? 0} selected{" "}
-							{automaticPromotion?.length === 1 ? "practice" : "practices"} to Send automatically.
-							Their eligible feedback will no longer wait for approval. Current coverage includes{" "}
-							{settings.coverageSummary.coveredRepositories} of{" "}
-							{settings.coverageSummary.monitoredRepositories} monitored repositories and{" "}
-							{settings.coverageSummary.coveredPeople} of {settings.coverageSummary.eligiblePeople}{" "}
-							eligible people. {settings.coverageSummary.recentReviewVolume} review jobs entered
-							this workspace's queue during the last {settings.coverageSummary.estimateWindowDays}{" "}
-							days.
+							Set {automaticPromotionLabel(automaticPromotion)} to Send automatically. Eligible new
+							feedback affected by this setting can proceed without approval, subject to delivery
+							policy. Feedback already awaiting approval will remain unchanged.
 						</AlertDialogDescription>
 					</AlertDialogHeader>
 					<AlertDialogFooter>
-						<AlertDialogCancel>Keep current settings</AlertDialogCancel>
+						<AlertDialogCancel>Cancel</AlertDialogCancel>
 						<AlertDialogAction
 							onClick={() => {
 								if (automaticPromotion !== null) {
-									onBulkSetAutonomy(automaticPromotion, "AUTOMATIC");
+									applyAutomaticPromotion(automaticPromotion, {
+										onSetWorkspaceDefault,
+										onSetGroupAutonomy,
+										onSetPracticeAutonomy,
+										onBulkSetAutonomy,
+									});
 								}
 								setAutomaticPromotion(null);
 							}}
 						>
-							Send automatically
+							Start sending automatically
 						</AlertDialogAction>
 					</AlertDialogFooter>
 				</AlertDialogContent>
@@ -176,7 +181,13 @@ export function PracticeAutonomyPage({
 			<WorkspaceDecisionCard
 				settings={settings}
 				saving={pending.workspace}
-				onSetWorkspaceDefault={onSetWorkspaceDefault}
+				onSetWorkspaceDefault={(autonomy) => {
+					if (autonomy === "AUTOMATIC") {
+						setAutomaticPromotion({ scope: "workspace" });
+						return;
+					}
+					onSetWorkspaceDefault(autonomy);
+				}}
 				onClearWorkspaceDefault={onClearWorkspaceDefault}
 			/>
 			<div className="sticky top-0 z-20 space-y-3 border-b bg-background/95 py-3 backdrop-blur supports-backdrop-filter:bg-background/80">
@@ -189,7 +200,7 @@ export function PracticeAutonomyPage({
 					bulk={pending.bulk}
 					onSet={(autonomy) => {
 						if (autonomy === "AUTOMATIC") {
-							setAutomaticPromotion(actionable);
+							setAutomaticPromotion({ scope: "bulk", slugs: actionable });
 							return;
 						}
 						onBulkSetAutonomy(actionable, autonomy);
@@ -235,9 +246,30 @@ export function PracticeAutonomyPage({
 									return next;
 								})
 							}
-							onSetGroupAutonomy={onSetGroupAutonomy}
+							onSetGroupAutonomy={(groupSlug, autonomy) => {
+								if (autonomy === "AUTOMATIC") {
+									setAutomaticPromotion({ scope: "group", slug: groupSlug, name: group.name });
+									return;
+								}
+								onSetGroupAutonomy(groupSlug, autonomy);
+							}}
 							onClearGroupAutonomy={onClearGroupAutonomy}
-							onSetPracticeAutonomy={onSetPracticeAutonomy}
+							onSetPracticeAutonomy={(practiceSlug, autonomy) => {
+								if (autonomy === "AUTOMATIC") {
+									const practice = group.practices.find(
+										(candidate) => candidate.slug === practiceSlug,
+									);
+									if (practice) {
+										setAutomaticPromotion({
+											scope: "practice",
+											slug: practiceSlug,
+											name: practice.name,
+										});
+									}
+									return;
+								}
+								onSetPracticeAutonomy(practiceSlug, autonomy);
+							}}
 							onClearPracticeAutonomy={onClearPracticeAutonomy}
 						/>
 					))}
@@ -245,6 +277,36 @@ export function PracticeAutonomyPage({
 			)}
 		</div>
 	);
+}
+
+function automaticPromotionLabel(promotion: AutomaticPromotion | null): string {
+	if (promotion === null) return "this selection";
+	if (promotion.scope === "workspace") return "the workspace default";
+	if (promotion.scope === "group") return `the ${promotion.name} group`;
+	if (promotion.scope === "practice") return promotion.name;
+	return `${promotion.slugs.length} selected ${promotion.slugs.length === 1 ? "practice" : "practices"}`;
+}
+
+function applyAutomaticPromotion(
+	promotion: AutomaticPromotion,
+	actions: Pick<
+		PracticeAutonomyPageProps,
+		"onSetWorkspaceDefault" | "onSetGroupAutonomy" | "onSetPracticeAutonomy" | "onBulkSetAutonomy"
+	>,
+) {
+	switch (promotion.scope) {
+		case "workspace":
+			actions.onSetWorkspaceDefault("AUTOMATIC");
+			return;
+		case "group":
+			actions.onSetGroupAutonomy(promotion.slug, "AUTOMATIC");
+			return;
+		case "practice":
+			actions.onSetPracticeAutonomy(promotion.slug, "AUTOMATIC");
+			return;
+		case "bulk":
+			actions.onBulkSetAutonomy(promotion.slugs, "AUTOMATIC");
+	}
 }
 
 function WorkspaceDecisionCard({
@@ -606,7 +668,6 @@ export interface DecisionNoteProps {
 	onClear: () => void;
 }
 
-/** `DecisionNote` reads `null` as "chosen here, so offer the reset" — narrowed once, not per site. */
 function inheritedSentenceOrNull(
 	assignment: Parameters<typeof autonomySourceOf>[0],
 	inheritedFrom: string,


### PR DESCRIPTION
## Description

Adds a confirmation step before workspace administrators promote a practice, group, bulk selection, or the workspace default to **Send automatically**. The dialog makes clear that delivery remains subject to policy and that feedback already awaiting approval is unchanged.

This is intentionally a focused safety improvement related to #1357 and #1358. It does not claim to implement their server-bound activation preview, scoped blast-radius calculation, or proposal acknowledgment workflow.

## How to test

1. Open a workspace's **Practices → Review → How much** page.
2. Choose **Send automatically** for a practice, group, or workspace default and verify that no setting changes before confirmation.
3. Confirm and verify that the selected scope changes.
4. Repeat for the workspace default, choose **Cancel**, and verify that it remains unchanged.
5. Select multiple practices, choose **Send automatically**, and verify that the exact selection changes only after confirmation.

Automated coverage includes all four promotion scopes, cancellation, the full webapp test suite, and Storybook browser interactions.

## Checklist

- [x] My changeset summary reads as an operator/user-facing note (it becomes the changelog entry) — see `.changeset/README.md`
- [x] This change requires no operator action or migration.
