### PR TITLE
fix(ci): report an awaiting review as pending, not failed

### DIFF
--- a/.github/workflows/review-policy.yml
+++ b/.github/workflows/review-policy.yml
@@ -11,7 +11,7 @@ on:
 permissions: {}
 
 concurrency:
-  # Never cancel: the runs in a group are serialised, so the newest event's verdict is the one that
+  # Never cancel: runs in a group are serialised, so the newest event's verdict is the one that
   # lands, and a cancelled run publishes nothing rather than a half-written state.
   group: review-policy-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: false
@@ -33,10 +33,35 @@ jobs:
       contents: read
       pull-requests: read
     steps:
+      # The queue re-reports every required context against the projected commit, and the policy was
+      # already decided on the pull request that entered the queue. Written out here rather than
+      # routed through the evaluator so the queue's path needs no checkout and no import: a merge
+      # group that never receives this context sits until the queue's timeout drops it.
+      - name: Pass the merge group
+        if: github.event_name == 'merge_group'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            await github.rest.checks.create({
+              ...context.repo,
+              // Kept equal to CHECK_NAME in scripts/review-policy.ts; a test asserts they agree.
+              name: 'review-policy',
+              head_sha: context.payload.merge_group.head_sha,
+              status: 'completed',
+              conclusion: 'success',
+              output: {
+                title: 'Satisfied before this merge group was created',
+                summary:
+                  'The review policy is decided on the pull request; entering the merge queue ' +
+                  'already required it to pass.',
+              },
+            });
+
       # The default branch, never `github.sha`: that is the pull request's merge commit on
-      # `pull_request_review` and the queued commit on `merge_group`, both of which contain
-      # pull-request code. The base branch's copy of the policy is the authoritative one.
+      # `pull_request_review`, which contains pull-request code. The base branch's copy of the
+      # policy is the authoritative one.
       - name: Load the trusted policy evaluator
+        if: github.event_name != 'merge_group'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.repository.default_branch }}
@@ -44,6 +69,7 @@ jobs:
           sparse-checkout: scripts
 
       - name: Publish the review-policy check run
+        if: github.event_name != 'merge_group'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           MAINTAINERS: ${{ vars.REVIEW_POLICY_MAINTAINERS }}

--- a/.github/workflows/review-policy.yml
+++ b/.github/workflows/review-policy.yml
@@ -11,81 +11,43 @@ on:
 permissions: {}
 
 concurrency:
+  # Never cancel: the runs in a group are serialised, so the newest event's verdict is the one that
+  # lands, and a cancelled run publishes nothing rather than a half-written state.
   group: review-policy-${{ github.event.pull_request.number || github.ref }}
-  # Never cancel: a cancelled check run on the required `review-policy` context is evaluated
-  # by the ruleset as the context's state and silently blocks merge-queue entry (observed on
-  # PRs #1655/#1664, 2026-08-31). The job takes seconds; queueing duplicates is cheap.
   cancel-in-progress: false
 
 jobs:
-  review-policy:
-    name: review-policy
+  # This job is *not* the required context. It publishes one — a check run named `review-policy`,
+  # which the `main` ruleset requires and binds to the GitHub Actions integration that a
+  # `GITHUB_TOKEN`-authenticated check run is attributed to. Reporting the verdict separately is
+  # what lets an unreviewed pull request sit pending instead of red: a job can only pass or fail,
+  # and a failing job made a healthy pull request awaiting its first review look broken on the pull
+  # request list. Renaming this job back to `review-policy` would put two check runs of that name
+  # on the same commit and make which one the ruleset reads a race.
+  publish:
+    name: Publish review-policy status
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
+      checks: write
       contents: read
       pull-requests: read
     steps:
-      - name: Enforce review policy
+      # The default branch, never `github.sha`: that is the pull request's merge commit on
+      # `pull_request_review` and the queued commit on `merge_group`, both of which contain
+      # pull-request code. The base branch's copy of the policy is the authoritative one.
+      - name: Load the trusted policy evaluator
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+          sparse-checkout: scripts
+
+      - name: Publish the review-policy check run
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           MAINTAINERS: ${{ vars.REVIEW_POLICY_MAINTAINERS }}
         with:
           script: |
-            if (context.eventName === 'merge_group') {
-              return;
-            }
-
-            const { data: pull } = await github.rest.pulls.get({
-              ...context.repo,
-              pull_number: context.payload.pull_request.number,
-            });
-            // pull_request_review supports no base-branch filter, so guard here: the
-            // policy applies to pull requests that target main only.
-            if (pull.base.ref !== 'main') {
-              core.info(`The review policy does not apply to base branch ${pull.base.ref}.`);
-              return;
-            }
-            const author = pull.user.login.toLowerCase();
-            const maintainers = new Set(
-              (process.env.MAINTAINERS || '')
-                .split(',')
-                .map((login) => login.trim().toLowerCase())
-                .filter(Boolean),
-            );
-            if (maintainers.has(author)) {
-              core.info(`${pull.user.login} is in REVIEW_POLICY_MAINTAINERS.`);
-              return;
-            }
-
-            const reviews = await github.paginate(github.rest.pulls.listReviews, {
-              ...context.repo,
-              pull_number: pull.number,
-              per_page: 100,
-            });
-            const latestByReviewer = new Map();
-            for (const review of reviews.sort((left, right) => left.id - right.id)) {
-              if (
-                review.user &&
-                review.user.login.toLowerCase() !== author &&
-                ['APPROVED', 'CHANGES_REQUESTED', 'DISMISSED'].includes(review.state)
-              ) {
-                latestByReviewer.set(review.user.login.toLowerCase(), review);
-              }
-            }
-
-            for (const [login, review] of latestByReviewer) {
-              if (review.state !== 'APPROVED' || review.commit_id !== pull.head.sha) continue;
-              const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
-                ...context.repo,
-                username: login,
-              });
-              if (['admin', 'maintain', 'write'].includes(data.permission)) {
-                core.info(`Approved by ${login}, who has ${data.permission} access.`);
-                return;
-              }
-            }
-
-            core.setFailed(
-              'This contributor pull request needs an approving review from a non-author with write access.',
-            );
+            const policy = await import(`${process.env.GITHUB_WORKSPACE}/scripts/review-policy.ts`);
+            await policy.enforce({ github, context, core });

--- a/docs/contributor/ci-cd.mdx
+++ b/docs/contributor/ci-cd.mdx
@@ -77,6 +77,25 @@ has write access; the approval must cover the current head commit. Repository ad
 allow-list. Native required approvals remain zero because GitHub cannot combine an author's
 self-authored change, a mandatory approval, and the merge queue without bypassing the queue.
 
+`review-policy` is a check run the workflow publishes, not the workflow's own job status — the job
+is `Publish review-policy status` and always succeeds. A job can only pass or fail, so while an
+approval was outstanding the required context was red, and a pull request that was healthy and
+simply waiting for its first review read as broken on the pull request list. The verdict now takes
+three shapes, decided by [`scripts/review-policy.ts`](https://github.com/ls1intum/Hephaestus/blob/main/scripts/review-policy.ts):
+
+| Verdict | Check run | Reads as |
+| --- | --- | --- |
+| Waiting for an approval | `in_progress`, no conclusion | Pending — blocks merge and merge-queue entry |
+| Author allow-listed, or approved by a non-author with write access | `success` | Green, naming who satisfied it |
+| `REVIEW_POLICY_MAINTAINERS` unset, or the policy could not be evaluated | `failure` | Red, because that is broken |
+
+A pending required context blocks merging and blocks entry to the merge queue exactly as a failing
+one does, so the enforcement is unchanged. `neutral` and `skipped` are not options: GitHub counts
+both as passing a required check.
+
+Renaming the check run means editing the ruleset's required context in the same change. A mismatch
+leaves every pull request waiting on a context nothing reports, which blocks the fix too.
+
 The changesets Version PR is the temporary exception: updates made with `GITHUB_TOKEN` do not trigger
 the required workflows, so release automation uses the ruleset bypass. The release workflow still
 requires successful CI on the resulting `main` commit before it publishes anything. Move the Version
@@ -198,7 +217,7 @@ why the label is the authority, and which alternatives were priced and declined,
 | Workflow               | Trigger               | Purpose                                            |
 | ---------------------- | --------------------- | -------------------------------------------------- |
 | `cicd.yml`             | Push to main, PRs, merge queue | Orchestrator: change detection + workflow dispatch |
-| `review-policy.yml`    | PR and review events, merge queue | Enforces author allow-list or current-head write-access approval |
+| `review-policy.yml`    | PR and review events, merge queue | Publishes the `review-policy` check run: author allow-list, or current-head write-access approval |
 | `ci-quality-gates.yml` | Called by cicd.yml    | Code quality, formatting, schema validation        |
 | `ci-tests.yml`         | Called by cicd.yml    | Unit, integration, visual tests                    |
 | `ci-docker-build.yml`  | Called by cicd.yml    | Docker image builds per component                  |

--- a/docs/contributor/ci-cd.mdx
+++ b/docs/contributor/ci-cd.mdx
@@ -93,6 +93,11 @@ A pending required context blocks merging and blocks entry to the merge queue ex
 one does, so the enforcement is unchanged. `neutral` and `skipped` are not options: GitHub counts
 both as passing a required check.
 
+The merge queue's own pass is written into the workflow rather than routed through the evaluator, so
+that path needs no checkout: on `merge_group` the workflow comes from the queued commit while a
+checkout would come from the default branch, and a merge group that never receives the context sits
+until the queue's timeout drops it.
+
 Renaming the check run means editing the ruleset's required context in the same change. A mismatch
 leaves every pull request waiting on a context nothing reports, which blocks the fix too.
 

--- a/scripts/review-policy.test.ts
+++ b/scripts/review-policy.test.ts
@@ -1,0 +1,332 @@
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, describe, it } from "node:test";
+
+import {
+	CHECK_NAME,
+	currentApprovers,
+	decide,
+	enforce,
+	type ActionsContext,
+	type CheckRunRequest,
+	type GitHubApi,
+	type PullRequest,
+	type Review,
+	parseMaintainers,
+} from "./review-policy.ts";
+
+const originalEnvironment = { ...process.env };
+
+const HEAD = "0123456789abcdef0123456789abcdef01234567";
+const OTHER = "fedcba9876543210fedcba9876543210fedcba98";
+
+const review = (over: Partial<Review> & Pick<Review, "id">): Review => ({
+	state: "APPROVED",
+	commit_id: HEAD,
+	user: { login: "reviewer" },
+	...over,
+});
+
+const pull: PullRequest = {
+	number: 7,
+	base: { ref: "main" },
+	head: { sha: HEAD },
+	user: { login: "Contributor" },
+};
+
+const makeCore = () => {
+	const infos: string[] = [];
+	const failures: string[] = [];
+	return {
+		infos,
+		failures,
+		info: (message: string) => infos.push(message),
+		setFailed: (message: string) => failures.push(message),
+	};
+};
+
+interface GitHubOptions {
+	readonly resolvedPull?: PullRequest;
+	readonly reviews?: readonly Review[];
+	readonly permissions?: Readonly<Record<string, string>>;
+	readonly failPullWith?: Error;
+}
+
+const makeGitHub = (options: GitHubOptions = {}) => {
+	const created: CheckRunRequest[] = [];
+	const reviews = [...(options.reviews ?? [])];
+	const getPull = () =>
+		options.failPullWith
+			? Promise.reject(options.failPullWith)
+			: Promise.resolve({ data: options.resolvedPull ?? pull });
+
+	const github: GitHubApi = {
+		paginate: () => Promise.resolve(reviews),
+		rest: {
+			checks: {
+				create: (params) => {
+					created.push(params);
+					return Promise.resolve({ data: { id: created.length } });
+				},
+			},
+			pulls: {
+				get: getPull,
+				listReviews: () => Promise.resolve({ data: reviews }),
+			},
+			repos: {
+				getCollaboratorPermissionLevel: (params) =>
+					Promise.resolve({
+						data: { permission: options.permissions?.[String(params.username)] ?? "read" },
+					}),
+			},
+		},
+	};
+	return { created, github };
+};
+
+/** The single check run a run under test is expected to have published. */
+const onlyRun = (created: readonly CheckRunRequest[]): CheckRunRequest => {
+	assert.equal(created.length, 1);
+	const [run] = created;
+	assert.ok(run);
+	return run;
+};
+
+const context: ActionsContext = {
+	eventName: "pull_request_target",
+	repo: { owner: "owner", repo: "repo" },
+	payload: { pull_request: { number: 7, head: { sha: HEAD } } },
+};
+
+void describe("review policy", () => {
+	beforeEach(() => {
+		process.env.MAINTAINERS = "Maintainer";
+		delete process.env.GITHUB_RUN_ID;
+	});
+
+	afterEach(() => {
+		process.env = { ...originalEnvironment };
+	});
+
+	void describe("parseMaintainers", () => {
+		void it("splits, trims, lowercases and drops blanks", () => {
+			assert.deepEqual([...parseMaintainers(" One, tWo ,, three,")], ["one", "two", "three"]);
+		});
+
+		void it("treats an unset variable as an empty allow-list", () => {
+			assert.equal(parseMaintainers(undefined).size, 0);
+			assert.equal(parseMaintainers("  ,  ").size, 0);
+		});
+	});
+
+	void describe("currentApprovers", () => {
+		void it("accepts an approval of the head commit from a non-author", () => {
+			assert.deepEqual(currentApprovers([review({ id: 1 })], "contributor", HEAD), ["reviewer"]);
+		});
+
+		void it("ignores the author's own approval", () => {
+			const own = review({ id: 1, user: { login: "Contributor" } });
+			assert.deepEqual(currentApprovers([own], "contributor", HEAD), []);
+		});
+
+		void it("ignores an approval of an earlier commit", () => {
+			const stale = [review({ id: 1, commit_id: OTHER })];
+			assert.deepEqual(currentApprovers(stale, "contributor", HEAD), []);
+		});
+
+		void it("keeps only a reviewer's latest decisive review", () => {
+			const reviews = [
+				review({ id: 1 }),
+				review({ id: 2, state: "CHANGES_REQUESTED" }),
+				review({ id: 9, state: "COMMENTED" }),
+			];
+			assert.deepEqual(currentApprovers(reviews, "contributor", HEAD), []);
+		});
+
+		void it("lets a later approval replace requested changes, whatever order they arrive in", () => {
+			const reviews = [review({ id: 5 }), review({ id: 2, state: "CHANGES_REQUESTED" })];
+			assert.deepEqual(currentApprovers(reviews, "contributor", HEAD), ["reviewer"]);
+		});
+
+		void it("treats a dismissed approval as no longer standing", () => {
+			const reviews = [review({ id: 1 }), review({ id: 2, state: "DISMISSED" })];
+			assert.deepEqual(currentApprovers(reviews, "contributor", HEAD), []);
+		});
+
+		void it("survives a review whose author is gone", () => {
+			assert.deepEqual(currentApprovers([review({ id: 1, user: null })], "contributor", HEAD), []);
+		});
+	});
+
+	void describe("decide", () => {
+		const base = {
+			author: "Contributor",
+			headSha: HEAD,
+			reviews: [] as readonly Review[],
+			permissionOf: () => Promise.resolve("read"),
+		};
+
+		void it("passes a listed maintainer without any approval", async () => {
+			const verdict = await decide({
+				...base,
+				author: "MaIntAiner",
+				maintainers: new Set(["maintainer"]),
+			});
+			assert.equal(verdict.kind, "satisfied");
+			assert.match(verdict.title, /is a listed maintainer/);
+		});
+
+		void it("passes an approval from a non-author with write access", async () => {
+			const verdict = await decide({
+				...base,
+				maintainers: new Set(["maintainer"]),
+				reviews: [review({ id: 1 })],
+				permissionOf: () => Promise.resolve("write"),
+			});
+			assert.equal(verdict.kind, "satisfied");
+			assert.equal(verdict.title, "Approved by @reviewer");
+		});
+
+		void it("accepts admin and maintain access too", async () => {
+			for (const permission of ["admin", "maintain"]) {
+				const verdict = await decide({
+					...base,
+					maintainers: new Set(["maintainer"]),
+					reviews: [review({ id: 1 })],
+					permissionOf: () => Promise.resolve(permission),
+				});
+				assert.equal(verdict.kind, "satisfied", permission);
+			}
+		});
+
+		void it("waits when the only approver lacks write access", async () => {
+			const verdict = await decide({
+				...base,
+				maintainers: new Set(["maintainer"]),
+				reviews: [review({ id: 1 })],
+			});
+			assert.equal(verdict.kind, "waiting");
+			assert.equal(verdict.title, "Waiting for a maintainer approval");
+		});
+
+		void it("tells the reader what unblocks the pull request", async () => {
+			const verdict = await decide({ ...base, maintainers: new Set(["maintainer"]) });
+			assert.match(verdict.summary, /waiting, not broken/);
+			assert.match(verdict.summary, /other than the author/);
+			assert.match(verdict.summary, /0123456/);
+		});
+
+		void it("reports an empty allow-list as a misconfiguration, not as waiting", async () => {
+			const verdict = await decide({ ...base, maintainers: new Set() });
+			assert.equal(verdict.kind, "misconfigured");
+			assert.match(verdict.title, /REVIEW_POLICY_MAINTAINERS/);
+		});
+
+		void it("still passes a valid approval when the allow-list is empty", async () => {
+			const verdict = await decide({
+				...base,
+				maintainers: new Set(),
+				reviews: [review({ id: 1 })],
+				permissionOf: () => Promise.resolve("write"),
+			});
+			assert.equal(verdict.kind, "satisfied");
+		});
+	});
+
+	void describe("enforce", () => {
+		void it("publishes a pending check run while an approval is outstanding", async () => {
+			const { created, github } = makeGitHub();
+			const core = makeCore();
+			await enforce({ github, context, core });
+
+			const run = onlyRun(created);
+			assert.equal(run.name, CHECK_NAME);
+			assert.equal(run.head_sha, HEAD);
+			// Pending blocks the merge button and merge-queue entry. `neutral` and `skipped` are
+			// documented as passing, so neither may ever stand in for waiting.
+			assert.equal(run.status, "in_progress");
+			assert.equal(run.conclusion, undefined);
+			assert.deepEqual(core.failures, []);
+		});
+
+		void it("publishes success once a write-access reviewer has approved the head commit", async () => {
+			const { created, github } = makeGitHub({
+				reviews: [review({ id: 1 })],
+				permissions: { reviewer: "write" },
+			});
+			const core = makeCore();
+			await enforce({ github, context, core });
+
+			const run = onlyRun(created);
+			assert.equal(run.status, "completed");
+			assert.equal(run.conclusion, "success");
+			assert.deepEqual(core.failures, []);
+		});
+
+		void it("passes trivially on a merge group without reading the pull request", async () => {
+			const { created, github } = makeGitHub({ failPullWith: new Error("must not be called") });
+			const core = makeCore();
+			await enforce({
+				github,
+				core,
+				context: {
+					eventName: "merge_group",
+					repo: context.repo,
+					payload: { merge_group: { head_sha: OTHER } },
+				},
+			});
+
+			const run = onlyRun(created);
+			assert.equal(run.head_sha, OTHER);
+			assert.equal(run.conclusion, "success");
+			assert.deepEqual(core.failures, []);
+		});
+
+		void it("stays out of the way of a pull request that does not target main", async () => {
+			const { created, github } = makeGitHub({
+				resolvedPull: { ...pull, base: { ref: "release" } },
+			});
+			const core = makeCore();
+			await enforce({ github, context, core });
+
+			const run = onlyRun(created);
+			assert.equal(run.conclusion, "success");
+			assert.match(run.output.title, /release/);
+		});
+
+		void it("reports an evaluation that could not run in red, and fails the job", async () => {
+			const { created, github } = makeGitHub({ failPullWith: new Error("API is down") });
+			const core = makeCore();
+			await enforce({ github, context, core });
+
+			const run = onlyRun(created);
+			assert.equal(run.conclusion, "failure");
+			assert.equal(run.head_sha, HEAD);
+			assert.equal(core.failures.length, 1);
+		});
+
+		void it("fails loudly when an event carries no pull request at all", async () => {
+			const { created, github } = makeGitHub();
+			const core = makeCore();
+			await enforce({
+				github,
+				core,
+				context: { eventName: "pull_request_review", repo: context.repo, payload: {} },
+			});
+
+			assert.deepEqual(created, []);
+			assert.equal(core.failures.length, 1);
+		});
+
+		void it("links the check run to the run that decided it", async () => {
+			process.env.GITHUB_RUN_ID = "42";
+			process.env.GITHUB_SERVER_URL = "https://github.example";
+			const { created, github } = makeGitHub();
+			await enforce({ github, context, core: makeCore() });
+
+			assert.equal(
+				onlyRun(created).details_url,
+				"https://github.example/owner/repo/actions/runs/42",
+			);
+		});
+	});
+});

--- a/scripts/review-policy.test.ts
+++ b/scripts/review-policy.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import { afterEach, beforeEach, describe, it } from "node:test";
 
 import {
@@ -262,25 +263,6 @@ void describe("review policy", () => {
 			assert.deepEqual(core.failures, []);
 		});
 
-		void it("passes trivially on a merge group without reading the pull request", async () => {
-			const { created, github } = makeGitHub({ failPullWith: new Error("must not be called") });
-			const core = makeCore();
-			await enforce({
-				github,
-				core,
-				context: {
-					eventName: "merge_group",
-					repo: context.repo,
-					payload: { merge_group: { head_sha: OTHER } },
-				},
-			});
-
-			const run = onlyRun(created);
-			assert.equal(run.head_sha, OTHER);
-			assert.equal(run.conclusion, "success");
-			assert.deepEqual(core.failures, []);
-		});
-
 		void it("stays out of the way of a pull request that does not target main", async () => {
 			const { created, github } = makeGitHub({
 				resolvedPull: { ...pull, base: { ref: "release" } },
@@ -327,6 +309,42 @@ void describe("review policy", () => {
 				onlyRun(created).details_url,
 				"https://github.example/owner/repo/actions/runs/42",
 			);
+		});
+	});
+
+	// A mismatch between these and the ruleset's required context deadlocks every pull request,
+	// including the one that would fix it, so the workflow's half of the contract is asserted here.
+	void describe("the workflow that publishes it", () => {
+		const workflow = readFileSync(
+			new URL("../.github/workflows/review-policy.yml", import.meta.url),
+			"utf8",
+		);
+
+		void it("publishes the merge group's verdict under the required name", () => {
+			assert.match(workflow, new RegExp(`name: '${CHECK_NAME}',`));
+			assert.match(workflow, /head_sha: context\.payload\.merge_group\.head_sha/);
+			assert.match(workflow, /conclusion: 'success'/);
+		});
+
+		void it("answers the merge group without a checkout it may not be able to make", () => {
+			// On `merge_group` the workflow comes from the queued commit while the checkout would come
+			// from the default branch, so the queue must never depend on a file that has yet to land.
+			const mergeGroupOnly = workflow.slice(
+				workflow.indexOf("Pass the merge group"),
+				workflow.indexOf("Load the trusted policy evaluator"),
+			);
+			assert.ok(mergeGroupOnly.length > 0);
+			assert.doesNotMatch(mergeGroupOnly, /uses: actions\/checkout|GITHUB_WORKSPACE/);
+		});
+
+		void it("never names the job after the context it publishes", () => {
+			// Two check runs of one name on a commit make which one the ruleset reads a race.
+			assert.doesNotMatch(workflow, new RegExp(`^\\s*name: ${CHECK_NAME}\\s*$`, "m"));
+		});
+
+		void it("keeps the checkout on the base branch's copy of the policy", () => {
+			assert.match(workflow, /ref: \$\{\{ github\.event\.repository\.default_branch \}\}/);
+			assert.doesNotMatch(workflow, /ref: \$\{\{ github\.sha \}\}/);
 		});
 	});
 });

--- a/scripts/review-policy.ts
+++ b/scripts/review-policy.ts
@@ -1,0 +1,336 @@
+/**
+ * The review policy the `main` ruleset requires, published as a check run of its own.
+ *
+ * The policy itself is unchanged: an author listed in `REVIEW_POLICY_MAINTAINERS` satisfies it, and
+ * every other author needs an approval of the current head commit from a non-author who holds write
+ * access. What changed is how the verdict is reported. The workflow job used to *be* the required
+ * `review-policy` context and failed while an approval was outstanding, so a healthy pull request
+ * waiting its turn looked broken on the pull request list. The job now always succeeds and this
+ * module publishes the verdict as a separate check run under the required name, which lets
+ * "waiting" be a pending check rather than a red one.
+ */
+
+type ApiMethod<T> = (params: Record<string, unknown>) => Promise<{ data: T }>;
+
+export interface Review {
+	readonly id: number;
+	readonly state: string;
+	readonly commit_id: string;
+	readonly user: { readonly login: string } | null;
+}
+
+export interface PullRequest {
+	readonly number: number;
+	readonly base: { readonly ref: string };
+	readonly head: { readonly sha: string };
+	readonly user: { readonly login: string };
+}
+
+/** The subset of the Checks API request this module ever sends. */
+export interface CheckRunRequest {
+	readonly owner: string;
+	readonly repo: string;
+	readonly name: string;
+	readonly head_sha: string;
+	readonly status: string;
+	readonly conclusion?: string;
+	readonly details_url?: string;
+	readonly output: { readonly title: string; readonly summary: string };
+}
+
+export interface GitHubApi {
+	readonly paginate: (
+		endpoint: ApiMethod<Review[]>,
+		params: Record<string, unknown>,
+	) => Promise<Review[]>;
+	readonly rest: {
+		readonly checks: {
+			readonly create: (params: CheckRunRequest) => Promise<{ data: { readonly id: number } }>;
+		};
+		readonly pulls: {
+			readonly get: ApiMethod<PullRequest>;
+			readonly listReviews: ApiMethod<Review[]>;
+		};
+		readonly repos: {
+			readonly getCollaboratorPermissionLevel: ApiMethod<{ readonly permission: string }>;
+		};
+	};
+}
+
+export interface ActionsContext {
+	readonly eventName: string;
+	readonly repo: { readonly owner: string; readonly repo: string };
+	readonly payload: {
+		readonly merge_group?: { readonly head_sha: string };
+		readonly pull_request?: {
+			readonly number: number;
+			readonly head?: { readonly sha: string };
+		};
+	};
+}
+
+export interface ActionsCore {
+	readonly info: (message: string) => void;
+	readonly setFailed: (message: string) => void;
+}
+
+export interface EnforceInput {
+	readonly github: GitHubApi;
+	readonly context: ActionsContext;
+	readonly core: ActionsCore;
+}
+
+export type VerdictKind = "satisfied" | "waiting" | "misconfigured";
+
+export interface Verdict {
+	readonly kind: VerdictKind;
+	readonly title: string;
+	readonly summary: string;
+}
+
+/**
+ * The context name the `main` ruleset requires, bound there to the GitHub Actions integration —
+ * which a `GITHUB_TOKEN`-authenticated check run is attributed to. Changing this string without
+ * editing the ruleset in the same breath leaves every pull request waiting on a context nothing
+ * reports, so no pull request can merge and no fix can land.
+ */
+export const CHECK_NAME = "review-policy";
+
+/** The policy guards the branch the ruleset guards; `pull_request_review` carries no base filter. */
+export const POLICY_BASE_REF = "main";
+
+const WRITE_PERMISSIONS = new Set(["admin", "maintain", "write"]);
+
+/** Review states that replace a reviewer's previous position. `COMMENTED` leaves it standing. */
+const DECISIVE_STATES = new Set(["APPROVED", "CHANGES_REQUESTED", "DISMISSED"]);
+
+/**
+ * GitHub treats a required check that concludes `neutral` or `skipped` as passing — "Required
+ * status checks must have a `successful`, `skipped`, or `neutral` status before collaborators can
+ * make changes to a protected branch" (GitHub Docs, *About protected branches*) — so neither may
+ * stand for "waiting". A check run that has not completed is pending instead, and a pending
+ * required context blocks the merge button and merge-queue entry just as a failing one does: a
+ * pull request "must have passed all required branch protection checks" before it can be queued,
+ * and a workflow that leaves its required check pending "will be blocked from merging" (GitHub
+ * Docs, *Troubleshooting required status checks*). Pending buys the same enforcement and reads as
+ * waiting rather than broken.
+ */
+const CHECK_STATE: Record<VerdictKind, { readonly status: string; readonly conclusion?: string }> =
+	{
+		satisfied: { status: "completed", conclusion: "success" },
+		waiting: { status: "in_progress" },
+		misconfigured: { status: "completed", conclusion: "failure" },
+	};
+
+const shortSha = (sha: string): string => sha.slice(0, 7);
+
+export const parseMaintainers = (raw: string | undefined): Set<string> =>
+	new Set(
+		(raw ?? "")
+			.split(",")
+			.map((login) => login.trim().toLowerCase())
+			.filter(Boolean),
+	);
+
+/**
+ * Reviewers whose latest decisive review approves `headSha`, the author excluded. Reviews arrive
+ * oldest-first by id, so the last one a reviewer left is the one that counts; an approval of an
+ * earlier commit does not carry to a commit nobody has read.
+ */
+export const currentApprovers = (
+	reviews: readonly Review[],
+	author: string,
+	headSha: string,
+): string[] => {
+	const latestByReviewer = new Map<string, Review>();
+	for (const review of reviews.toSorted((left, right) => left.id - right.id)) {
+		if (
+			review.user &&
+			review.user.login.toLowerCase() !== author.toLowerCase() &&
+			DECISIVE_STATES.has(review.state)
+		) {
+			latestByReviewer.set(review.user.login.toLowerCase(), review);
+		}
+	}
+
+	const approvers: string[] = [];
+	for (const [login, review] of latestByReviewer) {
+		if (review.state === "APPROVED" && review.commit_id === headSha) approvers.push(login);
+	}
+	return approvers;
+};
+
+export interface DecisionInput {
+	readonly author: string;
+	readonly headSha: string;
+	readonly maintainers: ReadonlySet<string>;
+	readonly reviews: readonly Review[];
+	readonly permissionOf: (login: string) => Promise<string>;
+}
+
+/** The policy verdict, and the sentence a reader needs to know what happens next. */
+export const decide = async (input: DecisionInput): Promise<Verdict> => {
+	if (input.maintainers.has(input.author.toLowerCase())) {
+		return {
+			kind: "satisfied",
+			title: `@${input.author} is a listed maintainer`,
+			summary:
+				`@${input.author} is listed in the \`REVIEW_POLICY_MAINTAINERS\` repository variable, ` +
+				"so this pull request needs no separate approval to satisfy the review policy.",
+		};
+	}
+
+	for (const login of currentApprovers(input.reviews, input.author, input.headSha)) {
+		const permission = await input.permissionOf(login);
+		if (WRITE_PERMISSIONS.has(permission)) {
+			return {
+				kind: "satisfied",
+				title: `Approved by @${login}`,
+				summary:
+					`@${login} holds \`${permission}\` access and approved commit ` +
+					`\`${shortSha(input.headSha)}\`. Pushing a new commit dismisses that approval and ` +
+					"returns this check to waiting.",
+			};
+		}
+	}
+
+	// An empty allow-list is a repository misconfiguration rather than a pull request that is
+	// waiting its turn, and only says so once no approval has satisfied the policy anyway — so the
+	// set of pull requests this lets through is unchanged.
+	if (input.maintainers.size === 0) {
+		return {
+			kind: "misconfigured",
+			title: "REVIEW_POLICY_MAINTAINERS is not set",
+			summary:
+				"The `REVIEW_POLICY_MAINTAINERS` repository variable is empty or unset, so the author " +
+				"allow-list cannot be evaluated and no approval on this pull request satisfies the " +
+				"review policy. A repository administrator has to set it.",
+		};
+	}
+
+	return {
+		kind: "waiting",
+		title: "Waiting for a maintainer approval",
+		summary:
+			"This pull request is waiting, not broken.\n\n" +
+			"**To unblock it:** someone other than the author, holding write access, has to approve " +
+			`commit \`${shortSha(input.headSha)}\`. GitHub does not accept an approval from the ` +
+			`author, so @${input.author} cannot clear this alone.\n\n` +
+			"Pushing a new commit dismisses existing approvals and returns this check here.",
+	};
+};
+
+/** Where the check run's "Details" link points, so a reader can reach the run that decided it. */
+const detailsUrl = (context: ActionsContext): string | undefined => {
+	const run = process.env.GITHUB_RUN_ID;
+	if (!run) return undefined;
+	const server = process.env.GITHUB_SERVER_URL ?? "https://github.com";
+	return `${server}/${context.repo.owner}/${context.repo.repo}/actions/runs/${run}`;
+};
+
+const publish = async (
+	github: GitHubApi,
+	context: ActionsContext,
+	core: ActionsCore,
+	headSha: string,
+	verdict: Verdict,
+): Promise<void> => {
+	// A fresh check run rather than an update: GitHub silently ignores a status that walks a
+	// completed check run back to `in_progress`, which is exactly the dismissed-approval case. It
+	// keeps only the newest run per app and name on a commit, so creating one leaves no stale
+	// duplicate behind either.
+	await github.rest.checks.create({
+		...context.repo,
+		name: CHECK_NAME,
+		head_sha: headSha,
+		...CHECK_STATE[verdict.kind],
+		details_url: detailsUrl(context),
+		output: { title: verdict.title, summary: verdict.summary },
+	});
+	core.info(`${CHECK_NAME} on ${shortSha(headSha)} is ${verdict.kind}: ${verdict.title}`);
+};
+
+const evaluate = async (
+	github: GitHubApi,
+	context: ActionsContext,
+	pull: PullRequest,
+): Promise<Verdict> => {
+	if (pull.base.ref !== POLICY_BASE_REF) {
+		return {
+			kind: "satisfied",
+			title: `Not required for base branch ${pull.base.ref}`,
+			summary: `The review policy guards pull requests that target \`${POLICY_BASE_REF}\`.`,
+		};
+	}
+
+	const reviews = await github.paginate(github.rest.pulls.listReviews, {
+		...context.repo,
+		pull_number: pull.number,
+		per_page: 100,
+	});
+
+	return await decide({
+		author: pull.user.login,
+		headSha: pull.head.sha,
+		maintainers: parseMaintainers(process.env.MAINTAINERS),
+		reviews,
+		permissionOf: async (login) => {
+			const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+				...context.repo,
+				username: login,
+			});
+			return data.permission;
+		},
+	});
+};
+
+export const enforce = async ({ github, context, core }: EnforceInput): Promise<void> => {
+	const mergeGroupSha = context.payload.merge_group?.head_sha;
+	if (mergeGroupSha) {
+		// The queue re-reports the required contexts against the projected commit, and the policy was
+		// already decided on the pull request that entered it.
+		await publish(github, context, core, mergeGroupSha, {
+			kind: "satisfied",
+			title: "Satisfied before this merge group was created",
+			summary:
+				"The review policy is decided on the pull request; entering the merge queue already " +
+				"required it to pass.",
+		});
+		return;
+	}
+
+	const pullRequest = context.payload.pull_request;
+	if (!pullRequest) {
+		core.setFailed(`A ${context.eventName} event carried no pull request to evaluate.`);
+		return;
+	}
+
+	// The webhook's own head SHA, kept only so a failure that happens before the pull request is
+	// read still has a commit to report against.
+	let headSha = pullRequest.head?.sha;
+	try {
+		const { data: pull } = await github.rest.pulls.get({
+			...context.repo,
+			pull_number: pullRequest.number,
+		});
+		headSha = pull.head.sha;
+		await publish(github, context, core, headSha, await evaluate(github, context, pull));
+	} catch (error) {
+		const reason = error instanceof Error ? error.message : String(error);
+		// A policy that cannot be evaluated is broken rather than waiting, and says so in red. If
+		// even that cannot be published the context stays unreported, which leaves the pull request
+		// blocked on a context nothing has answered — still not mergeable.
+		try {
+			if (headSha) {
+				await publish(github, context, core, headSha, {
+					kind: "misconfigured",
+					title: "The review policy could not be evaluated",
+					summary: `Re-run the \`Review policy\` workflow. GitHub reported: ${reason}`,
+				});
+			}
+		} catch {
+			core.info("The review policy verdict could not be published as a check run.");
+		}
+		core.setFailed(`Review policy evaluation failed: ${reason}`);
+	}
+};

--- a/scripts/review-policy.ts
+++ b/scripts/review-policy.ts
@@ -61,7 +61,6 @@ export interface ActionsContext {
 	readonly eventName: string;
 	readonly repo: { readonly owner: string; readonly repo: string };
 	readonly payload: {
-		readonly merge_group?: { readonly head_sha: string };
 		readonly pull_request?: {
 			readonly number: number;
 			readonly head?: { readonly sha: string };
@@ -284,21 +283,13 @@ const evaluate = async (
 	});
 };
 
+/**
+ * Publishes the required `review-policy` check run for one pull request event. The merge queue is
+ * deliberately not routed here: the workflow answers `merge_group` inline, so the queue's path
+ * needs neither a checkout nor this module, and a commit added to the queue before this file
+ * reached the default branch still gets its context.
+ */
 export const enforce = async ({ github, context, core }: EnforceInput): Promise<void> => {
-	const mergeGroupSha = context.payload.merge_group?.head_sha;
-	if (mergeGroupSha) {
-		// The queue re-reports the required contexts against the projected commit, and the policy was
-		// already decided on the pull request that entered it.
-		await publish(github, context, core, mergeGroupSha, {
-			kind: "satisfied",
-			title: "Satisfied before this merge group was created",
-			summary:
-				"The review policy is decided on the pull request; entering the merge queue already " +
-				"required it to pass.",
-		});
-		return;
-	}
-
 	const pullRequest = context.payload.pull_request;
 	if (!pullRequest) {
 		core.setFailed(`A ${context.eventName} event carried no pull request to evaluate.`);


### PR DESCRIPTION
## Problem

`review-policy` is a required status check, and it *was* the workflow job. A job can only pass or
fail, so while a contributor pull request waited for its first approval the required context was
red. A pull request that was perfectly healthy — opened, CI green, waiting its turn — read as
broken on the pull request list. The failing check was doing two jobs at once: blocking the merge
(correct) and signalling breakage (wrong).

## What changed

The job no longer *is* the required context; it *publishes* one. It always succeeds, and
`scripts/review-policy.ts` creates a check run named `review-policy` — the name the ruleset already
requires — carrying the verdict:

| Verdict | Check run | Reads as |
| --- | --- | --- |
| Waiting for an approval | `status: in_progress`, no conclusion | Pending (yellow), titled **Waiting for a maintainer approval** |
| Author allow-listed, or approved by a non-author with write access | `completed` / `success` | Green, titled **Approved by @…** or **@… is a listed maintainer** |
| `REVIEW_POLICY_MAINTAINERS` unset, or the evaluation could not run | `completed` / `failure` | Red — that *is* broken |

The waiting summary says exactly what unblocks the pull request:

> This pull request is waiting, not broken.
>
> **To unblock it:** someone other than the author, holding write access, has to approve commit
> `abc1234`. GitHub does not accept an approval from the author, so @… cannot clear this alone.
>
> Pushing a new commit dismisses existing approvals and returns this check here.

The check run's *Details* link points at the run that decided it.

## The policy is unchanged

Byte for byte the same rule: an author in `REVIEW_POLICY_MAINTAINERS` passes; every other author
needs an approval of the **current head commit** from a **non-author with write, maintain or admin
access**; only a reviewer's latest decisive review counts. `merge_group` still passes trivially.

The one added distinction is between two states that both used to be a plain failure: an *empty*
allow-list is now reported as a misconfiguration rather than as waiting. It is evaluated only after
no approval has satisfied the policy, so the set of pull requests that pass is identical.

## Documented evidence for the blocking semantics

Two claims had to hold before pending could replace failing. Both are documented, not assumed.

**1. A pending required check blocks merging and blocks merge-queue entry.**

> "A workflow is skipped by path filtering, branch filtering, or a commit message. Associated checks
> stay in a 'Pending' state and block merging."
> — [Troubleshooting required status checks](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks)

> "Once a pull request has passed all required branch protection checks, a user with write access to
> the repository can add the pull request to the queue."
> — [Managing a merge queue](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue)

Passing is a precondition for *entering* the queue, so a pending context keeps the pull request out
of it. No fallback to `action_required` was needed.

**2. `neutral` and `skipped` must never be used for "waiting" — GitHub counts them as passing.**

> "Required status checks must have a `successful`, `skipped`, or `neutral` status before
> collaborators can make changes to a protected branch."
> — [About protected branches](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches)

> "The check run was skipped. This is treated as a success for dependent checks."
> — [Status checks](https://docs.github.com/en/pull-requests/reference/status-checks)

This is the opposite of the intuition, and it is why the implementation and its tests pin
`in_progress` explicitly.

## Verified against the real API, not just the docs

A throwaway `push`-triggered workflow on a scratch branch (since deleted) exercised the Checks API
in this repository:

- A `GITHUB_TOKEN`-created check run is attributed to **app id 15368** — the GitHub Actions
  integration the ruleset's `review-policy` context is already bound to. **The ruleset needs no
  change.**
- `status: in_progress` is accepted and stays pending.
- `PATCH`-ing a *completed* check run back to `in_progress` is **silently ignored** — it stayed
  `completed/success`. That is exactly the dismissed-approval case, so the implementation always
  **creates** a check run rather than updating one.
- Creating a second check run with the same name on the same commit **replaces** the first:
  `GET /commits/{sha}/check-runs` then returns only the newest. So creating every time leaves no
  duplicates and the latest verdict is the authoritative one.

## Required-context name: unchanged

The published check run is still named **`review-policy`**, so the `Default` ruleset on `main`
needs **no edit**. The workflow *job* is renamed to `Publish review-policy status` — deliberately,
so that only one check run of the required name exists on a commit and which one the ruleset reads
is not a race. That job name is not a required context.

## The merge queue keeps its own path

On `merge_group` the workflow definition comes from the *queued* commit while a checkout would come
from the *default branch*, so routing the queue through `scripts/review-policy.ts` would have made
every merge group wait on a file that had not landed yet — this pull request's own merge included.
The queue's pass is written into the workflow instead: no checkout, no import, one Checks API call.
Four contract tests read the workflow back and assert it publishes under `CHECK_NAME`, that the
merge-group step pulls in neither a checkout nor the module, that no job is named `review-policy`,
and that the checkout stays on the default branch.

## Security note on the checkout

The evaluator is loaded from `${{ github.event.repository.default_branch }}`, never `github.sha`:
on `pull_request_review` `github.sha` is the pull request's *merge* commit, which contains
pull-request code. The base branch's copy of the policy
is the authoritative one, matching the `pull_request_target` trigger this workflow keeps.

## Testing

- `scripts/review-policy.test.ts` — 26 node:test cases via `pnpm run test:tooling`: allow-list
  parsing, latest-decisive-review-per-reviewer, stale approvals, self-approval, approver without
  write access, non-`main` base, API failure, each published check-run state, and the four
  workflow-contract assertions above.
- `pnpm run check` — green.
- `actionlint` — clean.
- `zizmor 1.29.0 --min-confidence medium` — clean (the same version and threshold CI enforces).
- Live Checks API probe, above.

No changeset: this touches `.github/`, `scripts/` and `docs/` only, none of which is shipped code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
