### PR TITLE
ci(ci): avoid redundant post-merge validation

### DIFF
--- a/.github/workflows/ci-compose-validate.yml
+++ b/.github/workflows/ci-compose-validate.yml
@@ -1,27 +1,13 @@
 name: Validate Compose
 
-# The self-hosted stack (docker/self-host/) composes the reference deployment's
-# service definitions via `include`, so a change to docker/compose.*.yaml can
-# break a stranger's install without touching a single self-host file. Rendering
-# both stacks here turns interpolation- and merge-level breakage into a red check
-# instead of a bad first boot. (Semantic breakage — a renamed service silently
-# joining the stack, an inherited runtime bug — still needs a real boot.)
-#
-# Runs on every PR (not just docker/ changes) so it can be a required check,
-# matching how verify-changesets.yml is wired. It is cheap: only `docker compose
-# config`, no image pulls.
+# Shared Compose files can break either the reference or self-hosted stack, so
+# render both configurations.
 
 on:
-  pull_request:
-  push:
-    branches: [main]
+  workflow_call:
 
 permissions:
   contents: read
-
-concurrency:
-  group: validate-compose-${{ github.event.pull_request.number || github.run_id }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   validate:
@@ -37,9 +23,7 @@ jobs:
         working-directory: docker/self-host
         run: |
           set -euo pipefail
-          # Fill the required values the way an operator would; `docker compose
-          # config` fails on any variable the stack requires but .env.example
-          # does not carry, which is exactly the drift we want to catch.
+          # Supply required operator values; missing defaults must still fail rendering.
           cp .env.example .env
           sed -i \
             -e 's|^APP_HOSTNAME=$|APP_HOSTNAME=hephaestus.example.com|' \
@@ -66,8 +50,7 @@ jobs:
         working-directory: docker/self-host
         run: |
           set -euo pipefail
-          # `config` only warns about variables missing from .env; a warning here
-          # means .env.example has fallen behind the stack it renders.
+          # `config` warns rather than fails when .env omits a referenced variable.
           if docker compose config 2>&1 >/dev/null | grep "variable is not set"; then
             echo "::error::docker/self-host/.env.example is missing variables the stack references (see warnings above)"
             exit 1
@@ -86,9 +69,7 @@ jobs:
             grep -qx "$required" <<< "$services" || {
               echo "::error::'$required' is missing from the self-hosted stack"; exit 1; }
           done
-          # Compose 2.21-2.23 parse `!override` but silently ignore it, which would
-          # publish the reference's dashboard port and keep the maintainers' ACME
-          # email. Assert the merged result rather than trust the runner's version.
+          # Some Compose releases accept `!override` without applying it.
           rendered=$(docker compose config)
           for required in \
             'entrypoints.https.http.middlewares=security-headers@docker' \

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -34,6 +34,7 @@ jobs:
       ci-config: ${{ steps.filter.outputs.ci-config }}
       docker-config: ${{ steps.filter.outputs.docker-config }}
       pmd-canary: ${{ steps.filter.outputs.pmd-canary }}
+      version-bump: ${{ steps.version_bump.outputs.changed }}
       any-code: ${{ steps.filter.outputs.webapp == 'true' || steps.filter.outputs.application-server == 'true' || steps.filter.outputs.tooling == 'true' || steps.filter.outputs.agent-images == 'true' || steps.filter.outputs.postgres-image == 'true' }}
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
     timeout-minutes: 5
@@ -47,6 +48,16 @@ jobs:
         uses: fkirc/skip-duplicate-actions@b974a9395958c231af965b70070979a577efa578 # v5.3.2
         with:
           do_not_skip: '["workflow_dispatch", "push", "merge_group"]'
+
+      - name: Detect version bump
+        id: version_bump
+        if: github.event_name == 'push'
+        run: |
+          current=$(jq -r .version package.json)
+          previous=$(git show HEAD^:package.json | jq -r .version)
+          changed=false
+          [ "$current" = "$previous" ] || changed=true
+          echo "changed=$changed" >> "$GITHUB_OUTPUT"
 
       - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: filter
@@ -183,6 +194,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [detect-changes]
     if: |
+      (github.event_name != 'push' || needs.detect-changes.outputs.version-bump == 'true') &&
       needs.detect-changes.outputs.should_skip != 'true' && (
         needs.detect-changes.outputs.ci-config == 'true' ||
         github.event_name != 'pull_request'
@@ -207,6 +219,8 @@ jobs:
     name: "Zizmor"
     timeout-minutes: 10
     runs-on: ubuntu-latest
+    needs: [detect-changes]
+    if: github.event_name != 'push' || needs.detect-changes.outputs.version-bump == 'true'
     permissions:
       contents: read
       security-events: write
@@ -230,6 +244,7 @@ jobs:
     uses: ./.github/workflows/ci-quality-gates.yml
     needs: [detect-changes]
     if: |
+      (github.event_name != 'push' || needs.detect-changes.outputs.version-bump == 'true') &&
       needs.detect-changes.outputs.should_skip != 'true' && (
         needs.detect-changes.outputs.any-code == 'true' ||
         needs.detect-changes.outputs.ci-config == 'true' ||
@@ -251,6 +266,7 @@ jobs:
     uses: ./.github/workflows/ci-security-scan.yml
     needs: [detect-changes]
     if: |
+      (github.event_name != 'push' || needs.detect-changes.outputs.version-bump == 'true') &&
       needs.detect-changes.outputs.should_skip != 'true' && (
         needs.detect-changes.outputs.any-code == 'true' ||
         needs.detect-changes.outputs.ci-config == 'true' ||
@@ -266,6 +282,7 @@ jobs:
     uses: ./.github/workflows/ci-tests.yml
     needs: [detect-changes]
     if: |
+      (github.event_name != 'push' || needs.detect-changes.outputs.version-bump == 'true') &&
       needs.detect-changes.outputs.should_skip != 'true' && (
         needs.detect-changes.outputs.any-code == 'true' ||
         needs.detect-changes.outputs.ci-config == 'true' ||
@@ -289,6 +306,13 @@ jobs:
   Changesets:
     if: github.event_name == 'pull_request'
     uses: ./.github/workflows/verify-changesets.yml
+    permissions:
+      contents: read
+
+  Compose:
+    needs: [detect-changes]
+    if: github.event_name != 'push' || needs.detect-changes.outputs.version-bump == 'true'
+    uses: ./.github/workflows/ci-compose-validate.yml
     permissions:
       contents: read
 
@@ -331,7 +355,7 @@ jobs:
     permissions:
       actions: read
       statuses: write
-    needs: [detect-changes, workflow-lint, zizmor, Quality, Security, Test, Changesets, Docker]
+    needs: [detect-changes, workflow-lint, zizmor, Quality, Security, Test, Changesets, Compose, Docker]
     if: always()
     steps:
       - name: Generate workflow timeline
@@ -388,6 +412,7 @@ jobs:
           echo "Security:       ${{ needs.Security.result }}"
           echo "Test:           ${{ needs.Test.result }}"
           echo "Changesets:     ${{ needs.Changesets.result }}"
+          echo "Compose:        ${{ needs.Compose.result }}"
           echo "Docker:         ${{ needs.Docker.result }}"
 
           if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]]; then
@@ -437,6 +462,7 @@ jobs:
           echo "| Quality | $(result_to_emoji '${{ needs.Quality.result }}') |" >> $GITHUB_STEP_SUMMARY
           echo "| Test | $(result_to_emoji '${{ needs.Test.result }}') |" >> $GITHUB_STEP_SUMMARY
           echo "| Changesets | $(result_to_emoji '${{ needs.Changesets.result }}') |" >> $GITHUB_STEP_SUMMARY
+          echo "| Compose | $(result_to_emoji '${{ needs.Compose.result }}') |" >> $GITHUB_STEP_SUMMARY
           echo "| Security | $(result_to_emoji '${{ needs.Security.result }}') |" >> $GITHUB_STEP_SUMMARY
           echo "| Docker | $(result_to_emoji '${{ needs.Docker.result }}') |" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY

--- a/docs/contributor/ci-cd.mdx
+++ b/docs/contributor/ci-cd.mdx
@@ -7,32 +7,24 @@ description: High-performance trunk-based CI/CD with release-gated staging and p
 
 # CI/CD Architecture
 
-Hephaestus uses trunk-based delivery powered by GitHub Actions. Every merge to `main` is verified; signed releases deploy automatically to staging, with production requiring manual approval.
+Hephaestus uses trunk-based delivery through GitHub's merge queue. Pull requests provide early
+feedback, merge groups validate projected `main`, and pushes to `main` produce release images. Signed
+releases deploy automatically to staging; production requires approval.
 
 ## 🏗️ Architecture Overview
 
 ```mermaid
 flowchart TD
     accTitle: Pull request delivery pipeline
-    accDescr: A pull request satisfies review policy, passes projected-main CI in the merge queue, and becomes a signed release that deploys to staging before production approval.
-    PR[Pull Request] --> Policy{Review policy}
-    Policy --> Queue[Merge queue]
-    Queue --> MG[Projected-main CI]
-    MG --> Merge[Merge to main]
-    Merge --> CI[CI/CD Pipeline]
-
-    subgraph CI/CD
-    CI --> Q[Quality Gates]
-    CI --> T[Tests]
-    CI --> D[Docker Build]
-    end
-
-    Q --> Pass{All Pass?}
-    T --> Pass
-    D --> Pass
-
-    Pass -->|Yes| VP[changesets action updates Version PR]
-    VP -->|Maintainer merges Version PR| Release[Build evidence and signed lock]
+    accDescr: Pull-request and merge-group validation protect main; final-SHA images become signed releases that deploy to staging before production approval.
+    PR[Pull request] --> PRCI[Pull-request validation]
+    PRCI --> Queue[Merge queue]
+    Queue --> MG[Projected-main validation]
+    MG --> Main[Merge to main]
+    Main --> Images[Build and attest final-SHA images]
+    Main --> VP[Update Version PR]
+    VP -->|Maintainer merges| ReleaseCI[Validate and build version commit]
+    ReleaseCI --> Release[Build evidence and signed lock]
     Release --> Verify{Verify release}
     Verify -->|Pass| Staging[Deploy complete topology to staging]
     Staging -->|Approve| Prod[Deploy complete topology to production]
@@ -40,9 +32,9 @@ flowchart TD
 
 ## 🚀 Release Flow
 
-Every merge to `main` runs CI and updates the accumulating **Version PR** (changesets). Merging that PR
-cuts the release — tag `vX.Y.Z`, GitHub Release, docker tags `X.Y.Z`/`X.Y`/`latest`, then staging
-(automatic) and production (after approval). Full flow: [Release Management](./release-management.mdx).
+Every merge to `main` produces commit-addressed container images and updates the accumulating **Version
+PR**. Merging the Version PR creates the signed release, promotes versioned image tags, deploys to
+staging, and waits for production approval. Full flow: [Release Management](./release-management.mdx).
 
 ## 🛡️ Quality Gates
 
@@ -67,9 +59,10 @@ Before any release, code must pass:
 ### Merge policy
 
 Pull requests targeting `main` merge through GitHub's merge queue after these GitHub
-Actions contexts pass: `CI Status Gate`, `Actionlint`, `Zizmor`, and `review-policy`. The queue runs
-the same checks against the projected `main` commit through the `merge_group` event. Each required
-context is bound to the GitHub Actions integration rather than accepting a same-named external status.
+Actions contexts pass: `CI Status Gate`, `Actionlint`, `Zizmor`, and `review-policy`. Required
+workflows run again for the merge group, which includes the current base and queued changes ahead of
+the pull request. Each required context is bound to the GitHub Actions integration rather than
+accepting a same-named external status.
 
 `review-policy` accepts an author listed in the comma-separated repository variable
 `REVIEW_POLICY_MAINTAINERS`. Every other author needs an approval from a non-author who currently
@@ -102,9 +95,9 @@ Renaming the check run means editing the ruleset's required context in the same 
 leaves every pull request waiting on a context nothing reports, which blocks the fix too.
 
 The changesets Version PR is the temporary exception: updates made with `GITHUB_TOKEN` do not trigger
-the required workflows, so release automation uses the ruleset bypass. The release workflow still
-requires successful CI on the resulting `main` commit before it publishes anything. Move the Version
-PR to a machine identity that triggers workflows before removing this exception.
+the required workflows, so release automation uses the ruleset bypass. The resulting version bump
+runs source validation on `main` before release; other pushes build final-SHA images without repeating
+source validation.
 
 ## 🔒 Security
 
@@ -221,8 +214,8 @@ why the label is the authority, and which alternatives were priced and declined,
 
 | Workflow               | Trigger               | Purpose                                            |
 | ---------------------- | --------------------- | -------------------------------------------------- |
-| `cicd.yml`             | Push to main, PRs, merge queue | Orchestrator: change detection + workflow dispatch |
-| `review-policy.yml`    | PR and review events, merge queue | Publishes the `review-policy` check run: author allow-list, or current-head write-access approval |
+| `cicd.yml`             | PR, merge group, push to main | Validates changes before merge and builds final-SHA images after merge |
+| `review-policy.yml`    | PR and review events, merge queue | Publishes the `review-policy` check: author allow-list or current-head write-access approval |
 | `ci-quality-gates.yml` | Called by cicd.yml    | Code quality, formatting, schema validation        |
 | `ci-tests.yml`         | Called by cicd.yml    | Unit, integration, visual tests                    |
 | `ci-docker-build.yml`  | Called by cicd.yml    | Docker image builds per component                  |
@@ -230,7 +223,7 @@ why the label is the authority, and which alternatives were priced and declined,
 | `ci-profile.yml` | Weekly, manual | Profiles server integration tests and Spring contexts |
 | `ci-server-clean-reference.yml` | Weekly, manual | Records cold server phases and compares generated JARs |
 | `verify-changesets.yml`| Called by cicd.yml    | Tests changeset/version-sync policy and enforces release-note presence |
-| `ci-compose-validate.yml` | PRs, push to main  | Renders the reference and self-host compose stacks so an interpolation or merge break is a red check, not a stranger's bad first boot |
+| `ci-compose-validate.yml` | Called by cicd.yml | Validates rendered reference and self-hosted Compose stacks |
 | `deploy-preview.yml` | `preview` label added, or a push, reopen or ready-for-review on a labelled PR | Waits for this commit's attested CI images, deploys them, and registers the native GitHub deployment |
 | `cleanup-preview.yml` | Label removed, PR closed or drafted | Removes and verifies resources, then retains a cleanup tombstone |
 | `reconcile-previews.yml` | Nightly, manual | Re-sends teardown for any preview environment whose pull request is closed, drafted or unlabelled |
@@ -251,35 +244,6 @@ why the label is the authority, and which alternatives were priced and declined,
 
 Repository-local actions require checkout first. Jobs without checkout use the external SHA-pinned
 action directly rather than checking out the repository only to reach a wrapper.
-
-### Workflow Architecture
-
-```mermaid
-flowchart LR
-    accTitle: Continuous integration job dependencies
-    accDescr: Required quality, test, changeset, image, and security jobs feed the final continuous integration status gate.
-    subgraph cicd.yml
-        DC[Detect Changes] --> QG[Quality Gates]
-        DC --> TS[Test Suite]
-        DC --> DB[Docker Build]
-        DC --> SS[Security Scan]
-        CS[Changesets]
-    end
-
-    QG --> Gate[CI Status Gate]
-    TS --> Gate
-    DB --> Gate
-    SS --> Gate
-    CS --> Gate
-
-    Gate -->|All Pass| Release[release.yml]
-```
-
-The `cicd.yml` workflow:
-
-1. **Detects changes** using `dorny/paths-filter`
-2. **Dispatches required sub-workflows**, using component-specific flags where applicable
-3. **Aggregates results** in the CI Status Gate job
 
 ## 🎯 Performance Optimizations
 

--- a/docs/contributor/release-management.mdx
+++ b/docs/contributor/release-management.mdx
@@ -52,8 +52,8 @@ sequenceDiagram
    `CHANGELOG.md` section. It is safe to leave open — it updates itself. It is opened by
    `github-actions[bot]` and deliberately runs **no CI**: it only bumps a version string and
    rewrites the changelog. `GITHUB_TOKEN` updates do not trigger the required workflows, so release
-   automation uses the ruleset bypass. Validation happens after the merge: `main` runs the full suite
-   and a release is only cut if that run succeeds. Versioning also moves any
+   automation uses the ruleset bypass. The version bump runs the full source-validation suite on
+   `main`, and a release is only cut if that run succeeds. Versioning also moves any
    migration fragments at the existing `### Next release` anchor in `MIGRATION.md`, creates the
    versioned section beneath it, and consumes the fragments.
 3. **Merging the Version PR cuts the release.** The workflow creates a draft release at the merge

--- a/scripts/ci-contract.test.ts
+++ b/scripts/ci-contract.test.ts
@@ -176,6 +176,30 @@ void describe("CI contract", () => {
 		assert.match(pathFilter(detection, "webapp-image"), /- 'patches\/\*\*'/);
 	});
 
+	void test("separates pre-merge validation from post-merge artifact production", async () => {
+		const source = await readFile(".github/workflows/cicd.yml", "utf8");
+		for (const event of ["workflow_dispatch", "push", "pull_request", "merge_group"]) {
+			assert.match(source, new RegExp(`^ {2}${event}:`, "m"));
+		}
+		assert.match(
+			job(source, "detect-changes"),
+			/version-bump: \${{ steps\.version_bump\.outputs\.changed }}/,
+		);
+		for (const name of ["workflow-lint", "zizmor", "Quality", "Security", "Test", "Compose"]) {
+			assert.match(job(source, name), /needs: \[detect-changes\]/);
+			assert.match(
+				job(source, name),
+				/github\.event_name != 'push'.*needs\.detect-changes\.outputs\.version-bump == 'true'/s,
+			);
+		}
+		assert.doesNotMatch(job(source, "Docker"), /version-bump/);
+		assert.match(job(source, "all-ci-passed"), /needs: \[[^\]]*Compose[^\]]*Docker\]/);
+
+		const compose = await readFile(".github/workflows/ci-compose-validate.yml", "utf8");
+		assert.match(compose, /on:\n {2}workflow_call:\n/);
+		assert.match(job(source, "Compose"), /uses: \.\/\.github\/workflows\/ci-compose-validate\.yml/);
+	});
+
 	void test("pins every external action to a full commit SHA with a version comment", async () => {
 		const invalid: string[] = [];
 		const files = await Array.fromAsync(glob(".github/{actions,workflows}/**/*.{yml,yaml}"));


### PR DESCRIPTION
## Description

GitHub's merge queue already validates the projected `main` commit, but CI repeated the complete source-validation suite after every merge. This change keeps source validation on pull requests and merge groups, while ordinary `main` pushes build and attest the final-SHA container images without rerunning the same checks.

Automated Version PRs remain a deliberate exception: because their `GITHUB_TOKEN` updates do not trigger normal required checks and they use the release ruleset bypass, version bumps on `main` still run the full validation suite before release. Compose rendering is now a reusable workflow included in `CI Status Gate`, so it blocks both pull requests and merge groups consistently.

## How to test

- Run `pnpm run format`.
- Run `pnpm run check`.
- Run `pnpm run verify`.
- In GitHub Actions, confirm this pull request runs source validation and Compose through `CI Status Gate`.
- When this change enters the merge queue, confirm the merge-group run performs the same required validation.
- After an ordinary queued merge, confirm the `main` run skips repeated source validation and builds final-SHA images.
- After a Version PR merge, confirm `Detect version bump` reports `changed=true` and the full source-validation suite runs before release.

## Checklist

- [x] No changeset is required because this changes repository CI and contributor documentation, not shipped code.
- [x] No operator action or migration is required.
- [x] I did not commit generated-artifact changes that this PR did not cause.
