### PR TITLE
fix(security): make Sentry reports private and actionable

### DIFF
--- a/.changeset/private-actionable-errors.md
+++ b/.changeset/private-actionable-errors.md
@@ -1,0 +1,5 @@
+---
+"hephaestus": patch
+---
+
+Browser errors now carry release and source-map context and show recovery controls. Server and browser reports omit Sentry request, user, and breadcrumb context.

--- a/.github/workflows/ci-docker-build.yml
+++ b/.github/workflows/ci-docker-build.yml
@@ -2,6 +2,13 @@ name: Docker
 
 on:
   workflow_call:
+    secrets:
+      SENTRY_AUTH_TOKEN:
+        required: false
+      SENTRY_ORG:
+        required: false
+      SENTRY_PROJECT:
+        required: false
     inputs:
       should_skip:
         description: "Whether to skip the workflow"
@@ -48,6 +55,10 @@ jobs:
       packages: write
       id-token: write
       attestations: write
+    secrets:
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+      SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
     with:
       image-name: "ls1intum/hephaestus/webapp"
       docker-file: "./webapp/Dockerfile"

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -294,6 +294,10 @@ jobs:
 
   Docker:
     uses: ./.github/workflows/ci-docker-build.yml
+    secrets:
+      SENTRY_AUTH_TOKEN: ${{ github.event_name != 'pull_request' && secrets.SENTRY_AUTH_TOKEN || '' }}
+      SENTRY_ORG: ${{ github.event_name != 'pull_request' && secrets.SENTRY_ORG || '' }}
+      SENTRY_PROJECT: ${{ github.event_name != 'pull_request' && secrets.SENTRY_PROJECT || '' }}
     # Image builds consume the detected source tree, not Quality outputs. Running both branches at
     # once keeps image and preview confidence without adding Docker as a second CI stage.
     needs: [detect-changes]

--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -2,6 +2,13 @@ name: Docker Build (Cached)
 
 on:
   workflow_call:
+    secrets:
+      SENTRY_AUTH_TOKEN:
+        required: false
+      SENTRY_ORG:
+        required: false
+      SENTRY_PROJECT:
+        required: false
     inputs:
       image-name:
         type: string
@@ -159,6 +166,10 @@ jobs:
           file: ${{ inputs.docker-file }}
           platforms: ${{ matrix.platform }}
           build-args: ${{ inputs.build-args }}
+          secrets: |
+            sentry_auth_token=${{ github.event_name != 'pull_request' && matrix.platform == 'linux/amd64' && secrets.SENTRY_AUTH_TOKEN || '' }}
+            sentry_org=${{ github.event_name != 'pull_request' && matrix.platform == 'linux/amd64' && secrets.SENTRY_ORG || '' }}
+            sentry_project=${{ github.event_name != 'pull_request' && matrix.platform == 'linux/amd64' && secrets.SENTRY_PROJECT || '' }}
           labels: ${{ steps.meta.outputs.labels }}
           tags: ${{ inputs.single-arch && steps.meta.outputs.tags || '' }}
           push: ${{ inputs.single-arch }}

--- a/docs/admin/configuration-readiness.mdx
+++ b/docs/admin/configuration-readiness.mdx
@@ -107,4 +107,9 @@ recommendation is non-fatal.
 ## Optional observability
 
 Sentry is optional. When configured, `hephaestus.sentry.dsn` must use HTTPS. The fact is classified
-`OPTIONAL` and never prevents startup.
+`OPTIONAL` and never prevents startup. Activating it requires the processing review in the
+[processor checklist](./dsms/processor-checklist#follow-up-if-the-processing-surface-changes).
+
+Frontend error rates include only browsers whose users accepted error monitoring. Treat them as
+consent-biased diagnostics, not as an availability metric or a basis for comparing deployments.
+Server-side error rates do not have this selection bias.

--- a/docs/contributor/release-management.mdx
+++ b/docs/contributor/release-management.mdx
@@ -97,6 +97,15 @@ The latest release is rescanned weekly. A policy violation or scan failure is re
 [the vulnerability response issue](https://github.com/ls1intum/Hephaestus/issues/1369); scanner failure
 is never treated as no findings.
 
+## Browser source maps
+
+Image builds upload hidden source maps through Sentry's debug-ID integration when the repository
+secrets `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, and `SENTRY_PROJECT` are all configured. The token must be
+authorized to upload artifacts to that project. Builds reject a partial configuration, pass the
+values as BuildKit secrets to the `amd64` build outside pull requests, and remove maps before creating
+either nginx image. The runtime release remains the same version the application server receives
+from the verified release lock.
+
 ### Operator verification
 
 The [release image lock](../admin/release-image-lock) is the canonical verification procedure. It

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -422,6 +422,9 @@ importers:
       '@primer/primitives':
         specifier: 11.9.0
         version: 11.9.0
+      '@sentry/vite-plugin':
+        specifier: 5.4.0
+        version: 5.4.0(supports-color@8.1.1)(webpack@5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(esbuild@0.27.7)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26))
       '@storybook/addon-a11y':
         specifier: 10.4.0
         version: 10.4.0(storybook@10.4.0(patch_hash=266885747f5f3e33f57d0f78661b7a0ce1644e54acf135146ad9efa4860e37cf)(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8)(vite-plus@0.3.0(@types/node@24.12.4)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-v8@4.1.11)(esbuild@0.27.7)(jiti@2.7.0)(jsdom@29.1.1)(msw@2.14.6(@types/node@24.12.4)(typescript@7.0.2))(terser@5.51.0)(typescript@7.0.2)(vite@8.2.2(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.51.0)(yaml@2.9.0))(yaml@2.9.0)))
@@ -4007,6 +4010,70 @@ packages:
     resolution: {integrity: sha512-fTE9tUDoggJSFv8cQ+h1UA9onovOoUNJWu8Var1MXmUVuVG/W3WqzJFVyKArZMj95lizZkq8aiS63SURvrBsFQ==}
     engines: {node: '>=18'}
 
+  '@sentry/bundler-plugins@10.71.0':
+    resolution: {integrity: sha512-cTgFyV4N8rFx+4/QMcJBotCCthYFBT/g6VoqG9tFz7CJJtoORIH3RiR+DTfpfBMe7IuVC40XP9MlD4P1LWwXCg==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      rollup: '>=3.2.0'
+      webpack: '>=5.0.0'
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+      webpack:
+        optional: true
+
+  '@sentry/cli-darwin@2.58.6':
+    resolution: {integrity: sha512-udAVvcyfNa0R+95GvPz/+43/N3TC0TYKdkQ7D7jhPSzbcMc7l2fxRNN5yB3UpCA5fWFnW4toeaqwDBhb/Wh3LA==}
+    engines: {node: '>=10'}
+    os: [darwin]
+
+  '@sentry/cli-linux-arm64@2.58.6':
+    resolution: {integrity: sha512-q8mEcNNmeXMy5i+jWT30TVpH7LcP4HD21CD5XRSPAd/a912HF6EpK0ybf/1USO14WOhoXbAGi9txwaWabSe33g==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-arm@2.58.6':
+    resolution: {integrity: sha512-pD0LAt5PcUzAinBwvDqc66x9+2CabHEv486yP0gRjWO7SakbaxmfVq/EXd8VLq/Tzi39LAu422UYK1lpW3MILw==}
+    engines: {node: '>=10'}
+    cpu: [arm]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-i686@2.58.6':
+    resolution: {integrity: sha512-q8vNJi1eOV/4vxAFWBsEwLHoSYapaZHIf4j76KJGJXFKTkEbsjCOOsKbwUIBTQQhRgV4DFWh3ryfsPS/que4Kg==}
+    engines: {node: '>=10'}
+    cpu: [x86, ia32]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-x64@2.58.6':
+    resolution: {integrity: sha512-DZu956Mhi3ZRjTBe1WdbGV46ldVbA8d2rgp/fh51GsI25zjBHah4wZnPTSzpc+YqxU6pJpg579B/r3jrIK530Q==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-win32-arm64@2.58.6':
+    resolution: {integrity: sha512-nj0Ff/kmAB73EPDhR8B4O9r+NUHK5GkPCkGWC+kXVemqAJWL5jcJ5KdxG0l/S0z6RoEoltID8/43/B+TaMlT7A==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@sentry/cli-win32-i686@2.58.6':
+    resolution: {integrity: sha512-WNZiDzPbgsEMQWq4avsQ391v/xWKJDIWWWo9GYl+N/w5qcYKkoDW7wQG7T9FasI6ENn68phChTOAPXXxbfAdOg==}
+    engines: {node: '>=10'}
+    cpu: [x86, ia32]
+    os: [win32]
+
+  '@sentry/cli-win32-x64@2.58.6':
+    resolution: {integrity: sha512-R35WJ17oF4D2eqI1DR2sQQqr0fjRTt5xoP16WrTu91XM2lndRMFsnjh+/GttbxapLCBNlrjzia99MJ0PZHZpgA==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@sentry/cli@2.58.6':
+    resolution: {integrity: sha512-baBcNPLLfUi9WuL+Tpri9BFaAdvugZIKelC5X0tt0Zdy+K0K+PCVSrnNmwMWU/HyaF/SEv6b6UHnXIdqanBlcg==}
+    engines: {node: '>= 10'}
+    hasBin: true
+
   '@sentry/conventions@0.16.0':
     resolution: {integrity: sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ==}
     engines: {node: '>=14'}
@@ -4032,6 +4099,10 @@ packages:
   '@sentry/replay@10.71.0':
     resolution: {integrity: sha512-ytEgVg7isvavQL6hgsgYeuSCkcA3EyOKm9lMLQOZTLkiUCtFT/ItWwGNhzS46vQ6wsTv3Uc0Y1JlcJHSFKe/Kg==}
     engines: {node: '>=18'}
+
+  '@sentry/vite-plugin@5.4.0':
+    resolution: {integrity: sha512-fFJgCxs5hDyAm9BbZJ+LbA+LK2tjX5OoD0v0ARU4StR6KQmGUduoPs69yJ9AfqZ0om3Rlp5JDliiwFcNkasORA==}
+    engines: {node: '>= 18'}
 
   '@sideway/address@4.1.5':
     resolution: {integrity: sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==}
@@ -7127,6 +7198,10 @@ packages:
     resolution: {integrity: sha512-9ZonPT4ZAK4a+1pUPVPZJapbi7O5qbbJPdYw/NOQWZZbVLdDTYM3A4R9z/DpAM08IDaFGsvPgiGZ82WEwUDWjg==}
     engines: {node: '>=14.16'}
 
+  find-up@5.0.0:
+    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
+    engines: {node: '>=10'}
+
   find-up@6.3.0:
     resolution: {integrity: sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -8118,6 +8193,10 @@ packages:
     resolution: {integrity: sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==}
     engines: {node: '>=8.9.0'}
 
+  locate-path@6.0.0:
+    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
+    engines: {node: '>=10'}
+
   locate-path@7.2.0:
     resolution: {integrity: sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -8852,9 +8931,17 @@ packages:
     resolution: {integrity: sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==}
     engines: {node: '>=4'}
 
+  p-limit@3.1.0:
+    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
+    engines: {node: '>=10'}
+
   p-limit@4.0.0:
     resolution: {integrity: sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  p-locate@5.0.0:
+    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
+    engines: {node: '>=10'}
 
   p-locate@6.0.0:
     resolution: {integrity: sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==}
@@ -8936,6 +9023,10 @@ packages:
 
   path-data-parser@0.1.0:
     resolution: {integrity: sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==}
+
+  path-exists@4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
 
   path-exists@5.0.0:
     resolution: {integrity: sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==}
@@ -11120,6 +11211,10 @@ packages:
   yargs@18.1.0:
     resolution: {integrity: sha512-2rAgRKu54VsHkqI0/tYkmluGXHD4KW7yZoycuqDQ15QOTnc2VVfy0nN/1eMhnQLO00A+dwtK20xuCnc1YGeUyg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=23}
+
+  yocto-queue@0.1.0:
+    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
+    engines: {node: '>=10'}
 
   yocto-queue@1.2.2:
     resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
@@ -15714,6 +15809,65 @@ snapshots:
       '@sentry/replay': 10.71.0
       '@sentry/replay-canvas': 10.71.0
 
+  '@sentry/bundler-plugins@10.71.0(supports-color@8.1.1)(webpack@5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(esbuild@0.27.7)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26))':
+    dependencies:
+      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@sentry/cli': 2.58.6(supports-color@8.1.1)
+      '@sentry/core': 10.71.0
+      dotenv: 17.4.2
+      find-up: 5.0.0
+      glob: 13.0.6
+      magic-string: 0.30.21
+    optionalDependencies:
+      webpack: 5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(esbuild@0.27.7)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  '@sentry/cli-darwin@2.58.6':
+    optional: true
+
+  '@sentry/cli-linux-arm64@2.58.6':
+    optional: true
+
+  '@sentry/cli-linux-arm@2.58.6':
+    optional: true
+
+  '@sentry/cli-linux-i686@2.58.6':
+    optional: true
+
+  '@sentry/cli-linux-x64@2.58.6':
+    optional: true
+
+  '@sentry/cli-win32-arm64@2.58.6':
+    optional: true
+
+  '@sentry/cli-win32-i686@2.58.6':
+    optional: true
+
+  '@sentry/cli-win32-x64@2.58.6':
+    optional: true
+
+  '@sentry/cli@2.58.6(supports-color@8.1.1)':
+    dependencies:
+      https-proxy-agent: 5.0.1(supports-color@8.1.1)
+      node-fetch: 2.7.0
+      progress: 2.0.3
+      proxy-from-env: 1.1.0
+      which: 2.0.2
+    optionalDependencies:
+      '@sentry/cli-darwin': 2.58.6
+      '@sentry/cli-linux-arm': 2.58.6
+      '@sentry/cli-linux-arm64': 2.58.6
+      '@sentry/cli-linux-i686': 2.58.6
+      '@sentry/cli-linux-x64': 2.58.6
+      '@sentry/cli-win32-arm64': 2.58.6
+      '@sentry/cli-win32-i686': 2.58.6
+      '@sentry/cli-win32-x64': 2.58.6
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
   '@sentry/conventions@0.16.0': {}
 
   '@sentry/core@10.71.0':
@@ -15740,6 +15894,15 @@ snapshots:
     dependencies:
       '@sentry/browser-utils': 10.71.0
       '@sentry/core': 10.71.0
+
+  '@sentry/vite-plugin@5.4.0(supports-color@8.1.1)(webpack@5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(esbuild@0.27.7)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26))':
+    dependencies:
+      '@sentry/bundler-plugins': 10.71.0(supports-color@8.1.1)(webpack@5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(esbuild@0.27.7)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26))
+    transitivePeerDependencies:
+      - encoding
+      - rollup
+      - supports-color
+      - webpack
 
   '@sideway/address@4.1.5':
     dependencies:
@@ -18864,6 +19027,11 @@ snapshots:
       common-path-prefix: 3.0.0
       pkg-dir: 7.0.0
 
+  find-up@5.0.0:
+    dependencies:
+      locate-path: 6.0.0
+      path-exists: 4.0.0
+
   find-up@6.3.0:
     dependencies:
       locate-path: 7.2.0
@@ -19852,6 +20020,10 @@ snapshots:
       big.js: 5.2.2
       emojis-list: 3.0.0
       json5: 2.2.3
+
+  locate-path@6.0.0:
+    dependencies:
+      p-locate: 5.0.0
 
   locate-path@7.2.0:
     dependencies:
@@ -20941,9 +21113,17 @@ snapshots:
 
   p-finally@1.0.0: {}
 
+  p-limit@3.1.0:
+    dependencies:
+      yocto-queue: 0.1.0
+
   p-limit@4.0.0:
     dependencies:
       yocto-queue: 1.2.2
+
+  p-locate@5.0.0:
+    dependencies:
+      p-limit: 3.1.0
 
   p-locate@6.0.0:
     dependencies:
@@ -21055,6 +21235,8 @@ snapshots:
       tslib: 2.8.1
 
   path-data-parser@0.1.0: {}
+
+  path-exists@4.0.0: {}
 
   path-exists@5.0.0: {}
 
@@ -23443,6 +23625,8 @@ snapshots:
       string-width: 8.2.2
       y18n: 5.0.8
       yargs-parser: 22.0.0
+
+  yocto-queue@0.1.0: {}
 
   yocto-queue@1.2.2: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,6 +18,7 @@ allowBuilds:
   '@google/genai': false
   '@nestjs/core': false
   '@openapitools/openapi-generator-cli': false
+  '@sentry/cli': true
   "@swc/core": true
   core-js: false
   esbuild: true

--- a/scripts/check-package-manager.ts
+++ b/scripts/check-package-manager.ts
@@ -99,6 +99,7 @@ expectConfig("allowBuilds", {
 	esbuild: true,
 	"@google/genai": false,
 	"@swc/core": true,
+	"@sentry/cli": true,
 });
 
 const setup = readFileSync(".github/actions/setup-node-pnpm/action.yml", "utf8");

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/config/SentryConfiguration.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/config/SentryConfiguration.java
@@ -42,10 +42,15 @@ public class SentryConfiguration {
 
             Sentry.init(options -> {
                 options.setDsn(dsn);
-                options.setSendDefaultPii(true);
+                options.setSendDefaultPii(false);
+                options.setBeforeSend((event, hint) -> {
+                    event.setUser(null);
+                    event.setRequest(null);
+                    event.setBreadcrumbs(null);
+                    return event;
+                });
                 options.setEnvironment(getEnvironment());
                 options.setRelease(hephaestusVersion);
-                options.setTracesSampleRate(getTracesSampleRate());
             });
 
             log.info("Initialized Sentry");
@@ -62,13 +67,5 @@ public class SentryConfiguration {
         } else {
             return "local";
         }
-    }
-
-    private double getTracesSampleRate() {
-        return switch (getEnvironment()) {
-            case "test" -> 1.0;
-            case "prod" -> 0.2;
-            default -> 0.0;
-        };
     }
 }

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/config/SentryConfigurationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/config/SentryConfigurationTest.java
@@ -1,0 +1,47 @@
+package de.tum.cit.aet.hephaestus.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.sentry.Hint;
+import io.sentry.Sentry;
+import io.sentry.SentryEvent;
+import io.sentry.protocol.Request;
+import io.sentry.protocol.User;
+import java.util.Objects;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.env.MockEnvironment;
+
+@Tag("unit")
+class SentryConfigurationTest {
+    @AfterEach
+    void closeSentry() {
+        Sentry.close();
+    }
+
+    @Test
+    void initEnforcesThePrivacyContract() {
+        var configuration = new SentryConfiguration(
+                new MockEnvironment().withProperty("spring.profiles.active", "test"),
+                "1.2.3",
+                new SentryProperties("https://public@example.invalid/1"));
+
+        configuration.init();
+
+        assertThat(Sentry.getCurrentScopes().getOptions().isSendDefaultPii()).isFalse();
+        var event = new SentryEvent();
+        event.setUser(new User());
+        event.setRequest(new Request());
+        event.addBreadcrumb("visited /private/person/42");
+
+        var beforeSend =
+                Objects.requireNonNull(Sentry.getCurrentScopes().getOptions().getBeforeSend());
+        var scrubbed = beforeSend.execute(event, new Hint());
+
+        assertThat(scrubbed).isNotNull();
+        assertThat(scrubbed.getUser()).isNull();
+        assertThat(scrubbed.getRequest()).isNull();
+        assertThat(scrubbed.getBreadcrumbs()).isNull();
+    }
+}

--- a/webapp/Dockerfile
+++ b/webapp/Dockerfile
@@ -11,7 +11,15 @@ RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store,sharing=locked \
 RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store,sharing=locked \
     pnpm install --offline --frozen-lockfile --filter webapp
 COPY webapp/ /repo/webapp/
-RUN pnpm --filter webapp run build
+RUN --mount=type=secret,id=sentry_auth_token,required=false \
+    --mount=type=secret,id=sentry_org,required=false \
+    --mount=type=secret,id=sentry_project,required=false \
+    export SENTRY_AUTH_TOKEN="$(cat /run/secrets/sentry_auth_token 2>/dev/null || true)" && \
+    export SENTRY_ORG="$(cat /run/secrets/sentry_org 2>/dev/null || true)" && \
+    export SENTRY_PROJECT="$(cat /run/secrets/sentry_project 2>/dev/null || true)" && \
+    pnpm --filter webapp run build && \
+    find webapp/dist -name '*.map' -delete && \
+    ! find webapp/dist -name '*.map' -print -quit | grep -q .
 
 FROM nginx:stable-alpine@sha256:97d490c12ba55b4946b01546d1c3ed324e8d41ab1c9fcb2a616aa470620e5b46
 ARG COOLIFY_BRANCH

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -72,6 +72,7 @@
 		"@oxlint/plugins": "1.79.0",
 		"@playwright/test": "1.60.0",
 		"@primer/primitives": "11.9.0",
+		"@sentry/vite-plugin": "5.4.0",
 		"@storybook/addon-a11y": "10.4.0",
 		"@storybook/addon-docs": "10.4.0",
 		"@storybook/addon-onboarding": "10.4.0",

--- a/webapp/src/integrations/sentry/RouteError.test.tsx
+++ b/webapp/src/integrations/sentry/RouteError.test.tsx
@@ -1,0 +1,46 @@
+import {
+	createMemoryHistory,
+	createRootRoute,
+	createRoute,
+	createRouter,
+	RouterProvider,
+} from "@tanstack/react-router";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { StrictMode } from "react";
+import { expect, it, vi } from "vitest";
+
+import { RouteError } from "./RouteError";
+
+const { captureException } = vi.hoisted(() => ({ captureException: vi.fn() }));
+
+vi.mock("@/integrations/sentry", () => ({ captureException }));
+
+it("reports a thrown route error once and renders recovery controls", async () => {
+	const error = new Error("failed route");
+	const rootRoute = createRootRoute();
+	const route = createRoute({
+		getParentRoute: () => rootRoute,
+		path: "/",
+		component: () => {
+			throw error;
+		},
+	});
+	const router = createRouter({
+		routeTree: rootRoute.addChildren([route]),
+		history: createMemoryHistory({ initialEntries: ["/"] }),
+		defaultErrorComponent: RouteError,
+	});
+
+	render(
+		<StrictMode>
+			<RouterProvider router={router} />
+		</StrictMode>,
+	);
+
+	expect((await screen.findByRole("alert")).textContent).toContain("Something went wrong");
+	expect(captureException).toHaveBeenCalledExactlyOnceWith(error);
+
+	await userEvent.click(screen.getByRole("button", { name: "Try again" }));
+	await vi.waitFor(() => expect(captureException).toHaveBeenCalledTimes(2));
+});

--- a/webapp/src/integrations/sentry/RouteError.tsx
+++ b/webapp/src/integrations/sentry/RouteError.tsx
@@ -1,0 +1,30 @@
+import { type ErrorComponentProps, useRouter } from "@tanstack/react-router";
+import { useEffect, useRef } from "react";
+
+import { Button } from "@/components/ui/button";
+import { captureException } from "@/integrations/sentry";
+
+export function RouteError({ error }: ErrorComponentProps) {
+	const router = useRouter();
+	const reportedError = useRef<unknown>(undefined);
+	useEffect(() => {
+		if (reportedError.current !== error) {
+			captureException(error);
+			reportedError.current = error;
+		}
+	}, [error]);
+
+	return (
+		<div className="flex min-h-[50vh] items-center justify-center p-6">
+			<section className="max-w-md space-y-4 text-center" role="alert">
+				<h1 className="text-2xl font-semibold">Something went wrong</h1>
+				<p className="text-muted-foreground">
+					An unexpected error stopped this page from loading. Trying again usually helps.
+				</p>
+				<div className="flex justify-center gap-2">
+					<Button onClick={() => void router.invalidate()}>Try again</Button>
+				</div>
+			</section>
+		</div>
+	);
+}

--- a/webapp/src/integrations/sentry/index.test.ts
+++ b/webapp/src/integrations/sentry/index.test.ts
@@ -1,20 +1,29 @@
 import { describe, expect, it } from "vitest";
 
-import { DATA_COLLECTION } from "./index";
+import { DATA_COLLECTION, stripRequestUserAndBreadcrumbs } from "./index";
 
-/** Every value in the collection map, however deeply Sentry nests its categories. */
 function leaves(value: unknown): unknown[] {
 	return typeof value === "object" && value !== null && !Array.isArray(value)
 		? Object.values(value).flatMap(leaves)
 		: [value];
 }
 
-// The type on `DATA_COLLECTION` forces a decision about each category Sentry defines. This forces
-// that decision to be "off" — including inside `httpHeaders`, `graphQL` and `genAI`, where a
-// widening is a nested field nobody reads twice.
 describe("the data an error report may carry", () => {
 	it("turns no category on", () => {
 		expect(leaves(DATA_COLLECTION).filter((leaf) => leaf === true)).toStrictEqual([]);
 		expect(DATA_COLLECTION.httpBodies).toStrictEqual([]);
 	});
+});
+
+it("strips request, user, and breadcrumb fields", () => {
+	const event = stripRequestUserAndBreadcrumbs({
+		type: undefined,
+		request: { url: "https://example.test/private?token=secret", headers: { cookie: "secret" } },
+		user: { id: "person" },
+		breadcrumbs: [{ category: "navigation", data: { from: "/private" } }],
+	});
+
+	expect(event.request).toBeUndefined();
+	expect(event.user).toBeUndefined();
+	expect(event.breadcrumbs).toBeUndefined();
 });

--- a/webapp/src/integrations/sentry/index.ts
+++ b/webapp/src/integrations/sentry/index.ts
@@ -1,5 +1,6 @@
 import * as Sentry from "@sentry/react";
 
+import environment from "@/environment";
 import { hasErrorMonitoringConsent } from "@/integrations/consent";
 import { sentryDsn, sentryEnvironment } from "@/integrations/sentry/config";
 
@@ -7,21 +8,7 @@ let initialized = false;
 
 type DataCollection = NonNullable<NonNullable<Parameters<typeof Sentry.init>[0]>["dataCollection"]>;
 
-/**
- * What an error report may carry: nothing this file did not decide to send. TUM-student data
- * subjects are the reason the rule has no exceptions.
- *
- * Supplying `dataCollection` at all switches every category you *omit* to Sentry's permissive
- * defaults, so a partial object collects more than no object would — silently, because each field
- * is optional. `Required` removes the silence: a category Sentry adds in a release fails the build
- * here rather than turning itself on. `queryParams` is excluded as the deprecated alias of
- * `urlQueryParams`, which Sentry resolves to the same value.
- *
- * None of this is load-bearing for a default browser integration today; it is stated so that adding
- * tracing, replay or an HTTP-client integration cannot quietly widen what a report carries. Search
- * params still reach Sentry inside `event.request.url` via `httpContextIntegration`, which no
- * category here gates.
- */
+// Keep the SDK's collection inventory exhaustive so additions require an explicit decision.
 export const DATA_COLLECTION = {
 	userInfo: false,
 	cookies: false,
@@ -35,11 +22,17 @@ export const DATA_COLLECTION = {
 	frameContextLines: 5,
 } satisfies Required<Omit<DataCollection, "queryParams">>;
 
-/**
- * Initialize Sentry, gated on BOTH a configured DSN and explicit error-monitoring consent.
- * Idempotent: safe to call again after the user grants consent. Without consent (or a DSN) this
- * is a no-op, so no Sentry client is created and no events are sent.
- */
+export function stripRequestUserAndBreadcrumbs(event: Sentry.ErrorEvent): Sentry.ErrorEvent {
+	delete event.user;
+	delete event.request;
+	delete event.breadcrumbs;
+	return event;
+}
+
+export function captureException(error: unknown) {
+	if (initialized) Sentry.captureException(error);
+}
+
 export function initSentry() {
 	if (initialized) {
 		return;
@@ -50,25 +43,17 @@ export function initSentry() {
 	Sentry.init({
 		dsn: sentryDsn,
 		environment: sentryEnvironment,
+		release: environment.version,
 		dataCollection: DATA_COLLECTION,
+		beforeSend: stripRequestUserAndBreadcrumbs,
 	});
 	initialized = true;
 }
 
-/**
- * Tear Sentry down when error-monitoring consent is withdrawn (GDPR compliance).
- *
- * Closing the client flushes/stops the transport so no further events are captured or
- * sent; resetting the latch makes a subsequent `initSentry()` re-initialise if consent
- * is granted again. Safe to call when Sentry was never initialised (no-op).
- */
 export function disableSentry() {
 	if (!initialized) {
 		return;
 	}
-	// Detach the client synchronously so no *future* event is captured the moment consent is
-	// withdrawn. `close()` also flushes buffered events and tears down the transport, but it is
-	// async; we don't await it (best-effort flush) since teardown runs from a render/effect path.
 	void Sentry.getClient()?.close();
 	initialized = false;
 }

--- a/webapp/src/integrations/tanstack-query/root-provider.test.ts
+++ b/webapp/src/integrations/tanstack-query/root-provider.test.ts
@@ -1,0 +1,32 @@
+import { beforeEach, expect, it, vi } from "vitest";
+
+import { getJwksOptions } from "@/api/@tanstack/react-query.gen";
+
+import { getContext } from "./root-provider";
+
+const { captureException } = vi.hoisted(() => ({ captureException: vi.fn() }));
+
+vi.mock("@/integrations/sentry", () => ({ captureException }));
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	getContext().queryClient.clear();
+});
+
+it("reports rejected queries and mutations without changing their rejection contract", async () => {
+	const queryError = new Error("query failed");
+	await expect(
+		getContext().queryClient.query({
+			...getJwksOptions({}),
+			queryFn: () => Promise.reject(queryError),
+		}),
+	).rejects.toBe(queryError);
+	expect(captureException).toHaveBeenNthCalledWith(1, queryError);
+
+	const mutationError = new Error("mutation failed");
+	const mutation = getContext()
+		.queryClient.getMutationCache()
+		.build(getContext().queryClient, { mutationFn: () => Promise.reject(mutationError) });
+	await expect(mutation.execute(undefined)).rejects.toBe(mutationError);
+	expect(captureException).toHaveBeenNthCalledWith(2, mutationError);
+});

--- a/webapp/src/integrations/tanstack-query/root-provider.tsx
+++ b/webapp/src/integrations/tanstack-query/root-provider.tsx
@@ -1,6 +1,10 @@
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MutationCache, QueryCache, QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import { captureException } from "@/integrations/sentry";
 
 const queryClient = new QueryClient({
+	queryCache: new QueryCache({ onError: (error) => captureException(error) }),
+	mutationCache: new MutationCache({ onError: (error) => captureException(error) }),
 	defaultOptions: {
 		queries: {
 			/**

--- a/webapp/src/main.tsx
+++ b/webapp/src/main.tsx
@@ -6,6 +6,7 @@ import ReactDOM from "react-dom/client";
 
 import { client } from "@/api/client.gen";
 import environment from "@/environment";
+import { RouteError } from "@/integrations/sentry/RouteError";
 
 import "./styles.css";
 
@@ -70,6 +71,7 @@ const router = createRouter({
 	scrollRestorationBehavior: "instant",
 	defaultStructuralSharing: true,
 	defaultPreloadStaleTime: 0,
+	defaultErrorComponent: RouteError,
 });
 
 // Register the router instance for type safety
@@ -141,10 +143,9 @@ const rootElement = document.getElementById("app");
 if (rootElement && !rootElement.innerHTML) {
 	const root = ReactDOM.createRoot(rootElement, {
 		onUncaughtError: Sentry.reactErrorHandler((error, errorInfo) => {
-			// oxlint-disable-next-line no-console -- Supplying `onUncaughtError` replaces React's own console report, so without this line an uncaught render error leaves nothing in the browser console for a developer with devtools open; the component stack is available nowhere else on the page.
+			// oxlint-disable-next-line no-console -- The custom handler replaces React's console report.
 			console.warn("Uncaught error", error, errorInfo.componentStack);
 		}),
-		onCaughtError: Sentry.reactErrorHandler(),
 		onRecoverableError: Sentry.reactErrorHandler(),
 	});
 	root.render(

--- a/webapp/vite.config.ts
+++ b/webapp/vite.config.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs";
 import path, { resolve } from "node:path";
 
+import { sentryVitePlugin } from "@sentry/vite-plugin";
 import { tanstackRouter } from "@tanstack/router-plugin/vite";
 import { parse } from "jsonc-parser";
 import type { OxfmtConfig } from "oxfmt";
@@ -35,6 +36,17 @@ const lint = {
 	options: { ...lintConfig.options, typeAware: true, typeCheck: true },
 };
 
+const sentryUploadValues = [
+	process.env.SENTRY_AUTH_TOKEN,
+	process.env.SENTRY_ORG,
+	process.env.SENTRY_PROJECT,
+];
+const sentryUploadConfigured = sentryUploadValues.every(Boolean);
+if (sentryUploadValues.some(Boolean) && !sentryUploadConfigured) {
+	throw new Error(
+		"Sentry source-map upload requires SENTRY_AUTH_TOKEN, SENTRY_ORG, and SENTRY_PROJECT",
+	);
+}
 const viteConfig = {
 	root: import.meta.dirname,
 	fmt,
@@ -42,6 +54,13 @@ const viteConfig = {
 	plugins: [
 		tanstackRouter({ autoCodeSplitting: true }),
 		...appSourcePlugins(),
+		sentryVitePlugin({
+			org: process.env.SENTRY_ORG,
+			project: process.env.SENTRY_PROJECT,
+			authToken: process.env.SENTRY_AUTH_TOKEN,
+			disable: !sentryUploadConfigured,
+			telemetry: false,
+		}),
 		...Terminal({ output: ["terminal", "console"] }).map(
 			(plugin) => plugin && { ...plugin, apply: "serve" as const },
 		),
@@ -81,7 +100,7 @@ const viteConfig = {
 		},
 	],
 	build: {
-		sourcemap: false,
+		sourcemap: "hidden" as const,
 	},
 	optimizeDeps: {
 		exclude: ["storybook-static"],


### PR DESCRIPTION
## Description

Makes the 1.0 Sentry connection privacy-consistent and actionable without enabling tracing or replay. Server and browser events now drop Sentry request, user, and breadcrumb context; browser failures carry the application release, upload hidden source maps through Sentry's official Vite integration, and render a recoverable TanStack Router error state.

Query and mutation failures that application code handles are also reported without changing their rejection behavior. The image build keeps upload credentials out of pull requests and image layers, uploads once per multi-platform build, and removes source maps before serving the webapp.

Fixes #1641

## How to test

Automated coverage verifies the server and browser privacy callbacks, QueryCache and MutationCache reporting, and a real TanStack memory router's error and retry flow.

1. Run `pnpm run format && pnpm run check`.
2. Run `pnpm run test:webapp`.
3. Run `cd server && ./mvnw -pl application -am test -Dsurefire.includedGroups=unit -T 2C --batch-mode -q`.
4. Build with `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, and `SENTRY_PROJECT` configured, then trigger a route render error in a disposable Sentry project. Confirm the event is release-tagged and symbolicated, the recovery UI retries the route, and request, user, and breadcrumb fields are absent.
5. Inspect the final webapp image and confirm `/usr/share/nginx/html` contains no `*.map` files.

## Checklist

- [x] My changeset summary reads as an operator/user-facing note (it becomes the changelog entry) — see `.changeset/README.md`
- [x] No operator action is required. Source-map upload is enabled only when all three optional Sentry repository secrets are configured; partial configuration fails the build.

## Screenshots

Not included: the recovery UI is intentionally reachable only after a render failure. Its accessible alert, recovery control, reporting behavior, and retry flow are covered by the router integration test.

## Follow-up

Canonical correlation IDs remain owned by #1642. This PR does not introduce a competing trace identifier or enable the out-of-scope performance-tracing integration.
