### PR TITLE
fix(ci): stop cancelling review-policy runs so the required check cannot report cancelled

### DIFF
--- a/.github/workflows/review-policy.yml
+++ b/.github/workflows/review-policy.yml
@@ -12,7 +12,10 @@ permissions: {}
 
 concurrency:
   group: review-policy-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  # Never cancel: a cancelled check run on the required `review-policy` context is evaluated
+  # by the ruleset as the context's state and silently blocks merge-queue entry (observed on
+  # PRs #1655/#1664, 2026-08-31). The job takes seconds; queueing duplicates is cheap.
+  cancel-in-progress: false
 
 jobs:
   review-policy:


### PR DESCRIPTION
## Description

The `review-policy` workflow's `cancel-in-progress: true` concurrency leaves **cancelled check runs** on the required `review-policy` context. The ruleset evaluates that cancelled run as the context's state, silently blocking merge-queue entry even when a newer run on the same commit succeeded. Observed twice today (#1655, #1664); both needed manual reruns of the cancelled runs to enqueue. The job is a seconds-long API read — queueing superseded runs costs nothing, so cancellation buys nothing and breaks the queue.

One line: `cancel-in-progress: true` → `false`, with an explanatory comment.

Part of the merge-queue reliability work (#1592 follow-through).

## How to test
- Push two rapid events to any PR (e.g. approve + push): both review-policy runs complete instead of one cancelling the other; `gh pr view --json mergeStateStatus` shows the PR queueable once green.

No changeset: CI-only, no shipped paths.