### PR TITLE
fix(release): declare the inventory schema version the release gate requires

### DIFF
--- a/scripts/check-release-image-inventory.test.ts
+++ b/scripts/check-release-image-inventory.test.ts
@@ -9,6 +9,12 @@ await test("repository release builds are covered by the evidence inventory", ()
 	assert.deepEqual(validateInventory(inventory, workflow), []);
 });
 
+await test("the shipped inventory declares the schema version the release validator requires", () => {
+	const inventory: unknown = JSON.parse(readFileSync("security/release-images.json", "utf8"));
+	assert.ok(typeof inventory === "object" && inventory !== null && "schemaVersion" in inventory);
+	assert.equal(inventory.schemaVersion, 1);
+});
+
 await test("rejects missing and duplicate inventory entries", () => {
 	assert.deepEqual(
 		validateInventory({ images: ["server"], upstream: [] }, 'image-name: "hephaestus-build/new"'),

--- a/scripts/check-release-image-inventory.ts
+++ b/scripts/check-release-image-inventory.ts
@@ -58,6 +58,11 @@ if (import.meta.main) {
 		!Array.isArray(inventory.upstream)
 	)
 		throw new Error("malformed upstream image inventory");
+	// The release-time validator in verify-release-evidence.ts rejects an inventory
+	// without schemaVersion 1. Assert it here too, where every pull request runs:
+	// otherwise the mismatch only surfaces mid-release, after the tag is cut.
+	if (!("schemaVersion" in inventory) || inventory.schemaVersion !== 1)
+		throw new Error("release image inventory must declare schemaVersion 1");
 	const compose = [
 		"docker/compose.app.yaml",
 		"docker/compose.core.yaml",

--- a/security/release-images.json
+++ b/security/release-images.json
@@ -1,5 +1,11 @@
 {
-	"images": ["webapp", "application-server", "agent-pi", "postgres"],
+	"schemaVersion": 1,
+	"images": [
+		"webapp",
+		"application-server",
+		"agent-pi",
+		"postgres"
+	],
 	"upstream": [
 		{
 			"name": "alpine",


### PR DESCRIPTION
## Description

The v0.75.0 release cut its tag, then `tag-images` failed with **`release image inventory is malformed`**.

`scripts/verify-release-evidence.ts` (introduced in #1628) requires `schemaVersion === 1` on `security/release-images.json`, but the field was never added — and v0.75.0 is the first release since #1628 merged, so this is the first time it fired.

Worse, the gate that runs on **every pull request** (`check-release-image-inventory.ts`) validated only the `images` and `upstream` arrays and never looked at `schemaVersion` — so no PR could have caught the mismatch. Two validators disagreed about the same document, and only the release-time one was strict.

This adds the field, asserts it in the PR-time gate too, and pins the shipped file with a test.

## How to test
- `node scripts/check-release-image-inventory.ts` passes.
- `node --test scripts/check-release-image-inventory.test.ts scripts/verify-release-evidence.test.ts` — 19/19 green.
- Re-running the release gets `tag-images` past inventory validation.

No changeset: release evidence tooling only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release validation by requiring the release image inventory to declare schema version 1.
  * Added checks to catch invalid or missing inventory schema information earlier in the release process.

* **Chores**
  * Updated the release image inventory format to include its schema version without changing the listed images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->