### PR TITLE
refactor(server): migrate LLM proxy to per-job JWTs

### DIFF
--- a/.changeset/tidy-job-jwts.md
+++ b/.changeset/tidy-job-jwts.md
@@ -1,0 +1,5 @@
+---
+"hephaestus": patch
+---
+
+Agent sandboxes now use short-lived, proxy-scoped JWTs instead of reusable database-backed job secrets.

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobExecutor.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobExecutor.java
@@ -34,6 +34,7 @@ import de.tum.cit.aet.hephaestus.agent.usage.LlmPriceSnapshot;
 import de.tum.cit.aet.hephaestus.agent.usage.LlmUsageRecorder;
 import de.tum.cit.aet.hephaestus.core.WorkspaceAgnostic;
 import de.tum.cit.aet.hephaestus.core.runtime.RuntimeRole;
+import de.tum.cit.aet.hephaestus.core.runtime.hub.auth.WorkerJwtIssuer;
 import de.tum.cit.aet.hephaestus.evidence.AutomatedReviewReadinessReport;
 import de.tum.cit.aet.hephaestus.observability.StructuredLogKeys;
 import io.micrometer.core.instrument.Counter;
@@ -148,6 +149,7 @@ public class AgentJobExecutor {
     private final WorkspaceAgentBindingRepository bindingRepository;
     private final JobTypeHandlerRegistry handlerRegistry;
     private final PracticePiAdapter practiceAgent;
+    private final WorkerJwtIssuer workerJwtIssuer;
 
     private final SandboxManager sandboxManager;
     private final AsyncTaskExecutor sandboxExecutor;
@@ -187,6 +189,7 @@ public class AgentJobExecutor {
             WorkspaceAgentBindingRepository bindingRepository,
             JobTypeHandlerRegistry handlerRegistry,
             PracticePiAdapter practiceAgent,
+            WorkerJwtIssuer workerJwtIssuer,
             SandboxManager sandboxManager,
             @Qualifier("sandboxExecutor") AsyncTaskExecutor sandboxExecutor,
             TransactionTemplate transactionTemplate,
@@ -203,6 +206,7 @@ public class AgentJobExecutor {
         this.bindingRepository = bindingRepository;
         this.handlerRegistry = handlerRegistry;
         this.practiceAgent = practiceAgent;
+        this.workerJwtIssuer = workerJwtIssuer;
         this.sandboxManager = sandboxManager;
         this.sandboxExecutor = sandboxExecutor;
         this.transactionTemplate = transactionTemplate;
@@ -715,15 +719,19 @@ public class AgentJobExecutor {
             return handler.prepareInputs(managedJob);
         });
 
-        // Every sandbox reaches the provider through the in-app LLM proxy with the job's own token;
-        // there is no worker-side BYO-LLM override.
+        // Sandboxes access providers through the LLM proxy with an attempt-scoped credential.
+        String jobToken = workerJwtIssuer.issueForJob(
+                jobId,
+                job.getWorkspace().getId(),
+                job.getRetryCount(),
+                Duration.ofSeconds(snapshot.timeoutSeconds()).plusMinutes(5));
         PracticeAgentRequest adapterRequest = new PracticeAgentRequest(
                 snapshot.apiProtocol(),
                 snapshot.upstreamModelId(),
                 snapshot.contextWindow(),
                 snapshot.maxOutputTokens(),
                 snapshot.supportsReasoning(),
-                job.getJobToken(),
+                jobToken,
                 snapshot.allowInternet(),
                 snapshot.timeoutSeconds());
 

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/proxy/JobTokenAuthenticationFilter.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/proxy/JobTokenAuthenticationFilter.java
@@ -6,6 +6,9 @@ import de.tum.cit.aet.hephaestus.agent.job.AgentJobRepository;
 import de.tum.cit.aet.hephaestus.agent.job.AgentJobStatus;
 import de.tum.cit.aet.hephaestus.agent.usage.LlmPriceSnapshot;
 import de.tum.cit.aet.hephaestus.agent.usage.LlmUsageSourceType;
+import de.tum.cit.aet.hephaestus.core.runtime.hub.auth.JobJwt;
+import de.tum.cit.aet.hephaestus.core.runtime.hub.auth.WorkerJwtInvalidException;
+import de.tum.cit.aet.hephaestus.core.runtime.hub.auth.WorkerJwtVerifier;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -14,7 +17,6 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-import java.security.MessageDigest;
 import java.util.Optional;
 import java.util.regex.Pattern;
 import org.jspecify.annotations.Nullable;
@@ -36,20 +38,21 @@ public class JobTokenAuthenticationFilter extends OncePerRequestFilter {
 
     private static final Logger log = LoggerFactory.getLogger(JobTokenAuthenticationFilter.class);
 
-    /** Base64-URL characters (no padding). */
-    private static final Pattern BASE64_URL_PATTERN = Pattern.compile("^[A-Za-z0-9_-]+$");
-
     private static final String BEARER_PREFIX = "Bearer ";
+    private static final String LLM_PROXY_SCOPE = "llm_proxy";
 
     private final AgentJobRepository agentJobRepository;
+    private final WorkerJwtVerifier jwtVerifier;
     private final MentorProxyCredentialRegistry mentorRegistry;
     private final ObjectMapper objectMapper;
 
     JobTokenAuthenticationFilter(
             AgentJobRepository agentJobRepository,
+            WorkerJwtVerifier jwtVerifier,
             MentorProxyCredentialRegistry mentorRegistry,
             ObjectMapper objectMapper) {
         this.agentJobRepository = agentJobRepository;
+        this.jwtVerifier = jwtVerifier;
         this.mentorRegistry = mentorRegistry;
         this.objectMapper = objectMapper;
     }
@@ -69,12 +72,25 @@ public class JobTokenAuthenticationFilter extends OncePerRequestFilter {
             return;
         }
 
-        if (!BASE64_URL_PATTERN.matcher(token).matches()) {
-            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Invalid token format");
-            return;
+        Optional<ProxyRouting> routing = mentorRegistry.validate(token);
+        if (routing.isEmpty()) {
+            JobJwt jwt;
+            try {
+                if (!(jwtVerifier.verify(token) instanceof JobJwt jobJwt)) {
+                    response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Invalid or expired token");
+                    return;
+                }
+                jwt = jobJwt;
+            } catch (WorkerJwtInvalidException e) {
+                response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Invalid or expired token");
+                return;
+            }
+            if (!jwt.scopes().contains(LLM_PROXY_SCOPE)) {
+                response.sendError(HttpServletResponse.SC_FORBIDDEN, "Insufficient token scope");
+                return;
+            }
+            routing = resolveJobRouting(jwt);
         }
-
-        Optional<ProxyRouting> routing = resolveJobRouting(token).or(() -> mentorRegistry.validate(token));
         if (routing.isEmpty()) {
             response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Invalid or expired token");
             return;
@@ -88,20 +104,15 @@ public class JobTokenAuthenticationFilter extends OncePerRequestFilter {
         }
     }
 
-    /**
-     * Look up an {@code AgentJob} by token and translate its frozen {@link ConfigSnapshot} into routing.
-     * The attempt's identity and spend-so-far are read here because the row and snapshot already loaded
-     * carry both, so the budget gate costs no extra query.
-     */
-    private Optional<ProxyRouting> resolveJobRouting(String token) {
-        String hash = AgentJob.computeTokenHash(token);
-        Optional<AgentJob> optionalJob = agentJobRepository.findByJobTokenHashAndStatus(hash, AgentJobStatus.RUNNING);
+    private Optional<ProxyRouting> resolveJobRouting(JobJwt jwt) {
+        Optional<AgentJob> optionalJob = agentJobRepository.findByIdWithWorkspace(jwt.jobId());
         if (optionalJob.isEmpty()) {
             return Optional.empty();
         }
         AgentJob job = optionalJob.get();
-        if (!MessageDigest.isEqual(token.getBytes(), job.getJobToken().getBytes())) {
-            log.warn("Token hash matched but constant-time comparison failed — possible collision");
+        if (job.getStatus() != AgentJobStatus.RUNNING
+                || !job.getWorkspace().getId().equals(jwt.workspaceId())
+                || job.getRetryCount() != jwt.attempt()) {
             return Optional.empty();
         }
         if (job.getConfigSnapshot() == null) {

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/proxy/LlmProxySecurityConfig.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/proxy/LlmProxySecurityConfig.java
@@ -2,6 +2,7 @@ package de.tum.cit.aet.hephaestus.agent.proxy;
 
 import de.tum.cit.aet.hephaestus.agent.job.AgentJobRepository;
 import de.tum.cit.aet.hephaestus.core.runtime.RuntimeRole;
+import de.tum.cit.aet.hephaestus.core.runtime.hub.auth.WorkerJwtVerifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -14,7 +15,8 @@ import tools.jackson.databind.ObjectMapper;
 
 /**
  * Separate security filter chain for the internal LLM proxy endpoints, ordered ahead of the main JWT
- * chain so these requests authenticate with proxy-scoped bearer tokens instead of JWTs.
+ * chain so these requests authenticate with proxy-scoped bearer credentials instead of the
+ * application user-authentication chain.
  *
  * <p>Gated on the worker/sandbox capability rather than the practice-job feature flag, because
  * disabling practice reviews must not break mentor turns.
@@ -28,6 +30,7 @@ class LlmProxySecurityConfig {
     SecurityFilterChain llmProxyFilterChain(
             HttpSecurity http,
             AgentJobRepository agentJobRepository,
+            WorkerJwtVerifier jwtVerifier,
             MentorProxyCredentialRegistry mentorRegistry,
             ObjectMapper objectMapper)
             throws Exception {
@@ -36,7 +39,7 @@ class LlmProxySecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth.anyRequest().authenticated())
                 .addFilterBefore(
-                        new JobTokenAuthenticationFilter(agentJobRepository, mentorRegistry, objectMapper),
+                        new JobTokenAuthenticationFilter(agentJobRepository, jwtVerifier, mentorRegistry, objectMapper),
                         UsernamePasswordAuthenticationFilter.class);
 
         return http.build();

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/runtime/hub/HubConfiguration.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/runtime/hub/HubConfiguration.java
@@ -1,26 +1,15 @@
 package de.tum.cit.aet.hephaestus.core.runtime.hub;
 
 import de.tum.cit.aet.hephaestus.core.runtime.RuntimeRole;
-import de.tum.cit.aet.hephaestus.core.runtime.hub.auth.JavaJwtWorkerJwtVerifier;
 import de.tum.cit.aet.hephaestus.core.runtime.hub.auth.WorkerJwtHandshakeInterceptor;
-import de.tum.cit.aet.hephaestus.core.runtime.hub.auth.WorkerJwtIssuer;
 import de.tum.cit.aet.hephaestus.core.runtime.hub.auth.WorkerJwtVerifier;
-import de.tum.cit.aet.hephaestus.core.runtime.hub.auth.WorkerKeyRing;
-import de.tum.cit.aet.hephaestus.core.runtime.hub.auth.WorkerTokenDenylistRepository;
-import de.tum.cit.aet.hephaestus.core.runtime.hub.auth.WorkerTokenDenylistService;
-import de.tum.cit.aet.hephaestus.core.runtime.hub.auth.WorkerTokenProperties;
 import de.tum.cit.aet.hephaestus.core.runtime.worker.protocol.FrameCodec;
 import io.micrometer.core.instrument.MeterRegistry;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.env.Environment;
-import org.springframework.core.env.Profiles;
 import org.springframework.web.socket.config.annotation.EnableWebSocket;
 import tools.jackson.databind.ObjectMapper;
 
@@ -31,11 +20,8 @@ import tools.jackson.databind.ObjectMapper;
  */
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnProperty(name = RuntimeRole.SERVER_PROPERTY, havingValue = "true", matchIfMissing = true)
-@EnableConfigurationProperties({WorkerTokenProperties.class})
 @EnableWebSocket
 public class HubConfiguration {
-
-    private static final Logger log = LoggerFactory.getLogger(HubConfiguration.class);
 
     @Bean
     @ConditionalOnMissingBean(FrameCodec.class)
@@ -51,45 +37,6 @@ public class HubConfiguration {
     @Bean
     WorkerJobCancelDispatcher workerJobCancelDispatcher(WorkerSessionRegistry registry) {
         return new WorkerJobCancelDispatcher(registry);
-    }
-
-    @Bean
-    WorkerKeyRing workerKeyRing(WorkerTokenProperties properties, Environment environment) {
-        WorkerKeyRing ring = WorkerKeyRing.fromConfig(properties);
-        if (ring.active().ephemeral()) {
-            // Ephemeral keys are fine for dev but unsafe in prod (worker reconnects across pod
-            // restarts must verify already-issued JWTs), so only the prod profile warns.
-            if (environment.acceptsProfiles(Profiles.of("prod"))) {
-                log.warn(
-                        "Worker JWT is using an EPHEMERAL signing key (kid={}). Configure a stable key via "
-                                + "hephaestus.worker.hub.token.keys[*].private-key for production.",
-                        ring.active().kid());
-            } else {
-                log.info(
-                        "Worker JWT using ephemeral signing key (kid={}) — fine for dev.",
-                        ring.active().kid());
-            }
-        }
-        return ring;
-    }
-
-    @Bean
-    WorkerTokenDenylistService workerTokenDenylistService(WorkerTokenDenylistRepository repository) {
-        return new WorkerTokenDenylistService(repository);
-    }
-
-    @Bean
-    WorkerJwtVerifier workerJwtVerifier(
-            WorkerKeyRing keyRing,
-            WorkerTokenProperties properties,
-            WorkerTokenDenylistService denylist,
-            MeterRegistry meterRegistry) {
-        return new JavaJwtWorkerJwtVerifier(keyRing, properties, denylist, meterRegistry);
-    }
-
-    @Bean
-    WorkerJwtIssuer workerJwtIssuer(WorkerKeyRing keyRing, WorkerTokenProperties properties) {
-        return new WorkerJwtIssuer(keyRing, properties);
     }
 
     @Bean

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/runtime/hub/WorkerControlWebSocketHandler.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/runtime/hub/WorkerControlWebSocketHandler.java
@@ -2,6 +2,7 @@ package de.tum.cit.aet.hephaestus.core.runtime.hub;
 
 import de.tum.cit.aet.hephaestus.core.runtime.hub.auth.WorkerJwt;
 import de.tum.cit.aet.hephaestus.core.runtime.hub.auth.WorkerJwtHandshakeInterceptor;
+import de.tum.cit.aet.hephaestus.core.runtime.hub.auth.WorkerSessionJwt;
 import de.tum.cit.aet.hephaestus.core.runtime.worker.protocol.CancelJob;
 import de.tum.cit.aet.hephaestus.core.runtime.worker.protocol.CapacityReport;
 import de.tum.cit.aet.hephaestus.core.runtime.worker.protocol.ForceReconnect;
@@ -67,14 +68,17 @@ public class WorkerControlWebSocketHandler extends TextWebSocketHandler {
         WebSocketSession transport = new ConcurrentWebSocketSessionDecorator(
                 rawTransport, (int) HubProperties.SEND_TIME_LIMIT.toMillis(), HubProperties.SEND_BUFFER_SIZE_BYTES);
         String sessionId = UUID.randomUUID().toString();
-        WorkerSession session =
-                new WorkerSession(jwt.workerId(), sessionId, jwt.jti(), jwt.expiresAt(), transport, codec);
+        if (!(jwt instanceof WorkerSessionJwt workerJwt)) {
+            throw new IllegalStateException("job-scoped JWT cannot open a worker control session");
+        }
+        String workerId = workerJwt.workerId();
+        WorkerSession session = new WorkerSession(workerId, sessionId, jwt.jti(), jwt.expiresAt(), transport, codec);
         rawTransport.getAttributes().put(ATTR_WORKER_SESSION, session);
         // Close half-open sessions that authenticate but never send WorkerHello.
         ScheduledFuture<?> helloDeadline = helloTimeoutScheduler.schedule(
                 () -> {
                     if (!rawTransport.isOpen()) return;
-                    log.warn("WorkerHello timeout for workerId={} sessionId={}; closing.", jwt.workerId(), sessionId);
+                    log.warn("WorkerHello timeout for workerId={} sessionId={}; closing.", workerId, sessionId);
                     meterRegistry.counter("worker.hub.hello.timeout").increment();
                     close(rawTransport, CloseStatus.SESSION_NOT_RELIABLE);
                 },
@@ -83,7 +87,7 @@ public class WorkerControlWebSocketHandler extends TextWebSocketHandler {
         session.armHelloDeadline(helloDeadline);
         log.info(
                 "WSS connection opened: workerId={}, sessionId={}, jwtExpiresAt={}",
-                jwt.workerId(),
+                workerId,
                 sessionId,
                 jwt.expiresAt());
     }

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/runtime/hub/auth/JavaJwtWorkerJwtVerifier.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/runtime/hub/auth/JavaJwtWorkerJwtVerifier.java
@@ -8,7 +8,11 @@ import com.auth0.jwt.interfaces.JWTVerifier;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Instant;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import org.jspecify.annotations.Nullable;
 
 public class JavaJwtWorkerJwtVerifier implements WorkerJwtVerifier {
 
@@ -63,8 +67,7 @@ public class JavaJwtWorkerJwtVerifier implements WorkerJwtVerifier {
         } catch (JWTVerificationException e) {
             throw new WorkerJwtInvalidException("decode failed: " + e.getClass().getSimpleName(), "decode", e);
         }
-        // Allowlist alg before key dispatch — guards against future verifier refactors that
-        // could be steered into alg-confusion (RFC 8725 §3.1).
+        // Reject the untrusted header algorithm before selecting a verifier (RFC 8725 §3.1).
         if (!EXPECTED_ALG.equals(decoded.getAlgorithm())) {
             throw new WorkerJwtInvalidException("alg not allowed: " + decoded.getAlgorithm(), "alg");
         }
@@ -82,21 +85,84 @@ public class JavaJwtWorkerJwtVerifier implements WorkerJwtVerifier {
         } catch (JWTVerificationException e) {
             throw new WorkerJwtInvalidException("verify failed: " + e.getClass().getSimpleName(), "sig", e);
         }
+        String tokenType = verified.getType();
+        if (!WorkerJwtIssuer.WORKER_TOKEN_TYPE.equals(tokenType) && !WorkerJwtIssuer.JOB_TOKEN_TYPE.equals(tokenType)) {
+            throw new WorkerJwtInvalidException("token type not allowed", "typ");
+        }
         String workerId = verified.getSubject();
         String jti = verified.getId();
+        Instant issuedAt = verified.getIssuedAtAsInstant();
         Instant expiresAt = verified.getExpiresAtAsInstant();
-        if (workerId == null || workerId.isBlank()) {
-            throw new WorkerJwtInvalidException("missing sub claim", "claim");
-        }
         if (jti == null || jti.isBlank()) {
             throw new WorkerJwtInvalidException("missing jti claim", "claim");
         }
         if (expiresAt == null) {
             throw new WorkerJwtInvalidException("missing exp claim", "claim");
         }
+        if (issuedAt == null) {
+            throw new WorkerJwtInvalidException("missing iat claim", "claim");
+        }
         if (denylist.isRevoked(jti)) {
             throw new WorkerJwtInvalidException("token revoked", "revoked");
         }
-        return new WorkerJwt(workerId, jti, expiresAt);
+        UUID jobId = uuidClaim(verified, "job_id");
+        if (WorkerJwtIssuer.WORKER_TOKEN_TYPE.equals(tokenType)) {
+            if (workerId == null || workerId.isBlank()) {
+                throw new WorkerJwtInvalidException("missing sub claim", "claim");
+            }
+            if (jobId != null || !scopeClaim(verified).isEmpty() || longClaim(verified, "workspace_id") != null) {
+                throw new WorkerJwtInvalidException("worker token contains job claims", "claim");
+            }
+            return new WorkerSessionJwt(workerId, jti, issuedAt, expiresAt);
+        }
+        if (jobId == null) {
+            throw new WorkerJwtInvalidException("missing job_id claim", "claim");
+        }
+        if (workerId != null) {
+            throw new WorkerJwtInvalidException("job token contains sub claim", "claim");
+        }
+        Long workspaceId = longClaim(verified, "workspace_id");
+        Integer attempt = intClaim(verified, "attempt");
+        if (workspaceId == null || attempt == null || attempt < 0) {
+            throw new WorkerJwtInvalidException("missing or invalid job binding claim", "claim");
+        }
+        return new JobJwt(jobId, workspaceId, attempt, scopeClaim(verified), jti, issuedAt, expiresAt);
+    }
+
+    private static @Nullable UUID uuidClaim(DecodedJWT jwt, String name) {
+        try {
+            String value = jwt.getClaim(name).asString();
+            if (value == null) return null;
+            return UUID.fromString(value);
+        } catch (RuntimeException e) {
+            throw new WorkerJwtInvalidException("invalid " + name + " claim", "claim", e);
+        }
+    }
+
+    private static @Nullable Long longClaim(DecodedJWT jwt, String name) {
+        try {
+            Long value = jwt.getClaim(name).asLong();
+            if (value == null || value <= 0) return null;
+            return value;
+        } catch (RuntimeException e) {
+            throw new WorkerJwtInvalidException("invalid " + name + " claim", "claim", e);
+        }
+    }
+
+    private static @Nullable Integer intClaim(DecodedJWT jwt, String name) {
+        try {
+            return jwt.getClaim(name).asInt();
+        } catch (RuntimeException e) {
+            throw new WorkerJwtInvalidException("invalid " + name + " claim", "claim", e);
+        }
+    }
+
+    private static Set<String> scopeClaim(DecodedJWT jwt) {
+        try {
+            List<String> values = jwt.getClaim("scope").asList(String.class);
+            return values == null ? Set.of() : Set.copyOf(values);
+        } catch (RuntimeException e) {
+            throw new WorkerJwtInvalidException("invalid scope claim", "claim", e);
+        }
     }
 }

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/runtime/hub/auth/JobJwt.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/runtime/hub/auth/JobJwt.java
@@ -1,0 +1,14 @@
+package de.tum.cit.aet.hephaestus.core.runtime.hub.auth;
+
+import java.time.Instant;
+import java.util.Set;
+import java.util.UUID;
+
+public record JobJwt(
+        UUID jobId, Long workspaceId, int attempt, Set<String> scopes, String jti, Instant issuedAt, Instant expiresAt)
+        implements WorkerJwt {
+    public JobJwt {
+        scopes = Set.copyOf(scopes);
+        if (attempt < 0) throw new IllegalArgumentException("attempt must not be negative");
+    }
+}

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/runtime/hub/auth/WorkerJwt.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/runtime/hub/auth/WorkerJwt.java
@@ -2,25 +2,10 @@ package de.tum.cit.aet.hephaestus.core.runtime.hub.auth;
 
 import java.time.Instant;
 
-/**
- * Verified worker-JWT claims surfaced to the handshake interceptor. Decouples the {@code
- * com.auth0} types from the rest of the codebase so a future verifier swap (Nimbus, OAuth2
- * resource server) is a one-class change.
- *
- * @param workerId the {@code sub} claim
- * @param jti     the {@code jti} claim, used for denylist lookups
- * @param expiresAt the {@code exp} claim
- */
-public record WorkerJwt(String workerId, String jti, Instant expiresAt) {
-    public WorkerJwt {
-        if (workerId == null || workerId.isBlank()) {
-            throw new IllegalArgumentException("workerId (sub) must not be blank");
-        }
-        if (jti == null || jti.isBlank()) {
-            throw new IllegalArgumentException("jti must not be blank");
-        }
-        if (expiresAt == null) {
-            throw new IllegalArgumentException("expiresAt must not be null");
-        }
-    }
+public sealed interface WorkerJwt permits WorkerSessionJwt, JobJwt {
+    String jti();
+
+    Instant issuedAt();
+
+    Instant expiresAt();
 }

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/runtime/hub/auth/WorkerJwtConfiguration.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/runtime/hub/auth/WorkerJwtConfiguration.java
@@ -1,0 +1,57 @@
+package de.tum.cit.aet.hephaestus.core.runtime.hub.auth;
+
+import de.tum.cit.aet.hephaestus.core.runtime.RuntimeRole;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.Profiles;
+
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnExpression("${" + RuntimeRole.SERVER_PROPERTY + ":true} or ${" + RuntimeRole.WORKER_PROPERTY + ":true}")
+@EnableConfigurationProperties(WorkerTokenProperties.class)
+public class WorkerJwtConfiguration {
+
+    private static final Logger log = LoggerFactory.getLogger(WorkerJwtConfiguration.class);
+
+    @Bean
+    WorkerKeyRing workerKeyRing(WorkerTokenProperties properties, Environment environment) {
+        WorkerKeyRing ring = WorkerKeyRing.fromConfig(properties);
+        if (ring.active().ephemeral()) {
+            if (environment.acceptsProfiles(Profiles.of("prod"))) {
+                log.warn(
+                        "Worker JWT is using an EPHEMERAL signing key (kid={}). Configure a stable key via "
+                                + "hephaestus.worker.hub.token.keys[*].private-key for production.",
+                        ring.active().kid());
+            } else {
+                log.info(
+                        "Worker JWT using ephemeral signing key (kid={}) — fine for dev.",
+                        ring.active().kid());
+            }
+        }
+        return ring;
+    }
+
+    @Bean
+    WorkerTokenDenylistService workerTokenDenylistService(WorkerTokenDenylistRepository repository) {
+        return new WorkerTokenDenylistService(repository);
+    }
+
+    @Bean
+    WorkerJwtVerifier workerJwtVerifier(
+            WorkerKeyRing keyRing,
+            WorkerTokenProperties properties,
+            WorkerTokenDenylistService denylist,
+            MeterRegistry meterRegistry) {
+        return new JavaJwtWorkerJwtVerifier(keyRing, properties, denylist, meterRegistry);
+    }
+
+    @Bean
+    WorkerJwtIssuer workerJwtIssuer(WorkerKeyRing keyRing, WorkerTokenProperties properties) {
+        return new WorkerJwtIssuer(keyRing, properties);
+    }
+}

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/runtime/hub/auth/WorkerJwtHandshakeInterceptor.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/runtime/hub/auth/WorkerJwtHandshakeInterceptor.java
@@ -12,14 +12,7 @@ import org.springframework.http.server.ServerHttpResponse;
 import org.springframework.web.socket.WebSocketHandler;
 import org.springframework.web.socket.server.HandshakeInterceptor;
 
-/**
- * Validates {@code Authorization: Bearer <jwt>} on the WSS upgrade request, stuffs the verified
- * claims into the handshake-attributes map so {@link
- * de.tum.cit.aet.hephaestus.core.runtime.hub.WorkerControlWebSocketHandler} can read them out.
- *
- * <p>Maps every verifier failure to a single 401. Detailed error class name goes to the WARN
- * log; clients see only the status code.
- */
+/** Authenticates worker control-channel WebSocket upgrades. */
 public class WorkerJwtHandshakeInterceptor implements HandshakeInterceptor {
 
     private static final Logger log = LoggerFactory.getLogger(WorkerJwtHandshakeInterceptor.class);
@@ -45,6 +38,11 @@ public class WorkerJwtHandshakeInterceptor implements HandshakeInterceptor {
         }
         try {
             WorkerJwt jwt = verifier.verify(token);
+            if (!(jwt instanceof WorkerSessionJwt)) {
+                log.warn("worker handshake rejected: token is not scoped to a worker session");
+                reject401(response);
+                return false;
+            }
             attributes.put(ATTR_JWT, jwt);
             return true;
         } catch (WorkerJwtInvalidException e) {
@@ -64,9 +62,7 @@ public class WorkerJwtHandshakeInterceptor implements HandshakeInterceptor {
             ServerHttpRequest request,
             ServerHttpResponse response,
             WebSocketHandler wsHandler,
-            @Nullable Exception exception) {
-        // no-op; handler takes over after upgrade
-    }
+            @Nullable Exception exception) {}
 
     private static @Nullable String extractBearer(@Nullable List<String> headers) {
         if (headers == null || headers.isEmpty()) {

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/runtime/hub/auth/WorkerJwtIssuer.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/runtime/hub/auth/WorkerJwtIssuer.java
@@ -2,10 +2,16 @@ package de.tum.cit.aet.hephaestus.core.runtime.hub.auth;
 
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
+import java.time.Duration;
 import java.time.Instant;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 public class WorkerJwtIssuer {
+
+    static final String WORKER_TOKEN_TYPE = "worker-session+jwt";
+    static final String JOB_TOKEN_TYPE = "job+jwt";
 
     private final WorkerKeyRing keyRing;
     private final WorkerTokenProperties properties;
@@ -25,7 +31,7 @@ public class WorkerJwtIssuer {
         Instant expires = now.plus(properties.ttl());
         String jti = UUID.randomUUID().toString();
         String token = JWT.create()
-                .withKeyId(active.kid())
+                .withHeader(Map.of("kid", active.kid(), "typ", WORKER_TOKEN_TYPE))
                 .withIssuer(properties.issuer())
                 .withAudience(properties.audience())
                 .withSubject(workerId)
@@ -35,6 +41,25 @@ public class WorkerJwtIssuer {
                 .withExpiresAt(expires)
                 .sign(algorithm);
         return new IssuedWorkerJwt(token, jti, expires);
+    }
+
+    public String issueForJob(UUID jobId, Long workspaceId, int attempt, Duration ttl) {
+        if (ttl.isNegative() || ttl.isZero()) throw new IllegalArgumentException("ttl must be positive");
+        WorkerSigningKey active = keyRing.active();
+        Instant now = Instant.now();
+        return JWT.create()
+                .withHeader(Map.of("kid", active.kid(), "typ", JOB_TOKEN_TYPE))
+                .withIssuer(properties.issuer())
+                .withAudience(properties.audience())
+                .withClaim("job_id", jobId.toString())
+                .withClaim("workspace_id", workspaceId)
+                .withClaim("attempt", attempt)
+                .withClaim("scope", List.of("llm_proxy"))
+                .withJWTId(UUID.randomUUID().toString())
+                .withIssuedAt(now)
+                .withNotBefore(now)
+                .withExpiresAt(now.plus(ttl))
+                .sign(Algorithm.RSA256(active.publicKey(), active.privateKey()));
     }
 
     public record IssuedWorkerJwt(String token, String jti, Instant expiresAt) {}

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/runtime/hub/auth/WorkerJwtVerifier.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/runtime/hub/auth/WorkerJwtVerifier.java
@@ -1,16 +1,11 @@
 package de.tum.cit.aet.hephaestus.core.runtime.hub.auth;
 
-/**
- * Strategy interface for verifying worker-presented JWTs. Default impl is
- * {@link JavaJwtWorkerJwtVerifier}; tests can substitute trivially.
- */
 public interface WorkerJwtVerifier {
     /**
      * Validate the token, returning its claims if all checks pass.
      *
-     * @throws WorkerJwtInvalidException on any verification failure (signature, expiry, claims).
-     *     The exception's message is safe to log but not surface to remote callers — the
-     *     handshake interceptor maps it to a generic 401.
+     * @throws WorkerJwtInvalidException on any verification failure. Its message must not be
+     *     returned to the caller.
      */
     WorkerJwt verify(String token);
 }

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/runtime/hub/auth/WorkerSessionJwt.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/runtime/hub/auth/WorkerSessionJwt.java
@@ -1,0 +1,5 @@
+package de.tum.cit.aet.hephaestus.core.runtime.hub.auth;
+
+import java.time.Instant;
+
+public record WorkerSessionJwt(String workerId, String jti, Instant issuedAt, Instant expiresAt) implements WorkerJwt {}

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/runtime/hub/auth/package-info.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/runtime/hub/auth/package-info.java
@@ -1,2 +1,3 @@
+@org.springframework.modulith.NamedInterface("worker-auth")
 @org.jspecify.annotations.NullMarked
 package de.tum.cit.aet.hephaestus.core.runtime.hub.auth;

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobExecutorTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobExecutorTest.java
@@ -44,6 +44,7 @@ import de.tum.cit.aet.hephaestus.agent.usage.LlmBudgetBlockReason;
 import de.tum.cit.aet.hephaestus.agent.usage.LlmBudgetDecision;
 import de.tum.cit.aet.hephaestus.agent.usage.LlmBudgetService;
 import de.tum.cit.aet.hephaestus.agent.usage.LlmUsageRecorder;
+import de.tum.cit.aet.hephaestus.core.runtime.hub.auth.WorkerJwtIssuer;
 import de.tum.cit.aet.hephaestus.evidence.ArtifactSourceManifest;
 import de.tum.cit.aet.hephaestus.evidence.AutomatedReviewReadinessDecision;
 import de.tum.cit.aet.hephaestus.evidence.AutomatedReviewReadinessReport;
@@ -111,6 +112,9 @@ class AgentJobExecutorTest extends BaseUnitTest {
     private PracticePiAdapter practiceAgent;
 
     @Mock
+    private WorkerJwtIssuer workerJwtIssuer;
+
+    @Mock
     private SandboxManager sandboxManager;
 
     @Mock
@@ -148,6 +152,7 @@ class AgentJobExecutorTest extends BaseUnitTest {
                 bindingRepository,
                 handlerRegistry,
                 practiceAgent,
+                workerJwtIssuer,
                 sandboxManager,
                 sandboxExecutor,
                 transactionTemplate,
@@ -215,6 +220,9 @@ class AgentJobExecutorTest extends BaseUnitTest {
 
         lenient().when(transactionTemplate.getTransactionManager()).thenReturn(transactionManager);
         lenient().when(transactionManager.getTransaction(any())).thenReturn(mock(TransactionStatus.class));
+        lenient()
+                .when(workerJwtIssuer.issueForJob(any(), anyLong(), anyInt(), any()))
+                .thenReturn("job-jwt");
 
         lenient()
                 .doAnswer(inv -> {
@@ -275,6 +283,7 @@ class AgentJobExecutorTest extends BaseUnitTest {
                     bindingRepository,
                     handlerRegistry,
                     practiceAgent,
+                    workerJwtIssuer,
                     sandboxManager,
                     sandboxExecutor,
                     transactionTemplate,
@@ -992,6 +1001,7 @@ class AgentJobExecutorTest extends BaseUnitTest {
                     bindingRepository,
                     handlerRegistry,
                     practiceAgent,
+                    workerJwtIssuer,
                     sandboxManager,
                     sandboxExecutor,
                     transactionTemplate,
@@ -1054,6 +1064,7 @@ class AgentJobExecutorTest extends BaseUnitTest {
                     bindingRepository,
                     handlerRegistry,
                     practiceAgent,
+                    workerJwtIssuer,
                     sandboxManager,
                     sandboxExecutor,
                     transactionTemplate,
@@ -1098,6 +1109,7 @@ class AgentJobExecutorTest extends BaseUnitTest {
                     bindingRepository,
                     handlerRegistry,
                     practiceAgent,
+                    workerJwtIssuer,
                     sandboxManager,
                     sandboxExecutor,
                     transactionTemplate,
@@ -1526,15 +1538,15 @@ class AgentJobExecutorTest extends BaseUnitTest {
     class LlmProxyRouting {
 
         @Test
-        @DisplayName(
-                "the practice request carries the snapshot's resolved behaviour + the job's own token — ONE credential path")
-        void requestCarriesSnapshotBehaviourAndJobToken() {
+        @DisplayName("the practice request carries resolved routing and an attempt-scoped job JWT")
+        void passesResolvedRoutingAndJobJwtToSandboxRequest() {
             executor = new AgentJobExecutor(
                     AGENT_PROPS,
                     jobRepository,
                     bindingRepository,
                     handlerRegistry,
                     practiceAgent,
+                    workerJwtIssuer,
                     sandboxManager,
                     sandboxExecutor,
                     transactionTemplate,
@@ -1572,7 +1584,7 @@ class AgentJobExecutorTest extends BaseUnitTest {
 
             assertThat(request.apiProtocol()).isEqualTo("anthropic-messages");
             assertThat(request.upstreamModelId()).isEqualTo("claude-sonnet-4");
-            assertThat(request.jobToken()).isEqualTo("test-token");
+            assertThat(request.jobToken()).isEqualTo("job-jwt");
         }
     }
 
@@ -1600,6 +1612,7 @@ class AgentJobExecutorTest extends BaseUnitTest {
                     bindingRepository,
                     handlerRegistry,
                     practiceAgent,
+                    workerJwtIssuer,
                     sandboxManager,
                     sandboxExecutor,
                     transactionTemplate,
@@ -1649,6 +1662,7 @@ class AgentJobExecutorTest extends BaseUnitTest {
                     bindingRepository,
                     handlerRegistry,
                     practiceAgent,
+                    workerJwtIssuer,
                     sandboxManager,
                     sandboxExecutor,
                     transactionTemplate,
@@ -1710,6 +1724,7 @@ class AgentJobExecutorTest extends BaseUnitTest {
                         bindingRepository,
                         handlerRegistry,
                         practiceAgent,
+                        workerJwtIssuer,
                         sandboxManager,
                         realPool,
                         transactionTemplate,
@@ -1744,6 +1759,7 @@ class AgentJobExecutorTest extends BaseUnitTest {
                     bindingRepository,
                     handlerRegistry,
                     practiceAgent,
+                    workerJwtIssuer,
                     sandboxManager,
                     sandboxExecutor,
                     transactionTemplate,
@@ -1785,6 +1801,7 @@ class AgentJobExecutorTest extends BaseUnitTest {
                     bindingRepository,
                     handlerRegistry,
                     practiceAgent,
+                    workerJwtIssuer,
                     sandboxManager,
                     sandboxExecutor,
                     transactionTemplate,
@@ -1843,6 +1860,7 @@ class AgentJobExecutorTest extends BaseUnitTest {
                     bindingRepository,
                     handlerRegistry,
                     practiceAgent,
+                    workerJwtIssuer,
                     sandboxManager,
                     sandboxExecutor,
                     transactionTemplate,
@@ -1880,6 +1898,7 @@ class AgentJobExecutorTest extends BaseUnitTest {
                     bindingRepository,
                     handlerRegistry,
                     practiceAgent,
+                    workerJwtIssuer,
                     sandboxManager,
                     sandboxExecutor,
                     transactionTemplate,

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/proxy/JobTokenAuthenticationFilterTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/proxy/JobTokenAuthenticationFilterTest.java
@@ -3,7 +3,6 @@ package de.tum.cit.aet.hephaestus.agent.proxy;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -16,14 +15,19 @@ import de.tum.cit.aet.hephaestus.agent.job.AgentJobStatus;
 import de.tum.cit.aet.hephaestus.agent.usage.FundingSource;
 import de.tum.cit.aet.hephaestus.agent.usage.LlmPriceSnapshot;
 import de.tum.cit.aet.hephaestus.agent.usage.PricingState;
+import de.tum.cit.aet.hephaestus.core.runtime.hub.auth.JobJwt;
+import de.tum.cit.aet.hephaestus.core.runtime.hub.auth.WorkerJwtInvalidException;
+import de.tum.cit.aet.hephaestus.core.runtime.hub.auth.WorkerJwtVerifier;
 import de.tum.cit.aet.hephaestus.testconfig.BaseUnitTest;
 import de.tum.cit.aet.hephaestus.workspace.Workspace;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 import org.jspecify.annotations.Nullable;
@@ -49,19 +53,19 @@ class JobTokenAuthenticationFilterTest extends BaseUnitTest {
     @Mock
     private FilterChain filterChain;
 
+    @Mock
+    private WorkerJwtVerifier jwtVerifier;
+
     private MentorProxyCredentialRegistry mentorRegistry;
     private JobTokenAuthenticationFilter filter;
     private final ObjectMapper objectMapper = new ObjectMapper();
 
-    /** A valid Base64-URL token (43 chars, 256 bits). */
-    private static final String VALID_TOKEN = "dGVzdC10b2tlbi0xMjM0NTY3ODkwMTIzNDU2Nzg5MDE";
-
-    private static final String VALID_TOKEN_HASH = AgentJob.computeTokenHash(VALID_TOKEN);
+    private static final String JOB_JWT = "job-jwt";
 
     @BeforeEach
     void setUp() {
         mentorRegistry = new MentorProxyCredentialRegistry();
-        filter = new JobTokenAuthenticationFilter(agentJobRepository, mentorRegistry, objectMapper);
+        filter = new JobTokenAuthenticationFilter(agentJobRepository, jwtVerifier, mentorRegistry, objectMapper);
         SecurityContextHolder.clearContext();
     }
 
@@ -77,7 +81,7 @@ class JobTokenAuthenticationFilterTest extends BaseUnitTest {
         void shouldRejectNonPrivateIp() throws Exception {
             var request = new MockHttpServletRequest();
             request.setRemoteAddr("8.8.8.8");
-            request.addHeader("Authorization", "Bearer " + VALID_TOKEN);
+            request.addHeader("Authorization", "Bearer " + JOB_JWT);
             var response = new MockHttpServletResponse();
 
             filter.doFilterInternal(request, response, filterChain);
@@ -161,7 +165,7 @@ class JobTokenAuthenticationFilterTest extends BaseUnitTest {
         void shouldRejectXApiKeyProviderHeader() throws Exception {
             var request = new MockHttpServletRequest();
             request.setRemoteAddr("10.0.0.2");
-            request.addHeader("x-api-key", VALID_TOKEN);
+            request.addHeader("x-api-key", JOB_JWT);
             var response = new MockHttpServletResponse();
 
             filter.doFilterInternal(request, response, filterChain);
@@ -173,8 +177,8 @@ class JobTokenAuthenticationFilterTest extends BaseUnitTest {
         @Test
         void shouldExtractFromBearerAuth() throws Exception {
             var job = createRunningJob();
-            when(agentJobRepository.findByJobTokenHashAndStatus(eq(VALID_TOKEN_HASH), eq(AgentJobStatus.RUNNING)))
-                    .thenReturn(Optional.of(job));
+            when(jwtVerifier.verify(JOB_JWT)).thenReturn(jobJwt(job, Set.of("llm_proxy")));
+            when(agentJobRepository.findByIdWithWorkspace(job.getId())).thenReturn(Optional.of(job));
 
             var authCapture = new AtomicReference<Authentication>();
             doAnswer(invocation -> {
@@ -187,7 +191,7 @@ class JobTokenAuthenticationFilterTest extends BaseUnitTest {
 
             var request = new MockHttpServletRequest();
             request.setRemoteAddr("10.0.0.2");
-            request.addHeader("Authorization", "Bearer " + VALID_TOKEN);
+            request.addHeader("Authorization", "Bearer " + JOB_JWT);
             var response = new MockHttpServletResponse();
 
             filter.doFilterInternal(request, response, filterChain);
@@ -204,7 +208,7 @@ class JobTokenAuthenticationFilterTest extends BaseUnitTest {
         void shouldRejectApiKeyProviderHeader() throws Exception {
             var request = new MockHttpServletRequest();
             request.setRemoteAddr("10.0.0.2");
-            request.addHeader("api-key", VALID_TOKEN);
+            request.addHeader("api-key", JOB_JWT);
             var response = new MockHttpServletResponse();
 
             filter.doFilterInternal(request, response, filterChain);
@@ -215,6 +219,8 @@ class JobTokenAuthenticationFilterTest extends BaseUnitTest {
 
         @Test
         void shouldReturn401ForMalformedToken() throws Exception {
+            when(jwtVerifier.verify("not a valid base64!!!"))
+                    .thenThrow(new WorkerJwtInvalidException("invalid token", "decode"));
             var request = new MockHttpServletRequest();
             request.setRemoteAddr("10.0.0.2");
             request.addHeader("Authorization", "Bearer not a valid base64!!!");
@@ -226,13 +232,14 @@ class JobTokenAuthenticationFilterTest extends BaseUnitTest {
         }
 
         @Test
-        void shouldReturn401WhenNoRunningJobFound() throws Exception {
-            when(agentJobRepository.findByJobTokenHashAndStatus(any(), eq(AgentJobStatus.RUNNING)))
-                    .thenReturn(Optional.empty());
+        void shouldReturn401WhenJobDoesNotExist() throws Exception {
+            AgentJob job = createRunningJob();
+            when(jwtVerifier.verify(JOB_JWT)).thenReturn(jobJwt(job, Set.of("llm_proxy")));
+            when(agentJobRepository.findByIdWithWorkspace(job.getId())).thenReturn(Optional.empty());
 
             var request = new MockHttpServletRequest();
             request.setRemoteAddr("10.0.0.2");
-            request.addHeader("Authorization", "Bearer " + VALID_TOKEN);
+            request.addHeader("Authorization", "Bearer " + JOB_JWT);
             var response = new MockHttpServletResponse();
 
             filter.doFilterInternal(request, response, filterChain);
@@ -241,17 +248,55 @@ class JobTokenAuthenticationFilterTest extends BaseUnitTest {
         }
 
         @Test
-        @DisplayName(
-                "a job with no config snapshot (should be impossible in prod — column is NOT NULL) is refused, not NPE'd")
+        void shouldReturn403WhenScopeIsMissing() throws Exception {
+            AgentJob job = createRunningJob();
+            when(jwtVerifier.verify(JOB_JWT)).thenReturn(jobJwt(job, Set.of()));
+
+            assertThat(authenticate(JOB_JWT).getStatus()).isEqualTo(HttpServletResponse.SC_FORBIDDEN);
+            verify(agentJobRepository, never()).findByIdWithWorkspace(any());
+        }
+
+        @Test
+        void shouldReturn401WhenAttemptDoesNotMatch() throws Exception {
+            AgentJob job = createRunningJob();
+            JobJwt current = jobJwt(job, Set.of("llm_proxy"));
+            JobJwt stale = new JobJwt(
+                    current.jobId(),
+                    current.workspaceId(),
+                    current.attempt() + 1,
+                    current.scopes(),
+                    current.jti(),
+                    current.issuedAt(),
+                    current.expiresAt());
+            when(jwtVerifier.verify(JOB_JWT)).thenReturn(stale);
+            when(agentJobRepository.findByIdWithWorkspace(job.getId())).thenReturn(Optional.of(job));
+
+            assertThat(authenticate(JOB_JWT).getStatus()).isEqualTo(HttpServletResponse.SC_UNAUTHORIZED);
+        }
+
+        private MockHttpServletResponse authenticate(String token) throws Exception {
+            var request = new MockHttpServletRequest();
+            request.setRemoteAddr("10.0.0.2");
+            request.addHeader("Authorization", "Bearer " + token);
+            var response = new MockHttpServletResponse();
+            filter.doFilterInternal(request, response, filterChain);
+            return response;
+        }
+
+        @Test
         void shouldReturn401WhenJobHasNoConfigSnapshot() throws Exception {
             var job = new AgentJob();
-            job.setJobToken(VALID_TOKEN);
-            when(agentJobRepository.findByJobTokenHashAndStatus(eq(VALID_TOKEN_HASH), eq(AgentJobStatus.RUNNING)))
-                    .thenReturn(Optional.of(job));
+            job.setId(UUID.randomUUID());
+            Workspace workspace = new Workspace();
+            workspace.setId(7L);
+            job.setWorkspace(workspace);
+            job.setStatus(AgentJobStatus.RUNNING);
+            when(jwtVerifier.verify(JOB_JWT)).thenReturn(jobJwt(job, Set.of("llm_proxy")));
+            when(agentJobRepository.findByIdWithWorkspace(job.getId())).thenReturn(Optional.of(job));
 
             var request = new MockHttpServletRequest();
             request.setRemoteAddr("10.0.0.2");
-            request.addHeader("Authorization", "Bearer " + VALID_TOKEN);
+            request.addHeader("Authorization", "Bearer " + JOB_JWT);
             var response = new MockHttpServletResponse();
 
             filter.doFilterInternal(request, response, filterChain);
@@ -278,9 +323,9 @@ class JobTokenAuthenticationFilterTest extends BaseUnitTest {
         void shouldAcceptCaseInsensitiveBearer() throws Exception {
             var job = createRunningJob();
 
-            Authentication installed = authenticateAndCaptureAuthentication(job, "bearer " + VALID_TOKEN, null);
+            Authentication installed = authenticateAndCaptureAuthentication(job, "bearer " + JOB_JWT, null);
 
-            assertThatTheChainRanAsTheJob(installed, job);
+            assertAuthenticatedAsJob(installed, job);
         }
 
         @Test
@@ -288,17 +333,12 @@ class JobTokenAuthenticationFilterTest extends BaseUnitTest {
             var job = createRunningJob();
 
             Authentication installed =
-                    authenticateAndCaptureAuthentication(job, "Bearer " + VALID_TOKEN, "provider-key-must-be-ignored");
+                    authenticateAndCaptureAuthentication(job, "Bearer " + JOB_JWT, "provider-key-must-be-ignored");
 
-            assertThatTheChainRanAsTheJob(installed, job);
+            assertAuthenticatedAsJob(installed, job);
         }
 
-        /**
-         * MockHttpServletResponse's status defaults to 200, so asserting SC_OK proves nothing on its
-         * own — a filter that forwarded the chain WITHOUT installing the job's authentication would
-         * pass that. What has to hold is that the downstream chain ran as this job.
-         */
-        private void assertThatTheChainRanAsTheJob(Authentication installed, AgentJob job) {
+        private void assertAuthenticatedAsJob(Authentication installed, AgentJob job) {
             assertThat(installed).isInstanceOf(JobTokenAuthentication.class);
             ProxyRouting routing = (ProxyRouting) ((JobTokenAuthentication) installed).getPrincipal();
             assertThat(routing.principalDescription()).isEqualTo("job:" + job.getId());
@@ -307,8 +347,8 @@ class JobTokenAuthenticationFilterTest extends BaseUnitTest {
 
         private Authentication authenticateAndCaptureAuthentication(
                 AgentJob job, String authorizationHeader, @Nullable String providerKeyHeader) throws Exception {
-            when(agentJobRepository.findByJobTokenHashAndStatus(eq(VALID_TOKEN_HASH), eq(AgentJobStatus.RUNNING)))
-                    .thenReturn(Optional.of(job));
+            when(jwtVerifier.verify(JOB_JWT)).thenReturn(jobJwt(job, Set.of("llm_proxy")));
+            when(agentJobRepository.findByIdWithWorkspace(job.getId())).thenReturn(Optional.of(job));
             var authCapture = new AtomicReference<Authentication>();
             doAnswer(invocation -> {
                         authCapture.set(Objects.requireNonNull(
@@ -334,8 +374,8 @@ class JobTokenAuthenticationFilterTest extends BaseUnitTest {
         @Test
         void shouldClearContextOnFilterChainException() throws Exception {
             var job = createRunningJob();
-            when(agentJobRepository.findByJobTokenHashAndStatus(eq(VALID_TOKEN_HASH), eq(AgentJobStatus.RUNNING)))
-                    .thenReturn(Optional.of(job));
+            when(jwtVerifier.verify(JOB_JWT)).thenReturn(jobJwt(job, Set.of("llm_proxy")));
+            when(agentJobRepository.findByIdWithWorkspace(job.getId())).thenReturn(Optional.of(job));
             doAnswer(invocation -> {
                         throw new jakarta.servlet.ServletException("Simulated failure");
                     })
@@ -344,7 +384,7 @@ class JobTokenAuthenticationFilterTest extends BaseUnitTest {
 
             var request = new MockHttpServletRequest();
             request.setRemoteAddr("10.0.0.2");
-            request.addHeader("Authorization", "Bearer " + VALID_TOKEN);
+            request.addHeader("Authorization", "Bearer " + JOB_JWT);
             var response = new MockHttpServletResponse();
 
             assertThatThrownBy(() -> filter.doFilterInternal(request, response, filterChain))
@@ -354,23 +394,11 @@ class JobTokenAuthenticationFilterTest extends BaseUnitTest {
         }
 
         @Test
-        void shouldRejectTokenWithPadding() throws Exception {
-            var request = new MockHttpServletRequest();
-            request.setRemoteAddr("10.0.0.2");
-            request.addHeader("Authorization", "Bearer dGVzdA==");
-            var response = new MockHttpServletResponse();
-
-            filter.doFilterInternal(request, response, filterChain);
-
-            assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_UNAUTHORIZED);
-        }
-
-        @Test
         void shouldNotBeBypassedByXForwardedFor() throws Exception {
             var request = new MockHttpServletRequest();
             request.setRemoteAddr("8.8.8.8");
             request.addHeader("X-Forwarded-For", "10.0.0.2");
-            request.addHeader("Authorization", "Bearer " + VALID_TOKEN);
+            request.addHeader("Authorization", "Bearer " + JOB_JWT);
             var response = new MockHttpServletResponse();
 
             filter.doFilterInternal(request, response, filterChain);
@@ -381,13 +409,11 @@ class JobTokenAuthenticationFilterTest extends BaseUnitTest {
     }
 
     @Nested
-    @DisplayName("Mentor session token fallback — the mentor sandbox is not an AgentJob row")
+    @DisplayName("Mentor credentials")
     class MentorTokenFallback {
 
         @Test
-        void aMentorRegistryTokenAuthenticatesWhenNoJobMatches() throws Exception {
-            when(agentJobRepository.findByJobTokenHashAndStatus(any(), eq(AgentJobStatus.RUNNING)))
-                    .thenReturn(Optional.empty());
+        void authenticatesValidMentorCredential() throws Exception {
             String mentorToken = mentorRegistry.mint(
                     UUID.randomUUID(),
                     new MentorProxyCredentialRegistry.Route(
@@ -419,12 +445,11 @@ class JobTokenAuthenticationFilterTest extends BaseUnitTest {
 
         @Test
         void aTokenMatchingNeitherJobNorMentorRegistryIsRefused() throws Exception {
-            when(agentJobRepository.findByJobTokenHashAndStatus(any(), eq(AgentJobStatus.RUNNING)))
-                    .thenReturn(Optional.empty());
+            when(jwtVerifier.verify(JOB_JWT)).thenThrow(new WorkerJwtInvalidException("invalid token", "decode"));
 
             var request = new MockHttpServletRequest();
             request.setRemoteAddr("10.0.0.2");
-            request.addHeader("Authorization", "Bearer " + VALID_TOKEN);
+            request.addHeader("Authorization", "Bearer " + JOB_JWT);
             var response = new MockHttpServletResponse();
 
             filter.doFilterInternal(request, response, filterChain);
@@ -435,11 +460,10 @@ class JobTokenAuthenticationFilterTest extends BaseUnitTest {
     }
 
     @Nested
-    @DisplayName("the billed attempt resolved from the row")
+    @DisplayName("Billed attempt")
     class BilledAttempt {
 
         @Test
-        @DisplayName("carries the row's retry_count, so a later attempt's write can be told apart")
         void theRoutingCarriesTheAttemptNumber() throws Exception {
             var job = createRunningJob();
             job.setRetryCount(3);
@@ -451,9 +475,7 @@ class JobTokenAuthenticationFilterTest extends BaseUnitTest {
             assertThat(routing.attempt().sourceId()).isEqualTo(job.getId());
         }
 
-        /** 1M input at $10/1M plus 100k output at $30/1M is the $13 asserted below. */
         @Test
-        @DisplayName("prices the calls the attempt has already made with the rates frozen at admission")
         void theRoutingPricesWhatTheAttemptHasAlreadySpent() throws Exception {
             var job = createRunningJob(new LlmPriceSnapshot(
                     FundingSource.INSTANCE,
@@ -472,9 +494,7 @@ class JobTokenAuthenticationFilterTest extends BaseUnitTest {
             assertThat(routing.inFlightSpendUsd()).isEqualByComparingTo("13");
         }
 
-        /** Only reachable for a job that never went through {@code LlmAdmissionService}, which refuses one. */
         @Test
-        @DisplayName("a snapshot with no frozen price contributes no in-flight spend")
         void aSnapshotWithoutAPriceContributesNothing() throws Exception {
             var job = createRunningJob();
             job.setLlmTotalInputTokens(1_000_000);
@@ -485,8 +505,8 @@ class JobTokenAuthenticationFilterTest extends BaseUnitTest {
         }
 
         private ProxyRouting authenticateAndCaptureRouting(AgentJob job) throws Exception {
-            when(agentJobRepository.findByJobTokenHashAndStatus(eq(VALID_TOKEN_HASH), eq(AgentJobStatus.RUNNING)))
-                    .thenReturn(Optional.of(job));
+            when(jwtVerifier.verify(JOB_JWT)).thenReturn(jobJwt(job, Set.of("llm_proxy")));
+            when(agentJobRepository.findByIdWithWorkspace(job.getId())).thenReturn(Optional.of(job));
             var authCapture = new AtomicReference<Authentication>();
             doAnswer(invocation -> {
                         authCapture.set(Objects.requireNonNull(
@@ -498,7 +518,7 @@ class JobTokenAuthenticationFilterTest extends BaseUnitTest {
 
             var request = new MockHttpServletRequest();
             request.setRemoteAddr("10.0.0.2");
-            request.addHeader("Authorization", "Bearer " + VALID_TOKEN);
+            request.addHeader("Authorization", "Bearer " + JOB_JWT);
             filter.doFilterInternal(request, new MockHttpServletResponse(), filterChain);
 
             Authentication authentication = authCapture.get();
@@ -514,7 +534,6 @@ class JobTokenAuthenticationFilterTest extends BaseUnitTest {
 
     private AgentJob createRunningJob(@org.jspecify.annotations.Nullable LlmPriceSnapshot price) {
         var job = new AgentJob();
-        job.setJobToken(VALID_TOKEN);
         ConfigSnapshot snapshot = new ConfigSnapshot(
                 ConfigSnapshot.SCHEMA_VERSION,
                 "openai-completions",
@@ -536,20 +555,10 @@ class JobTokenAuthenticationFilterTest extends BaseUnitTest {
         Workspace workspace = new Workspace();
         workspace.setId(7L);
         job.setWorkspace(workspace);
+        job.setStatus(AgentJobStatus.RUNNING);
         return job;
     }
 
-    /**
-     * Why the proxy chain may disable CSRF. CSRF is exploitable only where the browser attaches a
-     * credential by itself; this filter reads one only from {@code Authorization}, so a forged
-     * cross-site request has nothing ambient to ride on. Static analysis flags the
-     * {@code csrf.disable()} in {@link LlmProxySecurityConfig} and cannot see that, so these tests
-     * are what keep the justification honest.
-     *
-     * <p>The negative cases send a token the last case proves is good, so "authenticates nobody"
-     * cannot pass for the trivial reason that the token was bad. They assert the repository is
-     * never even consulted: the filter does not find a credential to look up.
-     */
     @Nested
     class NoAmbientCredentialIsAccepted {
 
@@ -557,12 +566,12 @@ class JobTokenAuthenticationFilterTest extends BaseUnitTest {
         void theSameTokenInACookieAuthenticatesNobody() throws Exception {
             var request = new MockHttpServletRequest();
             request.setRemoteAddr("10.0.0.2");
-            request.setCookies(new Cookie("hephaestus_session", VALID_TOKEN), new Cookie("JSESSIONID", VALID_TOKEN));
+            request.setCookies(new Cookie("hephaestus_session", JOB_JWT), new Cookie("JSESSIONID", JOB_JWT));
 
             filter.doFilterInternal(request, new MockHttpServletResponse(), filterChain);
 
             assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
-            verify(agentJobRepository, never()).findByJobTokenHashAndStatus(any(), any());
+            verify(jwtVerifier, never()).verify(any());
             verify(filterChain, never()).doFilter(any(), any());
         }
 
@@ -570,20 +579,21 @@ class JobTokenAuthenticationFilterTest extends BaseUnitTest {
         void theSameTokenInAQueryParameterAuthenticatesNobody() throws Exception {
             var request = new MockHttpServletRequest();
             request.setRemoteAddr("10.0.0.2");
-            request.setParameter("access_token", VALID_TOKEN);
-            request.setParameter("token", VALID_TOKEN);
+            request.setParameter("access_token", JOB_JWT);
+            request.setParameter("token", JOB_JWT);
 
             filter.doFilterInternal(request, new MockHttpServletResponse(), filterChain);
 
             assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
-            verify(agentJobRepository, never()).findByJobTokenHashAndStatus(any(), any());
+            verify(jwtVerifier, never()).verify(any());
             verify(filterChain, never()).doFilter(any(), any());
         }
 
         @Test
         void theSameTokenInTheHeaderDoesAuthenticate() throws Exception {
-            when(agentJobRepository.findByJobTokenHashAndStatus(eq(VALID_TOKEN_HASH), eq(AgentJobStatus.RUNNING)))
-                    .thenReturn(Optional.of(createRunningJob()));
+            AgentJob job = createRunningJob();
+            when(jwtVerifier.verify(JOB_JWT)).thenReturn(jobJwt(job, Set.of("llm_proxy")));
+            when(agentJobRepository.findByIdWithWorkspace(job.getId())).thenReturn(Optional.of(job));
             var authInsideChain = new AtomicReference<Authentication>();
             doAnswer(invocation -> {
                         authInsideChain.set(Objects.requireNonNull(
@@ -594,11 +604,23 @@ class JobTokenAuthenticationFilterTest extends BaseUnitTest {
                     .doFilter(any(), any());
             var request = new MockHttpServletRequest();
             request.setRemoteAddr("10.0.0.2");
-            request.addHeader("Authorization", "Bearer " + VALID_TOKEN);
+            request.addHeader("Authorization", "Bearer " + JOB_JWT);
 
             filter.doFilterInternal(request, new MockHttpServletResponse(), filterChain);
 
             assertThat(authInsideChain.get()).isNotNull();
         }
+    }
+
+    private static JobJwt jobJwt(AgentJob job, Set<String> scopes) {
+        Instant now = Instant.now();
+        return new JobJwt(
+                job.getId(),
+                job.getWorkspace().getId(),
+                job.getRetryCount(),
+                scopes,
+                UUID.randomUUID().toString(),
+                now,
+                now.plusSeconds(60));
     }
 }

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/proxy/LlmProxyIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/proxy/LlmProxyIntegrationTest.java
@@ -18,11 +18,14 @@ import de.tum.cit.aet.hephaestus.agent.job.AgentJob;
 import de.tum.cit.aet.hephaestus.agent.job.AgentJobRepository;
 import de.tum.cit.aet.hephaestus.agent.job.AgentJobStatus;
 import de.tum.cit.aet.hephaestus.agent.usage.FundingSource;
+import de.tum.cit.aet.hephaestus.core.runtime.hub.auth.WorkerJwtIssuer;
+import de.tum.cit.aet.hephaestus.core.runtime.hub.auth.WorkerJwtVerifier;
 import de.tum.cit.aet.hephaestus.integration.scm.domain.user.User;
 import de.tum.cit.aet.hephaestus.testconfig.LlmCatalogTestFixtures;
 import de.tum.cit.aet.hephaestus.workspace.AbstractWorkspaceIntegrationTest;
 import de.tum.cit.aet.hephaestus.workspace.AccountType;
 import de.tum.cit.aet.hephaestus.workspace.Workspace;
+import java.time.Duration;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.AfterEach;
@@ -56,13 +59,20 @@ class LlmProxyIntegrationTest extends AbstractWorkspaceIntegrationTest {
     @Autowired
     private LlmModelResolver modelResolver;
 
+    @Autowired
+    private WorkerJwtVerifier jwtVerifier;
+
+    @Autowired
+    private WorkerJwtIssuer jwtIssuer;
+
     private JobTokenAuthenticationFilter filter;
     private Workspace workspace;
 
     @BeforeEach
     void setUp() {
         SecurityContextHolder.clearContext();
-        filter = new JobTokenAuthenticationFilter(jobRepository, new MentorProxyCredentialRegistry(), objectMapper);
+        filter = new JobTokenAuthenticationFilter(
+                jobRepository, jwtVerifier, new MentorProxyCredentialRegistry(), objectMapper);
         User owner = persistUser("proxy-owner");
         workspace = createWorkspace("proxy-ws", "Proxy Workspace", "proxy-org", AccountType.ORG, owner);
     }
@@ -75,7 +85,8 @@ class LlmProxyIntegrationTest extends AbstractWorkspaceIntegrationTest {
     @Test
     void shouldAuthenticateRunningJobTokenAgainstPersistedRouting() throws Exception {
         AgentJob job = runningJob(true);
-        AuthenticationResult result = authenticate(job.getJobToken());
+        AuthenticationResult result = authenticate(
+                jwtIssuer.issueForJob(job.getId(), workspace.getId(), job.getRetryCount(), Duration.ofMinutes(5)));
 
         assertThat(result.status()).isEqualTo(200);
         assertThat(result.authentication())

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/proxy/LlmProxyIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/proxy/LlmProxyIntegrationTest.java
@@ -96,6 +96,39 @@ class LlmProxyIntegrationTest extends AbstractWorkspaceIntegrationTest {
     }
 
     @Test
+    void shouldRejectLegacyOpaqueJobToken() throws Exception {
+        // The database-backed secret the entity still persists is a pre-migration credential; the
+        // proxy accepts only per-job JWTs — there is deliberately no dual-accept window.
+        AgentJob job = runningJob(true);
+
+        AuthenticationResult result = authenticate(job.getJobToken());
+
+        assertThat(result.status()).isEqualTo(401);
+        assertThat(result.authentication()).isNull();
+    }
+
+    @Test
+    void shouldRejectWorkerSessionJwtAtTheProxy() throws Exception {
+        runningJob(true);
+
+        AuthenticationResult result = authenticate(jwtIssuer.issue("worker-1").token());
+
+        assertThat(result.status()).isEqualTo(401);
+        assertThat(result.authentication()).isNull();
+    }
+
+    @Test
+    void shouldRejectJobJwtBoundToAnotherWorkspace() throws Exception {
+        AgentJob job = runningJob(true);
+
+        AuthenticationResult result = authenticate(
+                jwtIssuer.issueForJob(job.getId(), workspace.getId() + 1, job.getRetryCount(), Duration.ofMinutes(5)));
+
+        assertThat(result.status()).isEqualTo(401);
+        assertThat(result.authentication()).isNull();
+    }
+
+    @Test
     void shouldFailClosedWhenCatalogModelIsDisabled() {
         AgentJob job = runningJob(false);
         long connectionId = job.getConfigSnapshot().get("connectionId").asLong();

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/runtime/hub/auth/WorkerJwtTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/runtime/hub/auth/WorkerJwtTest.java
@@ -15,6 +15,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Base64;
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Stream;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -46,12 +47,25 @@ class WorkerJwtTest extends BaseUnitTest {
     @Test
     void issuedTokenVerifiesWithExpectedClaims() {
         WorkerJwtIssuer.IssuedWorkerJwt issued = issuer.issue("worker-1");
-        WorkerJwt jwt = verifier.verify(issued.token());
+        WorkerSessionJwt jwt = (WorkerSessionJwt) verifier.verify(issued.token());
 
         assertThat(jwt.workerId()).isEqualTo("worker-1");
         assertThat(jwt.jti()).isEqualTo(issued.jti());
         assertThat(jwt.expiresAt())
                 .isCloseTo(issued.expiresAt(), Assertions.within(1, java.time.temporal.ChronoUnit.SECONDS));
+    }
+
+    @Test
+    void issuedJobTokenVerifiesWithRequiredClaims() {
+        UUID jobId = UUID.randomUUID();
+
+        JobJwt jwt = (JobJwt) verifier.verify(issuer.issueForJob(jobId, 42L, 0, Duration.ofMinutes(5)));
+
+        assertThat(jwt.jobId()).isEqualTo(jobId);
+        assertThat(jwt.workspaceId()).isEqualTo(42L);
+        assertThat(jwt.scopes()).containsExactly("llm_proxy");
+        assertThat(jwt.issuedAt()).isNotNull();
+        assertThat(jwt.jti()).isNotBlank();
     }
 
     @Test

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/runtime/hub/auth/WorkerJwtTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/runtime/hub/auth/WorkerJwtTest.java
@@ -15,6 +15,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Base64;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Stream;
 import org.assertj.core.api.Assertions;
@@ -66,6 +67,65 @@ class WorkerJwtTest extends BaseUnitTest {
         assertThat(jwt.scopes()).containsExactly("llm_proxy");
         assertThat(jwt.issuedAt()).isNotNull();
         assertThat(jwt.jti()).isNotBlank();
+    }
+
+    @Test
+    void expiredJobTokenRejected() {
+        WorkerSigningKey active = keyRing.active();
+        Instant past = Instant.now().minusSeconds(120);
+        String token = JWT.create()
+                .withHeader(Map.of("kid", active.kid(), "typ", "job+jwt"))
+                .withIssuer("hephaestus-test")
+                .withAudience("hephaestus-worker")
+                .withClaim("job_id", UUID.randomUUID().toString())
+                .withClaim("workspace_id", 42L)
+                .withClaim("attempt", 0)
+                .withClaim("scope", List.of("llm_proxy"))
+                .withJWTId(UUID.randomUUID().toString())
+                .withIssuedAt(past)
+                .withExpiresAt(past.plusSeconds(30))
+                .sign(Algorithm.RSA256(active.publicKey(), active.privateKey()));
+
+        assertThatThrownBy(() -> verifier.verify(token)).isInstanceOf(WorkerJwtInvalidException.class);
+    }
+
+    @Test
+    void legacyTokenWithoutExplicitTypeRejected() {
+        // Tokens minted before the claim-profile migration carry the library default "JWT" header
+        // type; the one-way cut rejects them even when the signature and claims would verify.
+        WorkerSigningKey active = keyRing.active();
+        String token = JWT.create()
+                .withKeyId(active.kid())
+                .withIssuer("hephaestus-test")
+                .withAudience("hephaestus-worker")
+                .withSubject("worker-1")
+                .withJWTId(UUID.randomUUID().toString())
+                .withIssuedAt(Instant.now())
+                .withExpiresAt(Instant.now().plusSeconds(60))
+                .sign(Algorithm.RSA256(active.publicKey(), active.privateKey()));
+
+        assertThatThrownBy(() -> verifier.verify(token))
+                .isInstanceOf(WorkerJwtInvalidException.class)
+                .hasMessageContaining("token type");
+    }
+
+    @Test
+    void workerSessionTokenCarryingJobClaimsRejected() {
+        WorkerSigningKey active = keyRing.active();
+        String token = JWT.create()
+                .withHeader(Map.of("kid", active.kid(), "typ", "worker-session+jwt"))
+                .withIssuer("hephaestus-test")
+                .withAudience("hephaestus-worker")
+                .withSubject("worker-1")
+                .withClaim("job_id", UUID.randomUUID().toString())
+                .withJWTId(UUID.randomUUID().toString())
+                .withIssuedAt(Instant.now())
+                .withExpiresAt(Instant.now().plusSeconds(60))
+                .sign(Algorithm.RSA256(active.publicKey(), active.privateKey()));
+
+        assertThatThrownBy(() -> verifier.verify(token))
+                .isInstanceOf(WorkerJwtInvalidException.class)
+                .hasMessageContaining("job claims");
     }
 
     @Test

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/runtime/hub/auth/WorkerTokenExchangeIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/runtime/hub/auth/WorkerTokenExchangeIntegrationTest.java
@@ -36,7 +36,7 @@ class WorkerTokenExchangeIntegrationTest extends BaseIntegrationTest {
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(response.getBody())
                 .isInstanceOfSatisfying(WorkerTokenExchangeController.ExchangeResponse.class, body -> {
-                    WorkerJwt jwt = verifier.verify(body.token());
+                    WorkerSessionJwt jwt = (WorkerSessionJwt) verifier.verify(body.token());
                     assertThat(jwt.workerId()).isEqualTo("worker-it");
                     assertThat(jwt.jti()).isNotBlank();
                     assertThat(body.expiresAt()).isNotNull();

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -105,7 +105,7 @@ export default defineConfig({
 				"vp -C webapp test --run --config vitest.config.storybook.ts",
 			),
 			"gate:verify:webapp-build": uncached("node scripts/verify-webapp-build.ts"),
-			"gate:verify:storybook-build": uncached("vp exec -C webapp storybook build --stats-json"),
+			"gate:verify:storybook-build": uncached("vp -C webapp exec storybook build --stats-json"),
 			"gate:verify:docs-build": uncached("vp run --filter docs build"),
 			"gate:verify:server": uncached("pnpm run test:server:verification"),
 			verification: uncached([


### PR DESCRIPTION
## Description

Replaces reusable database-backed job secrets at the internal LLM proxy with short-lived, attempt-scoped JWTs verified through `WorkerJwtVerifier`. Job credentials now carry an explicit token type and bind the job, workspace, retry attempt, scope, issued-at time, expiry, and unique token ID; invalid or expired credentials return 401, while valid credentials without `llm_proxy` scope return 403.

The same JWT configuration is available in server and worker runtime roles so a sandbox receives a credential minted and verified by the runtime hosting its proxy. Worker-session and job credentials remain separate claim profiles to prevent cross-purpose token reuse. Legacy opaque job tokens are intentionally rejected.

While running the complete local verification mirror, this also corrects the Vite+ Storybook-build command's argument order so the gate invokes the workspace binary rather than treating `-C` as a command.

Fixes #1165

## How to test

1. Run `pnpm run format` and `pnpm run check`.
2. Run `pnpm run test:server:unit`.
3. Run `pnpm run test:server:architecture` and confirm Spring Modulith verification passes.
4. Exercise `/internal/llm/**` with the migration cases covered by `JobTokenAuthenticationFilterTest`: a valid scoped job JWT is accepted; expired, malformed, wrong-purpose, stale-attempt, and legacy opaque credentials return 401; a JWT without `llm_proxy` scope returns 403.

## Checklist

- [x] My changeset summary reads as an operator/user-facing note (it becomes the changelog entry) — see `.changeset/README.md`
- [x] No operator action is required; existing worker JWT key configuration is reused
