### PR TITLE
build(release): move the image namespace to ghcr.io/hephaestus-build

### DIFF
--- a/.changeset/move-image-namespace.md
+++ b/.changeset/move-image-namespace.md
@@ -1,0 +1,7 @@
+---
+"hephaestus": minor
+---
+
+Moves the container images to `ghcr.io/hephaestus-build/<image>` after the repository's transfer to the hephaestus-build organization, dropping the redundant `hephaestus/` path segment. Releases published before the move keep their images and signatures at `ghcr.io/ls1intum/hephaestus/<image>`; upgrades, deploys, and signature verification select the right namespace and signing identity per release automatically.
+
+**Operators:** From this release on, images pull from `ghcr.io/hephaestus-build/<image>`. Update any registry mirrors, egress allowlists, or hand-written image references (such as a pinned `HEPHAESTUS_AGENT_IMAGE_REFERENCE`); the standard install and upgrade flow needs no changes. Older releases remain valid at their original `ghcr.io/ls1intum/hephaestus/<image>` paths.

--- a/.github/workflows/ci-docker-build.yml
+++ b/.github/workflows/ci-docker-build.yml
@@ -60,7 +60,7 @@ jobs:
       SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
       SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
     with:
-      image-name: "ls1intum/hephaestus/webapp"
+      image-name: "hephaestus-build/webapp"
       docker-file: "./webapp/Dockerfile"
       docker-context: "."
       registry: "ghcr.io"
@@ -98,7 +98,7 @@ jobs:
       id-token: write
       attestations: write
     with:
-      image-name: "ls1intum/hephaestus/application-server"
+      image-name: "hephaestus-build/application-server"
       # Paketo Cloud Native Buildpacks via spring-boot:build-image, with Application CDS.
       # See docs/admin/buildpacks-cds-decision.md and pom.xml's <image> block.
       use-buildpacks: true
@@ -136,7 +136,7 @@ jobs:
       id-token: write
       attestations: write
     with:
-      image-name: "ls1intum/hephaestus/agent-pi"
+      image-name: "hephaestus-build/agent-pi"
       docker-file: "./docker/agents/pi/Dockerfile"
       docker-context: "./docker/agents"
       registry: "ghcr.io"
@@ -170,7 +170,7 @@ jobs:
       id-token: write
       attestations: write
     with:
-      image-name: "ls1intum/hephaestus/postgres"
+      image-name: "hephaestus-build/postgres"
       docker-file: "./docker/postgres/Dockerfile"
       docker-context: "./docker/postgres"
       registry: "ghcr.io"
@@ -236,7 +236,7 @@ jobs:
           set -euo pipefail
 
           tag_image() {
-            local image="ghcr.io/ls1intum/hephaestus/$1"
+            local image="ghcr.io/hephaestus-build/$1"
             local source="$image:$BASE_SHA"
             local ref_tag="${GITHUB_REF_NAME//\//-}"
             local digest

--- a/.github/workflows/ci-quality-gates.yml
+++ b/.github/workflows/ci-quality-gates.yml
@@ -281,10 +281,10 @@ jobs:
         run: |
           # The base image may still be publishing; build the same Dockerfile as fallback.
           if [[ "${INPUTS_POSTGRES_IMAGE_CHANGED}" == "true" ]] ||
-            ! docker pull ghcr.io/ls1intum/hephaestus/postgres:${{ github.event.pull_request.base.sha || github.sha }}; then
+            ! docker pull ghcr.io/hephaestus-build/postgres:${{ github.event.pull_request.base.sha || github.sha }}; then
             docker build -t hephaestus-postgres:ci docker/postgres
           else
-            docker tag ghcr.io/ls1intum/hephaestus/postgres:${{ github.event.pull_request.base.sha || github.sha }} hephaestus-postgres:ci
+            docker tag ghcr.io/hephaestus-build/postgres:${{ github.event.pull_request.base.sha || github.sha }} hephaestus-postgres:ci
           fi
           docker run -d --name postgres-db \
             -e POSTGRES_DB=hephaestus -e POSTGRES_PASSWORD=root -e POSTGRES_USER=root \

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -289,10 +289,10 @@ jobs:
         run: |
           # The base image may still be publishing; build the same Dockerfile as fallback.
           if [[ "${INPUTS_POSTGRES_IMAGE_CHANGED}" == "true" ]] ||
-            ! docker pull ghcr.io/ls1intum/hephaestus/postgres:${{ github.event.pull_request.base.sha || github.sha }}; then
-            docker build -t ghcr.io/ls1intum/hephaestus/postgres:dev docker/postgres
+            ! docker pull ghcr.io/hephaestus-build/postgres:${{ github.event.pull_request.base.sha || github.sha }}; then
+            docker build -t ghcr.io/hephaestus-build/postgres:dev docker/postgres
           else
-            docker tag ghcr.io/ls1intum/hephaestus/postgres:${{ github.event.pull_request.base.sha || github.sha }} ghcr.io/ls1intum/hephaestus/postgres:dev
+            docker tag ghcr.io/hephaestus-build/postgres:${{ github.event.pull_request.base.sha || github.sha }} ghcr.io/hephaestus-build/postgres:dev
           fi
           docker compose -f server/compose.yaml up -d --wait --no-build postgres
           cleanup() {

--- a/.github/workflows/deploy-locked-compose.yml
+++ b/.github/workflows/deploy-locked-compose.yml
@@ -11,10 +11,12 @@ on:
         required: true
       expected-signer-repository:
         description: >-
-          owner/repo whose release workflow signed the lock being deployed. Defaults to
-          this repository. A lock signed before a repository transfer still carries the
-          old owner/repo in its certificate identity, so deploying such a release needs
-          this override pointed at the old slug (issue #1599).
+          owner/repo whose release workflow signed the lock being deployed. Left empty,
+          the identity is resolved per release version from
+          security/release-identities.json, which keeps deploys of releases signed
+          before the repository transfer verifying against the old owner/repo their
+          certificate still carries (issue #1599). Set it only to verify against a
+          repository the map does not know.
         type: string
         required: false
         default: ""
@@ -33,6 +35,10 @@ jobs:
 
       - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
+      - uses: ./.github/actions/setup-node-pnpm
+        with:
+          install: "none"
+
       - name: Verify release lock
         id: lock
         env:
@@ -40,15 +46,20 @@ jobs:
           RELEASE: ${{ inputs.release }}
           SERVER_URL: ${{ github.server_url }}
           # The lock's certificate names the repository whose release workflow signed it.
-          # Deriving the default from the run context keeps signing and verification
-          # aligned across a repository transfer — but locks signed *before* the move
-          # still verify against the old owner/repo, which is what the
-          # expected-signer-repository override is for (issue #1599).
-          EXPECTED_SIGNER_REPOSITORY: ${{ inputs.expected-signer-repository || github.repository }}
+          # Locks signed *before* the repository transfer carry the old owner/repo
+          # forever, so the default identity is resolved per release version from
+          # security/release-identities.json; the expected-signer-repository override
+          # remains for repositories the map does not know (issue #1599).
+          EXPECTED_SIGNER_REPOSITORY: ${{ inputs.expected-signer-repository }}
         run: |
           set -euo pipefail
           [[ "$RELEASE" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]] || {
             echo "::error::Deploy an immutable vX.Y.Z release, not '$RELEASE'"; exit 1; }
+          if [ -n "$EXPECTED_SIGNER_REPOSITORY" ]; then
+            identity="${SERVER_URL}/${EXPECTED_SIGNER_REPOSITORY}/.github/workflows/release.yml@refs/heads/main"
+          else
+            identity=$(node scripts/resolve-release-identity.ts "$RELEASE" certificate-identity)
+          fi
           asset="release-${RELEASE}.json"
           mkdir "$RUNNER_TEMP/verified-release"
           gh release download "$RELEASE" --repo "${{ github.repository }}" \
@@ -56,8 +67,7 @@ jobs:
             --pattern "$asset.sigstore.json" --pattern manifest.json
           cosign verify-blob \
             --bundle "$RUNNER_TEMP/verified-release/$asset.sigstore.json" \
-            --certificate-identity \
-              "${SERVER_URL}/${EXPECTED_SIGNER_REPOSITORY}/.github/workflows/release.yml@refs/heads/main" \
+            --certificate-identity "$identity" \
             --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
             "$RUNNER_TEMP/verified-release/$asset"
           commit=$(jq -er '.commit | select(test("^[a-f0-9]{40}$"))' \

--- a/.github/workflows/release-upgrade.yml
+++ b/.github/workflows/release-upgrade.yml
@@ -3,7 +3,11 @@ name: Seeded Release Upgrade
 on:
   workflow_call:
     inputs:
-      previous-application-image:
+      previous-version:
+        description: >-
+          Previous stable release version (X.Y.Z). Its image repository is resolved per
+          version from security/release-identities.json — releases published before the
+          repository transfer stay in the old GHCR namespace forever (issue #1599).
         type: string
         required: true
       candidate-application-image:
@@ -58,7 +62,7 @@ jobs:
         id: images
         env:
           GH_TOKEN: ${{ github.token }}
-          INPUT_PREVIOUS_APP: ${{ inputs.previous-application-image }}
+          INPUT_PREVIOUS_VERSION: ${{ inputs.previous-version }}
           INPUT_CANDIDATE_APP: ${{ inputs.candidate-application-image }}
           INPUT_POSTGRES: ${{ inputs.postgres-image }}
           REQUESTED_PREVIOUS: ${{ inputs.previous-tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -178,7 +178,7 @@ jobs:
 
           # Resolve every source digest before publishing any release tag.
           for img in "${IMAGES[@]}"; do
-            FULL_IMAGE="ghcr.io/ls1intum/hephaestus/$img"
+            FULL_IMAGE="ghcr.io/hephaestus-build/$img"
             for i in $(seq 1 24); do
               digest=$(docker buildx imagetools inspect "$FULL_IMAGE:$SHA" --format '{{json .Manifest}}' 2>/dev/null | jq -er '.digest' 2>/dev/null) || true
               if [[ "$digest" =~ ^sha256:[a-f0-9]{64}$ ]]; then
@@ -194,7 +194,7 @@ jobs:
           done
 
           for img in "${IMAGES[@]}"; do
-            FULL_IMAGE="ghcr.io/ls1intum/hephaestus/$img"
+            FULL_IMAGE="ghcr.io/hephaestus-build/$img"
             echo "::group::$img"
 
             SRC_DIGEST=${DIGESTS[$img]}
@@ -211,7 +211,7 @@ jobs:
 
       - name: Verify Node-only agent-pi sandbox
         env:
-          IMAGE: ghcr.io/ls1intum/hephaestus/agent-pi@${{ steps.retag.outputs.agent-pi-digest }}
+          IMAGE: ghcr.io/hephaestus-build/agent-pi@${{ steps.retag.outputs.agent-pi-digest }}
           LAYOUT: server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/runtime/SandboxLayout.java
         run: |
           set -euo pipefail
@@ -281,7 +281,7 @@ jobs:
             done
           }
           while IFS=$'\t' read -r image digest; do
-            generate_evidence "$image" "ghcr.io/ls1intum/hephaestus/$image" "$digest" first-party
+            generate_evidence "$image" "ghcr.io/hephaestus-build/$image" "$digest" first-party
           done < release-images.tsv
           jq -r '.upstream[] | [.name, .repository, .digest] | @tsv' security/release-images.json |
           while IFS=$'\t' read -r image repository digest; do
@@ -345,6 +345,9 @@ jobs:
           done < release-images.tsv > subjects.sha256
           sha256sum "$ASSET" >> subjects.sha256
           cat subjects.sha256
+          # purl namespace/name are canonically lowercase; derive them from the run
+          # context so the attestation follows a repository transfer (issue #1599).
+          echo "purl-repository=${GITHUB_REPOSITORY,,}" >> "$GITHUB_OUTPUT"
 
       - name: Attest release image lock
         uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
@@ -352,7 +355,7 @@ jobs:
           subject-checksums: subjects.sha256
           predicate-type: https://in-toto.io/attestation/release/v0.1
           predicate: |
-            { "purl": "pkg:github/ls1intum/hephaestus@${{ needs.release.outputs.tag_name }}" }
+            { "purl": "pkg:github/${{ steps.subjects.outputs.purl-repository }}@${{ needs.release.outputs.tag_name }}" }
 
       - name: Sign release image lock
         env:
@@ -391,9 +394,12 @@ jobs:
       contents: read
       packages: read
     with:
-      previous-application-image: ghcr.io/ls1intum/hephaestus/application-server:${{ needs.release.outputs.previous_version }}
-      candidate-application-image: ghcr.io/ls1intum/hephaestus/application-server@${{ needs.tag-images.outputs.application-server-digest }}
-      postgres-image: ghcr.io/ls1intum/hephaestus/postgres@${{ needs.tag-images.outputs.postgres-digest }}
+      # The previous release keeps the namespace it was published under (GHCR packages
+      # do not transfer between organizations — issue #1599), so the reusable workflow
+      # resolves its repository per version from security/release-identities.json.
+      previous-version: ${{ needs.release.outputs.previous_version }}
+      candidate-application-image: ghcr.io/hephaestus-build/application-server@${{ needs.tag-images.outputs.application-server-digest }}
+      postgres-image: ghcr.io/hephaestus-build/postgres@${{ needs.tag-images.outputs.postgres-digest }}
       candidate-source-sha: ${{ needs.release.outputs.sha }}
 
   supported-host-smoke:

--- a/.github/workflows/rescan-release-images.yml
+++ b/.github/workflows/rescan-release-images.yml
@@ -34,9 +34,13 @@ jobs:
           gh release download "$tag" --repo "${{ github.repository }}" --dir release-evidence
           (cd release-evidence && sha256sum -c SHA256SUMS)
           lock="release-$tag.json"
+          # A release signed before the repository transfer carries the old owner/repo in
+          # its certificate forever, so the expected identity is the release's, resolved
+          # from security/release-identities.json (issue #1599).
+          identity=$(node scripts/resolve-release-identity.ts "$tag" certificate-identity)
           cosign verify-blob \
             --bundle "release-evidence/$lock.sigstore.json" \
-            --certificate-identity '${{ github.server_url }}/${{ github.repository }}/.github/workflows/release.yml@refs/heads/main' \
+            --certificate-identity "$identity" \
             --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
             "release-evidence/$lock"
           node scripts/release-image-lock.ts "release-evidence/$lock" \

--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -13,7 +13,7 @@ on:
       image-name:
         type: string
         required: true
-        description: "Full image name (e.g., ls1intum/hephaestus/webapp)"
+        description: "Full image name (e.g., hephaestus-build/webapp)"
       docker-file:
         type: string
         required: false

--- a/.migration/move-image-namespace.md
+++ b/.migration/move-image-namespace.md
@@ -1,0 +1,22 @@
+#### 🔴 Container images moved to `ghcr.io/hephaestus-build/<image>`
+
+**Affected**: deployments with registry mirrors, egress allowlists, or hand-written image
+references. The standard install and upgrade flow — Compose plus the signed release lock — follows
+the move on its own.
+
+**Before**: all images lived under `ghcr.io/ls1intum/hephaestus/<image>`, and every release lock was
+signed as `ls1intum/Hephaestus`.
+
+**After**: this release and everything newer publish under `ghcr.io/hephaestus-build/<image>`
+(without the redundant `hephaestus/` segment) and sign as `hephaestus-build/Hephaestus`. Releases
+published before the move are unchanged: GHCR packages do not transfer between organizations, so
+their images stay at `ghcr.io/ls1intum/hephaestus/<image>`, and their signatures name the old
+repository forever. `security/release-identities.json` records which namespace and signing identity
+each release uses, and the upgrade gate, deploy workflows, and lock verifier resolve it per release.
+
+**Migration**: allow `ghcr.io/hephaestus-build/<image>` wherever registry access is restricted or
+mirrored. If you overrode an image reference by hand — for example a pinned
+`HEPHAESTUS_AGENT_IMAGE_REFERENCE` — repoint it at the new namespace when you next update the pin.
+When verifying an old release yourself, use the identity recorded for its version in
+`security/release-identities.json` (releases before the move:
+`https://github.com/ls1intum/Hephaestus/.github/workflows/release.yml@refs/heads/main`).

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -279,7 +279,7 @@ GITLAB_WORKSPACE_CREATION=false
 # release's cosign-verified digest on a release deploy — so setting it is an override of both, for
 # when neither names the image you mean. A digest is immutable and therefore reproducible; never a
 # release channel, which names whatever released most recently. See docs/admin/agent-image-digests.md.
-# HEPHAESTUS_AGENT_IMAGE_REFERENCE=ghcr.io/ls1intum/hephaestus/agent-pi@sha256:<digest>
+# HEPHAESTUS_AGENT_IMAGE_REFERENCE=ghcr.io/hephaestus-build/agent-pi@sha256:<digest>
 
 # A deploy that tracks main rather than a release sets BOTH of these: there is no signed pin asset
 # for a main commit, so the fetcher must be told to skip it and the digest requirement must come off.

--- a/docker/postgres/Dockerfile
+++ b/docker/postgres/Dockerfile
@@ -1,4 +1,4 @@
-# ghcr.io/ls1intum/hephaestus/postgres — official PostgreSQL (Debian) + pg_partman, used in every
+# ghcr.io/hephaestus-build/postgres — official PostgreSQL (Debian) + pg_partman, used in every
 # environment (Alpine has no partman package). No shared_preload_libraries: maintenance runs as plain
 # SQL from the app scheduler, so this stays stock Postgres + one extension. See ADR 0018 and ADR 0038.
 ARG PG_MAJOR=18

--- a/docker/preview/compose.app.yaml
+++ b/docker/preview/compose.app.yaml
@@ -15,7 +15,7 @@
 
 services:
   postgres:
-    image: ghcr.io/ls1intum/hephaestus/postgres:${SOURCE_COMMIT:?Coolify supplies the deployed commit}
+    image: ghcr.io/hephaestus-build/postgres:${SOURCE_COMMIT:?Coolify supplies the deployed commit}
     restart: unless-stopped
     environment:
       POSTGRES_DB: hephaestus
@@ -56,7 +56,7 @@ services:
   # volume is never mounted. This is the image staging itself runs, so pg_dump always matches the
   # server it reads.
   seed-loader:
-    image: ghcr.io/ls1intum/hephaestus/postgres:${SOURCE_COMMIT:?Coolify supplies the deployed commit}
+    image: ghcr.io/hephaestus-build/postgres:${SOURCE_COMMIT:?Coolify supplies the deployed commit}
     restart: "no"
     depends_on:
       postgres:
@@ -217,7 +217,7 @@ services:
           pids: 128
 
   appserver:
-    image: ghcr.io/ls1intum/hephaestus/application-server:${SOURCE_COMMIT:?Coolify supplies the deployed commit}
+    image: ghcr.io/hephaestus-build/application-server:${SOURCE_COMMIT:?Coolify supplies the deployed commit}
     restart: unless-stopped
     expose:
       - "8080"
@@ -322,7 +322,7 @@ services:
           memory: 2G
           pids: 512
   webapp:
-    image: ghcr.io/ls1intum/hephaestus/webapp:${SOURCE_COMMIT:?Coolify supplies the deployed commit}
+    image: ghcr.io/hephaestus-build/webapp:${SOURCE_COMMIT:?Coolify supplies the deployed commit}
     # `expose` is how Coolify learns which port to route ${SERVICE_FQDN_WEBAPP} to; the image's own
     # EXPOSE is not read for that.
     expose:

--- a/docs/admin/compatibility-policy.mdx
+++ b/docs/admin/compatibility-policy.mdx
@@ -70,7 +70,7 @@ provides no dedicated self-hosted support and expects operators to upgrade regul
 ## Docker image tags
 
 All images (`webapp`, `application-server`, `agent-pi`, `postgres`) under
-`ghcr.io/ls1intum/hephaestus/` are published with:
+`ghcr.io/hephaestus-build/` are published with:
 
 | Tag | Meaning | Stability |
 | --- | --- | --- |
@@ -78,5 +78,10 @@ All images (`webapp`, `application-server`, `agent-pi`, `postgres`) under
 | `X.Y` | Latest patch of a minor release | Moves on every patch release |
 | `latest` | Latest release | Moves on every release |
 | `main`, `<sha>` | Unreleased development builds | **Unsupported** — never deploy these |
+
+Releases published before the `ls1intum` → `hephaestus-build` organization transfer remain under
+`ghcr.io/ls1intum/hephaestus/` — GHCR packages do not transfer between organizations, and their
+signatures name the old repository forever. `security/release-identities.json` in the repository
+records which image namespace and signing identity each release uses.
 
 For digest-pinned release images, see [Release image lock](./release-image-lock.md).

--- a/docs/admin/release-image-lock.md
+++ b/docs/admin/release-image-lock.md
@@ -16,18 +16,26 @@ identity, release identity, schema, and equality with the release evidence manif
 
 ## Independent verification
 
+The certificate identity is the release's, not necessarily today's repository: a lock signed before
+the `ls1intum` → `hephaestus-build` transfer names the old repository in its Fulcio certificate
+forever. `security/release-identities.json` in the repository maps each version to its signing
+identity and image namespace; the verifier and every workflow resolve it from there. For releases
+before that map's `hephaestus-build` boundary, substitute
+`https://github.com/ls1intum/Hephaestus/.github/workflows/release.yml@refs/heads/main` below and
+`--owner ls1intum` in the attestation check.
+
 ```bash
 VERSION=vX.Y.Z
-gh release download "$VERSION" --repo ls1intum/Hephaestus \
+gh release download "$VERSION" --repo hephaestus-build/Hephaestus \
   --pattern "release-$VERSION.json" \
   --pattern "release-$VERSION.json.sigstore.json"
 cosign verify-blob \
   --bundle "release-$VERSION.json.sigstore.json" \
   --certificate-identity \
-    'https://github.com/ls1intum/Hephaestus/.github/workflows/release.yml@refs/heads/main' \
+    'https://github.com/hephaestus-build/Hephaestus/.github/workflows/release.yml@refs/heads/main' \
   --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
   "release-$VERSION.json"
-gh attestation verify "release-$VERSION.json" --owner ls1intum
+gh attestation verify "release-$VERSION.json" --owner hephaestus-build
 ```
 
 ## Rollback

--- a/docs/contributor/e2e-testing.md
+++ b/docs/contributor/e2e-testing.md
@@ -78,7 +78,7 @@ To test webhook ingestion too, configure `hephaestus.webhook.external-url` and a
 characters, then expose the webhook receiver through a trusted tunnel. GitLab group-hook registration
 requires the appropriate group role and license.
 
-The agent runs in a Docker sandbox (`ghcr.io/ls1intum/hephaestus/agent-pi`) and calls the LLM through
+The agent runs in a Docker sandbox (`ghcr.io/hephaestus-build/agent-pi`) and calls the LLM through
 the in-app proxy, so provider keys never enter the sandbox. Host-run E2E uses a non-internal Docker
 network (`allowInternet=true`) so the sandbox can reach that proxy through `host.docker.internal`.
 Feedback is posted back to the MR, and the observations behind it are shown under the workspace's **Practices → Runs** view.

--- a/docs/runbooks/auth-cutover.md
+++ b/docs/runbooks/auth-cutover.md
@@ -21,7 +21,7 @@ Operational guide for shipping and operating the auth replacement (ADR 0017). Re
 - [ ] Reverse proxy (Coolify / TUM) verified to NOT inject a `Domain=` on Set-Cookie — a
       `__Host-` cookie with a Domain attribute is silently dropped by browsers → infinite
       redirect loop. Smoke-test the full login on staging behind the real proxy.
-- [ ] Postgres image ships `pg_partman` (`ghcr.io/ls1intum/hephaestus/postgres` — see ADR 0018)
+- [ ] Postgres image ships `pg_partman` (`ghcr.io/hephaestus-build/postgres` — see ADR 0018)
       plus `citext`. `auth_event` is partman-managed (create-ahead + 12-month retention); maintenance
       runs via `AuthEventPartitionMaintenance` (`CALL run_maintenance_proc`, ShedLock) — no
       `shared_preload_libraries`. Liquibase's `create_parent` builds current+2 partitions + the

--- a/scripts/check-preview-stack.ts
+++ b/scripts/check-preview-stack.ts
@@ -15,7 +15,7 @@ import { isRecord } from "./lib/json.ts";
 const COMPOSE_FILE = "docker/preview/compose.app.yaml";
 const REFERENCE_FILE = "docker/compose.app.yaml";
 /** Images this repository builds, addressed by commit rather than digest. */
-const OWN_IMAGE_PREFIX = "ghcr.io/ls1intum/hephaestus/";
+const OWN_IMAGE_PREFIX = "ghcr.io/hephaestus-build/";
 
 /**
  * Reference variables a preview deliberately does not set. Inheriting the reference instead of

--- a/scripts/check-release-image-inventory.test.ts
+++ b/scripts/check-release-image-inventory.test.ts
@@ -11,10 +11,7 @@ await test("repository release builds are covered by the evidence inventory", ()
 
 await test("rejects missing and duplicate inventory entries", () => {
 	assert.deepEqual(
-		validateInventory(
-			{ images: ["server"], upstream: [] },
-			'image-name: "ls1intum/hephaestus/new"',
-		),
+		validateInventory({ images: ["server"], upstream: [] }, 'image-name: "hephaestus-build/new"'),
 		["new"],
 	);
 	assert.throws(

--- a/scripts/check-release-image-inventory.ts
+++ b/scripts/check-release-image-inventory.ts
@@ -17,7 +17,7 @@ function isUpstreamImage(value: unknown): value is UpstreamImage {
 }
 
 export function releaseImages(workflow: string): string[] {
-	return [...workflow.matchAll(/image-name:\s*["']ls1intum\/hephaestus\/([^"']+)["']/g)].map(
+	return [...workflow.matchAll(/image-name:\s*["']hephaestus-build\/([^"']+)["']/g)].map(
 		(match) => match[1] ?? "",
 	);
 }

--- a/scripts/coolify-preview.ts
+++ b/scripts/coolify-preview.ts
@@ -557,7 +557,7 @@ export function checkImages(
 		throw new Error("GITHUB_REPOSITORY is malformed.");
 	}
 	for (const image of ["application-server", "webapp", "postgres"]) {
-		const repositoryPath = `ghcr.io/ls1intum/hephaestus/${image}`;
+		const repositoryPath = `ghcr.io/hephaestus-build/${image}`;
 		const reference = `${repositoryPath}:${headSha}`;
 		const inspect = runner.run("docker", [
 			"buildx",

--- a/scripts/lib/release-identities.ts
+++ b/scripts/lib/release-identities.ts
@@ -1,0 +1,132 @@
+/**
+ * Per-release image namespace and signing identity (issue #1599).
+ *
+ * GHCR packages do not transfer between organizations and Fulcio certificates are
+ * immutable, so a release keeps the namespace and certificate identity it was
+ * published under forever. `security/release-identities.json` records that history;
+ * everything that resolves a *previous* release's images or verifies its lock must
+ * go through this map instead of assuming the run's own identity.
+ *
+ * The last entry is the current identity. Inside CI its certificate identity is
+ * derived from the run context (`release-signer.ts`), which keeps signing and
+ * verification aligned across a future transfer without touching the map; the
+ * recorded slug is the fallback for operators running outside CI.
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { asArray, asRecord, asString } from "./json.ts";
+import { releaseSignerIdentity } from "./release-signer.ts";
+
+export type ReleaseIdentity = {
+	firstVersion: string;
+	namespace: string;
+	certificateIdentityRepository: string;
+};
+
+const versionPattern = /^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)$/;
+const namespacePattern = /^ghcr\.io\/[a-z0-9][a-z0-9._-]*(?:\/[a-z0-9][a-z0-9._-]*)*$/;
+const repositoryPattern = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+
+const identitiesFile = join(import.meta.dirname, "../../security/release-identities.json");
+
+function versionCore(release: string): [number, number, number] {
+	const bare = release.startsWith("v") ? release.slice(1) : release;
+	const core = bare.split("-", 1)[0] ?? bare;
+	if (!versionPattern.test(core))
+		throw new Error(`'${release}' is not a release version (expected [v]X.Y.Z)`);
+	const [major = 0, minor = 0, patch = 0] = core.split(".").map(Number);
+	return [major, minor, patch];
+}
+
+function compare(left: [number, number, number], right: [number, number, number]): number {
+	for (const [index, part] of left.entries()) {
+		const difference = part - (right[index] ?? 0);
+		if (difference !== 0) return difference;
+	}
+	return 0;
+}
+
+export function parseReleaseIdentities(value: unknown): ReleaseIdentity[] {
+	const document = asRecord(value, "release identities");
+	if (document.schemaVersion !== 1) throw new Error("release identities must use schema version 1");
+	const entries = asArray(document.identities, "release identities entries").map(
+		(entry, index): ReleaseIdentity => {
+			const record = asRecord(entry, `identity ${index}`);
+			const identity = {
+				firstVersion: asString(record.firstVersion, `identity ${index} firstVersion`),
+				namespace: asString(record.namespace, `identity ${index} namespace`),
+				certificateIdentityRepository: asString(
+					record.certificateIdentityRepository,
+					`identity ${index} certificateIdentityRepository`,
+				),
+			};
+			if (!versionPattern.test(identity.firstVersion))
+				throw new Error(`identity ${index} firstVersion must be X.Y.Z`);
+			if (!namespacePattern.test(identity.namespace))
+				throw new Error(
+					`identity ${index} namespace must be a ghcr.io path without a trailing slash`,
+				);
+			if (!repositoryPattern.test(identity.certificateIdentityRepository))
+				throw new Error(`identity ${index} certificateIdentityRepository must be owner/name`);
+			return identity;
+		},
+	);
+	if (entries.length === 0) throw new Error("release identities must contain at least one entry");
+	if (entries[0]?.firstVersion !== "0.0.0")
+		throw new Error("the first release identity must start at 0.0.0 so every version resolves");
+	for (let index = 1; index < entries.length; index += 1) {
+		const previous = entries[index - 1];
+		const current = entries[index];
+		if (
+			previous === undefined ||
+			current === undefined ||
+			compare(versionCore(previous.firstVersion), versionCore(current.firstVersion)) >= 0
+		)
+			throw new Error("release identities must be ordered by strictly ascending firstVersion");
+	}
+	return entries;
+}
+
+export function loadReleaseIdentities(): ReleaseIdentity[] {
+	return parseReleaseIdentities(JSON.parse(readFileSync(identitiesFile, "utf8")));
+}
+
+/** The identity a release (`0.74.3` or `v0.74.3`) was published under. */
+export function releaseIdentityFor(
+	release: string,
+	identities: ReleaseIdentity[] = loadReleaseIdentities(),
+): ReleaseIdentity {
+	const version = versionCore(release);
+	const match = identities.findLast(
+		(entry) => compare(versionCore(entry.firstVersion), version) <= 0,
+	);
+	if (!match) throw new Error(`no release identity covers ${release}`);
+	return match;
+}
+
+/** The identity new releases are published under: the map's final entry. */
+export function currentReleaseIdentity(
+	identities: ReleaseIdentity[] = loadReleaseIdentities(),
+): ReleaseIdentity {
+	const current = identities.at(-1);
+	if (!current) throw new Error("release identities must contain at least one entry");
+	return current;
+}
+
+/**
+ * The cosign certificate identity that signed the given release's lock. Historical
+ * entries are pinned by the map; the current entry follows the run context so a
+ * fork or future transfer verifies its own releases without editing the map.
+ */
+export function releaseCertificateIdentity(
+	release: string,
+	environment: NodeJS.ProcessEnv,
+	identities: ReleaseIdentity[] = loadReleaseIdentities(),
+): string {
+	const identity = releaseIdentityFor(release, identities);
+	if (identity === identities.at(-1) && environment.GITHUB_REPOSITORY)
+		return releaseSignerIdentity(environment);
+	const serverUrl = environment.GITHUB_SERVER_URL ?? "https://github.com";
+	return `${serverUrl}/${identity.certificateIdentityRepository}/.github/workflows/release.yml@refs/heads/main`;
+}

--- a/scripts/lib/release-identities.ts
+++ b/scripts/lib/release-identities.ts
@@ -16,7 +16,7 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { asArray, asRecord, asString } from "./json.ts";
-import { releaseSignerIdentity } from "./release-signer.ts";
+import { releaseSignerRepository } from "./release-signer.ts";
 
 export type ReleaseIdentity = {
 	firstVersion: string;
@@ -115,18 +115,46 @@ export function currentReleaseIdentity(
 }
 
 /**
- * The cosign certificate identity that signed the given release's lock. Historical
- * entries are pinned by the map; the current entry follows the run context so a
- * fork or future transfer verifies its own releases without editing the map.
+ * The `owner/repo` whose workflows signed the given release's artifacts. Historical
+ * entries are pinned by the map; the current entry follows the run context so a fork
+ * or future transfer verifies its own releases without editing the map. In CI the
+ * run context is required rather than merely preferred — verifying a current release
+ * against the map's fallback would hide a misconfigured environment.
  */
-export function releaseCertificateIdentity(
+export function releaseRepository(
 	release: string,
 	environment: NodeJS.ProcessEnv,
 	identities: ReleaseIdentity[] = loadReleaseIdentities(),
 ): string {
 	const identity = releaseIdentityFor(release, identities);
-	if (identity === identities.at(-1) && environment.GITHUB_REPOSITORY)
-		return releaseSignerIdentity(environment);
+	if (identity === identities.at(-1) && (environment.GITHUB_REPOSITORY || environment.CI))
+		return releaseSignerRepository(environment);
+	return identity.certificateIdentityRepository;
+}
+
+/** The owner half of {@link releaseRepository} — `gh attestation verify --owner`. */
+export function releaseOwner(
+	release: string,
+	environment: NodeJS.ProcessEnv,
+	identities: ReleaseIdentity[] = loadReleaseIdentities(),
+): string {
+	const [owner] = releaseRepository(release, environment, identities).split("/");
+	if (!owner) throw new Error(`could not derive an owner for ${release}`);
+	return owner;
+}
+
+/**
+ * The cosign certificate identity of a workflow in the repository that cut the given
+ * release. Defaults to `release.yml`, which signs the release lock; the image indexes
+ * and their SBOM attestations are signed by `reusable-docker-build.yml`.
+ */
+export function releaseCertificateIdentity(
+	release: string,
+	environment: NodeJS.ProcessEnv,
+	identities: ReleaseIdentity[] = loadReleaseIdentities(),
+	workflow = "release.yml",
+): string {
 	const serverUrl = environment.GITHUB_SERVER_URL ?? "https://github.com";
-	return `${serverUrl}/${identity.certificateIdentityRepository}/.github/workflows/release.yml@refs/heads/main`;
+	const repository = releaseRepository(release, environment, identities);
+	return `${serverUrl}/${repository}/.github/workflows/${workflow}@refs/heads/main`;
 }

--- a/scripts/lib/release-signer.ts
+++ b/scripts/lib/release-signer.ts
@@ -7,7 +7,7 @@
 // owner/repo in their certificate either way.
 
 const FALLBACK_SERVER_URL = "https://github.com";
-const FALLBACK_REPOSITORY = "ls1intum/Hephaestus";
+const FALLBACK_REPOSITORY = "hephaestus-build/Hephaestus";
 
 export function releaseSignerRepository(environment: NodeJS.ProcessEnv): string {
 	const repository = environment.GITHUB_REPOSITORY;

--- a/scripts/prepare-release-lock.ts
+++ b/scripts/prepare-release-lock.ts
@@ -3,7 +3,8 @@ import { tmpdir } from "node:os";
 import { basename, dirname, join } from "node:path";
 
 import { run } from "./lib/process.ts";
-import { releaseSignerIdentity, releaseSignerRepository } from "./lib/release-signer.ts";
+import { releaseCertificateIdentity } from "./lib/release-identities.ts";
+import { releaseSignerRepository } from "./lib/release-signer.ts";
 import { isRelease } from "./release-image-lock.ts";
 
 const repositoryRoot = join(import.meta.dirname, "..");
@@ -37,7 +38,9 @@ try {
 		"--bundle",
 		join(directory, `${asset}.sigstore.json`),
 		"--certificate-identity",
-		releaseSignerIdentity(process.env),
+		// Locks signed before the repository transfer carry the old owner/repo in their
+		// certificate, so the expected identity is the release's, not the run's (issue #1599).
+		releaseCertificateIdentity(release, process.env),
 		"--certificate-oidc-issuer",
 		"https://token.actions.githubusercontent.com",
 		join(directory, asset),

--- a/scripts/release-deployment-policy.test.ts
+++ b/scripts/release-deployment-policy.test.ts
@@ -21,13 +21,18 @@ await test("deployment uses Compose metadata, waits for readiness, and preserves
 	assert.doesNotMatch(deployment, /docker image prune/);
 });
 
-await test("release publication requires the seeded upgrade gate", () => {
-	const upgrade = readFileSync(".github/workflows/release-upgrade.yml", "utf8");
+const upgrade = readFileSync(".github/workflows/release-upgrade.yml", "utf8");
 
+await test("release publication requires the seeded upgrade gate", () => {
 	assert.match(
 		release,
 		/publish-release:\n\s+needs: \[release, tag-images, upgrade-test, supported-host-smoke\]/,
 	);
+	// The previous release keeps its pre-transfer namespace forever, so the gate passes
+	// the version and lets resolve-release-upgrade-images.ts pick the repository from
+	// security/release-identities.json (issue #1599).
+	assert.match(release, /previous-version: \$\{\{ needs\.release\.outputs\.previous_version \}\}/);
+	assert.match(upgrade, /INPUT_PREVIOUS_VERSION: \$\{\{ inputs\.previous-version \}\}/);
 	assert.match(
 		release,
 		/candidate-application-image: .*@\$\{\{ needs\.tag-images\.outputs\.application-server-digest \}\}/,
@@ -54,25 +59,34 @@ await test("release upgrade runs the server topology without optional infrastruc
 	assert.doesNotMatch(upgradeDrill, /"NATS_ENABLED=false"/);
 });
 
-await test("signing and verification identity derives from the run context", () => {
+await test("verification identity is the release's own: run context now, the map for history", () => {
 	const rescan = readFileSync(".github/workflows/rescan-release-images.yml", "utf8");
 	const prepareLock = readFileSync("scripts/prepare-release-lock.ts", "utf8");
 	const derivedIdentity =
 		/\$\{\{ github\.server_url \}\}\/\$\{\{ github\.repository \}\}\/\.github\/workflows\/release\.yml@refs\/heads\/main/;
 
+	// release.yml verifies only the lock it signed itself, so the run's own identity is right.
 	assert.match(release, derivedIdentity);
-	assert.match(rescan, derivedIdentity);
-	assert.match(prepareLock, /releaseSignerIdentity\(process\.env\)/);
+	// Consumers that verify a *previous* release resolve its identity per version from
+	// security/release-identities.json — a lock signed before the repository transfer
+	// carries the old owner/repo in its certificate forever (issue #1599).
+	assert.match(rescan, /resolve-release-identity\.ts.*certificate-identity/);
+	assert.match(deployment, /resolve-release-identity\.ts.*certificate-identity/);
+	assert.match(prepareLock, /releaseCertificateIdentity\(release, process\.env\)/);
 	assert.match(prepareLock, /releaseSignerRepository\(process\.env\)/);
-	// No verify step may pin a repository slug: after a repository transfer, the run's
-	// own identity is the one the release workflow signs with (issue #1599).
-	for (const contents of [release, deployment, rescan, prepareLock])
+	// No verify step may pin a repository slug outside the identity map.
+	for (const contents of [release, deployment, rescan, prepareLock]) {
 		assert.doesNotMatch(contents, /certificate-identity[^\n]*\n?[^\n]*ls1intum\/Hephaestus/);
-	// Deploys verify locks that may predate a repository transfer, so the expected
-	// signer stays overridable while defaulting to the run's own repository.
+		assert.doesNotMatch(
+			contents,
+			/certificate-identity[^\n]*\n?[^\n]*hephaestus-build\/Hephaestus/,
+		);
+	}
+	// The expected signer stays overridable for repositories the map does not know,
+	// and the override must win over the map.
 	assert.match(
 		deployment,
-		/EXPECTED_SIGNER_REPOSITORY: \$\{\{ inputs\.expected-signer-repository \|\| github\.repository \}\}/,
+		/EXPECTED_SIGNER_REPOSITORY: \$\{\{ inputs\.expected-signer-repository \}\}/,
 	);
 	assert.match(
 		deployment,
@@ -84,18 +98,18 @@ await test("derived signer identity matches today's literals in the canonical re
 	const canonicalRun = {
 		CI: "true",
 		GITHUB_SERVER_URL: "https://github.com",
-		GITHUB_REPOSITORY: "ls1intum/Hephaestus",
+		GITHUB_REPOSITORY: "hephaestus-build/Hephaestus",
 	};
-	assert.equal(releaseSignerRepository(canonicalRun), "ls1intum/Hephaestus");
+	assert.equal(releaseSignerRepository(canonicalRun), "hephaestus-build/Hephaestus");
 	assert.equal(
 		releaseSignerIdentity(canonicalRun),
-		"https://github.com/ls1intum/Hephaestus/.github/workflows/release.yml@refs/heads/main",
+		"https://github.com/hephaestus-build/Hephaestus/.github/workflows/release.yml@refs/heads/main",
 	);
 	// The documented operator flow (docs/admin/install.mdx) runs outside CI and keeps
 	// the canonical fallback…
 	assert.equal(
 		releaseSignerIdentity({}),
-		"https://github.com/ls1intum/Hephaestus/.github/workflows/release.yml@refs/heads/main",
+		"https://github.com/hephaestus-build/Hephaestus/.github/workflows/release.yml@refs/heads/main",
 	);
 	// …but CI must never silently verify against a repository it is not running in.
 	assert.throws(() => releaseSignerRepository({ CI: "true" }), /GITHUB_REPOSITORY/);

--- a/scripts/release-identities.test.ts
+++ b/scripts/release-identities.test.ts
@@ -8,6 +8,8 @@ import {
 	parseReleaseIdentities,
 	releaseCertificateIdentity,
 	releaseIdentityFor,
+	releaseOwner,
+	releaseRepository,
 } from "./lib/release-identities.ts";
 
 const identities = loadReleaseIdentities();
@@ -108,6 +110,47 @@ await test("the map rejects malformed or unordered entries", () => {
 			}),
 		/owner\/name/,
 	);
+});
+
+await test("a misconfigured CI environment fails instead of using the map fallback", () => {
+	const boundary = currentReleaseIdentity(identities).firstVersion;
+	// Outside CI the map is the documented operator fallback…
+	assert.equal(releaseRepository(`v${boundary}`, {}, identities), "hephaestus-build/Hephaestus");
+	// …but CI without GITHUB_REPOSITORY must not silently verify against it.
+	assert.throws(
+		() => releaseRepository(`v${boundary}`, { CI: "true" }, identities),
+		/GITHUB_REPOSITORY/,
+	);
+	assert.throws(
+		() => releaseCertificateIdentity(`v${boundary}`, { CI: "true" }, identities),
+		/GITHUB_REPOSITORY/,
+	);
+	// A historical release is pinned by the map, so it never consults the run context.
+	assert.equal(releaseRepository("v0.74.0", { CI: "true" }, identities), "ls1intum/Hephaestus");
+});
+
+await test("image-index signatures resolve the building repository, owner and workflow", () => {
+	const currentRun = { GITHUB_REPOSITORY: "hephaestus-build/Hephaestus" };
+	assert.equal(releaseOwner("v0.74.0", currentRun, identities), "ls1intum");
+	assert.equal(releaseOwner("v1.0.0", currentRun, identities), "hephaestus-build");
+	// The indexes and their SBOM attestations are signed by reusable-docker-build.yml,
+	// not release.yml, in the repository that built that release.
+	assert.equal(
+		releaseCertificateIdentity("v0.74.0", currentRun, identities, "reusable-docker-build.yml"),
+		"https://github.com/ls1intum/Hephaestus/.github/workflows/reusable-docker-build.yml@refs/heads/main",
+	);
+	assert.equal(
+		releaseCertificateIdentity("v0.74.0", currentRun, identities),
+		"https://github.com/ls1intum/Hephaestus/.github/workflows/release.yml@refs/heads/main",
+	);
+});
+
+await test("evidence verification never derives a signer from the run context", () => {
+	const evidence = readFileSync("scripts/verify-release-evidence.ts", "utf8");
+	assert.doesNotMatch(evidence, /requiredEnvironment\("GITHUB_REPOSITORY/);
+	assert.doesNotMatch(evidence, /GITHUB_REPOSITORY_OWNER/);
+	assert.match(evidence, /releaseRepository\(release, process\.env\)/);
+	assert.match(evidence, /releaseOwner\(release, process\.env\)/);
 });
 
 await test("the previous-release upgrade gate resolves the previous namespace per version", () => {

--- a/scripts/release-identities.test.ts
+++ b/scripts/release-identities.test.ts
@@ -1,0 +1,118 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+
+import {
+	currentReleaseIdentity,
+	loadReleaseIdentities,
+	parseReleaseIdentities,
+	releaseCertificateIdentity,
+	releaseIdentityFor,
+} from "./lib/release-identities.ts";
+
+const identities = loadReleaseIdentities();
+
+await test("the committed identity map pins the pre-transfer namespace and identity", () => {
+	// GHCR packages do not transfer between organizations and Fulcio certificates are
+	// immutable, so every release cut under ls1intum resolves there forever (issue #1599).
+	const first = identities[0];
+	assert.deepEqual(first, {
+		firstVersion: "0.0.0",
+		namespace: "ghcr.io/ls1intum/hephaestus",
+		certificateIdentityRepository: "ls1intum/Hephaestus",
+	});
+	assert.deepEqual(currentReleaseIdentity(identities), {
+		firstVersion: identities.at(-1)?.firstVersion,
+		namespace: "ghcr.io/hephaestus-build",
+		certificateIdentityRepository: "hephaestus-build/Hephaestus",
+	});
+});
+
+await test("versions resolve to the identity they were published under", () => {
+	const boundary = currentReleaseIdentity(identities).firstVersion;
+	for (const old of ["0.1.0", "v0.74.0", "0.74.99"])
+		assert.equal(releaseIdentityFor(old, identities).namespace, "ghcr.io/ls1intum/hephaestus");
+	for (const current of [boundary, `v${boundary}`, "1.0.0", "12.0.3"])
+		assert.equal(releaseIdentityFor(current, identities).namespace, "ghcr.io/hephaestus-build");
+	assert.throws(() => releaseIdentityFor("latest", identities), /not a release version/);
+	assert.throws(() => releaseIdentityFor("v1.2", identities), /not a release version/);
+});
+
+await test("historical certificate identities stay pinned even inside CI", () => {
+	assert.equal(
+		releaseCertificateIdentity(
+			"v0.74.0",
+			{ GITHUB_SERVER_URL: "https://github.com", GITHUB_REPOSITORY: "hephaestus-build/Hephaestus" },
+			identities,
+		),
+		"https://github.com/ls1intum/Hephaestus/.github/workflows/release.yml@refs/heads/main",
+	);
+});
+
+await test("the current certificate identity follows the run context, with the map as fallback", () => {
+	const boundary = currentReleaseIdentity(identities).firstVersion;
+	assert.equal(
+		releaseCertificateIdentity(
+			`v${boundary}`,
+			{ GITHUB_SERVER_URL: "https://github.com", GITHUB_REPOSITORY: "some-fork/Hephaestus" },
+			identities,
+		),
+		"https://github.com/some-fork/Hephaestus/.github/workflows/release.yml@refs/heads/main",
+	);
+	// The operator flow runs outside CI and verifies against the canonical repository.
+	assert.equal(
+		releaseCertificateIdentity(`v${boundary}`, {}, identities),
+		"https://github.com/hephaestus-build/Hephaestus/.github/workflows/release.yml@refs/heads/main",
+	);
+});
+
+await test("the map rejects malformed or unordered entries", () => {
+	const entry = (firstVersion: string) => ({
+		firstVersion,
+		namespace: "ghcr.io/example",
+		certificateIdentityRepository: "example/Example",
+	});
+	assert.throws(
+		() => parseReleaseIdentities({ schemaVersion: 2, identities: [entry("0.0.0")] }),
+		/schema version 1/,
+	);
+	assert.throws(
+		() => parseReleaseIdentities({ schemaVersion: 1, identities: [] }),
+		/at least one entry/,
+	);
+	assert.throws(
+		() => parseReleaseIdentities({ schemaVersion: 1, identities: [entry("0.1.0")] }),
+		/start at 0\.0\.0/,
+	);
+	assert.throws(
+		() =>
+			parseReleaseIdentities({
+				schemaVersion: 1,
+				identities: [entry("0.0.0"), entry("2.0.0"), entry("1.0.0")],
+			}),
+		/strictly ascending/,
+	);
+	assert.throws(
+		() =>
+			parseReleaseIdentities({
+				schemaVersion: 1,
+				identities: [{ ...entry("0.0.0"), namespace: "ghcr.io/example/" }],
+			}),
+		/trailing slash/,
+	);
+	assert.throws(
+		() =>
+			parseReleaseIdentities({
+				schemaVersion: 1,
+				identities: [{ ...entry("0.0.0"), certificateIdentityRepository: "example" }],
+			}),
+		/owner\/name/,
+	);
+});
+
+await test("the previous-release upgrade gate resolves the previous namespace per version", () => {
+	const resolver = readFileSync("scripts/resolve-release-upgrade-images.ts", "utf8");
+	assert.match(resolver, /releaseIdentityFor\(/);
+	assert.match(resolver, /currentReleaseIdentity\(\)/);
+	assert.doesNotMatch(resolver, /ghcr\.io\//);
+});

--- a/scripts/release-image-lock.test.ts
+++ b/scripts/release-image-lock.test.ts
@@ -14,7 +14,7 @@ const rawLock = {
 	images: [
 		{
 			image: "webapp",
-			repository: "ghcr.io/ls1intum/hephaestus/webapp",
+			repository: "ghcr.io/hephaestus-build/webapp",
 			provenance: "first-party",
 			indexDigest: digest("b"),
 			platforms: { "linux/amd64": digest("c"), "linux/arm64": digest("d") },

--- a/scripts/resolve-release-identity.ts
+++ b/scripts/resolve-release-identity.ts
@@ -1,0 +1,37 @@
+/**
+ * Resolves the GHCR namespace and cosign certificate identity a release was
+ * published under (`security/release-identities.json`, issue #1599).
+ *
+ * usage: node scripts/resolve-release-identity.ts <vX.Y.Z | X.Y.Z> [field]
+ *
+ * With a field (`namespace` | `certificate-identity`) it prints just that value,
+ * for command substitution. Without one it prints both as `key=value` lines and
+ * appends them to `GITHUB_OUTPUT` when set, for use as a workflow step.
+ */
+import { appendFileSync } from "node:fs";
+import process from "node:process";
+
+import { releaseCertificateIdentity, releaseIdentityFor } from "./lib/release-identities.ts";
+
+const [release, field] = process.argv.slice(2);
+if (!release)
+	throw new Error(
+		"usage: resolve-release-identity <vX.Y.Z | X.Y.Z> [namespace|certificate-identity]",
+	);
+
+const values = {
+	namespace: releaseIdentityFor(release).namespace,
+	"certificate-identity": releaseCertificateIdentity(release, process.env),
+};
+
+if (field !== undefined) {
+	if (field !== "namespace" && field !== "certificate-identity")
+		throw new Error(`unknown field '${field}' (expected namespace or certificate-identity)`);
+	console.log(values[field]);
+} else {
+	const lines = Object.entries(values)
+		.map(([key, value]) => `${key}=${value}\n`)
+		.join("");
+	process.stdout.write(lines);
+	if (process.env.GITHUB_OUTPUT) appendFileSync(process.env.GITHUB_OUTPUT, lines);
+}

--- a/scripts/resolve-release-upgrade-images.ts
+++ b/scripts/resolve-release-upgrade-images.ts
@@ -2,8 +2,15 @@ import { spawnSync } from "node:child_process";
 import { appendFileSync } from "node:fs";
 import process from "node:process";
 
-const applicationRepository = "ghcr.io/ls1intum/hephaestus/application-server";
-const postgresRepository = "ghcr.io/ls1intum/hephaestus/postgres";
+import { currentReleaseIdentity, releaseIdentityFor } from "./lib/release-identities.ts";
+
+// The candidate is built by this repository's CI, so it lives in the current
+// namespace. The previous release keeps the namespace it was published under —
+// GHCR packages do not transfer between organizations (issue #1599) — so its
+// repository is resolved per version from security/release-identities.json.
+const currentNamespace = currentReleaseIdentity().namespace;
+const applicationRepository = `${currentNamespace}/application-server`;
+const postgresRepository = `${currentNamespace}/postgres`;
 
 function command(executable: string, args: string[]): string {
 	const result = spawnSync(executable, args, { encoding: "utf8" });
@@ -39,16 +46,32 @@ function immutable(reference: string, repository: string): string {
 	return `${repository}@${parsed.digest}`;
 }
 
+function previousApplicationReference(version: string): {
+	reference: string;
+	repository: string;
+} {
+	const repository = `${releaseIdentityFor(version).namespace}/application-server`;
+	return { reference: `${repository}:${version}`, repository };
+}
+
 const supplied = [
-	process.env.INPUT_PREVIOUS_APP,
+	process.env.INPUT_PREVIOUS_VERSION,
 	process.env.INPUT_CANDIDATE_APP,
 	process.env.INPUT_POSTGRES,
 ];
 if (supplied.some(Boolean) && !supplied.every(Boolean))
-	throw new Error("Reusable workflow callers must provide all three image references");
+	throw new Error(
+		"Reusable workflow callers must provide the previous version and both image references",
+	);
 
-let [previousApplication, candidateApplication, postgres] = supplied;
-if (!previousApplication || !candidateApplication || !postgres) {
+let previousApplication: { reference: string; repository: string };
+const suppliedPreviousVersion = supplied[0];
+let [, candidateApplication, postgres] = supplied;
+if (suppliedPreviousVersion && candidateApplication && postgres) {
+	if (!/^[0-9]+\.[0-9]+\.[0-9]+$/.test(suppliedPreviousVersion))
+		throw new Error("Previous version must be a stable X.Y.Z version");
+	previousApplication = previousApplicationReference(suppliedPreviousVersion);
+} else {
 	const repository = process.env.GITHUB_REPOSITORY;
 	if (!repository) throw new Error("GITHUB_REPOSITORY is required");
 	const requestedPrevious = nonEmpty(process.env.REQUESTED_PREVIOUS);
@@ -69,7 +92,7 @@ if (!previousApplication || !candidateApplication || !postgres) {
 	const candidate = nonEmpty(process.env.REQUESTED_CANDIDATE) ?? process.env.GITHUB_SHA;
 	if (!candidate || !/^[a-f0-9]{40}$/.test(candidate))
 		throw new Error("Candidate must be a full commit SHA");
-	previousApplication = `${applicationRepository}:${previous.slice(1)}`;
+	previousApplication = previousApplicationReference(previous.slice(1));
 	candidateApplication = `${applicationRepository}:${candidate}`;
 	postgres = `${postgresRepository}:${candidate}`;
 }
@@ -79,7 +102,7 @@ if (!output) throw new Error("GITHUB_OUTPUT is required");
 appendFileSync(
 	output,
 	[
-		`previous-app=${immutable(previousApplication, applicationRepository)}`,
+		`previous-app=${immutable(previousApplication.reference, previousApplication.repository)}`,
 		`candidate-app=${immutable(candidateApplication, applicationRepository)}`,
 		`postgres=${immutable(postgres, postgresRepository)}`,
 		"",

--- a/scripts/verify-release-evidence.test.ts
+++ b/scripts/verify-release-evidence.test.ts
@@ -9,6 +9,7 @@ import {
 } from "./verify-release-evidence.ts";
 
 const digest = `sha256:${"a".repeat(64)}`;
+const namespace = "ghcr.io/hephaestus-build";
 const inventory = { schemaVersion: 1, images: ["server"], upstream: [] };
 const subject = (platform: "linux/amd64" | "linux/arm64") => ({
 	digest,
@@ -16,7 +17,7 @@ const subject = (platform: "linux/amd64" | "linux/arm64") => ({
 	indexDigest: digest,
 	platform,
 	provenance: "first-party" as const,
-	repository: "ghcr.io/ls1intum/hephaestus/server",
+	repository: "ghcr.io/hephaestus-build/server",
 });
 
 void describe("release evidence manifest", () => {
@@ -24,13 +25,19 @@ void describe("release evidence manifest", () => {
 		const result = validateManifest(
 			{ schemaVersion: 1, subjects: [subject("linux/amd64"), subject("linux/arm64")] },
 			inventory,
+			namespace,
 		);
 		assert.equal(result.subjects.length, 2);
 	});
 
 	void it("fails closed on missing, reordered, and duplicate platforms", () => {
 		assert.throws(
-			() => validateManifest({ schemaVersion: 1, subjects: [subject("linux/amd64")] }, inventory),
+			() =>
+				validateManifest(
+					{ schemaVersion: 1, subjects: [subject("linux/amd64")] },
+					inventory,
+					namespace,
+				),
 			/canonical order/,
 		);
 		assert.throws(
@@ -38,6 +45,7 @@ void describe("release evidence manifest", () => {
 				validateManifest(
 					{ schemaVersion: 1, subjects: [subject("linux/arm64"), subject("linux/amd64")] },
 					inventory,
+					namespace,
 				),
 			/canonical order/,
 		);
@@ -46,6 +54,7 @@ void describe("release evidence manifest", () => {
 				validateManifest(
 					{ schemaVersion: 1, subjects: [subject("linux/amd64"), subject("linux/amd64")] },
 					inventory,
+					namespace,
 				),
 			/duplicate image platforms/,
 		);
@@ -65,6 +74,7 @@ void describe("release evidence manifest", () => {
 					validateManifest(
 						{ schemaVersion: 1, subjects: [invalid, subject("linux/arm64")] },
 						inventory,
+						namespace,
 					),
 				/malformed|does not match/,
 			);
@@ -78,6 +88,7 @@ void describe("release evidence manifest", () => {
 				validateManifest(
 					{ schemaVersion: 1, subjects },
 					{ schemaVersion: 1, images: ["server", "server"], upstream: [] },
+					namespace,
 				),
 			/duplicate release image/,
 		);
@@ -86,6 +97,7 @@ void describe("release evidence manifest", () => {
 				validateManifest(
 					{ schemaVersion: 1, subjects },
 					{ schemaVersion: 1, images: ["../server"], upstream: [] },
+					namespace,
 				),
 			/invalid image/,
 		);
@@ -114,13 +126,14 @@ void describe("release evidence manifest", () => {
 		});
 		const valid = [upstreamSubject("linux/amd64"), upstreamSubject("linux/arm64")];
 		assert.doesNotThrow(() =>
-			validateManifest({ schemaVersion: 1, subjects: valid }, upstreamInventory),
+			validateManifest({ schemaVersion: 1, subjects: valid }, upstreamInventory, namespace),
 		);
 		assert.throws(
 			() =>
 				validateManifest(
 					{ schemaVersion: 1, subjects: [{ ...valid[0], provenance: "first-party" }, valid[1]] },
 					upstreamInventory,
+					namespace,
 				),
 			/does not match its inventory/,
 		);
@@ -129,6 +142,7 @@ void describe("release evidence manifest", () => {
 				validateManifest(
 					{ schemaVersion: 1, subjects: [{ ...valid[0], indexDigest: digest }, valid[1]] },
 					upstreamInventory,
+					namespace,
 				),
 			/does not match its inventory/,
 		);
@@ -143,6 +157,7 @@ void describe("release evidence manifest", () => {
 						],
 					},
 					inventory,
+					namespace,
 				),
 			/one index digest/,
 		);

--- a/scripts/verify-release-evidence.ts
+++ b/scripts/verify-release-evidence.ts
@@ -5,7 +5,12 @@ import { isDeepStrictEqual } from "node:util";
 
 import { validateReleaseSbom } from "./check-release-sbom.ts";
 import { evaluate } from "./check-release-vulnerabilities.ts";
-import { releaseIdentityFor } from "./lib/release-identities.ts";
+import {
+	releaseCertificateIdentity,
+	releaseIdentityFor,
+	releaseOwner,
+	releaseRepository,
+} from "./lib/release-identities.ts";
 import { isRelease } from "./release-image-lock.ts";
 
 type Subject = {
@@ -199,12 +204,14 @@ export function verifyReleaseEvidence(
 		!isRelease(manifestValue.release)
 	)
 		throw new Error("release manifest must name the release it evidences");
-	// The evidence may belong to a release published under a pre-transfer namespace,
-	// which its images keep forever (issue #1599) — resolve it per version.
+	// The evidence may belong to a release published under a pre-transfer namespace and
+	// signed by the pre-transfer repository, both of which it keeps forever (issue
+	// #1599) — resolve namespace *and* signer per version, never from the run context.
+	const release = manifestValue.release;
 	const manifest = validateManifest(
 		manifestValue,
 		readJson(join(directory, "release-images.json")),
-		releaseIdentityFor(manifestValue.release).namespace,
+		releaseIdentityFor(release).namespace,
 	);
 	const policy = readJson(join(directory, "vulnerability-policy.json"));
 	for (const subject of manifest.subjects) {
@@ -245,13 +252,12 @@ export function verifyReleaseEvidence(
 		if (!indexContainsSubject(index, subject))
 			throw new Error(`${subject.image} index does not contain ${subject.platform} digest`);
 		if (mode === "verify-signatures" && subject.provenance === "first-party") {
-			const repository = requiredEnvironment("GITHUB_REPOSITORY");
 			const attestations = readJsonFromCommand("cosign", [
 				"verify-attestation",
 				"--type",
 				"spdxjson",
 				"--certificate-identity",
-				`https://github.com/${repository}/.github/workflows/release.yml@refs/heads/main`,
+				releaseCertificateIdentity(release, process.env),
 				"--certificate-oidc-issuer",
 				"https://token.actions.githubusercontent.com",
 				reference,
@@ -260,7 +266,7 @@ export function verifyReleaseEvidence(
 				throw new Error(`${subject.image} SBOM attestation does not match its durable evidence`);
 		}
 	}
-	if (mode === "verify-signatures") verifyIndexSignatures(manifest);
+	if (mode === "verify-signatures") verifyIndexSignatures(manifest, release);
 	return manifest;
 }
 
@@ -268,15 +274,11 @@ function readJsonFromCommand(name: string, args: string[]): unknown {
 	return JSON.parse(command(name, args, true)) as unknown;
 }
 
-function requiredEnvironment(name: string): string {
-	const value = process.env[name];
-	if (!value) throw new Error(`${name} is required`);
-	return value;
-}
-
-function verifyIndexSignatures(manifest: Manifest): void {
-	const repository = requiredEnvironment("GITHUB_REPOSITORY");
-	const owner = requiredEnvironment("GITHUB_REPOSITORY_OWNER");
+function verifyIndexSignatures(manifest: Manifest, release: string): void {
+	// The image indexes are signed by reusable-docker-build.yml in the repository that
+	// built them, which for a pre-transfer release is the pre-transfer slug (#1599).
+	const repository = releaseRepository(release, process.env);
+	const owner = releaseOwner(release, process.env);
 	const indexes = new Map(
 		manifest.subjects
 			.filter(({ provenance }) => provenance === "first-party")
@@ -292,7 +294,7 @@ function verifyIndexSignatures(manifest: Manifest): void {
 				"verify",
 				reference,
 				"--certificate-identity",
-				`https://github.com/${repository}/.github/workflows/reusable-docker-build.yml@refs/heads/main`,
+				releaseCertificateIdentity(release, process.env, undefined, "reusable-docker-build.yml"),
 				"--certificate-oidc-issuer",
 				"https://token.actions.githubusercontent.com",
 				"--certificate-github-workflow-repository",

--- a/scripts/verify-release-evidence.ts
+++ b/scripts/verify-release-evidence.ts
@@ -5,6 +5,8 @@ import { isDeepStrictEqual } from "node:util";
 
 import { validateReleaseSbom } from "./check-release-sbom.ts";
 import { evaluate } from "./check-release-vulnerabilities.ts";
+import { releaseIdentityFor } from "./lib/release-identities.ts";
+import { isRelease } from "./release-image-lock.ts";
 
 type Subject = {
 	digest: string;
@@ -79,7 +81,11 @@ export function attestationContainsSbom(value: unknown, sbom: unknown): boolean 
 	});
 }
 
-export function validateManifest(value: unknown, inventoryValue: unknown): Manifest {
+export function validateManifest(
+	value: unknown,
+	inventoryValue: unknown,
+	firstPartyNamespace: string,
+): Manifest {
 	if (!record(value) || value.schemaVersion !== 1 || !Array.isArray(value.subjects))
 		throw new Error("release manifest must use schema version 1 and contain subjects");
 	if (
@@ -101,7 +107,7 @@ export function validateManifest(value: unknown, inventoryValue: unknown): Manif
 	for (const image of images)
 		expectedImages.set(image, {
 			provenance: "first-party",
-			repository: `ghcr.io/ls1intum/hephaestus/${image}`,
+			repository: `${firstPartyNamespace}/${image}`,
 		});
 	for (const item of inventoryValue.upstream) {
 		if (
@@ -186,9 +192,19 @@ export function verifyReleaseEvidence(
 	directory: string,
 	mode: VerificationMode = "verify",
 ): Manifest {
+	const manifestValue = readJson(join(directory, "manifest.json"));
+	if (
+		!record(manifestValue) ||
+		typeof manifestValue.release !== "string" ||
+		!isRelease(manifestValue.release)
+	)
+		throw new Error("release manifest must name the release it evidences");
+	// The evidence may belong to a release published under a pre-transfer namespace,
+	// which its images keep forever (issue #1599) — resolve it per version.
 	const manifest = validateManifest(
-		readJson(join(directory, "manifest.json")),
+		manifestValue,
 		readJson(join(directory, "release-images.json")),
+		releaseIdentityFor(manifestValue.release).namespace,
 	);
 	const policy = readJson(join(directory, "vulnerability-policy.json"));
 	for (const subject of manifest.subjects) {

--- a/security/release-identities.json
+++ b/security/release-identities.json
@@ -1,0 +1,16 @@
+{
+	"comment": "Maps release versions to the GHCR namespace their images live in and the repository whose release workflow signed them. GHCR packages do not transfer between organizations and Fulcio certificates are immutable, so every release cut under ls1intum keeps its images and signing identity forever (issue #1599). Entries are ordered by firstVersion ascending; a version resolves to the last entry whose firstVersion is not greater than it. The final entry is the current identity: CI consumers derive its certificate identity from the run context and fall back to certificateIdentityRepository outside CI. firstVersion of the hephaestus-build entry must equal the first release cut after the transfer — verify it against the released history before merging.",
+	"schemaVersion": 1,
+	"identities": [
+		{
+			"firstVersion": "0.0.0",
+			"namespace": "ghcr.io/ls1intum/hephaestus",
+			"certificateIdentityRepository": "ls1intum/Hephaestus"
+		},
+		{
+			"firstVersion": "0.75.0",
+			"namespace": "ghcr.io/hephaestus-build",
+			"certificateIdentityRepository": "hephaestus-build/Hephaestus"
+		}
+	]
+}

--- a/server/application/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/server/application/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -188,11 +188,11 @@
       "name": "hephaestus.agent.image.reference",
       "values": [
         {
-          "value": "ghcr.io/ls1intum/hephaestus/agent-pi:${spring.application.version}",
+          "value": "ghcr.io/hephaestus-build/agent-pi:${spring.application.version}",
           "description": "Default \u2014 follows this deployment's own image tag, so the pair always matches."
         },
         {
-          "value": "ghcr.io/ls1intum/hephaestus/agent-pi@sha256:0000000000000000000000000000000000000000000000000000000000000000",
+          "value": "ghcr.io/hephaestus-build/agent-pi@sha256:0000000000000000000000000000000000000000000000000000000000000000",
           "description": "Production \u2014 digest-pinned. Imported by spring.config.import from the signed release asset."
         }
       ]

--- a/server/application/src/main/resources/application.yml
+++ b/server/application/src/main/resources/application.yml
@@ -511,7 +511,7 @@ hephaestus:
     # for QUEUED rows on a fixed interval. Disabled by default.
     agent:
         image:
-            reference: ghcr.io/ls1intum/hephaestus/agent-pi:${spring.application.version}
+            reference: ghcr.io/hephaestus-build/agent-pi:${spring.application.version}
         enabled: ${AGENT_ENABLED:false}
         # How long the poll loop sleeps when there is nothing to claim.
         poll-interval: ${AGENT_POLL_INTERVAL:1s}

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/practice/PracticePiAdapterTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/practice/PracticePiAdapterTest.java
@@ -15,7 +15,7 @@ import tools.jackson.databind.ObjectMapper;
 
 class PracticePiAdapterTest extends BaseUnitTest {
 
-    private static final String IMAGE = "ghcr.io/ls1intum/hephaestus/agent-pi:0.73.2";
+    private static final String IMAGE = "ghcr.io/hephaestus-build/agent-pi:0.73.2";
     private PracticePiAdapter adapter;
 
     @BeforeEach

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/runtime/AgentImageDefaultResolutionTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/runtime/AgentImageDefaultResolutionTest.java
@@ -37,14 +37,14 @@ class AgentImageDefaultResolutionTest extends BaseUnitTest {
     @Test
     void shouldFollowTheImageTagTheDeploymentIsRunning() throws IOException {
         assertThat(bindWith(Map.of("APP_VERSION", "1.2.3")).reference())
-                .isEqualTo("ghcr.io/ls1intum/hephaestus/agent-pi:1.2.3");
+                .isEqualTo("ghcr.io/hephaestus-build/agent-pi:1.2.3");
     }
 
     @Test
     void shouldFollowACommitShaDeploy() throws IOException {
         String sha = "9a1f0c2e1b7d4a6f8c3e5b2d9a7f4c1e0b8d6a35";
         assertThat(bindWith(Map.of("APP_VERSION", sha)).reference())
-                .isEqualTo("ghcr.io/ls1intum/hephaestus/agent-pi:" + sha);
+                .isEqualTo("ghcr.io/hephaestus-build/agent-pi:" + sha);
     }
 
     @Test
@@ -61,6 +61,6 @@ class AgentImageDefaultResolutionTest extends BaseUnitTest {
      */
     @Test
     void shouldNotRecoverFromAnEmptyImageTag() throws IOException {
-        assertThat(bindWith(Map.of("APP_VERSION", "")).reference()).isEqualTo("ghcr.io/ls1intum/hephaestus/agent-pi:");
+        assertThat(bindWith(Map.of("APP_VERSION", "")).reference()).isEqualTo("ghcr.io/hephaestus-build/agent-pi:");
     }
 }

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/sandbox/AgentImageReferenceGuardTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/sandbox/AgentImageReferenceGuardTest.java
@@ -22,15 +22,15 @@ class AgentImageReferenceGuardTest extends BaseUnitTest {
     @ParameterizedTest
     @ValueSource(
             strings = {
-                "ghcr.io/ls1intum/hephaestus/agent-pi:0.73.2",
-                "ghcr.io/ls1intum/hephaestus/agent-pi:9a1f0c2e1b7d4a6f8c3e5b2d9a7f4c1e0b8d6a35",
+                "ghcr.io/hephaestus-build/agent-pi:0.73.2",
+                "ghcr.io/hephaestus-build/agent-pi:9a1f0c2e1b7d4a6f8c3e5b2d9a7f4c1e0b8d6a35",
                 // A registry port is not a tag; a reference carrying both must still read the tag.
                 "localhost:5000/agent-pi:0.73.2",
                 // The series rule reaches only version-shaped tags that stop short of a patch, so a
                 // pre-release, a four-part build number and a hand-built dev tag all still name a build.
-                "ghcr.io/ls1intum/hephaestus/agent-pi:0.74.0-rc.1",
-                "ghcr.io/ls1intum/hephaestus/agent-pi:1.2.3.4",
-                "ghcr.io/ls1intum/hephaestus/agent-pi:dev",
+                "ghcr.io/hephaestus-build/agent-pi:0.74.0-rc.1",
+                "ghcr.io/hephaestus-build/agent-pi:1.2.3.4",
+                "ghcr.io/hephaestus-build/agent-pi:dev",
             })
     void shouldAcceptAReferenceThatCanNameAMatchedBuild(String reference) {
         assertThatCode(() -> guardFor(reference)).doesNotThrowAnyException();
@@ -38,17 +38,17 @@ class AgentImageReferenceGuardTest extends BaseUnitTest {
 
     @Test
     void shouldAcceptADigestPin() {
-        assertThatCode(() -> guardFor("ghcr.io/ls1intum/hephaestus/agent-pi@sha256:" + "a".repeat(64)))
+        assertThatCode(() -> guardFor("ghcr.io/hephaestus-build/agent-pi@sha256:" + "a".repeat(64)))
                 .doesNotThrowAnyException();
     }
 
     @ParameterizedTest
     @ValueSource(
             strings = {
-                "ghcr.io/ls1intum/hephaestus/agent-pi:latest",
-                "ghcr.io/ls1intum/hephaestus/agent-pi:stable",
-                "ghcr.io/ls1intum/hephaestus/agent-pi:edge",
-                "ghcr.io/ls1intum/hephaestus/agent-pi:main",
+                "ghcr.io/hephaestus-build/agent-pi:latest",
+                "ghcr.io/hephaestus-build/agent-pi:stable",
+                "ghcr.io/hephaestus-build/agent-pi:edge",
+                "ghcr.io/hephaestus-build/agent-pi:main",
             })
     void shouldRefuseAReleaseChannelBecauseItNamesAnotherReleasesImage(String reference) {
         assertThatThrownBy(() -> guardFor(reference))
@@ -66,9 +66,9 @@ class AgentImageReferenceGuardTest extends BaseUnitTest {
     @ParameterizedTest
     @ValueSource(
             strings = {
-                "ghcr.io/ls1intum/hephaestus/agent-pi:0.73",
-                "ghcr.io/ls1intum/hephaestus/agent-pi:0",
-                "ghcr.io/ls1intum/hephaestus/agent-pi:v1.2",
+                "ghcr.io/hephaestus-build/agent-pi:0.73",
+                "ghcr.io/hephaestus-build/agent-pi:0",
+                "ghcr.io/hephaestus-build/agent-pi:v1.2",
                 "localhost:5000/agent-pi:0.73",
             })
     void shouldRefuseAVersionSeriesBecauseItMovesOnTheNextPatchRelease(String reference) {
@@ -82,7 +82,7 @@ class AgentImageReferenceGuardTest extends BaseUnitTest {
 
     /** Docker resolves an untagged reference to the release channel, so this is the same defect. */
     @ParameterizedTest
-    @ValueSource(strings = {"ghcr.io/ls1intum/hephaestus/agent-pi", "localhost:5000/agent-pi"})
+    @ValueSource(strings = {"ghcr.io/hephaestus-build/agent-pi", "localhost:5000/agent-pi"})
     void shouldRefuseAReferenceThatNamesNoTag(String reference) {
         assertThatThrownBy(() -> guardFor(reference))
                 .isInstanceOf(IllegalStateException.class)
@@ -96,7 +96,7 @@ class AgentImageReferenceGuardTest extends BaseUnitTest {
      * to the empty string leaves the derivation with nothing to append.
      */
     @ParameterizedTest
-    @ValueSource(strings = {"ghcr.io/ls1intum/hephaestus/agent-pi:", "ghcr.io/ls1intum/hephaestus/agent-pi:-bad"})
+    @ValueSource(strings = {"ghcr.io/hephaestus-build/agent-pi:", "ghcr.io/hephaestus-build/agent-pi:-bad"})
     void shouldRefuseAReferenceWhoseTagIsNotUsable(String reference) {
         assertThatThrownBy(() -> guardFor(reference))
                 .isInstanceOf(IllegalStateException.class)
@@ -108,8 +108,8 @@ class AgentImageReferenceGuardTest extends BaseUnitTest {
     @ParameterizedTest
     @ValueSource(
             strings = {
-                "ghcr.io/ls1intum/hephaestus/agent-pi@sha256:abc123",
-                "ghcr.io/ls1intum/hephaestus/agent-pi@sha256:",
+                "ghcr.io/hephaestus-build/agent-pi@sha256:abc123",
+                "ghcr.io/hephaestus-build/agent-pi@sha256:",
             })
     void shouldRefuseAMalformedDigest(String reference) {
         assertThatThrownBy(() -> guardFor(reference))
@@ -129,8 +129,8 @@ class AgentImageReferenceGuardTest extends BaseUnitTest {
 
     @Test
     void shouldAllowStartupWhenTheTagCameFromAnUnsetAppVersion() {
-        assertThatCode(() -> guardFor(
-                        "ghcr.io/ls1intum/hephaestus/agent-pi:" + AgentImageReferenceGuard.DEVELOPMENT_VERSION))
+        assertThatCode(() ->
+                        guardFor("ghcr.io/hephaestus-build/agent-pi:" + AgentImageReferenceGuard.DEVELOPMENT_VERSION))
                 .doesNotThrowAnyException();
     }
 

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/AgentImageContractVerifierTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/AgentImageContractVerifierTest.java
@@ -15,7 +15,7 @@ import org.mockito.Mock;
 
 class AgentImageContractVerifierTest extends BaseUnitTest {
 
-    private static final String IMAGE = "ghcr.io/ls1intum/hephaestus/agent-pi:0.73.2";
+    private static final String IMAGE = "ghcr.io/hephaestus-build/agent-pi:0.73.2";
 
     @Mock
     private DockerImageOperations imageOps;

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/AgentImagePullBootstrapperTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/AgentImagePullBootstrapperTest.java
@@ -22,7 +22,7 @@ import org.mockito.Mockito;
 
 class AgentImagePullBootstrapperTest extends BaseUnitTest {
 
-    private static final String IMAGE = "ghcr.io/ls1intum/hephaestus/agent-pi:0.73.2";
+    private static final String IMAGE = "ghcr.io/hephaestus-build/agent-pi:0.73.2";
 
     @Mock
     private DockerImageOperations imageOps;

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/RepositoryTreeStagingLiveTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/RepositoryTreeStagingLiveTest.java
@@ -52,8 +52,8 @@ class RepositoryTreeStagingLiveTest {
 
     /** The image under test. A release-channel tag would test some other release's image (ADR 0031);
      * point this at a locally built agent image, or export the reference a deployment would use. */
-    private static final String AGENT_IMAGE = System.getenv()
-            .getOrDefault("HEPHAESTUS_AGENT_IMAGE_REFERENCE", "ghcr.io/ls1intum/hephaestus/agent-pi:dev");
+    private static final String AGENT_IMAGE =
+            System.getenv().getOrDefault("HEPHAESTUS_AGENT_IMAGE_REFERENCE", "ghcr.io/hephaestus-build/agent-pi:dev");
 
     /** A tree large enough that any per-file ceiling would have to reject it. */
     private static final int TREE_FILE_COUNT = 25_000;

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/interactive/DockerInteractiveSandboxLiveTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/interactive/DockerInteractiveSandboxLiveTest.java
@@ -72,8 +72,8 @@ class DockerInteractiveSandboxLiveTest {
 
     /** The image under test. A release-channel tag would test some other release's image (ADR 0031);
      * point this at a locally built agent image, or export the reference a deployment would use. */
-    private static final String AGENT_PI_IMAGE = System.getenv()
-            .getOrDefault("HEPHAESTUS_AGENT_IMAGE_REFERENCE", "ghcr.io/ls1intum/hephaestus/agent-pi:dev");
+    private static final String AGENT_PI_IMAGE =
+            System.getenv().getOrDefault("HEPHAESTUS_AGENT_IMAGE_REFERENCE", "ghcr.io/hephaestus-build/agent-pi:dev");
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
 

--- a/server/compose.yaml
+++ b/server/compose.yaml
@@ -11,7 +11,7 @@ services:
   postgres:
     build:
       context: ../docker/postgres
-    image: 'ghcr.io/ls1intum/hephaestus/postgres:dev'
+    image: 'ghcr.io/hephaestus-build/postgres:dev'
     environment:
       POSTGRES_DB: hephaestus
       POSTGRES_PASSWORD: root


### PR DESCRIPTION
## Motivation

Executes the namespace half of the organization transfer decided in #1599. GHCR packages do not transfer between organizations and Fulcio certificates are immutable, so the namespace published at 1.0 must be the final one. This PR converts every operational `ghcr.io/ls1intum/hephaestus/*` reference to `ghcr.io/hephaestus-build/<image>` (dropping the redundant `hephaestus/` segment) and makes every consumer that touches a **previous** release resolve its namespace and signing identity per version.

> [!NOTE]
> **The transfer is complete and all activation preconditions are met.** The repository is now `hephaestus-build/Hephaestus`; all four images are republished digest-identical and public under `ghcr.io/hephaestus-build/*` (main-tip `da6a343` plus `0.74.0` / `0.74` / `latest`). This PR is rebased onto post-transfer `main` and is ready to merge.

## What changed

- **Namespace sweep** — workflows (`release.yml`, `ci-docker-build.yml`, `ci-quality-gates.yml`, `ci-tests.yml`, `reusable-docker-build.yml` example), compose files (`docker/preview/compose.app.yaml`, `server/compose.yaml`), `docker/.env.example`, `docker/postgres/Dockerfile`, the baked `application.yml` agent-image default plus its configuration metadata, seven server test classes, `check-preview-stack.ts`, `coolify-preview.ts`, `check-release-image-inventory.ts`, and operational docs. Historical ADRs, MIGRATION.md history, and CHANGELOG stay untouched.
- **`security/release-identities.json`** — maps version ranges to `{namespace, certificateIdentityRepository}`. Releases `< 0.75.0` resolve to `ghcr.io/ls1intum/hephaestus` and the `ls1intum/Hephaestus` signing identity forever; the final (open) entry is the current identity, whose certificate identity CI derives from the run context so a future transfer or a fork needs no edit.
- **Per-version resolution wired into every previous-release consumer**:
  - the N-1 upgrade gate: `release.yml` passes `previous-version` and `resolve-release-upgrade-images.ts` picks the previous release's own namespace from the map;
  - `rescan-release-images.yml` and `deploy-locked-compose.yml` resolve the lock's certificate identity via the new `scripts/resolve-release-identity.ts` (the `expected-signer-repository` override still wins);
  - `prepare-release-lock.ts` (host smoke + operator install) verifies with the release's identity;
  - `verify-release-evidence.ts` derives the expected first-party repository from the evidence manifest's release version.
- **purl** — the release-lock attestation predicate derives `pkg:github/<owner>/<repo>` from the run context (lowercased) instead of a hardcoded slug.
- **Changeset (`minor`, `**Operators:**`) + `.migration/` fragment** — image pull paths change for new releases; old releases stay valid at their original paths.

## Boundary verification

The map's `hephaestus-build` entry starts at `0.75.0`. Verified against the live history: the latest published release is **v0.74.0**, the root package version is **0.74.0**, and `changeset status` computes the next release as **0.74.0 → 0.75.0 (minor)**. So `0.75.0` is exactly the first release that will be cut post-transfer, and every shipped release (≤ 0.74.x) resolves to the `ls1intum` namespace and identity — asserted directly in `scripts/release-identities.test.ts`.

The first post-merge release's N-1 upgrade gate therefore pulls `ghcr.io/ls1intum/hephaestus/application-server:0.74.0`, which is untouched and public in the old organization.

`release-pin-fetcher` was deliberately not migrated; it is referenced nowhere in this branch's operational surface (no compose service, workflow, script, or `security/release-images.json` entry) — only in historical MIGRATION.md and ADR prose, which this PR leaves alone. No impact.

## Gates

- `pnpm run test:tooling` 224/224 · `check:changesets` 5/5 · `verify-changesets` on the changeset **and** `--migration` fragment pairing · `check:preview-stack` 12/12 · `check:env` 19/19
- Compose renders clean (`docker/preview/compose.app.yaml`, `server/compose.yaml`) · `docs:lint` 0 errors · `format:check` and `lint:agents` clean
- actionlint: findings set-identical to `main` (zero new) · zizmor 1.29.0 `--min-confidence medium`: no findings
- Affected server unit tests (48) green; spotless applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Changes**
  * Container images are now published under `ghcr.io/hephaestus-build/<image>`.
  * Releases before version 0.75.0 remain available under the previous image namespace.
  * Existing installation and upgrade flows continue to work without changes.

* **Documentation**
  * Added migration guidance for registry mirrors, network allowlists, pinned image references, and verification of historical releases.
  * Updated image references and release verification instructions throughout the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->