### PR TITLE
docs: serve the documentation at docs.hephaestus.build

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -41,4 +41,4 @@ Example (a migration-bearing fix):
 Fixes duplicate leaderboard entries after a team rename.
 ```
 
-Full flow and rules: [release management guide](https://ls1intum.github.io/Hephaestus/contributor/release-management).
+Full flow and rules: [release management guide](https://docs.hephaestus.build/contributor/release-management).

--- a/.changeset/docs-live-at-their-own-address.md
+++ b/.changeset/docs-live-at-their-own-address.md
@@ -1,0 +1,5 @@
+---
+"hephaestus": patch
+---
+
+The documentation now lives at <https://docs.hephaestus.build>. Links in the web app, the sample configuration files, and server messages point at the new address, and the old github.io pages redirect there — no action needed.

--- a/.github/workflows/cd-docs.yml
+++ b/.github/workflows/cd-docs.yml
@@ -73,7 +73,7 @@ jobs:
             ${{ runner.os }}-docusaurus-production-
       - run: pnpm --filter docs run build
         env:
-          DOCUSAURUS_BASE_URL: "/Hephaestus/"
+          DOCUSAURUS_BASE_URL: "/"
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: docs-build-production

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contribution Guidelines for Hephaestus
 
-Read the [local development guide](https://ls1intum.github.io/Hephaestus/contributor/local-development) on how to set up your environment.
+Read the [local development guide](https://docs.hephaestus.build/contributor/local-development) on how to set up your environment.
 
 Repository tooling requires the Node.js version pinned in `package.json#devEngines.runtime`. pnpm
 installs dependencies and dispatches package scripts; TypeScript scripts and application tools execute
@@ -34,7 +34,7 @@ Contributions that do not adhere to these guidelines will be rejected. We align 
 
 Use `pnpm run check:affected` for fast feedback. Before pushing, run `pnpm run check`; the hook runs it
 automatically. Run `pnpm run verify` before requesting review. Scope, budgets, and exclusions are documented in the
-[local verification guide](https://ls1intum.github.io/Hephaestus/contributor/local-verification).
+[local verification guide](https://docs.hephaestus.build/contributor/local-verification).
 
 1. **External contributors only**: Fork the Repository and create a branch.
 2. **Create a feature branch**: Work on your changes in a separate branch.
@@ -63,7 +63,7 @@ coordinate with a maintainer.
 Want a running copy of your branch on a URL? Add the `preview` label to your pull request. It runs the
 images CI built for your commit and redeploys on every push; it never waits for your tests, so it
 exists even when they are red. Remove the label to tear it down. See
-[Preview Deployments](https://ls1intum.github.io/Hephaestus/contributor/ci-cd) for what a preview does
+[Preview Deployments](https://docs.hephaestus.build/contributor/ci-cd) for what a preview does
 and does not contain.
 
 ## Pull Request Title Guidelines
@@ -92,8 +92,8 @@ pnpm changeset --empty  # no user-facing effect — then write why in the file b
 
 Changesets accumulate into a **Version PR**; merging it cuts the release. How releases are cut, how to
 write good changesets, and what a version number promises all live in the
-[release management guide](https://ls1intum.github.io/Hephaestus/contributor/release-management) and the
-[compatibility policy](https://ls1intum.github.io/Hephaestus/admin/compatibility-policy).
+[release management guide](https://docs.hephaestus.build/contributor/release-management) and the
+[compatibility policy](https://docs.hephaestus.build/admin/compatibility-policy).
 
 ### Allowed Types
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -4,9 +4,9 @@ There is exactly **one supported install**: the Docker Compose stack in
 [`docker/self-host/`](docker/self-host/) on one 64-bit Linux host
 (4 vCPUs / 8 GB RAM / 40 GB SSD recommended). Other setups may work but are unsupported.
 
-**→ Follow the install guide: <https://ls1intum.github.io/Hephaestus/admin/install>**
+**→ Follow the install guide: <https://docs.hephaestus.build/admin/install>**
 
 For contributor/development setup, see the
-[contributor docs](https://ls1intum.github.io/Hephaestus/contributor/local-development) instead.
+[contributor docs](https://docs.hephaestus.build/contributor/local-development) instead.
 Contributors need the Node.js and pnpm versions pinned in `package.json`. The supported repository-based
 installation also uses the pinned Node.js version to verify signed release locks.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -2,7 +2,7 @@
 
 This document helps you upgrade between versions of Hephaestus. For what a version number promises
 (public contract, upgrade guarantee, support statement), see the
-[Compatibility Policy](https://docs.hephaestus.build/admin/compatibility-policy).
+[Compatibility Policy](https://ls1intum.github.io/Hephaestus/admin/compatibility-policy).
 
 > ⚠️ **Pre-1.0 Notice**: We are in active development. Minor versions (0.x.0) may contain breaking changes. Always test in staging before production.
 
@@ -77,7 +77,7 @@ rotated independently without invalidating sessions or unrelated encrypted data.
 
 **Migration**: before deploying, set `HEPHAESTUS_SECURITY_CREDENTIAL_ENCRYPTION_KEY` to the current
 value of `HEPHAESTUS_SECURITY_ENCRYPTION_KEY`. After every runtime is upgraded, follow the
-[credential-key rotation procedure](https://docs.hephaestus.build/admin/credential-key-rotation)
+[credential-key rotation procedure](https://ls1intum.github.io/Hephaestus/admin/credential-key-rotation)
 to replace it with an independent key. Self-hosted installations using `docker/self-host/setup.sh`
 receive the initial value automatically.
 
@@ -102,7 +102,7 @@ examples in the practice-review operations guide.
 the bundled PostgreSQL 17 image.
 
 **Migration**: before starting this release, follow the
-[Backup & Restore](https://docs.hephaestus.build/admin/backup-restore#postgresql-17-to-18).
+[Backup & Restore](https://ls1intum.github.io/Hephaestus/admin/backup-restore#postgresql-17-to-18).
 Keep the PostgreSQL 17 volume until the upgraded deployment passes its acceptance checks.
 
 ### v0.76.0
@@ -139,7 +139,7 @@ review runs and no feedback is prepared about them.
 
 **Operator action after upgrading**: open **Practices → Review → When and where** and confirm the
 **People** and **Repositories** counts. Existing members need no action. If expected contributors are
-missing, follow [Who counts as a person](https://docs.hephaestus.build/admin/practice-review#who-counts-as-a-person).
+missing, follow [Who counts as a person](https://ls1intum.github.io/Hephaestus/admin/practice-review#who-counts-as-a-person).
 
 #### 🔴 Production configuration is validated before startup
 
@@ -151,7 +151,7 @@ catalog together and refuse to start until every reported error is resolved. The
 identifies properties and documentation but never includes configured values.
 
 **Action**: before upgrading, compare every production role's settings with the
-[configuration readiness guide](https://docs.hephaestus.build/admin/configuration-readiness).
+[configuration readiness guide](https://ls1intum.github.io/Hephaestus/admin/configuration-readiness).
 Run a staging process with the production profile and correct every required setting it reports.
 After the server role starts, an instance administrator can inspect the redacted facts through
 `GET /api/admin/configuration-readiness`.
@@ -281,7 +281,7 @@ HEPHAESTUS_AGENT_IMAGE_REFERENCE=ghcr.io/ls1intum/hephaestus/agent-pi@sha256:<di
 
 A deployment tracking `main` keeps `HEPHAESTUS_RELEASE_PIN_SKIP=true` and
 `HEPHAESTUS_AGENT_IMAGE_REQUIRE_DIGEST=false`; the derived reference is a matched tag, not a digest.
-See [Release image lock](https://docs.hephaestus.build/admin/release-image-lock).
+See [Release image lock](https://ls1intum.github.io/Hephaestus/admin/release-image-lock).
 
 #### 🟡 Preview deployments name their own agent image
 
@@ -365,7 +365,7 @@ has drifted from what this deployment expects is left entirely alone and logged 
 `nats stream edit` before the bound can be applied.
 
 Full metric roster and the wedged-broker procedure:
-[Webhook ingestion operations](https://docs.hephaestus.build/admin/webhook-ingestion-operations).
+[Webhook ingestion operations](https://ls1intum.github.io/Hephaestus/admin/webhook-ingestion-operations).
 
 
 #### 🟡 Readiness now answers for more than "the process started"
@@ -786,7 +786,7 @@ containers and their memory sits outside these limits (`SANDBOX_MEMORY_BYTES`, d
 concurrent sandbox).
 
 **Migration**: on a host below 8 GB RAM, set lower values in `.env` before the first start of the new
-version. The [install guide](https://docs.hephaestus.build/admin/install) states the floor
+version. The [install guide](https://ls1intum.github.io/Hephaestus/admin/install) states the floor
 and how the limits relate to it.
 
 #### 🔴 A workspace's per-run AI timeout is capped at one hour
@@ -907,7 +907,7 @@ HEPHAESTUS_MENTOR_AGENT_PULL_POLICY=IF_NOT_PRESENT
 
 ### v1.0.0 (Future)
 
-At v1.0.0 the [Compatibility Policy](https://docs.hephaestus.build/admin/compatibility-policy)
+At v1.0.0 the [Compatibility Policy](https://ls1intum.github.io/Hephaestus/admin/compatibility-policy)
 takes effect — the public contract, the "any 1.x → any later 1.y" upgrade guarantee,
 deprecation-ahead-of-removal, and latest-release-only support. Until then, expect rapid iteration and
 occasional breaking changes in minor releases.
@@ -923,7 +923,7 @@ and review the release notes for endpoint changes.
 
 ### New Required Environment Variable
 
-1. Check the release notes and the [Production Setup](https://docs.hephaestus.build/admin/production-setup) guide for new variables
+1. Check the release notes and the [Production Setup](https://ls1intum.github.io/Hephaestus/admin/production-setup) guide for new variables
 2. Add them to your deployment's environment (see the `docker/compose.app.yaml` env block)
 3. Restart services
 
@@ -957,7 +957,7 @@ in CI and are not a supported recovery path. The supported recoveries, in order 
    changesets succeeded before deciding.
 2. **Restore from backup** if the instance must come back now and forward-fixing will take longer than
    the outage budget. Follow
-   [Backup & restore](https://docs.hephaestus.build/admin/backup-restore); restore the
+   [Backup & restore](https://ls1intum.github.io/Hephaestus/admin/backup-restore); restore the
    database dump *and* the `.env` holding `HEPHAESTUS_SECURITY_ENCRYPTION_KEY`, or every encrypted
    credential in the restored database is unreadable. Then pin `IMAGE_TAG` to the version the dump
    was taken under so it is not immediately re-migrated by the release that failed.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -2,7 +2,7 @@
 
 This document helps you upgrade between versions of Hephaestus. For what a version number promises
 (public contract, upgrade guarantee, support statement), see the
-[Compatibility Policy](https://ls1intum.github.io/Hephaestus/admin/compatibility-policy).
+[Compatibility Policy](https://docs.hephaestus.build/admin/compatibility-policy).
 
 > ⚠️ **Pre-1.0 Notice**: We are in active development. Minor versions (0.x.0) may contain breaking changes. Always test in staging before production.
 
@@ -77,7 +77,7 @@ rotated independently without invalidating sessions or unrelated encrypted data.
 
 **Migration**: before deploying, set `HEPHAESTUS_SECURITY_CREDENTIAL_ENCRYPTION_KEY` to the current
 value of `HEPHAESTUS_SECURITY_ENCRYPTION_KEY`. After every runtime is upgraded, follow the
-[credential-key rotation procedure](https://ls1intum.github.io/Hephaestus/admin/credential-key-rotation)
+[credential-key rotation procedure](https://docs.hephaestus.build/admin/credential-key-rotation)
 to replace it with an independent key. Self-hosted installations using `docker/self-host/setup.sh`
 receive the initial value automatically.
 
@@ -102,7 +102,7 @@ examples in the practice-review operations guide.
 the bundled PostgreSQL 17 image.
 
 **Migration**: before starting this release, follow the
-[Backup & Restore](https://ls1intum.github.io/Hephaestus/admin/backup-restore#postgresql-17-to-18).
+[Backup & Restore](https://docs.hephaestus.build/admin/backup-restore#postgresql-17-to-18).
 Keep the PostgreSQL 17 volume until the upgraded deployment passes its acceptance checks.
 
 ### v0.76.0
@@ -139,7 +139,7 @@ review runs and no feedback is prepared about them.
 
 **Operator action after upgrading**: open **Practices → Review → When and where** and confirm the
 **People** and **Repositories** counts. Existing members need no action. If expected contributors are
-missing, follow [Who counts as a person](https://ls1intum.github.io/Hephaestus/admin/practice-review#who-counts-as-a-person).
+missing, follow [Who counts as a person](https://docs.hephaestus.build/admin/practice-review#who-counts-as-a-person).
 
 #### 🔴 Production configuration is validated before startup
 
@@ -151,7 +151,7 @@ catalog together and refuse to start until every reported error is resolved. The
 identifies properties and documentation but never includes configured values.
 
 **Action**: before upgrading, compare every production role's settings with the
-[configuration readiness guide](https://ls1intum.github.io/Hephaestus/admin/configuration-readiness).
+[configuration readiness guide](https://docs.hephaestus.build/admin/configuration-readiness).
 Run a staging process with the production profile and correct every required setting it reports.
 After the server role starts, an instance administrator can inspect the redacted facts through
 `GET /api/admin/configuration-readiness`.
@@ -281,7 +281,7 @@ HEPHAESTUS_AGENT_IMAGE_REFERENCE=ghcr.io/ls1intum/hephaestus/agent-pi@sha256:<di
 
 A deployment tracking `main` keeps `HEPHAESTUS_RELEASE_PIN_SKIP=true` and
 `HEPHAESTUS_AGENT_IMAGE_REQUIRE_DIGEST=false`; the derived reference is a matched tag, not a digest.
-See [Release image lock](https://ls1intum.github.io/Hephaestus/admin/release-image-lock).
+See [Release image lock](https://docs.hephaestus.build/admin/release-image-lock).
 
 #### 🟡 Preview deployments name their own agent image
 
@@ -365,7 +365,7 @@ has drifted from what this deployment expects is left entirely alone and logged 
 `nats stream edit` before the bound can be applied.
 
 Full metric roster and the wedged-broker procedure:
-[Webhook ingestion operations](https://ls1intum.github.io/Hephaestus/admin/webhook-ingestion-operations).
+[Webhook ingestion operations](https://docs.hephaestus.build/admin/webhook-ingestion-operations).
 
 
 #### 🟡 Readiness now answers for more than "the process started"
@@ -786,7 +786,7 @@ containers and their memory sits outside these limits (`SANDBOX_MEMORY_BYTES`, d
 concurrent sandbox).
 
 **Migration**: on a host below 8 GB RAM, set lower values in `.env` before the first start of the new
-version. The [install guide](https://ls1intum.github.io/Hephaestus/admin/install) states the floor
+version. The [install guide](https://docs.hephaestus.build/admin/install) states the floor
 and how the limits relate to it.
 
 #### 🔴 A workspace's per-run AI timeout is capped at one hour
@@ -907,7 +907,7 @@ HEPHAESTUS_MENTOR_AGENT_PULL_POLICY=IF_NOT_PRESENT
 
 ### v1.0.0 (Future)
 
-At v1.0.0 the [Compatibility Policy](https://ls1intum.github.io/Hephaestus/admin/compatibility-policy)
+At v1.0.0 the [Compatibility Policy](https://docs.hephaestus.build/admin/compatibility-policy)
 takes effect — the public contract, the "any 1.x → any later 1.y" upgrade guarantee,
 deprecation-ahead-of-removal, and latest-release-only support. Until then, expect rapid iteration and
 occasional breaking changes in minor releases.
@@ -923,7 +923,7 @@ and review the release notes for endpoint changes.
 
 ### New Required Environment Variable
 
-1. Check the release notes and the [Production Setup](https://ls1intum.github.io/Hephaestus/admin/production-setup) guide for new variables
+1. Check the release notes and the [Production Setup](https://docs.hephaestus.build/admin/production-setup) guide for new variables
 2. Add them to your deployment's environment (see the `docker/compose.app.yaml` env block)
 3. Restart services
 
@@ -957,7 +957,7 @@ in CI and are not a supported recovery path. The supported recoveries, in order 
    changesets succeeded before deciding.
 2. **Restore from backup** if the instance must come back now and forward-fixing will take longer than
    the outage budget. Follow
-   [Backup & restore](https://ls1intum.github.io/Hephaestus/admin/backup-restore); restore the
+   [Backup & restore](https://docs.hephaestus.build/admin/backup-restore); restore the
    database dump *and* the `.env` holding `HEPHAESTUS_SECURITY_ENCRYPTION_KEY`, or every encrypted
    credential in the restored database is unreadable. Then pin `IMAGE_TAG` to the version the dump
    was taken under so it is not immediately re-migrated by the release that failed.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
   <p>
     <a href="https://hephaestus.aet.cit.tum.de"><img alt="Open the TUM-operated Hephaestus web app" src="https://img.shields.io/badge/web_app-try_it-493C83"></a>
-    <a href="https://ls1intum.github.io/Hephaestus/"><img alt="Read the Hephaestus documentation" src="https://img.shields.io/badge/docs-read_online-1F75CB?logo=docusaurus&logoColor=white"></a>
+    <a href="https://docs.hephaestus.build/"><img alt="Read the Hephaestus documentation" src="https://img.shields.io/badge/docs-read_online-1F75CB?logo=docusaurus&logoColor=white"></a>
     <a href="https://github.com/ls1intum/Hephaestus/releases/latest"><img alt="Latest Hephaestus release" src="https://img.shields.io/github/v/release/ls1intum/Hephaestus?display_name=tag&sort=semver"></a>
     <a href="https://github.com/ls1intum/Hephaestus/actions/workflows/cicd.yml"><img alt="Hephaestus CI status" src="https://github.com/ls1intum/Hephaestus/actions/workflows/cicd.yml/badge.svg?branch=main"></a>
     <a href="https://github.com/ls1intum/Hephaestus/blob/main/LICENSE"><img alt="MIT license" src="https://img.shields.io/github/license/ls1intum/Hephaestus"></a>
@@ -34,7 +34,7 @@ relationships stay with people.
     <source media="(prefers-color-scheme: light)" srcset="./docs/images/readme/landing-hero-light.png">
     <img alt="An illustration of one change through a project: issue #412 has no acceptance criteria, the pull request grows to 34 files, a reviewer asks a specific question, and it merges with that thread unresolved. Hephaestus points back to the issue." src="./docs/images/readme/landing-hero-light.png" width="1280">
   </picture>
-  <p><sub>An illustration of the feedback Hephaestus writes. See the <a href="https://ls1intum.github.io/Hephaestus/user/ai-code-review">user guide</a> for the real interface.</sub></p>
+  <p><sub>An illustration of the feedback Hephaestus writes. See the <a href="https://docs.hephaestus.build/user/ai-code-review">user guide</a> for the real interface.</sub></p>
 </div>
 
 > [!IMPORTANT]
@@ -43,7 +43,7 @@ relationships stay with people.
 > maintenance branches, no backports. Until 1.0, a *minor* release can change configuration or the
 > API in ways that need you to act, so read the release notes before every upgrade.
 > Version 1.0 is what makes upgrades, configuration, Compose and the REST API predictable:
-> [compatibility policy](https://ls1intum.github.io/Hephaestus/admin/compatibility-policy) ·
+> [compatibility policy](https://docs.hephaestus.build/admin/compatibility-policy) ·
 > [1.0 milestone](https://github.com/ls1intum/Hephaestus/issues/1378).
 
 ## What Hephaestus does
@@ -82,7 +82,7 @@ The feedback is advisory: it does not approve a change for merge or grade anyone
 ## Get started
 
 - **Try the hosted app:** open the [TUM deployment](https://hephaestus.aet.cit.tum.de).
-- **Learn how it works:** read the [user guide](https://ls1intum.github.io/Hephaestus/user/overview).
+- **Learn how it works:** read the [user guide](https://docs.hephaestus.build/user/overview).
 - **Run your own deployment.** One 64-bit Linux host, 4 vCPUs / 8 GB RAM / 40 GB SSD recommended:
 
   ```bash
@@ -94,13 +94,13 @@ The feedback is advisory: it does not approve a change for merge or grade anyone
   ```
 
   The stack refuses to start until `.env` is complete, so finish the
-  [installation guide](https://ls1intum.github.io/Hephaestus/admin/install) before the first
+  [installation guide](https://docs.hephaestus.build/admin/install) before the first
   `docker compose up -d` — it covers the sign-in OAuth app, TLS, and the first admin account. Before
   upgrading, read the release notes and the [migration guide](./MIGRATION.md), then test the upgrade
   in staging.
 
 - **Contribute:** start with the
-  [local development guide](https://ls1intum.github.io/Hephaestus/contributor/local-development); the
+  [local development guide](https://docs.hephaestus.build/contributor/local-development); the
   web app's components are browsable in
   [Storybook](https://main--66a8981a27ced8fef3190d41.chromatic.com/).
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -35,14 +35,14 @@ Hephaestus is pre-1.0 and released continuously from `main`; **only the latest r
 
 In scope: the code in this repository — the Spring Boot application server (including the webhook receiver), the React webapp, and the deployment/Docker configuration we ship.
 
-See the [published threat model](https://ls1intum.github.io/Hephaestus/admin/threat-model) for trust boundaries, attacker assumptions, controls, and residual risks.
+See the [published threat model](https://docs.hephaestus.build/admin/threat-model) for trust boundaries, attacker assumptions, controls, and residual risks.
 
 Out of scope:
 
 - Vulnerabilities in third-party dependencies without a Hephaestus-specific exploit path — report those upstream
 - Denial-of-service, volumetric attacks, and scanner output without a demonstrated impact
 - Social engineering or phishing of maintainers or users
-- Testing against deployments you do not operate — **do not test against our production instances**; run your own (see the [local development guide](https://ls1intum.github.io/Hephaestus/contributor/local-development))
+- Testing against deployments you do not operate — **do not test against our production instances**; run your own (see the [local development guide](https://docs.hephaestus.build/contributor/local-development))
 
 ## Automated Security Measures
 

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -130,7 +130,7 @@ NATS_MAX_PAYLOAD_BYTES=26214400
 # ceiling; MAX_BYTES is the floor under it, and which of the two binds is a function of your volume.
 # Read your own answer off `webhook.stream.oldest.message.age` rather than inferring it. The four
 # streams' ceilings must total under NATS_JS_MAX_FILE_BYTES or the receiver refuses to start.
-# https://ls1intum.github.io/Hephaestus/admin/webhook-ingestion-operations
+# https://docs.hephaestus.build/admin/webhook-ingestion-operations
 HEPHAESTUS_WEBHOOK_STREAM_MAX_AGE=180d
 HEPHAESTUS_WEBHOOK_STREAM_MAX_BYTES=1GB
 HEPHAESTUS_WEBHOOK_STREAM_MAX_BYTES_GITHUB=10GB

--- a/docker/preview/README.md
+++ b/docker/preview/README.md
@@ -8,7 +8,7 @@ the stack and frees its slot.
 
 This directory is infrastructure for this repository's own pull requests. It is not part of a
 self-hosted Hephaestus install — `docker/self-host/` is that. Contributors use previews through
-[CI/CD → Preview Deployments](https://ls1intum.github.io/Hephaestus/contributor/ci-cd).
+[CI/CD → Preview Deployments](https://docs.hephaestus.build/contributor/ci-cd).
 
 ## Security boundary
 

--- a/docker/self-host/.env.example
+++ b/docker/self-host/.env.example
@@ -1,5 +1,5 @@
 # Run `./setup.sh`, fill every required value, and follow the install guide:
-# https://ls1intum.github.io/Hephaestus/admin/install
+# https://docs.hephaestus.build/admin/install
 
 # --- General (REQUIRED) ------------------------------------------------------
 
@@ -61,7 +61,7 @@ HEPHAESTUS_AUTH_BOOTSTRAP_ADMINS=
 
 # --- GitHub App (optional — PAT-only mode works without any of these) --------
 # Needed for posting AI review feedback back to GitHub and higher rate limits.
-# Setup guide: https://ls1intum.github.io/Hephaestus/admin/github-integration
+# Setup guide: https://docs.hephaestus.build/admin/github-integration
 GH_APP_PRIVATE_KEY=
 #GH_APP_ID=
 #GH_APP_INSTALLATION_URL=
@@ -71,7 +71,7 @@ GH_AUTH_TOKEN=
 
 # --- Optional integrations ----------------------------------------------------
 # GitLab sync, Slack, Outline, AI practice review: enable by uncommenting here.
-# See https://ls1intum.github.io/Hephaestus/admin/production-setup for each bundle.
+# See https://docs.hephaestus.build/admin/production-setup for each bundle.
 #GITLAB_ENABLED=false
 #GITLAB_WORKSPACE_CREATION=false
 # Default GitLab instance for sync + workspace creation (compose otherwise defaults
@@ -103,7 +103,7 @@ GH_AUTH_TOKEN=
 # --- Misc (optional) -----------------------------------------------------------
 
 # Imprint/privacy pages (required for public instances in e.g. Germany):
-# see https://ls1intum.github.io/Hephaestus/admin/legal-pages
+# see https://docs.hephaestus.build/admin/legal-pages
 #LEGAL_PROFILE=
 
 # Sentry error tracking. Leave blank to disable.
@@ -123,7 +123,7 @@ SENTRY_ENVIRONMENT=production
 # NATS JetStream limits, sized for a single host. NATS_JS_MAX_FILE_BYTES is what the broker may hold
 # for all webhook streams together, in bytes, and the receiver refuses to start if the per-stream
 # bounds sum above it. Keep it below the free space on the nats-data volume.
-# https://ls1intum.github.io/Hephaestus/admin/webhook-ingestion-operations
+# https://docs.hephaestus.build/admin/webhook-ingestion-operations
 NATS_JS_MAX_MEM=1G
 NATS_JS_MAX_FILE_BYTES=10737418240
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 [![Documentation Status](https://github.com/ls1intum/Hephaestus/actions/workflows/cd-docs.yml/badge.svg)](https://github.com/ls1intum/Hephaestus/actions/workflows/cd-docs.yml)
 
-**Live Site:** [https://ls1intum.github.io/Hephaestus/](https://ls1intum.github.io/Hephaestus/)
+**Live Site:** [https://docs.hephaestus.build/](https://docs.hephaestus.build/)
 
 This site is powered by [Docusaurus 3](https://docusaurus.io/) with Rspack, SWC, and LightningCSS for 2-4x faster builds. The content is split into three guides:
 
@@ -39,7 +39,7 @@ into them by absolute GitHub URL rather than a relative path.
 
 ```bash
 # From repo root (recommended)
-pnpm run docs:dev       # Start dev server at http://localhost:3000/Hephaestus/
+pnpm run docs:dev       # Start dev server at http://localhost:3000/
 
 # Or from docs directory
 cd docs && pnpm run start

--- a/docs/admin/practice-catalog.mdx
+++ b/docs/admin/practice-catalog.mdx
@@ -126,5 +126,5 @@ what you passed over, and to add back anything you deleted.
 - [Practice Review](practice-review.mdx) — switch reviews on, set autonomy and scope, find out why a
   workspace went quiet.
 - [Practice Review Operations](practice-review-operations.mdx) — what it costs and what to watch.
-- [Practice catalog curation](https://ls1intum.github.io/Hephaestus/contributor/practice-catalogue)
+- [Practice catalog curation](https://docs.hephaestus.build/contributor/practice-catalogue)
   — for contributors changing the bundled defaults.

--- a/docs/contributor/practice-catalogue.md
+++ b/docs/contributor/practice-catalogue.md
@@ -40,7 +40,7 @@ All three scopes use the same definition fields. What differs is who owns the va
 
 Neither step silently rewrites a customized instance definition or an existing workspace practice.
 The badge tables an administrator reads for both scopes live in the
-[Practice Catalog admin guide](https://ls1intum.github.io/Hephaestus/admin/practice-catalog).
+[Practice Catalog admin guide](https://docs.hephaestus.build/admin/practice-catalog).
 
 | Stakeholder                | Primary task                                                                                                               | Deliberately not their task                      |
 | -------------------------- | -------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |

--- a/docs/contributor/release-management.mdx
+++ b/docs/contributor/release-management.mdx
@@ -14,7 +14,7 @@ Docker images. Our own instances ride the release cut — staging deploys automa
 after approval. Releases are managed with [changesets](https://github.com/changesets/changesets).
 
 What a released version number promises is defined in the
-[compatibility policy](https://ls1intum.github.io/Hephaestus/admin/compatibility-policy).
+[compatibility policy](https://docs.hephaestus.build/admin/compatibility-policy).
 
 ## The flow
 

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -10,7 +10,7 @@ New ADRs use the next available number and link from this index.
 
 `docs/decisions/`, `docs/runbooks/`, `docs/auth-architecture.md` and `docs/auth-glossary.md` are
 **not** registered with any Docusaurus plugin and never appear on
-[the site](https://ls1intum.github.io/Hephaestus/). That is a decision, not an oversight. They are
+[the site](https://docs.hephaestus.build/). That is a decision, not an oversight. They are
 written against internal class names, they are amended by the same PR that changes the code, and
 their reader already has the repository checked out. This index is their table of contents.
 

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -5,10 +5,11 @@ import { themes as prismThemes } from "prism-react-renderer";
 const envBaseUrl = process.env.DOCUSAURUS_BASE_URL;
 
 /*
- * PR previews on Surge.sh need '/', production GitHub Pages needs '/Hephaestus/'. Unset and empty
- * both mean production: an empty base URL would resolve every asset against the site root.
+ * Production (docs.hephaestus.build) and PR previews on Surge.sh both serve from the domain root.
+ * DOCUSAURUS_BASE_URL stays overridable for builds hosted under a path prefix; unset and empty both
+ * mean the root, because an empty base URL would resolve every asset against the current page.
  */
-const baseUrl = envBaseUrl === undefined || envBaseUrl === "" ? "/Hephaestus/" : envBaseUrl;
+const baseUrl = envBaseUrl === undefined || envBaseUrl === "" ? "/" : envBaseUrl;
 
 /** The site's one-sentence definition of the product, kept in step with the README's opening. */
 const DESCRIPTION =
@@ -44,7 +45,7 @@ const config: Config = {
 		},
 	},
 
-	url: "https://ls1intum.github.io",
+	url: "https://docs.hephaestus.build",
 	baseUrl,
 	organizationName: "ls1intum",
 	projectName: "Hephaestus",

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -8,7 +8,7 @@ before, the order of operations, and how to roll back.
 | [`auth-cutover.md`](auth-cutover.md) | Shipping the Keycloak → Spring-native auth replacement (ADR 0017): pre-launch checklist, first-instance-admin bootstrap, rollback. |
 
 **Repo-only, like `docs/decisions/`.** Nothing in this directory is registered with a Docusaurus
-plugin, so none of it appears on [the site](https://ls1intum.github.io/Hephaestus/). Link a runbook
+plugin, so none of it appears on [the site](https://docs.hephaestus.build/). Link a runbook
 from a published page by absolute GitHub URL
 (`https://github.com/ls1intum/Hephaestus/blob/main/docs/runbooks/<file>.md`), never by a relative
 path — see [`../decisions/README.md`](../decisions/README.md) for the full rule.

--- a/docs/static/robots.txt
+++ b/docs/static/robots.txt
@@ -1,8 +1,8 @@
 # Hephaestus Documentation - robots.txt
-# https://ls1intum.github.io/Hephaestus/
+# https://docs.hephaestus.build/
 
 User-agent: *
 Allow: /
 
 # Sitemap location
-Sitemap: https://ls1intum.github.io/Hephaestus/sitemap.xml
+Sitemap: https://docs.hephaestus.build/sitemap.xml

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/configuration/ConfigurationReadinessEvaluator.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/configuration/ConfigurationReadinessEvaluator.java
@@ -20,7 +20,7 @@ public final class ConfigurationReadinessEvaluator {
 
     private static final Logger log = LoggerFactory.getLogger(ConfigurationReadinessEvaluator.class);
 
-    static final String DOC = "https://ls1intum.github.io/Hephaestus/admin/configuration-readiness";
+    static final String DOC = "https://docs.hephaestus.build/admin/configuration-readiness";
     private static final Pattern DIGEST = Pattern.compile("^[a-z0-9][a-z0-9._/:\\-]*@sha256:[a-f0-9]{64}$");
 
     private final Environment environment;

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/webhook/WebhookProperties.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/webhook/WebhookProperties.java
@@ -126,7 +126,7 @@ public record WebhookProperties(
      * inside that window a shed webhook is recoverable from the provider API and outside it, by
      * nothing (ADR 0008: webhook deliveries are not redeliverable).
      *
-     * @see <a href="https://ls1intum.github.io/Hephaestus/admin/webhook-ingestion-operations">Webhook
+     * @see <a href="https://docs.hephaestus.build/admin/webhook-ingestion-operations">Webhook
      *     ingestion operations</a>
      */
     public record Stream(

--- a/webapp/src/components/info/about/AboutCallToActionSection.tsx
+++ b/webapp/src/components/info/about/AboutCallToActionSection.tsx
@@ -30,7 +30,7 @@ export function AboutCallToActionSection() {
 					<span className="sr-only">(opens in a new tab)</span>
 				</a>
 				<a
-					href="https://ls1intum.github.io/Hephaestus/contributor/overview"
+					href="https://docs.hephaestus.build/contributor/overview"
 					target="_blank"
 					rel="noopener noreferrer"
 					className={buttonVariants({ variant: "outline", size: "lg" })}

--- a/webapp/src/components/info/landing/LandingCtaSection.tsx
+++ b/webapp/src/components/info/landing/LandingCtaSection.tsx
@@ -53,7 +53,7 @@ export function LandingCtaSection({
 							className="w-full sm:w-auto"
 						/>
 						<a
-							href="https://ls1intum.github.io/Hephaestus/user/overview"
+							href="https://docs.hephaestus.build/user/overview"
 							target="_blank"
 							rel="noopener noreferrer"
 							className={buttonVariants({ size: "lg", variant: "outline" })}
@@ -69,7 +69,7 @@ export function LandingCtaSection({
 							Running your own deployment?{" "}
 							<a
 								className="font-medium text-foreground underline underline-offset-4"
-								href="https://ls1intum.github.io/Hephaestus/admin/install"
+								href="https://docs.hephaestus.build/admin/install"
 								target="_blank"
 								rel="noopener noreferrer"
 							>


### PR DESCRIPTION
## Motivation

Part of the #1599 transfer checklist: publish the docs at their own domain **before** the repository transfer. DNS already exists (`docs.hephaestus.build` CNAME → `ls1intum.github.io`, DNS-only). The Pages custom domain is a repository setting, so once set it transfers with the repository — which is the point: the docs URL stops encoding the org/repo slug entirely, and nothing published needs to change again when the repo moves.

## Description

- `docs/docusaurus.config.ts`: `url` → `https://docs.hephaestus.build`, default `baseUrl` → `/`. The `DOCUSAURUS_BASE_URL` override mechanism stays for builds hosted under a path prefix.
- `cd-docs.yml`: the production build now also uses base URL `/` (the Surge PR-preview build already did, and is unchanged).
- `docs/static/robots.txt`: sitemap URL moves to the new domain.
- Every operational `ls1intum.github.io/Hephaestus/...` link (48-link audit from #1599) now points at `https://docs.hephaestus.build/...` without the `/Hephaestus` prefix: README badges and links, INSTALL.md, SECURITY.md, CONTRIBUTING.md, `.changeset/README.md`, both `docker/*/.env.example` files, `docker/preview/README.md`, docs cross-links and repo-only docs READMEs, the server's configuration-readiness message URL and a webhook Javadoc link, and the web app's landing/about CTA links. Every target path was verified against the built site.
- Historical text keeps its github.io links on purpose: `CHANGELOG.md`, `MIGRATION.md` (release tooling owns it, and the changeset gate forbids editing it in a feature PR) and ADR 0008. GitHub redirects `ls1intum.github.io/Hephaestus/<path>` to `docs.hephaestus.build/<path>` once the custom domain is set, so they keep resolving. `editUrl` and repo links keep the current slug — GitHub redirects those after the transfer too.
- `webapp/public/.well-known/security.txt` carries no docs URL; untouched.

## Deploy sequencing

After this merges and `CD / Docs` deploys, the Pages **custom domain is flipped via the API** (separate step, not in this PR). Between deploy and flip there is a brief window where `ls1intum.github.io/Hephaestus/` serves a build with root-relative asset paths — broken styling on the old URL for a few minutes is expected and accepted.

## Checklist

- `pnpm run format` and `pnpm run check` pass (includes `docs:lint`).
- `pnpm run docs:build` passes with `onBrokenLinks/onBrokenAnchors/onBrokenMarkdownLinks: throw`; the build output contains no root-relative `/Hephaestus/` asset or link paths (remaining matches are `github.com/ls1intum/Hephaestus/...` repo links).
- Changeset: patch (`webapp/`, `server/`, `docker/` link changes; no operator action).

🤖 Generated with [Claude Code](https://claude.com/claude-code)