### PR TITLE
refactor(release): derive signing and verification identity from the run context

### DIFF
--- a/.github/workflows/deploy-locked-compose.yml
+++ b/.github/workflows/deploy-locked-compose.yml
@@ -9,6 +9,15 @@ on:
       release:
         type: string
         required: true
+      expected-signer-repository:
+        description: >-
+          owner/repo whose release workflow signed the lock being deployed. Defaults to
+          this repository. A lock signed before a repository transfer still carries the
+          old owner/repo in its certificate identity, so deploying such a release needs
+          this override pointed at the old slug (issue #1599).
+        type: string
+        required: false
+        default: ""
 
 jobs:
   deploy:
@@ -29,6 +38,13 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE: ${{ inputs.release }}
+          SERVER_URL: ${{ github.server_url }}
+          # The lock's certificate names the repository whose release workflow signed it.
+          # Deriving the default from the run context keeps signing and verification
+          # aligned across a repository transfer — but locks signed *before* the move
+          # still verify against the old owner/repo, which is what the
+          # expected-signer-repository override is for (issue #1599).
+          EXPECTED_SIGNER_REPOSITORY: ${{ inputs.expected-signer-repository || github.repository }}
         run: |
           set -euo pipefail
           [[ "$RELEASE" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]] || {
@@ -41,7 +57,7 @@ jobs:
           cosign verify-blob \
             --bundle "$RUNNER_TEMP/verified-release/$asset.sigstore.json" \
             --certificate-identity \
-              'https://github.com/ls1intum/Hephaestus/.github/workflows/release.yml@refs/heads/main' \
+              "${SERVER_URL}/${EXPECTED_SIGNER_REPOSITORY}/.github/workflows/release.yml@refs/heads/main" \
             --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
             "$RUNNER_TEMP/verified-release/$asset"
           commit=$(jq -er '.commit | select(test("^[a-f0-9]{40}$"))' \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,7 +101,7 @@ jobs:
           if [ -n "$PREV_TAG" ] && ! git diff --quiet "$PREV_TAG" "$SHA" -- server/application/src/main/resources/db/changelog/; then
             {
               echo "> [!WARNING]"
-              echo "> This release contains **schema migrations**. They run automatically on startup — back up your database before upgrading. See the [migration guide](https://github.com/ls1intum/Hephaestus/blob/main/MIGRATION.md)."
+              echo "> This release contains **schema migrations**. They run automatically on startup — back up your database before upgrading. See the [migration guide](${{ github.server_url }}/${{ github.repository }}/blob/main/MIGRATION.md)."
               echo ""
             } >> "$NOTES"
           fi
@@ -368,7 +368,7 @@ jobs:
           set -euo pipefail
           cosign verify-blob \
             --bundle "${ASSET}.sigstore.json" \
-            --certificate-identity 'https://github.com/ls1intum/Hephaestus/.github/workflows/release.yml@refs/heads/main' \
+            --certificate-identity '${{ github.server_url }}/${{ github.repository }}/.github/workflows/release.yml@refs/heads/main' \
             --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
             "$ASSET"
 
@@ -571,7 +571,7 @@ jobs:
           lock="release-${TAG_NAME}.json"
           cosign verify-blob \
             --bundle "evidence/$lock.sigstore.json" \
-            --certificate-identity 'https://github.com/ls1intum/Hephaestus/.github/workflows/release.yml@refs/heads/main' \
+            --certificate-identity '${{ github.server_url }}/${{ github.repository }}/.github/workflows/release.yml@refs/heads/main' \
             --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
             "evidence/$lock"
           node scripts/release-image-lock.ts "evidence/$lock" evidence/manifest.json \
@@ -579,7 +579,7 @@ jobs:
           node scripts/verify-release-evidence.ts evidence --verify-signatures
           asset="evidence/release-${TAG_NAME}.json"
           cosign verify-blob --bundle "${asset}.sigstore.json" \
-            --certificate-identity 'https://github.com/ls1intum/Hephaestus/.github/workflows/release.yml@refs/heads/main' \
+            --certificate-identity '${{ github.server_url }}/${{ github.repository }}/.github/workflows/release.yml@refs/heads/main' \
             --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' "$asset" >/dev/null
 
       - name: Promote verified image digests

--- a/.github/workflows/rescan-release-images.yml
+++ b/.github/workflows/rescan-release-images.yml
@@ -36,7 +36,7 @@ jobs:
           lock="release-$tag.json"
           cosign verify-blob \
             --bundle "release-evidence/$lock.sigstore.json" \
-            --certificate-identity 'https://github.com/ls1intum/Hephaestus/.github/workflows/release.yml@refs/heads/main' \
+            --certificate-identity '${{ github.server_url }}/${{ github.repository }}/.github/workflows/release.yml@refs/heads/main' \
             --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
             "release-evidence/$lock"
           node scripts/release-image-lock.ts "release-evidence/$lock" \

--- a/scripts/lib/release-signer.ts
+++ b/scripts/lib/release-signer.ts
@@ -1,0 +1,27 @@
+// The certificate identity cosign expects on a release lock: the release workflow of
+// the repository that cut the release, pinned to its default branch. Deriving it from
+// the run context (GITHUB_SERVER_URL / GITHUB_REPOSITORY) keeps signing and
+// verification aligned automatically across a repository transfer (issue #1599).
+// Outside CI — the operator flow documented in docs/admin/install.mdx — the canonical
+// repository remains the fallback; releases signed before a transfer keep the old
+// owner/repo in their certificate either way.
+
+const FALLBACK_SERVER_URL = "https://github.com";
+const FALLBACK_REPOSITORY = "ls1intum/Hephaestus";
+
+export function releaseSignerRepository(environment: NodeJS.ProcessEnv): string {
+	const repository = environment.GITHUB_REPOSITORY;
+	if (repository) return repository;
+	if (environment.CI) {
+		throw new Error(
+			"GITHUB_REPOSITORY is not set. CI must provide the run's own repository so " +
+				"release-lock verification follows the repository identity instead of a stale literal.",
+		);
+	}
+	return FALLBACK_REPOSITORY;
+}
+
+export function releaseSignerIdentity(environment: NodeJS.ProcessEnv): string {
+	const serverUrl = environment.GITHUB_SERVER_URL ?? FALLBACK_SERVER_URL;
+	return `${serverUrl}/${releaseSignerRepository(environment)}/.github/workflows/release.yml@refs/heads/main`;
+}

--- a/scripts/prepare-release-lock.ts
+++ b/scripts/prepare-release-lock.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { basename, dirname, join } from "node:path";
 
 import { run } from "./lib/process.ts";
+import { releaseSignerIdentity, releaseSignerRepository } from "./lib/release-signer.ts";
 import { isRelease } from "./release-image-lock.ts";
 
 const repositoryRoot = join(import.meta.dirname, "..");
@@ -21,7 +22,7 @@ try {
 		"download",
 		release,
 		"--repo",
-		"ls1intum/Hephaestus",
+		releaseSignerRepository(process.env),
 		"--dir",
 		directory,
 		"--pattern",
@@ -36,7 +37,7 @@ try {
 		"--bundle",
 		join(directory, `${asset}.sigstore.json`),
 		"--certificate-identity",
-		"https://github.com/ls1intum/Hephaestus/.github/workflows/release.yml@refs/heads/main",
+		releaseSignerIdentity(process.env),
 		"--certificate-oidc-issuer",
 		"https://token.actions.githubusercontent.com",
 		join(directory, asset),

--- a/scripts/release-deployment-policy.test.ts
+++ b/scripts/release-deployment-policy.test.ts
@@ -2,6 +2,8 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { test } from "node:test";
 
+import { releaseSignerIdentity, releaseSignerRepository } from "./lib/release-signer.ts";
+
 const release = readFileSync(".github/workflows/release.yml", "utf8");
 const deployment = readFileSync(".github/workflows/deploy-locked-compose.yml", "utf8");
 const upgradeDrill = readFileSync("scripts/release-upgrade-test.ts", "utf8");
@@ -50,6 +52,53 @@ await test("release upgrade runs the server topology without optional infrastruc
 	assert.match(upgradeDrill, /"HEPHAESTUS_RUNTIME_WEBHOOK_ENABLED=false"/);
 	assert.match(upgradeDrill, /"HEPHAESTUS_SYNC_NATS_ENABLED=false"/);
 	assert.doesNotMatch(upgradeDrill, /"NATS_ENABLED=false"/);
+});
+
+await test("signing and verification identity derives from the run context", () => {
+	const rescan = readFileSync(".github/workflows/rescan-release-images.yml", "utf8");
+	const prepareLock = readFileSync("scripts/prepare-release-lock.ts", "utf8");
+	const derivedIdentity =
+		/\$\{\{ github\.server_url \}\}\/\$\{\{ github\.repository \}\}\/\.github\/workflows\/release\.yml@refs\/heads\/main/;
+
+	assert.match(release, derivedIdentity);
+	assert.match(rescan, derivedIdentity);
+	assert.match(prepareLock, /releaseSignerIdentity\(process\.env\)/);
+	assert.match(prepareLock, /releaseSignerRepository\(process\.env\)/);
+	// No verify step may pin a repository slug: after a repository transfer, the run's
+	// own identity is the one the release workflow signs with (issue #1599).
+	for (const contents of [release, deployment, rescan, prepareLock])
+		assert.doesNotMatch(contents, /certificate-identity[^\n]*\n?[^\n]*ls1intum\/Hephaestus/);
+	// Deploys verify locks that may predate a repository transfer, so the expected
+	// signer stays overridable while defaulting to the run's own repository.
+	assert.match(
+		deployment,
+		/EXPECTED_SIGNER_REPOSITORY: \$\{\{ inputs\.expected-signer-repository \|\| github\.repository \}\}/,
+	);
+	assert.match(
+		deployment,
+		/"\$\{SERVER_URL\}\/\$\{EXPECTED_SIGNER_REPOSITORY\}\/\.github\/workflows\/release\.yml@refs\/heads\/main"/,
+	);
+});
+
+await test("derived signer identity matches today's literals in the canonical repository", () => {
+	const canonicalRun = {
+		CI: "true",
+		GITHUB_SERVER_URL: "https://github.com",
+		GITHUB_REPOSITORY: "ls1intum/Hephaestus",
+	};
+	assert.equal(releaseSignerRepository(canonicalRun), "ls1intum/Hephaestus");
+	assert.equal(
+		releaseSignerIdentity(canonicalRun),
+		"https://github.com/ls1intum/Hephaestus/.github/workflows/release.yml@refs/heads/main",
+	);
+	// The documented operator flow (docs/admin/install.mdx) runs outside CI and keeps
+	// the canonical fallback…
+	assert.equal(
+		releaseSignerIdentity({}),
+		"https://github.com/ls1intum/Hephaestus/.github/workflows/release.yml@refs/heads/main",
+	);
+	// …but CI must never silently verify against a repository it is not running in.
+	assert.throws(() => releaseSignerRepository({ CI: "true" }), /GITHUB_REPOSITORY/);
 });
 
 await test("release publication requires native smoke tests for every supported host", () => {


### PR DESCRIPTION
## Motivation

Preparation for the org-move decision (#1599). The release pipeline signs and verifies with the identity of the workflow run that produced the artifact, but three cosign `verify-blob` calls in `release.yml`, one in `rescan-release-images.yml`, one in `deploy-locked-compose.yml`, and two literals in `scripts/prepare-release-lock.ts` pinned `ls1intum/Hephaestus` while the surrounding steps in the same files already used `${{ github.repository }}`. After a repository transfer those pins would keep verifying against the old identity while signing moved with the run — a silent split. Deriving everything from the run context makes a transfer change signing and verification behavior together, and is a no-op for the current repository either way.

## What changed

- **`.github/workflows/release.yml`** — the three `--certificate-identity` literals (fail-fast verify, clean-environment durable-asset verify ×2) now use `${{ github.server_url }}/${{ github.repository }}/.github/workflows/release.yml@refs/heads/main`; the release-notes migration-guide link derives the same way.
- **`.github/workflows/rescan-release-images.yml`** — same conversion for the weekly rescan's lock verification.
- **`.github/workflows/deploy-locked-compose.yml`** — the lock-verification identity is now built from `SERVER_URL`/`EXPECTED_SIGNER_REPOSITORY` env, with a new optional `expected-signer-repository` input defaulting to `${{ github.repository }}`.
- **`scripts/prepare-release-lock.ts`** — the download repo and certificate identity come from a new `scripts/lib/release-signer.ts` helper that reads `GITHUB_SERVER_URL`/`GITHUB_REPOSITORY`, throws in CI when `GITHUB_REPOSITORY` is absent, and keeps `ls1intum/Hephaestus` only as the documented local-operator fallback (`docs/admin/install.mdx` flow).
- **`scripts/release-deployment-policy.test.ts`** — pins the derivation (not the literal): workflows must use the run-context identity, no verify step may pin a slug, the deploy override must default to the run's repository, and the helper must reproduce today's exact literals in `ls1intum/Hephaestus` context.

## Pre/post-transfer verification note

A release lock is signed by the release workflow of the repository that cut it. After a transfer, everything signed **post-move** verifies with the new derived identity automatically — but locks signed **pre-move** still carry the old `owner/repo` in their Fulcio certificate. Deploying such a release needs `expected-signer-repository` pointed at the old slug; that is the per-release identity-selection concern from #1599, kept explicit rather than papered over.

Intentionally untouched: GHCR image namespaces, the `pkg:github/ls1intum/hephaestus` attestation purl, MIGRATION.md, historical changelogs (namespace/post-decision territory).

## Verification

- `pnpm run check:agents` (format check, oxlint, typecheck, `test:tooling` — 218/218 pass, including the new derivation tests)
- `actionlint` clean on the three changed workflows; `zizmor --min-confidence medium`: 0 findings
- No changeset: no shipped paths (`server/`, `webapp/`, `docker/`) are touched — CI workflows and repository scripts only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Release verification now works correctly when the repository is transferred or hosted under a different repository path.
  * Signing identities are derived from the active repository and server context instead of fixed repository details.
  * Deployment verification supports an optional signer repository override for validating releases signed under a previous repository identity.

* **Tests**
  * Added coverage for repository-derived signing identities, fallback behavior, and deployment overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->