### PR TITLE
ci(docker): isolate pre-merge image builds

### DIFF
--- a/.github/workflows/ci-docker-build.yml
+++ b/.github/workflows/ci-docker-build.yml
@@ -15,8 +15,6 @@ on:
         required: false
         type: string
         default: "false"
-      # Path-based change detection for selective Docker builds
-      # These are pre-computed by the caller (cicd.yml) to include CI config fallback
       webapp_changed:
         description: "Whether webapp files changed (or should build for other reasons)"
         required: false
@@ -64,21 +62,11 @@ jobs:
       docker-file: "./webapp/Dockerfile"
       docker-context: "."
       registry: "ghcr.io"
-      # Bake commit + branch (the Dockerfile's ARGs) so the footer build strip is
-      # populated on CI-built deploys; Coolify sets these itself for previews.
-      # head_ref, not ref_name: on a pull request the latter is the merge ref `<n>/merge`, which is
-      # not a branch and does not resolve as one — the footer links it and got a 404.
+      # Use the PR source branch; ref_name identifies GitHub's synthetic merge ref on pull requests.
       build-args: |
         SOURCE_COMMIT=${{ github.sha }}
         COOLIFY_BRANCH=${{ github.head_ref || github.ref_name }}
-      # amd64-only on PRs (main/release build both arches). See reusable-docker-build.yml.
-      single-arch: ${{ github.event_name == 'pull_request' }}
-      tags: |
-        ${{ github.ref_name }}
-        ${{ github.sha }}
-        ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}
-        ci-${{ github.run_number }}
-        ${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.number) || '' }}
+      single-arch: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
       labels: |
         org.opencontainers.image.title=Hephaestus Webapp
         org.opencontainers.image.description=Web client for Hephaestus
@@ -99,32 +87,17 @@ jobs:
       attestations: write
     with:
       image-name: "hephaestus-build/application-server"
-      # Paketo Cloud Native Buildpacks via spring-boot:build-image, with Application CDS.
-      # See docs/admin/buildpacks-cds-decision.md and pom.xml's <image> block.
+      # Application CDS configuration lives in server/application/pom.xml; rationale: docs/admin/buildpacks-cds-decision.md.
       use-buildpacks: true
       maven-module: "server/application"
       registry: "ghcr.io"
-      # amd64-only on PRs (main/release build both arches). See reusable-docker-build.yml.
-      single-arch: ${{ github.event_name == 'pull_request' }}
-      # github.sha is a synthetic merge commit on pull_request. Coolify injects the checked-out PR
-      # head as SOURCE_COMMIT, so publish both immutable identifiers.
-      tags: |
-        ${{ github.ref_name }}
-        ${{ github.sha }}
-        ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}
-        ci-${{ github.run_number }}
-        ${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.number) || '' }}
+      single-arch: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
       labels: |
         org.opencontainers.image.title=Hephaestus Application Server
         org.opencontainers.image.description=Spring Boot server for Hephaestus
         org.opencontainers.image.vendor=AET TUM
         org.opencontainers.image.licenses=MIT
         hephaestus.component=application-server
-
-  # Note: the inbound webhook receiver lives in the application-server image
-  # (integration.core.webhook package) and is deployed as a separate container via
-  # SPRING_PROFILES_ACTIVE=prod,webhook. No separate image build is required. See
-  # docker/compose.core.yaml (webhook-server service) and ADR 0008.
 
   agent-pi-build:
     name: "Agent: Pi"
@@ -140,17 +113,7 @@ jobs:
       docker-file: "./docker/agents/pi/Dockerfile"
       docker-context: "./docker/agents"
       registry: "ghcr.io"
-      # amd64-only on PRs (main/release build both arches). See reusable-docker-build.yml.
-      single-arch: ${{ github.event_name == 'pull_request' }}
-      # The head-SHA tag matters here for the same reason it does on application-server: a preview
-      # runs at SOURCE_COMMIT and derives its agent image from that tag, so without it no preview can
-      # ever resolve a matched pair, however the pull request touched the agent tree (ADR 0031).
-      tags: |
-        ${{ github.ref_name }}
-        ${{ github.sha }}
-        ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}
-        ci-${{ github.run_number }}
-        ${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.number) || '' }}
+      single-arch: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
       labels: |
         org.opencontainers.image.title=Hephaestus Agent - Pi
         org.opencontainers.image.description=Sandboxed Pi coding agent for AI-powered code review
@@ -174,14 +137,7 @@ jobs:
       docker-file: "./docker/postgres/Dockerfile"
       docker-context: "./docker/postgres"
       registry: "ghcr.io"
-      # amd64-only on PRs (main/release build both arches). See reusable-docker-build.yml.
-      single-arch: ${{ github.event_name == 'pull_request' }}
-      tags: |
-        ${{ github.ref_name }}
-        ${{ github.sha }}
-        ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}
-        ci-${{ github.run_number }}
-        ${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.number) || '' }}
+      single-arch: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
       labels: |
         org.opencontainers.image.title=Hephaestus Postgres
         org.opencontainers.image.description=PostgreSQL + pg_partman for all environments (dev/preview/prod)
@@ -189,8 +145,7 @@ jobs:
         org.opencontainers.image.licenses=MIT
         hephaestus.component=postgres
 
-  # Preview stacks use one commit tag for every component. Point unchanged components at their
-  # verified base-commit digest instead of rebuilding identical content under a new name.
+  # Preview stacks resolve every component by PR head SHA; alias verified base digests for unchanged components.
   tag-unchanged-images:
     name: "Tag unchanged images"
     if: >-
@@ -229,16 +184,15 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           REPOSITORY: ${{ github.repository }}
           REPOSITORY_OWNER: ${{ github.repository_owner }}
-          CURRENT_SHA: ${{ github.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          RUN_NUMBER: ${{ github.run_number }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
         run: |
           set -euo pipefail
 
           tag_image() {
             local image="ghcr.io/hephaestus-build/$1"
             local source="$image:$BASE_SHA"
-            local ref_tag="${GITHUB_REF_NAME//\//-}"
             local digest
             digest=$(docker buildx imagetools inspect --format '{{.Manifest.Digest}}' "$source" 2>/dev/null || true)
             if [[ ! "$digest" =~ ^sha256:[a-f0-9]{64}$ ]]; then
@@ -262,11 +216,9 @@ jobs:
               > /dev/null
             gh attestation verify "oci://$verified" --owner "$REPOSITORY_OWNER"
             docker buildx imagetools create \
-              --tag "$image:$ref_tag" \
-              --tag "$image:$CURRENT_SHA" \
               --tag "$image:$HEAD_SHA" \
-              --tag "$image:ci-$RUN_NUMBER" \
               --tag "$image:pr-$PR_NUMBER" \
+              --tag "$image:run-$RUN_ID-$RUN_ATTEMPT" \
               "$verified"
           }
 

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -319,16 +319,12 @@ jobs:
   Docker:
     uses: ./.github/workflows/ci-docker-build.yml
     secrets:
-      SENTRY_AUTH_TOKEN: ${{ github.event_name != 'pull_request' && secrets.SENTRY_AUTH_TOKEN || '' }}
-      SENTRY_ORG: ${{ github.event_name != 'pull_request' && secrets.SENTRY_ORG || '' }}
-      SENTRY_PROJECT: ${{ github.event_name != 'pull_request' && secrets.SENTRY_PROJECT || '' }}
-    # Image builds consume the detected source tree, not Quality outputs. Running both branches at
-    # once keeps image and preview confidence without adding Docker as a second CI stage.
+      SENTRY_AUTH_TOKEN: ${{ github.event_name == 'push' && secrets.SENTRY_AUTH_TOKEN || '' }}
+      SENTRY_ORG: ${{ github.event_name == 'push' && secrets.SENTRY_ORG || '' }}
+      SENTRY_PROJECT: ${{ github.event_name == 'push' && secrets.SENTRY_PROJECT || '' }}
     needs: [detect-changes]
-    # A preview runs the images CI published for its exact head commit, so a same-repository pull
-    # request needs commit-addressed tags even when it touches only docs — `Tag unchanged images`
-    # re-tags rather than rebuilds. The path filters therefore gate fork pull requests only; forks
-    # never receive a preview.
+    # Same-repository previews require every image at the PR head tag; unchanged images are aliased.
+    # Forks cannot preview, so their image builds remain path-filtered.
     if: |
       needs.detect-changes.outputs.should_skip != 'true' && (
         github.event_name != 'pull_request' ||

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,15 +1,5 @@
 name: Release
 
-# Cuts a release when a merge to main bumped the root package version — i.e.
-# when the Version PR (maintained by version-pr.yml) has been merged. Triggered
-# after CI/CD succeeds so the Docker images for the commit already exist.
-#
-# A release: tags vX.Y.Z at the version-bump commit, creates the GitHub Release
-# from that version's CHANGELOG.md section (flagging schema migrations), verifies
-# a seeded previous-release upgrade before publication, retags the CI-built
-# images (X.Y.Z, X.Y, latest), and starts the deploy chain
-# (staging automatically, production after environment approval).
-#
 # Versioning contract: docs/admin/compatibility-policy.mdx
 
 on:
@@ -56,8 +46,6 @@ jobs:
 
       - name: Cut release if this commit bumped the version
         id: cut
-        # GITHUB_TOKEN suffices: the tag/Release it creates is not meant to
-        # trigger any workflow (deploys are wired via `needs`/dispatch below).
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SHA: ${{ github.event.workflow_run.head_sha }}
@@ -94,9 +82,6 @@ jobs:
           jq -e '.isDraft == false and .isPrerelease == false' <<< "$previous" >/dev/null || {
             echo "::error::$PREV_TAG is not a stable published release"; exit 1; }
 
-          # Release notes = this version's CHANGELOG.md section (the assembled
-          # changeset entries), with a first-class migration warning when the
-          # release touches the Liquibase changelog.
           NOTES=$(mktemp)
           if [ -n "$PREV_TAG" ] && ! git diff --quiet "$PREV_TAG" "$SHA" -- server/application/src/main/resources/db/changelog/; then
             {
@@ -171,7 +156,7 @@ jobs:
       - name: Capture release image digests
         id: retag
         env:
-          SHA: ${{ needs.release.outputs.sha }}
+          SOURCE_TAG: run-${{ github.event.workflow_run.id }}-${{ github.event.workflow_run.run_attempt }}
         run: |
           set -euo pipefail
 
@@ -180,17 +165,17 @@ jobs:
           declare -A DIGESTS=()
           : > release-images.tsv
 
-          # Resolve every source digest before publishing any release tag.
+          # Resolve the complete image inventory before generating evidence.
           for img in "${IMAGES[@]}"; do
             FULL_IMAGE="ghcr.io/hephaestus-build/$img"
             for i in $(seq 1 24); do
-              digest=$(docker buildx imagetools inspect "$FULL_IMAGE:$SHA" --format '{{json .Manifest}}' 2>/dev/null | jq -er '.digest' 2>/dev/null) || true
+              digest=$(docker buildx imagetools inspect "$FULL_IMAGE:$SOURCE_TAG" --format '{{json .Manifest}}' 2>/dev/null | jq -er '.digest' 2>/dev/null) || true
               if [[ "$digest" =~ ^sha256:[a-f0-9]{64}$ ]]; then
                 DIGESTS[$img]=$digest
                 break
               fi
               if [ "$i" -ge 24 ]; then
-                echo "::error::Could not resolve a valid digest for $FULL_IMAGE:$SHA after 120 s"
+                echo "::error::Could not resolve a valid digest for $FULL_IMAGE:$SOURCE_TAG after 120 s"
                 exit 1
               fi
               sleep 5
@@ -637,8 +622,6 @@ jobs:
       packages: read
     with:
       image-tag: ${{ needs.release.outputs.tag_name }}
-    # Deploy credentials include organization secrets, which reach nested reusable
-    # workflows only through inheritance — environment secrets alone do not cover them.
     secrets: inherit # zizmor: ignore[secrets-inherit]
 
   deploy-production:

--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -40,10 +40,6 @@ on:
         type: string
         default: "ghcr.io"
         description: "Container registry"
-      tags:
-        type: string
-        required: false
-        description: "Additional tags (one per line)"
       labels:
         type: string
         required: false
@@ -56,15 +52,20 @@ on:
         type: boolean
         required: false
         default: false
-        description: |
-          Build only linux/amd64. Callers set this on pull requests to halve Docker build
-          wall-clock + cost (the arm64 native build adds ~7 min and PR images are never deployed
-          to production). main + release builds leave this false so release tags and pinned
-          digests stay multi-arch.
+        description: "Build only linux/amd64 instead of the supported multi-architecture set."
     outputs:
       manifest-digest:
-        description: "Published image digest (a multi-architecture manifest-list digest for main and releases)."
+        description: "Published image digest; an index digest for multi-architecture builds."
         value: ${{ inputs.single-arch && jobs.build.outputs.manifest-digest || jobs.merge.outputs.manifest-digest }}
+
+env:
+  STANDARD_IMAGE_TAGS: |
+    ${{ github.event_name == 'push' && github.ref_name || '' }}
+    ${{ github.event_name == 'push' && github.sha || '' }}
+    ${{ github.event_name == 'push' && format('ci-{0}', github.run_number) || '' }}
+    ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}
+    ${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.number) || '' }}
+    run-${{ github.run_id }}-${{ github.run_attempt }}
 
 jobs:
   build:
@@ -88,15 +89,10 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
 
-      # Note: QEMU is NOT needed because we build natively:
-      # - linux/amd64 builds on ubuntu-24.04 (x86_64)
-      # - linux/arm64 builds on ubuntu-24.04-arm (aarch64)
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
         with:
-          # Use TUM's Docker Hub mirror to avoid rate limits (standard ls1intum approach)
-          # See: https://github.com/ls1intum/.github/blob/main/.github/workflows/build-and-push-docker-image.yml
+          # Avoid anonymous Docker Hub pull limits.
           buildkitd-config-inline: |
             [registry."docker.io"]
               mirrors = ["https://docker-mirror.ase.in.tum.de:8765"]
@@ -114,9 +110,6 @@ jobs:
         run: |
           {
             echo "tags<<EOF"
-            echo "type=ref,event=branch"
-            echo "type=ref,event=pr"
-            echo "type=sha,prefix="
             while IFS= read -r line || [[ -n "$line" ]]; do
               line=$(echo "$line" | xargs)
               [ -z "$line" ] && continue
@@ -129,11 +122,9 @@ jobs:
                   [ -n "$value" ] && echo "type=raw,value=$value"
                 done
               fi
-            done <<< "$INPUT_TAGS"
+            done <<< "$STANDARD_IMAGE_TAGS"
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
-        env:
-          INPUT_TAGS: ${{ inputs.tags }}
 
       - name: Extract metadata
         id: meta
@@ -154,7 +145,6 @@ jobs:
           INPUT_IMAGE_NAME: ${{ inputs.image-name }}
           MATRIX_PLATFORM: ${{ matrix.platform }}
 
-      # Only main may write the shared registry cache.
       - name: Build and push (Dockerfile)
         id: build
         if: ${{ !inputs.use-buildpacks }}
@@ -167,9 +157,9 @@ jobs:
           platforms: ${{ matrix.platform }}
           build-args: ${{ inputs.build-args }}
           secrets: |
-            sentry_auth_token=${{ github.event_name != 'pull_request' && matrix.platform == 'linux/amd64' && secrets.SENTRY_AUTH_TOKEN || '' }}
-            sentry_org=${{ github.event_name != 'pull_request' && matrix.platform == 'linux/amd64' && secrets.SENTRY_ORG || '' }}
-            sentry_project=${{ github.event_name != 'pull_request' && matrix.platform == 'linux/amd64' && secrets.SENTRY_PROJECT || '' }}
+            sentry_auth_token=${{ github.event_name == 'push' && matrix.platform == 'linux/amd64' && secrets.SENTRY_AUTH_TOKEN || '' }}
+            sentry_org=${{ github.event_name == 'push' && matrix.platform == 'linux/amd64' && secrets.SENTRY_ORG || '' }}
+            sentry_project=${{ github.event_name == 'push' && matrix.platform == 'linux/amd64' && secrets.SENTRY_PROJECT || '' }}
           labels: ${{ steps.meta.outputs.labels }}
           tags: ${{ inputs.single-arch && steps.meta.outputs.tags || '' }}
           push: ${{ inputs.single-arch }}
@@ -364,14 +354,8 @@ jobs:
         run: |
           {
             echo "tags<<EOF"
-            # Default tags. Note: `latest` is NOT applied here — it tracks the latest
-            # release and is applied by the release workflow's retag step, together
-            # with the X.Y.Z and X.Y tags.
-            echo "type=ref,event=branch"
-            echo "type=ref,event=pr"
-            echo "type=sha,prefix="
-            if [ -n "${INPUTS_TAGS}" ]; then
-              echo "${INPUTS_TAGS}" | while IFS= read -r line || [[ -n "$line" ]]; do
+            if [ -n "${STANDARD_IMAGE_TAGS}" ]; then
+              echo "${STANDARD_IMAGE_TAGS}" | while IFS= read -r line || [[ -n "$line" ]]; do
                 line=$(echo "$line" | xargs)
                 if [ -n "$line" ]; then
                   if [[ "$line" == *"type="* ]]; then
@@ -390,8 +374,6 @@ jobs:
             fi
             echo "EOF"
           } >> $GITHUB_OUTPUT
-        env:
-          INPUTS_TAGS: ${{ inputs.tags }}
 
       - name: Extract metadata
         id: meta
@@ -449,7 +431,6 @@ jobs:
         run: |
           cosign sign --yes --recursive "$IMAGE_REF"
 
-      # Pin cert SAN to this workflow + cross-check the workflow-repo OID.
       - name: Verify signature + attestation
         env:
           IMAGE_REF: ${{ inputs.registry }}/${{ inputs.image-name }}@${{ steps.digest.outputs.manifest-digest }}

--- a/docs/contributor/ci-cd.mdx
+++ b/docs/contributor/ci-cd.mdx
@@ -8,8 +8,8 @@ description: High-performance trunk-based CI/CD with release-gated staging and p
 # CI/CD Architecture
 
 Hephaestus uses trunk-based delivery through GitHub's merge queue. Pull requests provide early
-feedback, merge groups validate projected `main`, and pushes to `main` produce release images. Signed
-releases deploy automatically to staging; production requires approval.
+feedback, merge groups validate projected `main`, and pushes to `main` produce release images. Releases
+with signed image locks deploy automatically to staging; production requires approval.
 
 ## 🏗️ Architecture Overview
 
@@ -21,20 +21,27 @@ flowchart TD
     PRCI --> Queue[Merge queue]
     Queue --> MG[Projected-main validation]
     MG --> Main[Merge to main]
-    Main --> Images[Build and attest final-SHA images]
-    Main --> VP[Update Version PR]
-    VP -->|Maintainer merges| ReleaseCI[Validate and build version commit]
-    ReleaseCI --> Release[Build evidence and signed lock]
-    Release --> Verify{Verify release}
-    Verify -->|Pass| Staging[Deploy complete topology to staging]
-    Staging -->|Approve| Prod[Deploy complete topology to production]
+    Main --> Images[Build and attest images for final commit]
+    Main --> VP[Maintain Version PR]
+    VP -->|Maintainer merges| ReleaseCI[Validate version commit]
+    ReleaseCI --> Evidence[Build evidence and sign image lock]
+    Evidence --> Verify{Verify evidence and image lock}
+    Verify -->|Pass| Staging[Deploy to staging]
+    Staging -->|Approve| Prod[Deploy to production]
 ```
 
 ## 🚀 Release Flow
 
-Every merge to `main` produces commit-addressed container images and updates the accumulating **Version
-PR**. Merging the Version PR creates the signed release, promotes versioned image tags, deploys to
-staging, and waits for production approval. Full flow: [Release Management](./release-management.mdx).
+Every merge to `main` produces commit-addressed container images and maintains the accumulating
+**Version PR**. Merging the Version PR creates a release with a signed image lock, promotes versioned
+image tags, deploys to staging, and waits for production approval. Full flow:
+[Release Management](./release-management.mdx).
+
+Pull-request and merge-group jobs build amd64 images for preview and packaging validation. A merge
+group is a [temporary integration candidate](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#how-merge-queues-work)
+with its own SHA, so pushes to `main` build and attest multi-architecture images for the final commit.
+Releases promote those images by digest without rebuilding them; see
+[Release Management](./release-management.mdx).
 
 ## 🛡️ Quality Gates
 
@@ -142,14 +149,9 @@ Previews are opt-in and self-service. Add the **`preview`** label to your pull r
 no ceremony, and you can label your own PR. Every push redeploys, and **a preview never waits for
 your tests to pass**: it is most useful exactly when they do not.
 
-A preview runs the images CI published for your commit — the same artifacts staging and production
-run. It waits for those images, which CI builds in parallel with the tests, and never for the tests
-themselves. How long that takes is how long CI needs to publish the images your change actually
-rebuilds: a docs-only change re-tags unchanged images and is quick; touching the webapp or the server
-means waiting for that image to build.
-
-That is deliberate: a preview built a second way could start cleanly when the released image would
-not, which is the one thing a preview of a Spring Boot service is well placed to catch.
+A preview runs the amd64 images that pull-request CI builds in parallel with tests, using the release
+Dockerfiles and buildpack configuration. A docs-only change re-tags unchanged images; changes to the
+webapp or server rebuild the affected image.
 
 A sticky comment carries the URL, and GitHub records each accepted update as the transient
 environment `preview/pr-N`, so the pull request's **View deployment** link opens it too.

--- a/scripts/ci-contract.test.ts
+++ b/scripts/ci-contract.test.ts
@@ -200,6 +200,55 @@ void describe("CI contract", () => {
 		assert.match(job(source, "Compose"), /uses: \.\/\.github\/workflows\/ci-compose-validate\.yml/);
 	});
 
+	void test("builds pre-merge candidates on one architecture and final images on both", async () => {
+		const source = await readFile(".github/workflows/cicd.yml", "utf8");
+		const caller = job(source, "Docker");
+		for (const secret of ["SENTRY_AUTH_TOKEN", "SENTRY_ORG", "SENTRY_PROJECT"]) {
+			assert.match(
+				caller,
+				new RegExp(`${secret}: \\$\\{\\{ github\\.event_name == 'push' && secrets\\.${secret}`),
+			);
+		}
+
+		const docker = await readFile(".github/workflows/ci-docker-build.yml", "utf8");
+		for (const name of [
+			"webapp-build",
+			"application-server-build",
+			"agent-pi-build",
+			"postgres-build",
+		]) {
+			const image = job(docker, name);
+			assert.match(
+				image,
+				/single-arch: \${{ github\.event_name == 'pull_request' \|\| github\.event_name == 'merge_group' }}/,
+			);
+			assert.doesNotMatch(image, /^\s+tags:/m);
+		}
+		const inherited = job(docker, "tag-unchanged-images");
+		assert.match(inherited, /HEAD_SHA/);
+		assert.match(inherited, /pr-\$PR_NUMBER/);
+		assert.match(inherited, /run-\$RUN_ID-\$RUN_ATTEMPT/);
+
+		const reusable = await readFile(".github/workflows/reusable-docker-build.yml", "utf8");
+		for (const tag of [
+			/github\.event_name == 'push' && github\.ref_name/,
+			/github\.event_name == 'push' && github\.sha/,
+			/github\.event_name == 'push' && format\('ci-\{0\}', github\.run_number\)/,
+			/github\.event_name == 'pull_request' && github\.event\.pull_request\.head\.sha/,
+			/github\.event_name == 'pull_request' && format\('pr-\{0\}', github\.event\.number\)/,
+			/run-\${{ github\.run_id }}-\${{ github\.run_attempt }}/,
+		]) {
+			assert.match(reusable, tag);
+		}
+		for (const secret of ["SENTRY_AUTH_TOKEN", "SENTRY_ORG", "SENTRY_PROJECT"]) {
+			assert.match(reusable, new RegExp(`github\\.event_name == 'push'.*secrets\\.${secret}`));
+		}
+		assert.match(
+			reusable,
+			/inputs\.single-arch.*linux\/amd64.*ubuntu-24\.04.*linux\/arm64.*ubuntu-24\.04-arm/,
+		);
+	});
+
 	void test("pins every external action to a full commit SHA with a version comment", async () => {
 		const invalid: string[] = [];
 		const files = await Array.fromAsync(glob(".github/{actions,workflows}/**/*.{yml,yaml}"));
@@ -246,6 +295,12 @@ void describe("CI contract", () => {
 	void test("runs release evidence verification through tested TypeScript", async () => {
 		const release = await readFile(".github/workflows/release.yml", "utf8");
 		const rescan = await readFile(".github/workflows/rescan-release-images.yml", "utf8");
+		assert.match(
+			release,
+			/SOURCE_TAG: run-\${{ github\.event\.workflow_run\.id }}-\${{ github\.event\.workflow_run\.run_attempt }}/,
+		);
+		assert.match(release, /imagetools inspect "\$FULL_IMAGE:\$SOURCE_TAG"/);
+		assert.doesNotMatch(release, /imagetools inspect "\$FULL_IMAGE:\$SHA"/);
 		assert.match(rescan, /node scripts\/verify-release-evidence\.ts release-evidence/);
 		assert.doesNotMatch(rescan, /node scripts\/check-release-sbom\.ts/);
 		assert.equal((release.match(/node scripts\/verify-release-evidence\.ts/g) ?? []).length, 3);


### PR DESCRIPTION
## Description

Reduce duplicate container work without weakening the release boundary. Pull-request and merge-queue builds now publish amd64 images under candidate-only tags, while pushes to `main` continue to publish signed and attested amd64/arm64 images for the final commit. Sentry upload credentials are available only to `main` push builds.

GitHub creates a [temporary integration candidate](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#how-merge-queues-work) for a merge queue, and that candidate has its own SHA. Because Hephaestus records the source commit in each image, releases select images from the exact successful `main` workflow run and promote their verified digests without rebuilding. This avoids treating a temporary merge-group artifact as the final release artifact.

This changes repository CI and contributor documentation only, so no changeset, migration, or operator action is required.

## How to test

- [x] Run `pnpm run format`.
- [x] Run `pnpm run check`.
- [x] Run `pnpm run verify`.
- [x] Confirm PR Docker jobs build only `linux/amd64`.
- [x] Confirm CI contract tests cover event-specific platforms and tags, Sentry credential scope, and exact release source-tag selection.
- [x] Confirm the complete hosted CI suite passes.

After merge, verify that the `main` workflow publishes amd64/arm64 indexes with signatures and attestations. On the next version release, verify that source resolution uses `run-<run-id>-<attempt>` and that promotion preserves the resolved digests.

## Checklist

- [x] I did not commit generated-artifact changes that this PR did not cause.
