### PR TITLE
docs: clarify which runtime Vite+ does not manage

### DIFF
--- a/docs/contributor/local-verification.mdx
+++ b/docs/contributor/local-verification.mdx
@@ -54,4 +54,4 @@ Use `pnpm run check` for the local quality gate and `pnpm run verify` for the co
 Both enter the Vite+ task graph and reuse unchanged task results. Run `vp run --last-details` to
 inspect the latest run or `vp cache clean` to discard the local task cache.
 
-Node is pinned by `package.json#devEngines.runtime`; Vite+ does not manage the runtime.
+Node is pinned by `package.json#devEngines.runtime`; Vite+ does not manage the Node runtime.


### PR DESCRIPTION
Throwaway probe PR for an empirical merge-queue/ruleset experiment. Will be closed and the branch deleted.