### PR TITLE
fix(release): bind release SBOMs to the registry manifest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -276,7 +276,11 @@ jobs:
               [[ "$platform_digest" =~ ^sha256:[a-f0-9]{64}$ ]] || { echo "::error::$image $platform digest is malformed"; exit 1; }
               platform_ref="$repository@$platform_digest"
               printf '%s\t%s\t%s\t%s\t%s\t%s\n' "$image" "$platform" "$digest" "$platform_digest" "$repository" "$provenance" >> release-platforms.tsv
-              syft "$platform_ref" --scope squashed \
+              # Scan the registry artifact, never a daemon copy of it: a daemon pull
+              # re-serializes an OCI manifest as Docker schema 2, so the SBOM would
+              # record a locally computed manifestDigest instead of the released one.
+              # --platform makes Syft fail loudly if the digest is not this platform's.
+              syft --from registry "$platform_ref" --platform "$platform" --scope squashed \
                 -o "syft-json=evidence/$image-$suffix.syft.json" \
                 -o "spdx-json=evidence/$image-$suffix.spdx.json" \
                 -o "cyclonedx-json=evidence/$image-$suffix.cdx.json"

--- a/docs/contributor/release-management.mdx
+++ b/docs/contributor/release-management.mdx
@@ -75,8 +75,11 @@ clean boot; the seeded-upgrade gate separately proves the supported migration pa
 A release remains a draft until every first-party and upstream production image in
 `security/release-images.json` has passed the evidence
 gate. The gate resolves each image index and its `linux/amd64` and `linux/arm64` manifests to immutable
-digests. It generates a lossless Syft inventory plus SPDX and CycloneDX SBOMs for each deployed platform.
-The gate proves that the Syft source metadata identifies the exact digest and architecture, checks that
+digests. It generates a lossless Syft inventory plus SPDX and CycloneDX SBOMs for each deployed platform,
+scanning the registry manifest directly rather than a local Docker daemon copy, which would re-serialize
+the manifest and digest to something the release never published. The gate proves that all three documents
+name the repository, digest, and architecture of that one platform manifest — including the reference Syft
+resolved, so an index-wide scan cannot pass as per-platform evidence — checks that
 every discovered package survives both standard-format conversions, and records packages whose license
 could not be detected. It also scans each platform manifest with Trivy, signs its SPDX predicate as an OCI
 attestation, and verifies the image signature and build provenance. The SBOMs, license reports, scan

--- a/scripts/check-release-sbom.test.ts
+++ b/scripts/check-release-sbom.test.ts
@@ -2,7 +2,17 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 import { validateReleaseSbom } from "./check-release-sbom.ts";
 
-const digest = `sha256:${"a".repeat(64)}`;
+// The shapes below are the ones Syft 1.51.1 really emits for the released
+// ghcr.io/hephaestus-build/webapp image, digests and all: `--from registry` for the
+// passing fixtures, a Docker daemon pull and an index reference for the two ways an
+// SBOM can end up describing something other than the subject it is filed under.
+const repository = "ghcr.io/hephaestus-build/webapp";
+const digest = "sha256:1102d43b320b1b9c06bdfc7f9e616c068abadace9b6874dedfcf41e1f35da3f5";
+const indexDigest = "sha256:7baaa03d31d57baeb4c09f91d3579909e19b90e802e3e9afb148477edad4fe40";
+/** What the daemon re-serialization of the same artifact digests to. */
+const daemonDigest = "sha256:560d450d023441f2290fed7a93f06801bdbadae36e37d846681dd1332cbdf9c3";
+const subject = { repository, digest, platform: "linux/amd64" };
+
 const artifact = {
 	name: "example",
 	version: "1.2.3",
@@ -14,7 +24,16 @@ const artifact = {
 const syft = {
 	source: {
 		type: "image",
-		metadata: { manifestDigest: digest, os: "linux", architecture: "amd64" },
+		name: repository,
+		version: digest,
+		metadata: {
+			userInput: `${repository}@${digest}`,
+			manifestDigest: digest,
+			mediaType: "application/vnd.oci.image.manifest.v1+json",
+			os: "linux",
+			architecture: "amd64",
+			repoDigests: [`${repository}@${digest}`],
+		},
 	},
 	artifacts: [artifact],
 };
@@ -24,6 +43,12 @@ const spdx = {
 	documentNamespace: "https://example.com/sbom",
 	packages: [
 		{
+			name: repository,
+			versionInfo: digest,
+			SPDXID: "SPDXRef-DocumentRoot-Image-ghcr.io-hephaestus-build-webapp",
+			primaryPackagePurpose: "CONTAINER",
+		},
+		{
 			name: "example",
 			versionInfo: "1.2.3",
 			externalRefs: [{ referenceType: "purl", referenceLocator: artifact.purl }],
@@ -32,12 +57,20 @@ const spdx = {
 };
 const cycloneDx = {
 	bomFormat: "CycloneDX",
-	specVersion: "1.6",
+	specVersion: "1.7",
+	metadata: { component: { type: "container", name: repository, version: digest } },
 	components: [{ name: "example", version: "1.2.3", purl: artifact.purl }],
 };
 
+function withSourceMetadata(metadata: Record<string, unknown>): unknown {
+	return {
+		...syft,
+		source: { ...syft.source, metadata: { ...syft.source.metadata, ...metadata } },
+	};
+}
+
 await test("proves subject binding and lossless package conversion", () => {
-	assert.deepEqual(validateReleaseSbom(syft, spdx, cycloneDx, digest, "linux/amd64"), {
+	assert.deepEqual(validateReleaseSbom(syft, spdx, cycloneDx, subject), {
 		schemaVersion: 1,
 		digest,
 		platform: "linux/amd64",
@@ -50,17 +83,193 @@ await test("proves subject binding and lossless package conversion", () => {
 
 await test("rejects wrong subjects and packages lost during conversion", () => {
 	assert.throws(
-		() => validateReleaseSbom(syft, spdx, cycloneDx, `sha256:${"b".repeat(64)}`, "linux/amd64"),
+		() =>
+			validateReleaseSbom(syft, spdx, cycloneDx, {
+				...subject,
+				digest: `sha256:${"b".repeat(64)}`,
+			}),
 		/wrong manifest/,
 	);
 	assert.throws(
-		() => validateReleaseSbom(syft, { ...spdx, packages: [] }, cycloneDx, digest, "linux/amd64"),
-		/SPDX output omitted/,
+		() => validateReleaseSbom(syft, { ...spdx, packages: [] }, cycloneDx, subject),
+		/SPDX document must describe exactly one container/,
 	);
 	assert.throws(
-		() => validateReleaseSbom(syft, spdx, { ...cycloneDx, components: [] }, digest, "linux/amd64"),
+		() => validateReleaseSbom(syft, spdx, { ...cycloneDx, components: [] }, subject),
 		/CycloneDX output omitted/,
 	);
+	assert.throws(
+		() =>
+			validateReleaseSbom(
+				{ ...syft, artifacts: [{ ...artifact, purl: "pkg:npm/other@1.2.3" }] },
+				spdx,
+				cycloneDx,
+				subject,
+			),
+		/SPDX output omitted/,
+	);
+});
+
+await test("rejects an SBOM taken from a Docker daemon copy of the artifact", () => {
+	// The daemon re-serializes the registry's OCI manifest as Docker schema 2, so its
+	// digest is a local accident: `syft <ref>` without `--from registry` produced this
+	// and failed the v0.75.0 release. repoDigests still names the subject, so only the
+	// manifest digest can tell the copy from the artifact the release publishes.
+	assert.throws(
+		() =>
+			validateReleaseSbom(
+				withSourceMetadata({
+					manifestDigest: daemonDigest,
+					mediaType: "application/vnd.docker.distribution.manifest.v2+json",
+				}),
+				spdx,
+				cycloneDx,
+				subject,
+			),
+		/Syft SBOM is bound to the wrong manifest/,
+	);
+});
+
+await test("rejects an SBOM taken from the index instead of the platform manifest", () => {
+	// Scanning `repository@<index digest> --platform linux/amd64` reports this
+	// platform's manifestDigest, so only the resolved reference distinguishes it.
+	assert.throws(
+		() =>
+			validateReleaseSbom(
+				withSourceMetadata({
+					userInput: `${repository}@${indexDigest}`,
+					repoDigests: [`${repository}@${indexDigest}`],
+				}),
+				spdx,
+				cycloneDx,
+				subject,
+			),
+		new RegExp(`Syft SBOM was not resolved from ${repository}@${digest}`),
+	);
+	assert.throws(
+		() =>
+			validateReleaseSbom(
+				withSourceMetadata({
+					repoDigests: [`${repository}@${digest}`, `${repository}@${indexDigest}`],
+				}),
+				spdx,
+				cycloneDx,
+				subject,
+			),
+		/also resolves a digest the subject does not name/,
+	);
+	assert.throws(
+		() => validateReleaseSbom(withSourceMetadata({ repoDigests: [] }), spdx, cycloneDx, subject),
+		/Syft SBOM was not resolved from/,
+	);
+});
+
+await test("rejects an index, which describes more than one artifact", () => {
+	assert.throws(
+		() =>
+			validateReleaseSbom(
+				withSourceMetadata({ mediaType: "application/vnd.oci.image.index.v1+json" }),
+				spdx,
+				cycloneDx,
+				subject,
+			),
+		/does not describe a single-platform image manifest/,
+	);
+});
+
+await test("rejects an SBOM for the same image in another namespace", () => {
+	// The pre-transfer namespace still serves a webapp image (issue #1599).
+	const previous = "ghcr.io/ls1intum/hephaestus/webapp";
+	assert.throws(
+		() =>
+			validateReleaseSbom(
+				{ ...syft, source: { ...syft.source, name: previous } },
+				spdx,
+				cycloneDx,
+				subject,
+			),
+		/Syft SBOM is bound to the wrong repository/,
+	);
+	assert.throws(
+		() => validateReleaseSbom(syft, spdx, cycloneDx, { ...subject, repository: previous }),
+		/Syft SBOM is bound to the wrong repository/,
+	);
+});
+
+await test("rejects an SBOM for another platform of the same image", () => {
+	assert.throws(
+		() =>
+			validateReleaseSbom(withSourceMetadata({ architecture: "arm64" }), spdx, cycloneDx, subject),
+		/Syft SBOM is bound to the wrong platform/,
+	);
+	assert.throws(
+		() => validateReleaseSbom(syft, spdx, cycloneDx, { ...subject, platform: "windows/amd64" }),
+		/platform must be linux/,
+	);
+});
+
+await test("rejects SPDX and CycloneDX renderings of a different artifact", () => {
+	const other = `sha256:${"c".repeat(64)}`;
+	assert.throws(
+		() =>
+			validateReleaseSbom(
+				syft,
+				{ ...spdx, packages: [{ ...spdx.packages[0], versionInfo: other }, spdx.packages[1]] },
+				cycloneDx,
+				subject,
+			),
+		new RegExp(`SPDX document is not bound to ${repository}@${digest}`),
+	);
+	assert.throws(
+		() =>
+			validateReleaseSbom(
+				syft,
+				spdx,
+				{
+					...cycloneDx,
+					metadata: { component: { type: "container", name: repository, version: other } },
+				},
+				subject,
+			),
+		new RegExp(`CycloneDX document is not bound to ${repository}@${digest}`),
+	);
+	assert.throws(
+		() => validateReleaseSbom(syft, spdx, { ...cycloneDx, metadata: {} }, subject),
+		/CycloneDX metadata component must be an object/,
+	);
+});
+
+await test("accepts Docker Hub's index.docker.io form of an upstream repository", () => {
+	// Syft normalizes docker.io to index.docker.io; the release inventory does not.
+	const upstream = "docker.io/library/alpine";
+	const alpineDigest = "sha256:79ff19e9084a00eece421b2523fb93e22d730e2c0e525905de047e848e56d95f";
+	const result = validateReleaseSbom(
+		{
+			...syft,
+			source: {
+				...syft.source,
+				name: upstream,
+				metadata: {
+					...syft.source.metadata,
+					manifestDigest: alpineDigest,
+					repoDigests: [`index.docker.io/library/alpine@${alpineDigest}`],
+				},
+			},
+		},
+		{
+			...spdx,
+			packages: [
+				{ ...spdx.packages[0], name: upstream, versionInfo: alpineDigest },
+				spdx.packages[1],
+			],
+		},
+		{
+			...cycloneDx,
+			metadata: { component: { type: "container", name: upstream, version: alpineDigest } },
+		},
+		{ repository: upstream, digest: alpineDigest, platform: "linux/amd64" },
+	);
+	assert.equal(result.digest, alpineDigest);
 });
 
 await test("records unknown licenses instead of pretending they are known", () => {
@@ -68,8 +277,7 @@ await test("records unknown licenses instead of pretending they are known", () =
 		{ ...syft, artifacts: [{ ...artifact, licenses: [] }] },
 		spdx,
 		cycloneDx,
-		digest,
-		"linux/amd64",
+		subject,
 	);
 	assert.equal(result.packagesWithLicense, 0);
 	assert.deepEqual(result.packagesWithoutLicense, [{ name: "example", version: "1.2.3" }]);

--- a/scripts/check-release-sbom.ts
+++ b/scripts/check-release-sbom.ts
@@ -31,25 +31,69 @@ function purl(value: unknown): string | undefined {
 	return typeof item.purl === "string" && item.purl.length > 0 ? item.purl : undefined;
 }
 
+/**
+ * The media types of a *single* image manifest. An index (`…image.index.v1+json`,
+ * `…manifest.list.v2+json`) describes several artifacts at once, so it can never be
+ * the subject of a per-platform SBOM. Both single-manifest types stay valid: the
+ * release publishes OCI manifests, upstream registries may still serve schema 2.
+ */
+const manifestMediaTypes = new Set([
+	"application/vnd.oci.image.manifest.v1+json",
+	"application/vnd.docker.distribution.manifest.v2+json",
+]);
+
+/** Syft normalizes Docker Hub to `index.docker.io`; the inventory says `docker.io`. */
+function canonicalRepository(repository: string): string {
+	return repository.startsWith("index.docker.io/")
+		? `docker.io/${repository.slice("index.docker.io/".length)}`
+		: repository;
+}
+
+/** The subject an SBOM triple must describe: one image, one platform, one digest. */
+export type ReleaseSbomSubject = {
+	repository: string;
+	digest: string;
+	platform: string;
+};
+
 export function validateReleaseSbom(
 	syftInput: unknown,
 	spdxInput: unknown,
 	cycloneDxInput: unknown,
-	digest: string,
-	platform: string,
+	subject: ReleaseSbomSubject,
 ): JsonObject {
+	const { digest, platform } = subject;
 	if (!/^sha256:[a-f0-9]{64}$/.test(digest)) throw new Error("subject digest is malformed");
 	const [os, architecture] = platform.split("/");
 	if (os !== "linux" || !architecture) throw new Error("platform must be linux/<architecture>");
+	const repository = canonicalRepository(text(subject.repository, "subject repository"));
+	const reference = `${repository}@${digest}`;
 
 	const syft = object(syftInput, "Syft SBOM");
 	const source = object(syft.source, "Syft source");
 	const metadata = object(source.metadata, "Syft source metadata");
 	if (source.type !== "image") throw new Error("Syft source is not an image");
+	if (canonicalRepository(text(source.name, "Syft source name")) !== repository)
+		throw new Error("Syft SBOM is bound to the wrong repository");
+	if (!manifestMediaTypes.has(text(metadata.mediaType, "Syft source media type")))
+		throw new Error("Syft SBOM does not describe a single-platform image manifest");
+	// Only a registry scan digests the manifest the registry serves. Pulled through a
+	// Docker daemon the same artifact is re-serialized as a schema-2 manifest whose
+	// digest is a local accident, so the release scans with `syft --from registry`.
 	if (metadata.manifestDigest !== digest)
 		throw new Error("Syft SBOM is bound to the wrong manifest");
 	if (metadata.os !== os || metadata.architecture !== architecture)
 		throw new Error("Syft SBOM is bound to the wrong platform");
+	// `manifestDigest` alone cannot tell a scan of `repository@<index digest>` — which
+	// resolves to this platform's manifest — from a scan of the platform digest the
+	// release records. `repoDigests` carries the reference Syft actually resolved.
+	const repoDigests = array(metadata.repoDigests, "Syft source repository digests").map(
+		(value, index) => canonicalRepository(text(value, `Syft repository digest ${index}`)),
+	);
+	if (!repoDigests.includes(reference))
+		throw new Error(`Syft SBOM was not resolved from ${reference}`);
+	if (!repoDigests.every((entry) => entry.endsWith(`@${digest}`)))
+		throw new Error("Syft SBOM also resolves a digest the subject does not name");
 
 	const artifacts = array(syft.artifacts, "Syft artifacts");
 	if (artifacts.length === 0) throw new Error("Syft SBOM contains no packages");
@@ -76,8 +120,10 @@ export function validateReleaseSbom(
 	text(spdx.documentNamespace, "SPDX document namespace");
 	const spdxPurls = new Set<string>();
 	const spdxKeys = new Set<string>();
+	const spdxContainers: JsonObject[] = [];
 	for (const [index, value] of array(spdx.packages, "SPDX packages").entries()) {
 		const item = object(value, `SPDX package ${index}`);
+		if (item.primaryPackagePurpose === "CONTAINER") spdxContainers.push(item);
 		if (typeof item.name === "string" && typeof item.versionInfo === "string")
 			spdxKeys.add(`${item.name}\u0000${item.versionInfo}`);
 		for (const ref of Array.isArray(item.externalRefs) ? item.externalRefs : []) {
@@ -87,9 +133,30 @@ export function validateReleaseSbom(
 		}
 	}
 
+	// Package parity alone would accept an SPDX rendering of a *different* image that
+	// installs the same packages, so bind each document to the subject as well.
+	const [spdxContainer, ...spdxExtraContainers] = spdxContainers;
+	if (!spdxContainer || spdxExtraContainers.length > 0)
+		throw new Error("SPDX document must describe exactly one container");
+	if (
+		canonicalRepository(text(spdxContainer.name, "SPDX container name")) !== repository ||
+		spdxContainer.versionInfo !== digest
+	)
+		throw new Error(`SPDX document is not bound to ${reference}`);
+
 	const cycloneDx = object(cycloneDxInput, "CycloneDX SBOM");
 	if (cycloneDx.bomFormat !== "CycloneDX") throw new Error("invalid CycloneDX format");
 	text(cycloneDx.specVersion, "CycloneDX spec version");
+	const cycloneSubject = object(
+		object(cycloneDx.metadata, "CycloneDX metadata").component,
+		"CycloneDX metadata component",
+	);
+	if (
+		cycloneSubject.type !== "container" ||
+		canonicalRepository(text(cycloneSubject.name, "CycloneDX component name")) !== repository ||
+		cycloneSubject.version !== digest
+	)
+		throw new Error(`CycloneDX document is not bound to ${reference}`);
 	const cyclonePurls = new Set<string>();
 	const cycloneKeys = new Set<string>();
 	for (const [index, value] of array(cycloneDx.components, "CycloneDX components").entries()) {
@@ -122,14 +189,23 @@ export function validateReleaseSbom(
 }
 
 if (import.meta.main) {
-	const [syftPath, spdxPath, cycloneDxPath, digest, platform, outputPath] = process.argv.slice(2);
-	if (!syftPath || !spdxPath || !cycloneDxPath || !digest || !platform || !outputPath)
+	const [syftPath, spdxPath, cycloneDxPath, repository, digest, platform, outputPath] =
+		process.argv.slice(2);
+	if (
+		!syftPath ||
+		!spdxPath ||
+		!cycloneDxPath ||
+		!repository ||
+		!digest ||
+		!platform ||
+		!outputPath
+	)
 		throw new Error(
-			"usage: check-release-sbom <syft> <spdx> <cyclonedx> <digest> <platform> <output>",
+			"usage: check-release-sbom <syft> <spdx> <cyclonedx> <repository> <digest> <platform> <output>",
 		);
 	const readJson = (path: string): unknown => JSON.parse(readFileSync(path, "utf8")) as unknown;
 	writeFileSync(
 		outputPath,
-		`${JSON.stringify(validateReleaseSbom(readJson(syftPath), readJson(spdxPath), readJson(cycloneDxPath), digest, platform), null, 2)}\n`,
+		`${JSON.stringify(validateReleaseSbom(readJson(syftPath), readJson(spdxPath), readJson(cycloneDxPath), { repository, digest, platform }), null, 2)}\n`,
 	);
 }

--- a/scripts/verify-release-evidence.ts
+++ b/scripts/verify-release-evidence.ts
@@ -221,8 +221,7 @@ export function verifyReleaseEvidence(
 			readJson(`${prefix}.syft.json`),
 			readJson(`${prefix}.spdx.json`),
 			readJson(`${prefix}.cdx.json`),
-			subject.digest,
-			subject.platform,
+			subject,
 		);
 		persistOrVerify(`${prefix}.sbom-validation.json`, sbom, mode === "write-validation");
 		const reference = `${subject.repository}@${subject.digest}`;


### PR DESCRIPTION
## Description

The `tag-images` job of the v0.75.0 release failed with `Error: Syft SBOM is bound to the wrong manifest` ([run 33460195559](https://github.com/hephaestus-build/Hephaestus/actions/runs/33460195559)). The release generated its SBOMs through a Docker daemon copy of each image instead of the registry artifact, so every SBOM recorded a manifest digest the release never published. This scans the registry manifest directly and tightens the binding the evidence gate enforces.

### Root cause

`syft "$platform_ref"` passes no source, so Syft resolves the reference through the local Docker daemon, which pulls the image and re-serializes the registry's OCI manifest as a Docker schema-2 manifest. `source.metadata.manifestDigest` is then the digest of *that* local re-serialization. Reproduced with the pinned Syft 1.51.1 against the released `ghcr.io/hephaestus-build/webapp` image, `linux/amd64` manifest `sha256:1102d43b320b1b9c06bdfc7f9e616c068abadace9b6874dedfcf41e1f35da3f5`:

| Invocation | `manifestDigest` | `mediaType` | `os`/`architecture` |
|---|---|---|---|
| `syft <ref>` (daemon, what the release ran) | `sha256:560d450d0234…` ❌ | `…docker.distribution.manifest.v2+json` | `linux`/`amd64` |
| `syft --from registry <ref>` | `sha256:1102d43b320b…` ✅ | `…oci.image.manifest.v1+json` | empty ❌ |
| `syft --from registry <ref> --platform linux/amd64` | `sha256:1102d43b320b…` ✅ | `…oci.image.manifest.v1+json` | `linux`/`amd64` ✅ |

So it was neither an index-vs-platform digest mix-up nor the namespace change: the workflow passed the right digest, and Syft answered for a different artifact. The gate has never run against a real release before — it landed in #1553 (2026-08-28), five days after v0.74.0 — which is why this surfaced now.

Two related facts the investigation turned up, both now covered:

- `--from registry` alone leaves `os`/`architecture` empty, which would have tripped the platform assertion; `--platform` fills them and makes Syft exit 1 when the digest is not that platform's, so a mixed-up digest can no longer produce evidence at all.
- Scanning `repository@<index digest> --platform linux/amd64` reports the **platform** manifest digest, so the old assertion would have accepted index-wide evidence as per-platform evidence. `source.metadata.repoDigests` is what distinguishes the two.

### Fix

`.github/workflows/release.yml` — generate evidence with `syft --from registry "$platform_ref" --platform "$platform"`. The workflow already logs in to GHCR, so Syft authenticates through the Docker keychain; upstream Docker Hub images stay anonymous as before. Trivy is unchanged.

`scripts/check-release-sbom.ts` — the check is strengthened, not relaxed. On top of `manifestDigest === digest` and the platform assertion, an SBOM triple must now:

- name the subject repository (`source.name`), which pins evidence to the post-transfer namespace (issue #1599);
- describe a **single-platform** manifest, never an index media type;
- have been resolved from `<repository>@<digest>` (`repoDigests`), with no entry pinning another digest — this closes the index-scan hole above;
- carry SPDX and CycloneDX documents naming that same repository and digest (`SPDXRef-DocumentRoot-Image-*` / `metadata.component`). Package parity alone would have accepted a rendering of a different image that installs the same packages.

`docker.io` ↔ `index.docker.io` is normalized because Syft reports Docker Hub in the latter form while `security/release-images.json` uses the former.

## How to test

Unit tests use the exact shapes observed above, including the daemon digest, the index digest, and the Docker Hub normalization: `pnpm run test:tooling`.

End-to-end against the real released images, using the pinned Syft 1.51.1 and the new validator (private harness, both platforms):

- `ghcr.io/hephaestus-build/webapp` `linux/amd64` (75 packages) and `linux/arm64` — pass
- `ghcr.io/hephaestus-build/agent-pi` `linux/amd64` (269 packages, apk + npm) — pass
- `docker.io/library/alpine` upstream subject — pass
- the daemon-sourced SBOM that failed the release — still rejected, `Syft SBOM is bound to the wrong manifest`
- an index-sourced SBOM — now rejected, `Syft SBOM was not resolved from …@sha256:1102d43b…` (it passed the old check)
- arm64 evidence filed under the amd64 subject — rejected

No release workflow was triggered; v0.75.0 stays deferred.

Gates run: `pnpm run format`, `pnpm run check:agents` (lint, both typechecks, 235 tooling tests), `pnpm run check:changesets`, `pnpm run docs:lint`, actionlint 1.7.7 with `SHELLCHECK_OPTS=--severity=warning`, zizmor 1.29.0 at medium confidence — all clean. The Java leg of `pnpm run check` was skipped: no server code is touched.

No changeset: this changes release tooling only, not shipped code.

## Checklist

- [x] My changeset summary reads as an operator/user-facing note (it becomes the changelog entry) — see `.changeset/README.md`
- [x] If operators must act, the changeset and migration entry give actionable upgrade instructions
- [x] I did not commit generated-artifact changes that this PR did not cause
