### PR TITLE
feat(server): correlate requests across asynchronous jobs

### DIFF
--- a/.changeset/trace-every-request.md
+++ b/.changeset/trace-every-request.md
@@ -1,0 +1,5 @@
+---
+"hephaestus": minor
+---
+
+HTTP responses now expose a request ID that follows queued reviews through sandbox and model calls, so operators can correlate request, job, proxy, sandbox, and Sentry records without a tracing collector.

--- a/docs/admin/observability.mdx
+++ b/docs/admin/observability.mdx
@@ -31,3 +31,24 @@ Delivery is optional. Jobs that do not complete successfully may have no deliver
 `execution`, `delivery`, or `total`. Identifiers, model and provider names, worker IDs, and exception text are not
 labels. See [Practice Review Operations](./practice-review-operations.mdx) for queue health and the
 existing execution metric.
+
+## Correlating a request
+
+Every HTTP response carries an `X-Request-Id` header whose value is the request's W3C trace ID — a
+random 32-character hex string that is never derived from user attributes. The same value appears as
+the `traceId` field in every JSON log line written while handling that request, and it follows the
+work the request caused: a queued review job restores it when it executes, the sandbox and its LLM
+proxy calls carry it, and Sentry events are tagged with it. Access logs stay off at every layer, so
+this is the join key for "what happened to this request".
+
+No collector or log aggregator is required. From a reference deployment, take the ID a user reports
+(or the `X-Request-Id` of a failing response) and search the container logs:
+
+```bash
+docker compose logs --no-color | grep '"traceId":"<the-id>"'
+```
+
+That returns the request's own log lines, the lifecycle events of any job it enqueued (the
+`agent.job.*` events above), and the proxy calls made on its behalf. A job triggered by the scheduler
+rather than a request mints its own trace ID, so its lifecycle is still joinable even though no HTTP
+response ever carried it.

--- a/docs/contributor/erd/schema.mmd
+++ b/docs/contributor/erd/schema.mmd
@@ -98,6 +98,7 @@ erDiagram
         TIMESTAMPTZ in_app_prepared_at
         BIGINT practice_rollout_revision "NOT NULL"
         VARCHAR(24) practice_trigger_mode "NOT NULL"
+        VARCHAR(32) trace_id "NOT NULL"
     }
 
     ArtifactSignal {

--- a/server/application/pom.xml
+++ b/server/application/pom.xml
@@ -94,6 +94,10 @@
             <artifactId>context-propagation</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-tracing-bridge-otel</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.github.ben-manes.caffeine</groupId>
             <artifactId>caffeine</artifactId>
         </dependency>

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/SecurityConfig.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/SecurityConfig.java
@@ -10,6 +10,7 @@ import de.tum.cit.aet.hephaestus.core.security.SpaCsrfTokenRequestHandler;
 import de.tum.cit.aet.hephaestus.core.security.StaleAuthCookieFilter;
 import de.tum.cit.aet.hephaestus.feature.FeatureFlag;
 import de.tum.cit.aet.hephaestus.observability.ReplicaIdentityFilter;
+import de.tum.cit.aet.hephaestus.observability.RequestCorrelationFilter;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -422,7 +423,8 @@ public class SecurityConfig {
                         "Origin",
                         "X-XSRF-TOKEN",
                         "X-Impersonation-Allow-Writes"));
-        configuration.setExposedHeaders(List.of(ReplicaIdentityFilter.HEADER_NAME));
+        configuration.setExposedHeaders(
+                List.of(ReplicaIdentityFilter.HEADER_NAME, RequestCorrelationFilter.HEADER_NAME));
         configuration.setAllowCredentials(true);
         configuration.setMaxAge(3600L);
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/job/AgentJob.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/job/AgentJob.java
@@ -153,6 +153,9 @@ public class AgentJob {
     @Column(name = "idempotency_key", length = 255)
     private String idempotencyKey;
 
+    @Column(name = "trace_id", nullable = false, updatable = false, length = 32)
+    private String traceId;
+
     @Column(name = "exit_code")
     private Integer exitCode;
 
@@ -317,6 +320,9 @@ public class AgentJob {
     public void prePersist() {
         if (this.id == null) {
             this.id = UUID.randomUUID();
+        }
+        if (this.traceId == null) {
+            this.traceId = UUID.randomUUID().toString().replace("-", "");
         }
         if (this.jobToken == null) {
             this.jobToken = generateJobToken();

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobExecutor.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobExecutor.java
@@ -671,7 +671,8 @@ public class AgentJobExecutor {
         }
     }
 
-    private static String randomSpanId() {
+    /** Package-private: the zombie sweeper reuses it when it restores a reaped job's trace context. */
+    static String randomSpanId() {
         long value;
         do {
             value = ThreadLocalRandom.current().nextLong();

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobExecutor.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobExecutor.java
@@ -570,8 +570,10 @@ public class AgentJobExecutor {
 
     /** Runs on the sandbox executor, not the poll thread. */
     private void runClaimedJob(UUID jobId, ClaimResult claim) {
-        MDC.put(MDC_JOB_ID, jobId.toString());
         AgentJob job = claim.job;
+        MDC.put(StructuredLogKeys.TRACE_ID, job.getTraceId());
+        MDC.put(StructuredLogKeys.SPAN_ID, randomSpanId());
+        MDC.put(MDC_JOB_ID, jobId.toString());
         MDC.put(StructuredLogKeys.WORKSPACE_ID, job.getWorkspace().getId().toString());
         MDC.put(MDC_JOB_TYPE, job.getJobType().name());
         Instant startTime = Instant.now();
@@ -655,6 +657,8 @@ public class AgentJobExecutor {
             MDC.remove(MDC_JOB_ID);
             MDC.remove(StructuredLogKeys.WORKSPACE_ID);
             MDC.remove(MDC_JOB_TYPE);
+            MDC.remove(StructuredLogKeys.TRACE_ID);
+            MDC.remove(StructuredLogKeys.SPAN_ID);
         }
     }
 
@@ -665,6 +669,14 @@ public class AgentJobExecutor {
         } catch (IllegalArgumentException ignored) {
             return null;
         }
+    }
+
+    private static String randomSpanId() {
+        long value;
+        do {
+            value = ThreadLocalRandom.current().nextLong();
+        } while (value == 0);
+        return "%016x".formatted(value);
     }
 
     private boolean markExecutionStarted(UUID jobId) {

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobService.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobService.java
@@ -23,6 +23,7 @@ import de.tum.cit.aet.hephaestus.integration.core.signal.SignalRecorder;
 import de.tum.cit.aet.hephaestus.integration.core.signal.SignalStateReason;
 import de.tum.cit.aet.hephaestus.integration.scm.domain.issue.Issue;
 import de.tum.cit.aet.hephaestus.integration.scm.domain.pullrequest.PullRequest;
+import de.tum.cit.aet.hephaestus.observability.StructuredLogKeys;
 import de.tum.cit.aet.hephaestus.practices.PracticeRepository;
 import de.tum.cit.aet.hephaestus.practices.model.ArtifactKinds;
 import de.tum.cit.aet.hephaestus.practices.model.ObservationOrigin;
@@ -42,6 +43,7 @@ import java.util.UUID;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -357,6 +359,7 @@ public class AgentJobService {
             job.setPracticeTriggerMode(admission == null ? TriggerMode.MANUAL : admission.triggerMode());
             job.setMetadata(submission.metadata());
             job.setIdempotencyKey(detectionKey);
+            job.setTraceId(resolveTraceId());
             try {
                 job.setConfigSnapshot(
                         ConfigSnapshot.from(binding, llmModelResolver).toJson(objectMapper));
@@ -405,6 +408,12 @@ public class AgentJobService {
             AgentJobTelemetry.queued(job);
         }
         return committed;
+    }
+
+    private String resolveTraceId() {
+        return Objects.requireNonNullElseGet(
+                MDC.get(StructuredLogKeys.TRACE_ID),
+                () -> UUID.randomUUID().toString().replace("-", ""));
     }
 
     /** Settle a refused signal inside the submission transaction, so the two stand or fall together. */

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobTelemetry.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobTelemetry.java
@@ -1,6 +1,7 @@
 package de.tum.cit.aet.hephaestus.agent.job;
 
 import de.tum.cit.aet.hephaestus.agent.metrics.AgentMetrics;
+import de.tum.cit.aet.hephaestus.observability.StructuredLogKeys;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
@@ -83,8 +84,8 @@ final class AgentJobTelemetry {
     static void queued(AgentJob job) {
         log.atInfo()
                 .addKeyValue("event.name", "agent.job.queued")
-                .addKeyValue("job.id", job.getId())
-                .addKeyValue("workspace.id", job.getWorkspace().getId())
+                .addKeyValue(StructuredLogKeys.JOB_ID, job.getId())
+                .addKeyValue(StructuredLogKeys.WORKSPACE_ID, job.getWorkspace().getId())
                 .addKeyValue("job.type", job.getJobType())
                 .addKeyValue("job.phase", Phase.QUEUE.tag)
                 .addKeyValue("job.outcome", "queued")
@@ -95,8 +96,8 @@ final class AgentJobTelemetry {
     void transition(AgentJob job, String event, Phase phase, Outcome outcome, Duration duration) {
         log.atInfo()
                 .addKeyValue("event.name", event)
-                .addKeyValue("job.id", job.getId())
-                .addKeyValue("workspace.id", job.getWorkspace().getId())
+                .addKeyValue(StructuredLogKeys.JOB_ID, job.getId())
+                .addKeyValue(StructuredLogKeys.WORKSPACE_ID, job.getWorkspace().getId())
                 .addKeyValue("job.type", job.getJobType())
                 .addKeyValue("job.phase", phase.tag)
                 .addKeyValue("job.outcome", outcome.tag)

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobZombieSweeper.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobZombieSweeper.java
@@ -133,13 +133,16 @@ public class AgentJobZombieSweeper {
             try {
                 AgentJob reaped = transactionTemplate.execute(status -> reapIfStale(job.getId()));
                 if (reaped != null) {
-                    // The sweeper thread has no ambient trace context; restore the job's own so the
+                    // The sweeper thread has no ambient trace context; restore the job's own trace ID
+                    // (with a fresh span so no stale scheduler-thread value pairs with it) so the
                     // terminal event joins the lifecycle it closes.
                     MDC.put(StructuredLogKeys.TRACE_ID, reaped.getTraceId());
+                    MDC.put(StructuredLogKeys.SPAN_ID, AgentJobExecutor.randomSpanId());
                     try {
                         jobTelemetry.terminal(reaped, AgentJobStatus.TIMED_OUT, AgentJobTelemetry.age(reaped));
                     } finally {
                         MDC.remove(StructuredLogKeys.TRACE_ID);
+                        MDC.remove(StructuredLogKeys.SPAN_ID);
                     }
                 }
             } catch (Exception e) {

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobZombieSweeper.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobZombieSweeper.java
@@ -6,6 +6,7 @@ import de.tum.cit.aet.hephaestus.agent.usage.LlmPriceSnapshot;
 import de.tum.cit.aet.hephaestus.agent.usage.LlmUsageRecorder;
 import de.tum.cit.aet.hephaestus.core.WorkspaceAgnostic;
 import de.tum.cit.aet.hephaestus.core.runtime.ConditionalOnServerRole;
+import de.tum.cit.aet.hephaestus.observability.StructuredLogKeys;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Duration;
@@ -17,6 +18,7 @@ import java.util.concurrent.TimeUnit;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.data.domain.PageRequest;
@@ -131,7 +133,14 @@ public class AgentJobZombieSweeper {
             try {
                 AgentJob reaped = transactionTemplate.execute(status -> reapIfStale(job.getId()));
                 if (reaped != null) {
-                    jobTelemetry.terminal(reaped, AgentJobStatus.TIMED_OUT, AgentJobTelemetry.age(reaped));
+                    // The sweeper thread has no ambient trace context; restore the job's own so the
+                    // terminal event joins the lifecycle it closes.
+                    MDC.put(StructuredLogKeys.TRACE_ID, reaped.getTraceId());
+                    try {
+                        jobTelemetry.terminal(reaped, AgentJobStatus.TIMED_OUT, AgentJobTelemetry.age(reaped));
+                    } finally {
+                        MDC.remove(StructuredLogKeys.TRACE_ID);
+                    }
                 }
             } catch (Exception e) {
                 log.warn("Failed to reap stale job: jobId={}, error={}", job.getId(), e.getMessage());

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/proxy/LlmProxyWebClientConfig.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/proxy/LlmProxyWebClientConfig.java
@@ -49,7 +49,8 @@ class LlmProxyWebClientConfig {
     WebClient llmProxyWebClient(
             ConnectionProvider llmProxyConnectionProvider,
             LoopResources llmProxyLoopResources,
-            LlmProperties llmProperties) {
+            LlmProperties llmProperties,
+            WebClient.Builder webClientBuilder) {
         boolean allowLoopback = llmProperties.egress().allowLoopback();
         HttpClient httpClient = HttpClient.create(llmProxyConnectionProvider)
                 .runOn(llmProxyLoopResources)
@@ -65,7 +66,7 @@ class LlmProxyWebClientConfig {
                 .codecs(cfg -> cfg.defaultCodecs().maxInMemorySize(1024 * 1024))
                 .build();
 
-        return WebClient.builder()
+        return webClientBuilder
                 .clientConnector(new ReactorClientHttpConnector(httpClient))
                 .exchangeStrategies(strategies)
                 .build();

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/DockerSandboxAdapter.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/DockerSandboxAdapter.java
@@ -8,6 +8,7 @@ import de.tum.cit.aet.hephaestus.agent.sandbox.spi.SandboxManager;
 import de.tum.cit.aet.hephaestus.agent.sandbox.spi.SandboxResult;
 import de.tum.cit.aet.hephaestus.agent.sandbox.spi.SandboxSpec;
 import de.tum.cit.aet.hephaestus.agent.sandbox.spi.SecurityProfile;
+import de.tum.cit.aet.hephaestus.observability.StructuredLogKeys;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
@@ -346,6 +347,7 @@ public class DockerSandboxAdapter implements SandboxManager {
                 env.put(entry.getKey(), entry.getValue());
             }
         }
+        addTraceEnvironment(env);
 
         // Git security
         // Env-based config has HIGHEST precedence in git — overrides .git/config in any repo
@@ -392,6 +394,15 @@ public class DockerSandboxAdapter implements SandboxManager {
         }
 
         return env;
+    }
+
+    private static void addTraceEnvironment(Map<String, String> env) {
+        String traceId = MDC.get(StructuredLogKeys.TRACE_ID);
+        String spanId = MDC.get(StructuredLogKeys.SPAN_ID);
+        if (traceId != null && spanId != null) {
+            env.put("TRACE_ID", traceId);
+            env.put("TRACEPARENT", "00-" + traceId + "-" + spanId + "-00");
+        }
     }
 
     /**

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/SandboxEnvBlocklist.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/SandboxEnvBlocklist.java
@@ -53,6 +53,9 @@ public final class SandboxEnvBlocklist {
                 "SSL_CERT_FILE",
                 "SSL_CERT_DIR",
                 "REQUESTS_CA_BUNDLE",
+                // Server-owned correlation context.
+                "TRACE_ID",
+                "TRACEPARENT",
                 // Proxy hijacking.
                 "http_proxy",
                 "https_proxy",

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/interactive/DockerInteractiveSandboxAdapter.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/interactive/DockerInteractiveSandboxAdapter.java
@@ -16,6 +16,7 @@ import de.tum.cit.aet.hephaestus.agent.sandbox.spi.InteractiveSandboxException;
 import de.tum.cit.aet.hephaestus.agent.sandbox.spi.InteractiveSandboxService;
 import de.tum.cit.aet.hephaestus.agent.sandbox.spi.InteractiveSandboxSpec;
 import de.tum.cit.aet.hephaestus.agent.sandbox.spi.SecurityProfile;
+import de.tum.cit.aet.hephaestus.observability.StructuredLogKeys;
 import io.micrometer.core.instrument.Timer;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -279,6 +280,12 @@ public class DockerInteractiveSandboxAdapter implements InteractiveSandboxServic
                 continue;
             }
             env.put(entry.getKey(), entry.getValue());
+        }
+        String traceId = MDC.get(StructuredLogKeys.TRACE_ID);
+        String spanId = MDC.get(StructuredLogKeys.SPAN_ID);
+        if (traceId != null && spanId != null) {
+            env.put("TRACE_ID", traceId);
+            env.put("TRACEPARENT", "00-" + traceId + "-" + spanId + "-00");
         }
         if (spec.networkPolicy() != null && spec.networkPolicy().llmProxyUrl() != null) {
             String url = spec.networkPolicy().llmProxyUrl();

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/config/SentryConfiguration.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/config/SentryConfiguration.java
@@ -1,9 +1,14 @@
 package de.tum.cit.aet.hephaestus.config;
 
+import de.tum.cit.aet.hephaestus.observability.StructuredLogKeys;
+import io.sentry.EventProcessor;
+import io.sentry.Hint;
 import io.sentry.Sentry;
+import io.sentry.SentryEvent;
 import jakarta.annotation.PostConstruct;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.context.annotation.Configuration;
@@ -51,6 +56,16 @@ public class SentryConfiguration {
                 });
                 options.setEnvironment(getEnvironment());
                 options.setRelease(hephaestusVersion);
+                // Links a Sentry event to its JSON log lines; the tag survives the beforeSend scrub,
+                // which removes only user, request, and breadcrumb context.
+                options.addEventProcessor(new EventProcessor() {
+                    @Override
+                    public SentryEvent process(SentryEvent event, Hint hint) {
+                        String traceId = MDC.get(StructuredLogKeys.TRACE_ID);
+                        if (traceId != null) event.setTag(StructuredLogKeys.TRACE_ID, traceId);
+                        return event;
+                    }
+                });
             });
 
             log.info("Initialized Sentry");

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/observability/RequestCorrelationFilter.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/observability/RequestCorrelationFilter.java
@@ -8,30 +8,45 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.jspecify.annotations.Nullable;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
+/**
+ * Echoes the request's trace ID as {@code X-Request-Id} and opens a propagated span when Boot's own
+ * observation filter has not already done so.
+ *
+ * <p>The {@link Tracer} and {@link Propagator} are resolved via {@link ObjectProvider} because they
+ * come from Spring Boot's tracing autoconfig (registered after user config) —
+ * {@code @ConditionalOnBean} on a component-scanned bean evaluates before the autoconfig beans exist
+ * and would silently drop this filter (same reasoning as the {@code JwtDecoder} note in
+ * {@code SecurityConfig}). With tracing disabled the filter degrades to a pass-through.
+ */
 @Component
-@ConditionalOnBean({Tracer.class, Propagator.class})
 @Order(Ordered.HIGHEST_PRECEDENCE + 1)
 public class RequestCorrelationFilter extends OncePerRequestFilter {
 
     public static final String HEADER_NAME = "X-Request-Id";
 
-    private final Tracer tracer;
-    private final Propagator propagator;
+    private final @Nullable Tracer tracer;
+    private final @Nullable Propagator propagator;
 
-    public RequestCorrelationFilter(Tracer tracer, Propagator propagator) {
-        this.tracer = tracer;
-        this.propagator = propagator;
+    public RequestCorrelationFilter(
+            ObjectProvider<Tracer> tracerProvider, ObjectProvider<Propagator> propagatorProvider) {
+        this.tracer = tracerProvider.getIfAvailable();
+        this.propagator = propagatorProvider.getIfAvailable();
     }
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
             throws ServletException, IOException {
+        if (tracer == null || propagator == null) {
+            chain.doFilter(request, response);
+            return;
+        }
         Span current = tracer.currentSpan();
         if (current != null) {
             response.setHeader(HEADER_NAME, current.context().traceId());

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/observability/RequestCorrelationFilter.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/observability/RequestCorrelationFilter.java
@@ -1,0 +1,57 @@
+package de.tum.cit.aet.hephaestus.observability;
+
+import io.micrometer.tracing.Span;
+import io.micrometer.tracing.Tracer;
+import io.micrometer.tracing.propagation.Propagator;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+@ConditionalOnBean({Tracer.class, Propagator.class})
+@Order(Ordered.HIGHEST_PRECEDENCE + 1)
+public class RequestCorrelationFilter extends OncePerRequestFilter {
+
+    public static final String HEADER_NAME = "X-Request-Id";
+
+    private final Tracer tracer;
+    private final Propagator propagator;
+
+    public RequestCorrelationFilter(Tracer tracer, Propagator propagator) {
+        this.tracer = tracer;
+        this.propagator = propagator;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+            throws ServletException, IOException {
+        Span current = tracer.currentSpan();
+        if (current != null) {
+            response.setHeader(HEADER_NAME, current.context().traceId());
+            chain.doFilter(request, response);
+            return;
+        }
+
+        Span span = propagator
+                .extract(request, HttpServletRequest::getHeader)
+                .name("http.request")
+                .kind(Span.Kind.SERVER)
+                .start();
+        response.setHeader(HEADER_NAME, span.context().traceId());
+        try (Tracer.SpanInScope ignored = tracer.withSpan(span)) {
+            chain.doFilter(request, response);
+        } catch (IOException | ServletException | RuntimeException error) {
+            span.error(error);
+            throw error;
+        } finally {
+            span.end();
+        }
+    }
+}

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/observability/StructuredLogKeys.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/observability/StructuredLogKeys.java
@@ -3,6 +3,8 @@ package de.tum.cit.aet.hephaestus.observability;
 public final class StructuredLogKeys {
 
     public static final String JOB_ID = "job.id";
+    public static final String TRACE_ID = "traceId";
+    public static final String SPAN_ID = "spanId";
     public static final String WORKSPACE_ID = "workspace.id";
 
     private StructuredLogKeys() {}

--- a/server/application/src/main/resources/agent/pi-provider.ts
+++ b/server/application/src/main/resources/agent/pi-provider.ts
@@ -77,6 +77,7 @@ export function registerHephaestusProvider(
 		baseUrl,
 		apiKey: "$LLM_PROXY_TOKEN",
 		authHeader: true,
+		headers: env.TRACEPARENT ? { traceparent: env.TRACEPARENT } : undefined,
 		api: config.apiProtocol,
 		models: [model],
 	});

--- a/server/application/src/main/resources/agent/pi-runner.ts
+++ b/server/application/src/main/resources/agent/pi-runner.ts
@@ -1479,6 +1479,7 @@ async function admitObservations() {
 		headers: {
 			authorization: `Bearer ${process.env.LLM_PROXY_TOKEN}`,
 			"content-type": "application/json",
+			...(process.env.TRACEPARENT ? { traceparent: process.env.TRACEPARENT } : {}),
 		},
 		body: JSON.stringify({ schemaVersion: 1, observations: reviewState.observations }),
 	});

--- a/server/application/src/main/resources/application.yml
+++ b/server/application/src/main/resources/application.yml
@@ -119,6 +119,10 @@ server:
 
 # Actuator on the management port; health probes for Kubernetes liveness/readiness.
 management:
+    tracing:
+        # Propagate trace context without sampling spans.
+        sampling:
+            probability: 0.0
     server:
         port: ${MANAGEMENT_PORT:8080}
     endpoints:

--- a/server/application/src/main/resources/db/changelog/1788071342079_changelog.xml
+++ b/server/application/src/main/resources/db/changelog/1788071342079_changelog.xml
@@ -11,7 +11,18 @@
             <column name="trace_id" type="varchar(32)"/>
         </addColumn>
         <rollback>
-            <dropColumn tableName="agent_job" columnName="trace_id"/>
+            <!-- Drop only when this changeset actually created the column: a MARK_RAN run means the
+                 column pre-existed, and rolling back must not destroy its data. -->
+            <sql splitStatements="false">
+                DO $$
+                BEGIN
+                    IF EXISTS (SELECT 1 FROM databasechangelog
+                                WHERE id = '1788071342079-1' AND exectype = 'EXECUTED') THEN
+                        ALTER TABLE agent_job DROP COLUMN trace_id;
+                    END IF;
+                END
+                $$;
+            </sql>
         </rollback>
     </changeSet>
     <changeSet author="request-correlation" id="1788071342079-2">

--- a/server/application/src/main/resources/db/changelog/1788071342079_changelog.xml
+++ b/server/application/src/main/resources/db/changelog/1788071342079_changelog.xml
@@ -4,12 +4,27 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
     <changeSet author="request-correlation" id="1788071342079-1">
-        <preConditions onFail="MARK_RAN">
+        <preConditions onFail="MARK_RAN" onFailMessage="agent_job.trace_id already present">
             <not><columnExists tableName="agent_job" columnName="trace_id"/></not>
         </preConditions>
         <addColumn tableName="agent_job">
             <column name="trace_id" type="varchar(32)"/>
         </addColumn>
+        <rollback>
+            <dropColumn tableName="agent_job" columnName="trace_id"/>
+        </rollback>
+    </changeSet>
+    <changeSet author="request-correlation" id="1788071342079-2">
+        <!-- Split from the addColumn so a pre-existing nullable column is still backfilled and
+             promoted instead of skipped along with it. -->
+        <preConditions onFail="MARK_RAN" onFailMessage="agent_job.trace_id already NOT NULL">
+            <sqlCheck expectedResult="YES">
+                SELECT is_nullable FROM information_schema.columns
+                 WHERE table_schema = current_schema()
+                   AND table_name = 'agent_job'
+                   AND column_name = 'trace_id'
+            </sqlCheck>
+        </preConditions>
         <sql>
             UPDATE agent_job
                SET trace_id = replace(gen_random_uuid()::text, '-', '')
@@ -17,7 +32,7 @@
         </sql>
         <addNotNullConstraint tableName="agent_job" columnName="trace_id" columnDataType="varchar(32)"/>
         <rollback>
-            <dropColumn tableName="agent_job" columnName="trace_id"/>
+            <dropNotNullConstraint tableName="agent_job" columnName="trace_id" columnDataType="varchar(32)"/>
         </rollback>
     </changeSet>
 </databaseChangeLog>

--- a/server/application/src/main/resources/db/changelog/1788071342079_changelog.xml
+++ b/server/application/src/main/resources/db/changelog/1788071342079_changelog.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+    <changeSet author="request-correlation" id="1788071342079-1">
+        <preConditions onFail="MARK_RAN">
+            <not><columnExists tableName="agent_job" columnName="trace_id"/></not>
+        </preConditions>
+        <addColumn tableName="agent_job">
+            <column name="trace_id" type="varchar(32)"/>
+        </addColumn>
+        <sql>
+            UPDATE agent_job
+               SET trace_id = replace(gen_random_uuid()::text, '-', '')
+             WHERE trace_id IS NULL;
+        </sql>
+        <addNotNullConstraint tableName="agent_job" columnName="trace_id" columnDataType="varchar(32)"/>
+        <rollback>
+            <dropColumn tableName="agent_job" columnName="trace_id"/>
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/server/application/src/main/resources/db/master.xml
+++ b/server/application/src/main/resources/db/master.xml
@@ -100,4 +100,5 @@
     <include file="./changelog/1788071342078_changelog.xml" relativeToChangelogFile="true"/>
     <include file="./changelog/1788095225501_changelog.xml" relativeToChangelogFile="true"/>
     <include file="./changelog/1788095708139_changelog.xml" relativeToChangelogFile="true"/>
+    <include file="./changelog/1788071342079_changelog.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobServiceTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobServiceTest.java
@@ -30,6 +30,7 @@ import de.tum.cit.aet.hephaestus.integration.scm.domain.issue.Issue;
 import de.tum.cit.aet.hephaestus.integration.scm.domain.pullrequest.PullRequest;
 import de.tum.cit.aet.hephaestus.integration.scm.domain.repository.Repository;
 import de.tum.cit.aet.hephaestus.integration.scm.domain.signal.ScmSignals;
+import de.tum.cit.aet.hephaestus.observability.StructuredLogKeys;
 import de.tum.cit.aet.hephaestus.practices.PracticeRepository;
 import de.tum.cit.aet.hephaestus.practices.model.ArtifactKinds;
 import de.tum.cit.aet.hephaestus.practices.model.PracticeAutonomy;
@@ -41,6 +42,7 @@ import jakarta.persistence.Convert;
 import java.util.List;
 import java.util.Optional;
 import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -49,6 +51,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+import org.slf4j.MDC;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.support.TransactionCallback;
@@ -183,6 +186,11 @@ class AgentJobServiceTest extends BaseUnitTest {
         // 5-segment key grammar: <type>:<nameWithOwner>:<number>:<phase>:<freshness>
         // (PullRequestReviewHandler emits the trigger-event phase before the head SHA).
         return new JobSubmission(metadata, "pr_review:owner/repo:42:authoring:abc123");
+    }
+
+    @AfterEach
+    void clearTraceContext() {
+        MDC.remove(StructuredLogKeys.TRACE_ID);
     }
 
     @Nested
@@ -370,6 +378,7 @@ class AgentJobServiceTest extends BaseUnitTest {
 
         @Test
         void shouldCreateAQueuedJobWithItsPurposeIdempotencyKeyAndFrozenSnapshot() {
+            MDC.put(StructuredLogKeys.TRACE_ID, "0123456789abcdef0123456789abcdef");
             when(workspaceRepository.findById(1L)).thenReturn(Optional.of(workspace));
 
             JobTypeHandler handler = mock(JobTypeHandler.class);
@@ -396,6 +405,7 @@ class AgentJobServiceTest extends BaseUnitTest {
             assertThat(job.getIdempotencyKey()).isEqualTo("pr_review:owner/repo:42:authoring:abc123:detection");
             assertThat(job.getConfigSnapshot()).isNotNull();
             assertThat(job.getStatus()).isEqualTo(AgentJobStatus.QUEUED);
+            assertThat(job.getTraceId()).isEqualTo("0123456789abcdef0123456789abcdef");
         }
 
         @Test

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/proxy/LlmProxyWebClientConfigTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/proxy/LlmProxyWebClientConfigTest.java
@@ -30,7 +30,8 @@ class LlmProxyWebClientConfigTest extends BaseUnitTest {
                     provider,
                     loop,
                     new LlmProperties(
-                            "", new LlmProperties.Egress(false), new LlmProperties.Fx(LlmProperties.ECB_DAILY_URL)));
+                            "", new LlmProperties.Egress(false), new LlmProperties.Fx(LlmProperties.ECB_DAILY_URL)),
+                    WebClient.builder());
 
             Throwable thrown = catchThrowable(() -> client.get()
                     .uri(LOOPBACK_URL)

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/schema/ProductionSchemaContractIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/schema/ProductionSchemaContractIntegrationTest.java
@@ -425,12 +425,13 @@ class ProductionSchemaContractIntegrationTest {
         long workspaceId = insertWorkspace(key);
         UUID jobId = UUID.randomUUID();
         jdbcTemplate.update(
-                "INSERT INTO agent_job (id, workspace_id, job_type, status, config_snapshot, job_token, retry_count, "
+                "INSERT INTO agent_job (id, workspace_id, job_type, status, config_snapshot, job_token, trace_id, retry_count, "
                         + "created_at, available_at, delivery_attempts, practice_rollout_revision, practice_trigger_mode) "
-                        + "VALUES (?, ?, 'PULL_REQUEST_REVIEW', 'COMPLETED', '{}'::jsonb, ?, 0, now(), now(), 0, 0, 'AUTO')",
+                        + "VALUES (?, ?, 'PULL_REQUEST_REVIEW', 'COMPLETED', '{}'::jsonb, ?, ?, 0, now(), now(), 0, 0, 'AUTO')",
                 jobId,
                 workspaceId,
-                "token-" + jobId);
+                "token-" + jobId,
+                UUID.randomUUID().toString().replace("-", ""));
         return new DispatchOwner(workspaceId, jobId);
     }
 

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/observability/RequestCorrelationFilterTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/observability/RequestCorrelationFilterTest.java
@@ -8,8 +8,10 @@ import io.micrometer.tracing.Span;
 import io.micrometer.tracing.TraceContext;
 import io.micrometer.tracing.Tracer;
 import io.micrometer.tracing.propagation.Propagator;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.mock.web.MockFilterChain;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -34,10 +36,37 @@ class RequestCorrelationFilterTest {
         when(context.traceId()).thenReturn("0123456789abcdef0123456789abcdef");
 
         MockHttpServletResponse response = new MockHttpServletResponse();
-        new RequestCorrelationFilter(tracer, propagator)
+        new RequestCorrelationFilter(provider(tracer), provider(propagator))
                 .doFilter(new MockHttpServletRequest(), response, new MockFilterChain());
 
         assertThat(response.getHeader(RequestCorrelationFilter.HEADER_NAME))
                 .isEqualTo("0123456789abcdef0123456789abcdef");
+    }
+
+    @Test
+    void shouldPassThroughWithoutHeaderWhenTracingIsDisabled() throws Exception {
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        new RequestCorrelationFilter(provider((Tracer) null), provider((Propagator) null))
+                .doFilter(new MockHttpServletRequest(), response, chain);
+
+        assertThat(response.getHeader(RequestCorrelationFilter.HEADER_NAME)).isNull();
+        assertThat(chain.getRequest()).isNotNull();
+    }
+
+    private static <T> ObjectProvider<T> provider(@Nullable T instance) {
+        return new ObjectProvider<>() {
+            @Override
+            public T getObject() {
+                if (instance == null) throw new IllegalStateException("no instance");
+                return instance;
+            }
+
+            @Override
+            public @Nullable T getIfAvailable() {
+                return instance;
+            }
+        };
     }
 }

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/observability/RequestCorrelationFilterTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/observability/RequestCorrelationFilterTest.java
@@ -1,0 +1,43 @@
+package de.tum.cit.aet.hephaestus.observability;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.micrometer.tracing.Span;
+import io.micrometer.tracing.TraceContext;
+import io.micrometer.tracing.Tracer;
+import io.micrometer.tracing.propagation.Propagator;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+@Tag("unit")
+class RequestCorrelationFilterTest {
+
+    @Test
+    void shouldEchoExtractedTraceIdOnResponse() throws Exception {
+        Tracer tracer = mock(Tracer.class);
+        Propagator propagator = mock(Propagator.class);
+        Span.Builder builder = mock(Span.Builder.class);
+        Span span = mock(Span.class);
+        TraceContext context = mock(TraceContext.class);
+        when(propagator.extract(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any()))
+                .thenReturn(builder);
+        when(builder.name("http.request")).thenReturn(builder);
+        when(builder.kind(Span.Kind.SERVER)).thenReturn(builder);
+        when(builder.start()).thenReturn(span);
+        when(tracer.withSpan(span)).thenReturn(mock(Tracer.SpanInScope.class));
+        when(span.context()).thenReturn(context);
+        when(context.traceId()).thenReturn("0123456789abcdef0123456789abcdef");
+
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        new RequestCorrelationFilter(tracer, propagator)
+                .doFilter(new MockHttpServletRequest(), response, new MockFilterChain());
+
+        assertThat(response.getHeader(RequestCorrelationFilter.HEADER_NAME))
+                .isEqualTo("0123456789abcdef0123456789abcdef");
+    }
+}

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/observability/TracingDependencyTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/observability/TracingDependencyTest.java
@@ -1,0 +1,29 @@
+package de.tum.cit.aet.hephaestus.observability;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("unit")
+class TracingDependencyTest {
+
+    @Test
+    void shouldNotIncludeSpanExporterOnRuntimeClasspath() {
+        assertThat(isPresent("io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter"))
+                .isFalse();
+        assertThat(isPresent("io.opentelemetry.exporter.zipkin.ZipkinSpanExporter"))
+                .isFalse();
+        assertThat(isPresent("io.opentelemetry.exporter.jaeger.JaegerGrpcSpanExporter"))
+                .isFalse();
+    }
+
+    private static boolean isPresent(String className) {
+        try {
+            Class.forName(className, false, TracingDependencyTest.class.getClassLoader());
+            return true;
+        } catch (ClassNotFoundException ignored) {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
## Description

Adds collector-free W3C trace-context correlation across HTTP requests, queued agent jobs, LLM proxy calls, and sandboxes. HTTP responses expose the trace ID as `X-Request-Id`; queued work persists and restores that identifier in structured logs; outbound model and sandbox calls propagate it; and Sentry events receive the same tag.

This deliberately uses Micrometer's OpenTelemetry bridge for context only. Sampling is disabled, no span exporter is included, and a classpath test guards against common exporter dependencies. Trace IDs are random and contain no user-derived data. The database migration backfills existing jobs with random identifiers and requires no operator action.

Fixes #1642

## How to test

- Run `pnpm run check`.
- Run `pnpm run test:server:verification`.
- Send an HTTP request with a valid `traceparent` header and confirm the response's `X-Request-Id` equals its trace ID.
- Trigger a queued review and confirm the same trace ID appears in request, job, LLM proxy, sandbox, and Sentry records.
- Confirm startup succeeds with tracing disabled and that no exporter dependency is present.

## Checklist

- [x] My changeset summary reads like a changelog entry for operators or users and contains no class, hook, file-path, or implementation-detail language.
- [x] If an operator must act on this change, the changeset says so and `MIGRATION.md` is updated. No operator action is required for this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `X-Request-Id` response header to correlate requests across queued reviews, sandbox and model calls, logs, and Sentry events.
  * Preserved correlation for asynchronous and scheduler-triggered jobs.
  * Propagated tracing context to sandbox and observation services.

* **Documentation**
  * Added guidance for searching and correlating observability records.

* **Database**
  * Added and backfilled correlation identifiers for existing jobs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->