### PR TITLE
fix(release): stop SIGPIPE from killing release-notes extraction

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,12 +105,16 @@ jobs:
               echo ""
             } >> "$NOTES"
           fi
-          git show "$SHA:CHANGELOG.md" \
-            | awk -v ver="## $VERSION" '
+          # Materialise the changelog first: awk exits at the next section
+          # heading, which would SIGPIPE (exit 141) the still-writing `git show`
+          # once CHANGELOG.md outgrew the 64 KiB pipe buffer.
+          CHANGELOG_SNAPSHOT=$(mktemp)
+          git show "$SHA:CHANGELOG.md" > "$CHANGELOG_SNAPSHOT"
+          awk -v ver="## $VERSION" '
                 $0 == ver { on=1; next }
                 on && /^## / { exit }
                 on { print }
-              ' >> "$NOTES"
+              ' "$CHANGELOG_SNAPSHOT" >> "$NOTES"
           echo "----- release notes -----"; cat "$NOTES"; echo "-------------------------"
 
           if [ "$RESUME" = false ]; then


### PR DESCRIPTION
## Description

The v0.75.0 release job failed with **exit 141 (SIGPIPE)** right after logging `Cutting v0.75.0…`, before printing the release notes.

Root cause: the notes step pipes `git show "$SHA:CHANGELOG.md"` into an `awk` program that `exit`s when it reaches the next `## ` heading. `CHANGELOG.md` is now 157 KB — far past the 64 KiB pipe buffer — so `git show` is still blocked writing the remaining ~120 KB when `awk` exits, takes SIGPIPE, and `set -o pipefail` turns that into a failed step. **This blocks every release**, not just this one.

Fix: materialise the changelog into a temp file and run `awk` against the file. No writer is left holding a closed pipe, and the early `exit` still costs nothing.

Verified locally against the v0.75.0 commit: the old pipeline exits **141**, the new form exits **0**, and the extracted notes are **byte-identical** (231 lines / 34,191 bytes).

## How to test
- Re-run the Release workflow after merge: the `release` job passes the notes step and the draft release is created.

No changeset: release tooling only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release-note extraction by processing a stable snapshot of the changelog, making automated release workflows more reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->