### PR TITLE
ci(ci): satisfy the review policy with a native approval

### DIFF
--- a/.github/workflows/review-policy.yml
+++ b/.github/workflows/review-policy.yml
@@ -4,72 +4,44 @@ on:
   pull_request_target: # zizmor: ignore[dangerous-triggers] API reads only; no pull-request code is executed.
     branches: [main]
     types: [opened, reopened, synchronize, ready_for_review]
-  pull_request_review:
-    types: [submitted, dismissed]
-  merge_group:
 
 permissions: {}
 
 concurrency:
-  # Never cancel: runs in a group are serialised, so the newest event's verdict is the one that
-  # lands, and a cancelled run publishes nothing rather than a half-written state.
-  group: review-policy-${{ github.event.pull_request.number || github.ref }}
+  # Never cancel: runs in a group are serialised, so the newest event's decision is the one that
+  # lands, and a cancelled run leaves an approval unsubmitted rather than half-written.
+  group: review-policy-${{ github.event.pull_request.number }}
   cancel-in-progress: false
 
 jobs:
-  # This job is *not* the required context. It publishes one — a check run named `review-policy`,
-  # which the `main` ruleset requires and binds to the GitHub Actions integration that a
-  # `GITHUB_TOKEN`-authenticated check run is attributed to. Reporting the verdict separately is
-  # what lets an unreviewed pull request sit pending instead of red: a job can only pass or fail,
-  # and a failing job made a healthy pull request awaiting its first review look broken on the pull
-  # request list. Renaming this job back to `review-policy` would put two check runs of that name
-  # on the same commit and make which one the ruleset reads a race.
-  publish:
-    name: Publish review-policy status
+  # This job is *not* a required status check, and must never become one. The `main` ruleset requires
+  # one native approving review; all this job does is supply that approval for the authors listed in
+  # `REVIEW_POLICY_MAINTAINERS`. A pull request by anyone else gets no approval here and sits in
+  # GitHub's own "Review required" state, which blocks merging, merge-queue entry and auto-merge.
+  #
+  # `synchronize` is load-bearing: the ruleset dismisses stale approvals on push, so every push has
+  # to earn a fresh one.
+  approve:
+    name: Approve a maintainer's pull request
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
-      checks: write
       contents: read
-      pull-requests: read
+      pull-requests: write
     steps:
-      # The queue re-reports every required context against the projected commit, and the policy was
-      # already decided on the pull request that entered the queue. Written out here rather than
-      # routed through the evaluator so the queue's path needs no checkout and no import: a merge
-      # group that never receives this context sits until the queue's timeout drops it.
-      - name: Pass the merge group
-        if: github.event_name == 'merge_group'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        with:
-          script: |
-            await github.rest.checks.create({
-              ...context.repo,
-              // Kept equal to CHECK_NAME in scripts/review-policy.ts; a test asserts they agree.
-              name: 'review-policy',
-              head_sha: context.payload.merge_group.head_sha,
-              status: 'completed',
-              conclusion: 'success',
-              output: {
-                title: 'Satisfied before this merge group was created',
-                summary:
-                  'The review policy is decided on the pull request; entering the merge queue ' +
-                  'already required it to pass.',
-              },
-            });
-
-      # The default branch, never `github.sha`: that is the pull request's merge commit on
-      # `pull_request_review`, which contains pull-request code. The base branch's copy of the
-      # policy is the authoritative one.
+      # The default branch, never `github.sha` or the pull request's head: the base branch's copy of
+      # the policy is the authoritative one, and nothing from the pull request is fetched or run.
       - name: Load the trusted policy evaluator
-        if: github.event_name != 'merge_group'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
           sparse-checkout: scripts
 
-      - name: Publish the review-policy check run
-        if: github.event_name != 'merge_group'
+      # The review is attributed to `github-actions[bot]`, which counts toward the ruleset's
+      # `required_approving_review_count`. That needs the organisation's "Allow GitHub Actions to
+      # create and approve pull requests" setting left on.
+      - name: Approve when the author is a listed maintainer
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           MAINTAINERS: ${{ vars.REVIEW_POLICY_MAINTAINERS }}

--- a/docs/contributor/ci-cd.mdx
+++ b/docs/contributor/ci-cd.mdx
@@ -59,40 +59,45 @@ Before any release, code must pass:
 ### Merge policy
 
 Pull requests targeting `main` merge through GitHub's merge queue after these GitHub
-Actions contexts pass: `CI Status Gate`, `Actionlint`, `Zizmor`, and `review-policy`. Required
+Actions contexts pass: `CI Status Gate`, `Actionlint`, and `Zizmor`. Required
 workflows run again for the merge group, which includes the current base and queued changes ahead of
 the pull request. Each required context is bound to the GitHub Actions integration rather than
 accepting a same-named external status.
 
-`review-policy` accepts an author listed in the comma-separated repository variable
-`REVIEW_POLICY_MAINTAINERS`. Every other author needs an approval from a non-author who currently
-has write access; the approval must cover the current head commit. Repository administrators own the
-allow-list. Native required approvals remain zero because GitHub cannot combine an author's
-self-authored change, a mandatory approval, and the merge queue without bypassing the queue.
+Review is a *native* requirement, not a status check: the `main` ruleset sets
+`required_approving_review_count: 1` with `dismiss_stale_reviews_on_push`, so a pull request without
+a current approval sits in GitHub's own **Review required** state. That state blocks the merge
+button, blocks entry to the merge queue, and holds an armed auto-merge — and the checks list on a
+healthy pull request stays fully green, because waiting for a reviewer is no longer expressed as a
+yellow check.
 
-`review-policy` is a check run the workflow publishes, not the workflow's own job status — the job
-is `Publish review-policy status` and always succeeds. A job can only pass or fail, so while an
-approval was outstanding the required context was red, and a pull request that was healthy and
-simply waiting for its first review read as broken on the pull request list. The verdict now takes
-three shapes, decided by [`scripts/review-policy.ts`](https://github.com/ls1intum/Hephaestus/blob/main/scripts/review-policy.ts):
+The review requirement is not waived for anyone. It is *satisfied* automatically for the authors
+listed in the comma-separated repository variable `REVIEW_POLICY_MAINTAINERS`:
+[`review-policy.yml`](https://github.com/ls1intum/Hephaestus/blob/main/.github/workflows/review-policy.yml)
+submits an approving review with `GITHUB_TOKEN`, attributed to `github-actions[bot]`, which counts
+toward the required count. Every other author waits for a human with write access. Repository
+administrators own the allow-list.
 
-| Verdict | Check run | Reads as |
-| --- | --- | --- |
-| Waiting for an approval | `in_progress`, no conclusion | Pending — blocks merge and merge-queue entry |
-| Author allow-listed, or approved by a non-author with write access | `success` | Green, naming who satisfied it |
-| `REVIEW_POLICY_MAINTAINERS` unset, or the policy could not be evaluated | `failure` | Red, because that is broken |
+Be honest about what that is: auto-approval encodes exactly the policy the old custom
+`review-policy` check encoded — *a listed maintainer may merge their own work* — and it exists only
+because the repository has a single write-access collaborator, so there is nobody else to ask. It is
+not a review. **The moment a second write-access reviewer exists, delete the workflow and the
+`REVIEW_POLICY_MAINTAINERS` variable and let the native requirement stand on its own.** Nothing else
+has to change; the ruleset already asks for the approval.
 
-A pending required context blocks merging and blocks entry to the merge queue exactly as a failing
-one does, so the enforcement is unchanged. `neutral` and `skipped` are not options: GitHub counts
-both as passing a required check.
+Two settings this depends on, both already in place: the organisation's *Allow GitHub Actions to
+create and approve pull requests*, which governs whether `GITHUB_TOKEN` may approve at all, and
+`dismiss_stale_reviews_on_push`, which is why the workflow runs on `synchronize` as well as
+`opened`, `reopened` and `ready_for_review` — every push has to earn a fresh approval. The approval
+is pinned to the head commit it was decided against, and a run that finds its own approval already
+standing on that commit submits nothing, so re-runs do not stack duplicate reviews.
 
-The merge queue's own pass is written into the workflow rather than routed through the evaluator, so
-that path needs no checkout: on `merge_group` the workflow comes from the queued commit while a
-checkout would come from the default branch, and a merge group that never receives the context sits
-until the queue's timeout drops it.
-
-Renaming the check run means editing the ruleset's required context in the same change. A mismatch
-leaves every pull request waiting on a context nothing reports, which blocks the fix too.
+[`scripts/review-policy.ts`](https://github.com/ls1intum/Hephaestus/blob/main/scripts/review-policy.ts)
+holds the decision, and it reads the author login and nothing else — never the diff, the title or
+the body. That is what makes it safe under `pull_request_target` with `pull-requests: write`: the
+job checks out only `scripts` from the default branch, with `persist-credentials: false`, and runs
+no pull-request code. An empty or unset `REVIEW_POLICY_MAINTAINERS` approves nobody and warns, which
+leaves every pull request needing a human — the safe direction.
 
 The changesets Version PR is the temporary exception: updates made with `GITHUB_TOKEN` do not trigger
 the required workflows, so release automation uses the ruleset bypass. The resulting version bump
@@ -215,7 +220,7 @@ why the label is the authority, and which alternatives were priced and declined,
 | Workflow               | Trigger               | Purpose                                            |
 | ---------------------- | --------------------- | -------------------------------------------------- |
 | `cicd.yml`             | PR, merge group, push to main | Validates changes before merge and builds final-SHA images after merge |
-| `review-policy.yml`    | PR and review events, merge queue | Publishes the `review-policy` check: author allow-list or current-head write-access approval |
+| `review-policy.yml`    | PR opened, reopened, synchronized, ready for review | Approves a listed maintainer's pull request so the ruleset's required approval is met; does nothing for anyone else |
 | `ci-quality-gates.yml` | Called by cicd.yml    | Code quality, formatting, schema validation        |
 | `ci-tests.yml`         | Called by cicd.yml    | Unit, integration, visual tests                    |
 | `ci-docker-build.yml`  | Called by cicd.yml    | Docker image builds per component                  |

--- a/scripts/review-policy.test.ts
+++ b/scripts/review-policy.test.ts
@@ -3,12 +3,13 @@ import { readFileSync } from "node:fs";
 import { afterEach, beforeEach, describe, it } from "node:test";
 
 import {
-	CHECK_NAME,
-	currentApprovers,
+	APPROVAL_MARKER,
+	approvalBody,
+	approvalStands,
 	decide,
 	enforce,
 	type ActionsContext,
-	type CheckRunRequest,
+	type CreateReviewRequest,
 	type GitHubApi,
 	type PullRequest,
 	type Review,
@@ -20,9 +21,20 @@ const originalEnvironment = { ...process.env };
 const HEAD = "0123456789abcdef0123456789abcdef01234567";
 const OTHER = "fedcba9876543210fedcba9876543210fedcba98";
 
-const review = (over: Partial<Review> & Pick<Review, "id">): Review => ({
+/** A review this module submitted: it carries the marker. */
+const ours = (over: Partial<Review> & Pick<Review, "id">): Review => ({
 	state: "APPROVED",
 	commit_id: HEAD,
+	body: approvalBody("Maintainer"),
+	user: { login: "github-actions[bot]" },
+	...over,
+});
+
+/** A review somebody else submitted: no marker. */
+const theirs = (over: Partial<Review> & Pick<Review, "id">): Review => ({
+	state: "APPROVED",
+	commit_id: HEAD,
+	body: "Looks good.",
 	user: { login: "reviewer" },
 	...over,
 });
@@ -31,16 +43,19 @@ const pull: PullRequest = {
 	number: 7,
 	base: { ref: "main" },
 	head: { sha: HEAD },
-	user: { login: "Contributor" },
+	user: { login: "MaIntAiner" },
 };
 
 const makeCore = () => {
 	const infos: string[] = [];
+	const warnings: string[] = [];
 	const failures: string[] = [];
 	return {
 		infos,
+		warnings,
 		failures,
 		info: (message: string) => infos.push(message),
+		warning: (message: string) => warnings.push(message),
 		setFailed: (message: string) => failures.push(message),
 	};
 };
@@ -48,12 +63,12 @@ const makeCore = () => {
 interface GitHubOptions {
 	readonly resolvedPull?: PullRequest;
 	readonly reviews?: readonly Review[];
-	readonly permissions?: Readonly<Record<string, string>>;
 	readonly failPullWith?: Error;
+	readonly failReviewWith?: Error;
 }
 
 const makeGitHub = (options: GitHubOptions = {}) => {
-	const created: CheckRunRequest[] = [];
+	const submitted: CreateReviewRequest[] = [];
 	const reviews = [...(options.reviews ?? [])];
 	const getPull = () =>
 		options.failPullWith
@@ -63,45 +78,37 @@ const makeGitHub = (options: GitHubOptions = {}) => {
 	const github: GitHubApi = {
 		paginate: () => Promise.resolve(reviews),
 		rest: {
-			checks: {
-				create: (params) => {
-					created.push(params);
-					return Promise.resolve({ data: { id: created.length } });
-				},
-			},
 			pulls: {
 				get: getPull,
 				listReviews: () => Promise.resolve({ data: reviews }),
-			},
-			repos: {
-				getCollaboratorPermissionLevel: (params) =>
-					Promise.resolve({
-						data: { permission: options.permissions?.[String(params.username)] ?? "read" },
-					}),
+				createReview: (params) => {
+					if (options.failReviewWith) return Promise.reject(options.failReviewWith);
+					submitted.push(params);
+					return Promise.resolve({ data: { id: submitted.length } });
+				},
 			},
 		},
 	};
-	return { created, github };
+	return { submitted, github };
 };
 
-/** The single check run a run under test is expected to have published. */
-const onlyRun = (created: readonly CheckRunRequest[]): CheckRunRequest => {
-	assert.equal(created.length, 1);
-	const [run] = created;
-	assert.ok(run);
-	return run;
+/** The single review a run under test is expected to have submitted. */
+const onlyReview = (submitted: readonly CreateReviewRequest[]): CreateReviewRequest => {
+	assert.equal(submitted.length, 1);
+	const [review] = submitted;
+	assert.ok(review);
+	return review;
 };
 
 const context: ActionsContext = {
 	eventName: "pull_request_target",
 	repo: { owner: "owner", repo: "repo" },
-	payload: { pull_request: { number: 7, head: { sha: HEAD } } },
+	payload: { pull_request: { number: 7 } },
 };
 
 void describe("review policy", () => {
 	beforeEach(() => {
 		process.env.MAINTAINERS = "Maintainer";
-		delete process.env.GITHUB_RUN_ID;
 	});
 
 	afterEach(() => {
@@ -119,232 +126,254 @@ void describe("review policy", () => {
 		});
 	});
 
-	void describe("currentApprovers", () => {
-		void it("accepts an approval of the head commit from a non-author", () => {
-			assert.deepEqual(currentApprovers([review({ id: 1 })], "contributor", HEAD), ["reviewer"]);
+	void describe("approvalStands", () => {
+		void it("recognises this module's own approval of the head commit", () => {
+			assert.equal(approvalStands([ours({ id: 1 })], HEAD), true);
 		});
 
-		void it("ignores the author's own approval", () => {
-			const own = review({ id: 1, user: { login: "Contributor" } });
-			assert.deepEqual(currentApprovers([own], "contributor", HEAD), []);
+		void it("ignores an approval recorded against an earlier commit", () => {
+			// `dismiss_stale_reviews_on_push` and the `synchronize` event race; pinning on the commit
+			// settles it without waiting for the dismissal to land.
+			assert.equal(approvalStands([ours({ id: 1, commit_id: OTHER })], HEAD), false);
 		});
 
-		void it("ignores an approval of an earlier commit", () => {
-			const stale = [review({ id: 1, commit_id: OTHER })];
-			assert.deepEqual(currentApprovers(stale, "contributor", HEAD), []);
+		void it("ignores an approval this module did not submit", () => {
+			assert.equal(approvalStands([theirs({ id: 1 })], HEAD), false);
 		});
 
-		void it("keeps only a reviewer's latest decisive review", () => {
-			const reviews = [
-				review({ id: 1 }),
-				review({ id: 2, state: "CHANGES_REQUESTED" }),
-				review({ id: 9, state: "COMMENTED" }),
-			];
-			assert.deepEqual(currentApprovers(reviews, "contributor", HEAD), []);
+		void it("treats its own dismissed approval as no longer standing", () => {
+			const reviews = [ours({ id: 1 }), ours({ id: 2, state: "DISMISSED" })];
+			assert.equal(approvalStands(reviews, HEAD), false);
 		});
 
-		void it("lets a later approval replace requested changes, whatever order they arrive in", () => {
-			const reviews = [review({ id: 5 }), review({ id: 2, state: "CHANGES_REQUESTED" })];
-			assert.deepEqual(currentApprovers(reviews, "contributor", HEAD), ["reviewer"]);
+		void it("reads the latest decisive review whatever order they arrive in", () => {
+			const reviews = [ours({ id: 5 }), ours({ id: 2, state: "DISMISSED" })];
+			assert.equal(approvalStands(reviews, HEAD), true);
 		});
 
-		void it("treats a dismissed approval as no longer standing", () => {
-			const reviews = [review({ id: 1 }), review({ id: 2, state: "DISMISSED" })];
-			assert.deepEqual(currentApprovers(reviews, "contributor", HEAD), []);
+		void it("lets a comment leave a standing approval alone", () => {
+			const reviews = [ours({ id: 1 }), ours({ id: 2, state: "COMMENTED" })];
+			assert.equal(approvalStands(reviews, HEAD), true);
 		});
 
-		void it("survives a review whose author is gone", () => {
-			assert.deepEqual(currentApprovers([review({ id: 1, user: null })], "contributor", HEAD), []);
+		void it("survives a review with no body at all", () => {
+			assert.equal(approvalStands([theirs({ id: 1, body: null })], HEAD), false);
+		});
+
+		void it("finds no approval in an empty review list", () => {
+			assert.equal(approvalStands([], HEAD), false);
 		});
 	});
 
 	void describe("decide", () => {
 		const base = {
-			author: "Contributor",
+			author: "MaIntAiner",
+			baseRef: "main",
 			headSha: HEAD,
 			reviews: [] as readonly Review[],
-			permissionOf: () => Promise.resolve("read"),
 		};
 
-		void it("passes a listed maintainer without any approval", async () => {
-			const verdict = await decide({
+		void it("approves a listed maintainer, matching the login case-insensitively", () => {
+			const decision = decide({ ...base, maintainers: new Set(["maintainer"]) });
+			assert.equal(decision.kind, "approve");
+			assert.match(decision.reason, /REVIEW_POLICY_MAINTAINERS/);
+		});
+
+		void it("does nothing for an author who is not listed", () => {
+			const decision = decide({
 				...base,
-				author: "MaIntAiner",
+				author: "Contributor",
 				maintainers: new Set(["maintainer"]),
 			});
-			assert.equal(verdict.kind, "satisfied");
-			assert.match(verdict.title, /is a listed maintainer/);
+			assert.equal(decision.kind, "skip");
+			assert.match(decision.reason, /needs an approval from someone with write access/);
 		});
 
-		void it("passes an approval from a non-author with write access", async () => {
-			const verdict = await decide({
+		void it("approves nobody when the allow-list is empty", () => {
+			// The fail-safe direction: with nothing listed, every pull request needs a human.
+			assert.equal(decide({ ...base, maintainers: new Set() }).kind, "skip");
+		});
+
+		void it("does not approve a second time while its approval stands", () => {
+			const decision = decide({
 				...base,
 				maintainers: new Set(["maintainer"]),
-				reviews: [review({ id: 1 })],
-				permissionOf: () => Promise.resolve("write"),
+				reviews: [ours({ id: 1 })],
 			});
-			assert.equal(verdict.kind, "satisfied");
-			assert.equal(verdict.title, "Approved by @reviewer");
+			assert.equal(decision.kind, "standing");
 		});
 
-		void it("accepts admin and maintain access too", async () => {
-			for (const permission of ["admin", "maintain"]) {
-				const verdict = await decide({
-					...base,
-					maintainers: new Set(["maintainer"]),
-					reviews: [review({ id: 1 })],
-					permissionOf: () => Promise.resolve(permission),
-				});
-				assert.equal(verdict.kind, "satisfied", permission);
-			}
-		});
-
-		void it("waits when the only approver lacks write access", async () => {
-			const verdict = await decide({
+		void it("re-approves once a push has moved the head commit", () => {
+			const decision = decide({
 				...base,
 				maintainers: new Set(["maintainer"]),
-				reviews: [review({ id: 1 })],
+				reviews: [ours({ id: 1, commit_id: OTHER })],
 			});
-			assert.equal(verdict.kind, "waiting");
-			assert.equal(verdict.title, "Waiting for a maintainer approval");
+			assert.equal(decision.kind, "approve");
 		});
 
-		void it("tells the reader what unblocks the pull request", async () => {
-			const verdict = await decide({ ...base, maintainers: new Set(["maintainer"]) });
-			assert.match(verdict.summary, /waiting, not broken/);
-			assert.match(verdict.summary, /other than the author/);
-			assert.match(verdict.summary, /0123456/);
-		});
-
-		void it("reports an empty allow-list as a misconfiguration, not as waiting", async () => {
-			const verdict = await decide({ ...base, maintainers: new Set() });
-			assert.equal(verdict.kind, "misconfigured");
-			assert.match(verdict.title, /REVIEW_POLICY_MAINTAINERS/);
-		});
-
-		void it("still passes a valid approval when the allow-list is empty", async () => {
-			const verdict = await decide({
+		void it("ignores a stranger's approval when deciding whether to approve", () => {
+			// A read-access approval does not count toward the ruleset, so it must not talk this
+			// module out of supplying one that does.
+			const decision = decide({
 				...base,
-				maintainers: new Set(),
-				reviews: [review({ id: 1 })],
-				permissionOf: () => Promise.resolve("write"),
+				maintainers: new Set(["maintainer"]),
+				reviews: [theirs({ id: 1 })],
 			});
-			assert.equal(verdict.kind, "satisfied");
+			assert.equal(decision.kind, "approve");
+		});
+
+		void it("stays out of the way of a pull request that does not target main", () => {
+			const decision = decide({
+				...base,
+				baseRef: "release",
+				maintainers: new Set(["maintainer"]),
+			});
+			assert.equal(decision.kind, "skip");
+			assert.match(decision.reason, /release/);
+		});
+	});
+
+	void describe("approvalBody", () => {
+		void it("carries the marker approvalStands looks for", () => {
+			assert.ok(approvalBody("Maintainer").includes(APPROVAL_MARKER));
+			assert.equal(approvalStands([ours({ id: 1, body: approvalBody("Maintainer") })], HEAD), true);
 		});
 	});
 
 	void describe("enforce", () => {
-		void it("publishes a pending check run while an approval is outstanding", async () => {
-			const { created, github } = makeGitHub();
+		void it("submits an approving review for a listed maintainer, pinned to the head commit", async () => {
+			const { submitted, github } = makeGitHub();
 			const core = makeCore();
 			await enforce({ github, context, core });
 
-			const run = onlyRun(created);
-			assert.equal(run.name, CHECK_NAME);
-			assert.equal(run.head_sha, HEAD);
-			// Pending blocks the merge button and merge-queue entry. `neutral` and `skipped` are
-			// documented as passing, so neither may ever stand in for waiting.
-			assert.equal(run.status, "in_progress");
-			assert.equal(run.conclusion, undefined);
+			const review = onlyReview(submitted);
+			assert.equal(review.event, "APPROVE");
+			assert.equal(review.pull_number, 7);
+			assert.equal(review.commit_id, HEAD);
+			assert.ok(review.body.includes(APPROVAL_MARKER));
 			assert.deepEqual(core.failures, []);
 		});
 
-		void it("publishes success once a write-access reviewer has approved the head commit", async () => {
-			const { created, github } = makeGitHub({
-				reviews: [review({ id: 1 })],
-				permissions: { reviewer: "write" },
+		void it("submits nothing for an author who is not on the allow-list", async () => {
+			const { submitted, github } = makeGitHub({
+				resolvedPull: { ...pull, user: { login: "Contributor" } },
 			});
 			const core = makeCore();
 			await enforce({ github, context, core });
 
-			const run = onlyRun(created);
-			assert.equal(run.status, "completed");
-			assert.equal(run.conclusion, "success");
+			assert.deepEqual(submitted, []);
 			assert.deepEqual(core.failures, []);
 		});
 
-		void it("stays out of the way of a pull request that does not target main", async () => {
-			const { created, github } = makeGitHub({
+		void it("submits nothing when its own approval already stands", async () => {
+			const { submitted, github } = makeGitHub({ reviews: [ours({ id: 1 })] });
+			await enforce({ github, context, core: makeCore() });
+
+			assert.deepEqual(submitted, []);
+		});
+
+		void it("submits nothing for a pull request that does not target main", async () => {
+			const { submitted, github } = makeGitHub({
 				resolvedPull: { ...pull, base: { ref: "release" } },
 			});
-			const core = makeCore();
-			await enforce({ github, context, core });
+			await enforce({ github, context, core: makeCore() });
 
-			const run = onlyRun(created);
-			assert.equal(run.conclusion, "success");
-			assert.match(run.output.title, /release/);
+			assert.deepEqual(submitted, []);
 		});
 
-		void it("reports an evaluation that could not run in red, and fails the job", async () => {
-			const { created, github } = makeGitHub({ failPullWith: new Error("API is down") });
+		void it("warns, and approves nobody, when the allow-list is unset", async () => {
+			delete process.env.MAINTAINERS;
+			const { submitted, github } = makeGitHub();
 			const core = makeCore();
 			await enforce({ github, context, core });
 
-			const run = onlyRun(created);
-			assert.equal(run.conclusion, "failure");
-			assert.equal(run.head_sha, HEAD);
+			assert.deepEqual(submitted, []);
+			assert.equal(core.warnings.length, 1);
+			assert.match(String(core.warnings[0]), /REVIEW_POLICY_MAINTAINERS/);
+			assert.deepEqual(core.failures, []);
+		});
+
+		void it("reads the author from the API rather than from the webhook payload", async () => {
+			// The payload is attacker-adjacent under `pull_request_target`; the API is not.
+			const { submitted, github } = makeGitHub({
+				resolvedPull: { ...pull, user: { login: "Contributor" } },
+			});
+			await enforce({
+				github,
+				core: makeCore(),
+				context: { ...context, payload: { pull_request: { number: 7 } } },
+			});
+
+			assert.deepEqual(submitted, []);
+		});
+
+		void it("fails the job when the pull request cannot be read", async () => {
+			const { submitted, github } = makeGitHub({ failPullWith: new Error("API is down") });
+			const core = makeCore();
+			await enforce({ github, context, core });
+
+			assert.deepEqual(submitted, []);
 			assert.equal(core.failures.length, 1);
+			assert.match(String(core.failures[0]), /API is down/);
+		});
+
+		void it("fails the job when the review cannot be submitted", async () => {
+			const { github } = makeGitHub({ failReviewWith: new Error("review rejected") });
+			const core = makeCore();
+			await enforce({ github, context, core });
+
+			assert.equal(core.failures.length, 1);
+			assert.match(String(core.failures[0]), /review rejected/);
 		});
 
 		void it("fails loudly when an event carries no pull request at all", async () => {
-			const { created, github } = makeGitHub();
+			const { submitted, github } = makeGitHub();
 			const core = makeCore();
 			await enforce({
 				github,
 				core,
-				context: { eventName: "pull_request_review", repo: context.repo, payload: {} },
+				context: { eventName: "pull_request_target", repo: context.repo, payload: {} },
 			});
 
-			assert.deepEqual(created, []);
+			assert.deepEqual(submitted, []);
 			assert.equal(core.failures.length, 1);
-		});
-
-		void it("links the check run to the run that decided it", async () => {
-			process.env.GITHUB_RUN_ID = "42";
-			process.env.GITHUB_SERVER_URL = "https://github.example";
-			const { created, github } = makeGitHub();
-			await enforce({ github, context, core: makeCore() });
-
-			assert.equal(
-				onlyRun(created).details_url,
-				"https://github.example/owner/repo/actions/runs/42",
-			);
 		});
 	});
 
-	// A mismatch between these and the ruleset's required context deadlocks every pull request,
-	// including the one that would fix it, so the workflow's half of the contract is asserted here.
-	void describe("the workflow that publishes it", () => {
+	// The workflow half of the contract. It runs under `pull_request_target` with
+	// `pull-requests: write`, so the hardening below is the security boundary, not a preference.
+	void describe("the workflow that applies it", () => {
 		const workflow = readFileSync(
 			new URL("../.github/workflows/review-policy.yml", import.meta.url),
 			"utf8",
 		);
 
-		void it("publishes the merge group's verdict under the required name", () => {
-			assert.match(workflow, new RegExp(`name: '${CHECK_NAME}',`));
-			assert.match(workflow, /head_sha: context\.payload\.merge_group\.head_sha/);
-			assert.match(workflow, /conclusion: 'success'/);
-		});
-
-		void it("answers the merge group without a checkout it may not be able to make", () => {
-			// On `merge_group` the workflow comes from the queued commit while the checkout would come
-			// from the default branch, so the queue must never depend on a file that has yet to land.
-			const mergeGroupOnly = workflow.slice(
-				workflow.indexOf("Pass the merge group"),
-				workflow.indexOf("Load the trusted policy evaluator"),
-			);
-			assert.ok(mergeGroupOnly.length > 0);
-			assert.doesNotMatch(mergeGroupOnly, /uses: actions\/checkout|GITHUB_WORKSPACE/);
-		});
-
-		void it("never names the job after the context it publishes", () => {
-			// Two check runs of one name on a commit make which one the ruleset reads a race.
-			assert.doesNotMatch(workflow, new RegExp(`^\\s*name: ${CHECK_NAME}\\s*$`, "m"));
-		});
-
 		void it("keeps the checkout on the base branch's copy of the policy", () => {
 			assert.match(workflow, /ref: \$\{\{ github\.event\.repository\.default_branch \}\}/);
 			assert.doesNotMatch(workflow, /ref: \$\{\{ github\.sha \}\}/);
+			assert.doesNotMatch(workflow, /github\.event\.pull_request\.head/);
+		});
+
+		void it("checks out no more than the policy, and keeps no credentials", () => {
+			assert.match(workflow, /persist-credentials: false/);
+			assert.match(workflow, /sparse-checkout: scripts/);
+		});
+
+		void it("asks for write access to pull requests and nothing else", () => {
+			assert.match(workflow, /^permissions: \{\}$/m);
+			assert.match(workflow, /pull-requests: write/);
+			assert.doesNotMatch(workflow, /contents: write/);
+		});
+
+		void it("re-runs on every push, because the ruleset dismisses stale approvals", () => {
+			assert.match(workflow, /types: \[opened, reopened, synchronize, ready_for_review\]/);
+		});
+
+		void it("publishes no check run, now that the ruleset requires a native approval", () => {
+			// A required context nothing reports blocks every pull request, including the fix.
+			assert.doesNotMatch(workflow, /checks\.create|checks: write/);
+			assert.doesNotMatch(workflow, /merge_group/);
 		});
 	});
 });

--- a/scripts/review-policy.ts
+++ b/scripts/review-policy.ts
@@ -1,13 +1,27 @@
 /**
- * The review policy the `main` ruleset requires, published as a check run of its own.
+ * The review policy, expressed as a review rather than as a check run.
  *
- * The policy itself is unchanged: an author listed in `REVIEW_POLICY_MAINTAINERS` satisfies it, and
- * every other author needs an approval of the current head commit from a non-author who holds write
- * access. What changed is how the verdict is reported. The workflow job used to *be* the required
- * `review-policy` context and failed while an approval was outstanding, so a healthy pull request
- * waiting its turn looked broken on the pull request list. The job now always succeeds and this
- * module publishes the verdict as a separate check run under the required name, which lets
- * "waiting" be a pending check rather than a red one.
+ * The `main` ruleset now requires one native approval. This module supplies it for the authors the
+ * repository has decided need no second reader — the logins listed in `REVIEW_POLICY_MAINTAINERS` —
+ * by submitting an approving review with `GITHUB_TOKEN`, which GitHub attributes to
+ * `github-actions[bot]` and counts toward `required_approving_review_count`. Every other author gets
+ * nothing from this module, so their pull request sits in GitHub's own "Review required" state until
+ * a human with write access approves it.
+ *
+ * Two properties this replaces the old custom check run for. A pull request awaiting review now
+ * reads as *awaiting review* in the merge box instead of carrying a permanently yellow required
+ * context, and the checks list on a healthy pull request goes fully green. The enforcement is
+ * GitHub's, not ours: the count is evaluated at merge and at merge-queue entry, and an armed
+ * auto-merge will not fire while it is unmet.
+ *
+ * The policy this encodes — "a maintainer may merge their own work" — exists only because the
+ * repository has a single write-access collaborator, so there is nobody else to ask. The moment a
+ * second reviewer holds write access, delete this workflow and the allow-list with it and let the
+ * native requirement stand on its own.
+ *
+ * The decision reads the author login and nothing else. It never reads the diff, the title, the body
+ * or any other pull-request-controlled content, which is what makes it safe to run under
+ * `pull_request_target` with `pull-requests: write`.
  */
 
 type ApiMethod<T> = (params: Record<string, unknown>) => Promise<{ data: T }>;
@@ -16,6 +30,7 @@ export interface Review {
 	readonly id: number;
 	readonly state: string;
 	readonly commit_id: string;
+	readonly body?: string | null;
 	readonly user: { readonly login: string } | null;
 }
 
@@ -26,16 +41,14 @@ export interface PullRequest {
 	readonly user: { readonly login: string };
 }
 
-/** The subset of the Checks API request this module ever sends. */
-export interface CheckRunRequest {
+/** The subset of the review-creation request this module ever sends. */
+export interface CreateReviewRequest {
 	readonly owner: string;
 	readonly repo: string;
-	readonly name: string;
-	readonly head_sha: string;
-	readonly status: string;
-	readonly conclusion?: string;
-	readonly details_url?: string;
-	readonly output: { readonly title: string; readonly summary: string };
+	readonly pull_number: number;
+	readonly commit_id: string;
+	readonly event: string;
+	readonly body: string;
 }
 
 export interface GitHubApi {
@@ -44,15 +57,12 @@ export interface GitHubApi {
 		params: Record<string, unknown>,
 	) => Promise<Review[]>;
 	readonly rest: {
-		readonly checks: {
-			readonly create: (params: CheckRunRequest) => Promise<{ data: { readonly id: number } }>;
-		};
 		readonly pulls: {
 			readonly get: ApiMethod<PullRequest>;
 			readonly listReviews: ApiMethod<Review[]>;
-		};
-		readonly repos: {
-			readonly getCollaboratorPermissionLevel: ApiMethod<{ readonly permission: string }>;
+			readonly createReview: (
+				params: CreateReviewRequest,
+			) => Promise<{ data: { readonly id: number } }>;
 		};
 	};
 }
@@ -61,15 +71,13 @@ export interface ActionsContext {
 	readonly eventName: string;
 	readonly repo: { readonly owner: string; readonly repo: string };
 	readonly payload: {
-		readonly pull_request?: {
-			readonly number: number;
-			readonly head?: { readonly sha: string };
-		};
+		readonly pull_request?: { readonly number: number };
 	};
 }
 
 export interface ActionsCore {
 	readonly info: (message: string) => void;
+	readonly warning: (message: string) => void;
 	readonly setFailed: (message: string) => void;
 }
 
@@ -79,47 +87,19 @@ export interface EnforceInput {
 	readonly core: ActionsCore;
 }
 
-export type VerdictKind = "satisfied" | "waiting" | "misconfigured";
-
-export interface Verdict {
-	readonly kind: VerdictKind;
-	readonly title: string;
-	readonly summary: string;
-}
-
-/**
- * The context name the `main` ruleset requires, bound there to the GitHub Actions integration —
- * which a `GITHUB_TOKEN`-authenticated check run is attributed to. Changing this string without
- * editing the ruleset in the same breath leaves every pull request waiting on a context nothing
- * reports, so no pull request can merge and no fix can land.
- */
-export const CHECK_NAME = "review-policy";
-
-/** The policy guards the branch the ruleset guards; `pull_request_review` carries no base filter. */
+/** The policy guards the branch the ruleset guards. */
 export const POLICY_BASE_REF = "main";
 
-const WRITE_PERMISSIONS = new Set(["admin", "maintain", "write"]);
+/**
+ * Marks the reviews this module submitted, so a re-run recognises its own standing approval and adds
+ * no second one. Matching on the marker rather than on the reviewer login keeps a human approval —
+ * which may or may not carry write access, and so may or may not count — out of the decision: the
+ * only approval this module reasons about is the one it is responsible for.
+ */
+export const APPROVAL_MARKER = "<!-- review-policy: maintainer auto-approval -->";
 
 /** Review states that replace a reviewer's previous position. `COMMENTED` leaves it standing. */
 const DECISIVE_STATES = new Set(["APPROVED", "CHANGES_REQUESTED", "DISMISSED"]);
-
-/**
- * GitHub treats a required check that concludes `neutral` or `skipped` as passing — "Required
- * status checks must have a `successful`, `skipped`, or `neutral` status before collaborators can
- * make changes to a protected branch" (GitHub Docs, *About protected branches*) — so neither may
- * stand for "waiting". A check run that has not completed is pending instead, and a pending
- * required context blocks the merge button and merge-queue entry just as a failing one does: a
- * pull request "must have passed all required branch protection checks" before it can be queued,
- * and a workflow that leaves its required check pending "will be blocked from merging" (GitHub
- * Docs, *Troubleshooting required status checks*). Pending buys the same enforcement and reads as
- * waiting rather than broken.
- */
-const CHECK_STATE: Record<VerdictKind, { readonly status: string; readonly conclusion?: string }> =
-	{
-		satisfied: { status: "completed", conclusion: "success" },
-		waiting: { status: "in_progress" },
-		misconfigured: { status: "completed", conclusion: "failure" },
-	};
 
 const shortSha = (sha: string): string => sha.slice(0, 7);
 
@@ -132,196 +112,143 @@ export const parseMaintainers = (raw: string | undefined): Set<string> =>
 	);
 
 /**
- * Reviewers whose latest decisive review approves `headSha`, the author excluded. Reviews arrive
- * oldest-first by id, so the last one a reviewer left is the one that counts; an approval of an
- * earlier commit does not carry to a commit nobody has read.
+ * Whether this module's own approval still covers `headSha`.
+ *
+ * The ruleset sets `dismiss_stale_reviews_on_push`, so a push both invalidates the previous approval
+ * and fires `synchronize`. Pinning on `commit_id` rather than on the dismissal state settles that
+ * race in the safe direction: an approval recorded against an earlier commit does not count here
+ * either way, so a re-approval is submitted whether or not GitHub has finished dismissing it yet.
  */
-export const currentApprovers = (
-	reviews: readonly Review[],
-	author: string,
-	headSha: string,
-): string[] => {
-	const latestByReviewer = new Map<string, Review>();
-	for (const review of reviews.toSorted((left, right) => left.id - right.id)) {
-		if (
-			review.user &&
-			review.user.login.toLowerCase() !== author.toLowerCase() &&
-			DECISIVE_STATES.has(review.state)
-		) {
-			latestByReviewer.set(review.user.login.toLowerCase(), review);
-		}
-	}
+export const approvalStands = (reviews: readonly Review[], headSha: string): boolean => {
+	const ours = reviews
+		.filter((entry) => (entry.body ?? "").includes(APPROVAL_MARKER))
+		.filter((entry) => DECISIVE_STATES.has(entry.state))
+		.toSorted((left, right) => left.id - right.id);
 
-	const approvers: string[] = [];
-	for (const [login, review] of latestByReviewer) {
-		if (review.state === "APPROVED" && review.commit_id === headSha) approvers.push(login);
-	}
-	return approvers;
+	const latest = ours.at(-1);
+	return latest !== undefined && latest.state === "APPROVED" && latest.commit_id === headSha;
 };
+
+export type DecisionKind = "approve" | "standing" | "skip";
+
+export interface Decision {
+	readonly kind: DecisionKind;
+	readonly reason: string;
+}
 
 export interface DecisionInput {
 	readonly author: string;
+	readonly baseRef: string;
 	readonly headSha: string;
 	readonly maintainers: ReadonlySet<string>;
 	readonly reviews: readonly Review[];
-	readonly permissionOf: (login: string) => Promise<string>;
 }
 
-/** The policy verdict, and the sentence a reader needs to know what happens next. */
-export const decide = async (input: DecisionInput): Promise<Verdict> => {
-	if (input.maintainers.has(input.author.toLowerCase())) {
+/**
+ * What this module should do about one pull request. Purely a function of the author login, the base
+ * branch, the head commit and the approvals already on record — never of anything the author wrote.
+ */
+export const decide = (input: DecisionInput): Decision => {
+	if (input.baseRef !== POLICY_BASE_REF) {
 		return {
-			kind: "satisfied",
-			title: `@${input.author} is a listed maintainer`,
-			summary:
-				`@${input.author} is listed in the \`REVIEW_POLICY_MAINTAINERS\` repository variable, ` +
-				"so this pull request needs no separate approval to satisfy the review policy.",
+			kind: "skip",
+			reason: `The review policy guards pull requests that target ${POLICY_BASE_REF}, not ${input.baseRef}.`,
 		};
 	}
 
-	for (const login of currentApprovers(input.reviews, input.author, input.headSha)) {
-		const permission = await input.permissionOf(login);
-		if (WRITE_PERMISSIONS.has(permission)) {
-			return {
-				kind: "satisfied",
-				title: `Approved by @${login}`,
-				summary:
-					`@${login} holds \`${permission}\` access and approved commit ` +
-					`\`${shortSha(input.headSha)}\`. Pushing a new commit dismisses that approval and ` +
-					"returns this check to waiting.",
-			};
-		}
+	if (!input.maintainers.has(input.author.toLowerCase())) {
+		return {
+			kind: "skip",
+			reason:
+				`@${input.author} is not listed in REVIEW_POLICY_MAINTAINERS, so this pull request ` +
+				"needs an approval from someone with write access.",
+		};
 	}
 
-	// An empty allow-list is a repository misconfiguration rather than a pull request that is
-	// waiting its turn, and only says so once no approval has satisfied the policy anyway — so the
-	// set of pull requests this lets through is unchanged.
-	if (input.maintainers.size === 0) {
+	if (approvalStands(input.reviews, input.headSha)) {
 		return {
-			kind: "misconfigured",
-			title: "REVIEW_POLICY_MAINTAINERS is not set",
-			summary:
-				"The `REVIEW_POLICY_MAINTAINERS` repository variable is empty or unset, so the author " +
-				"allow-list cannot be evaluated and no approval on this pull request satisfies the " +
-				"review policy. A repository administrator has to set it.",
+			kind: "standing",
+			reason: `This pull request is already approved for ${shortSha(input.headSha)}.`,
 		};
 	}
 
 	return {
-		kind: "waiting",
-		title: "Waiting for a maintainer approval",
-		summary:
-			"This pull request is waiting, not broken.\n\n" +
-			"**To unblock it:** someone other than the author, holding write access, has to approve " +
-			`commit \`${shortSha(input.headSha)}\`. GitHub does not accept an approval from the ` +
-			`author, so @${input.author} cannot clear this alone.\n\n` +
-			"Pushing a new commit dismisses existing approvals and returns this check here.",
+		kind: "approve",
+		reason:
+			`@${input.author} is listed in REVIEW_POLICY_MAINTAINERS, so ${shortSha(input.headSha)} ` +
+			"is approved on the policy's behalf.",
 	};
 };
 
-/** Where the check run's "Details" link points, so a reader can reach the run that decided it. */
-const detailsUrl = (context: ActionsContext): string | undefined => {
-	const run = process.env.GITHUB_RUN_ID;
-	if (!run) return undefined;
-	const server = process.env.GITHUB_SERVER_URL ?? "https://github.com";
-	return `${server}/${context.repo.owner}/${context.repo.repo}/actions/runs/${run}`;
-};
-
-const publish = async (
-	github: GitHubApi,
-	context: ActionsContext,
-	core: ActionsCore,
-	headSha: string,
-	verdict: Verdict,
-): Promise<void> => {
-	// A fresh check run rather than an update: GitHub silently ignores a status that walks a
-	// completed check run back to `in_progress`, which is exactly the dismissed-approval case. It
-	// keeps only the newest run per app and name on a commit, so creating one leaves no stale
-	// duplicate behind either.
-	await github.rest.checks.create({
-		...context.repo,
-		name: CHECK_NAME,
-		head_sha: headSha,
-		...CHECK_STATE[verdict.kind],
-		details_url: detailsUrl(context),
-		output: { title: verdict.title, summary: verdict.summary },
-	});
-	core.info(`${CHECK_NAME} on ${shortSha(headSha)} is ${verdict.kind}: ${verdict.title}`);
-};
-
-const evaluate = async (
-	github: GitHubApi,
-	context: ActionsContext,
-	pull: PullRequest,
-): Promise<Verdict> => {
-	if (pull.base.ref !== POLICY_BASE_REF) {
-		return {
-			kind: "satisfied",
-			title: `Not required for base branch ${pull.base.ref}`,
-			summary: `The review policy guards pull requests that target \`${POLICY_BASE_REF}\`.`,
-		};
-	}
-
-	const reviews = await github.paginate(github.rest.pulls.listReviews, {
-		...context.repo,
-		pull_number: pull.number,
-		per_page: 100,
-	});
-
-	return await decide({
-		author: pull.user.login,
-		headSha: pull.head.sha,
-		maintainers: parseMaintainers(process.env.MAINTAINERS),
-		reviews,
-		permissionOf: async (login) => {
-			const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
-				...context.repo,
-				username: login,
-			});
-			return data.permission;
-		},
-	});
-};
+/** The body of the review this module submits, marker included. */
+export const approvalBody = (author: string): string =>
+	`${APPROVAL_MARKER}\nApproved automatically: @${author} is listed in the ` +
+	"`REVIEW_POLICY_MAINTAINERS` repository variable, which the repository treats as satisfying the " +
+	"review requirement. See the review policy in `docs/contributor/ci-cd.mdx`.";
 
 /**
- * Publishes the required `review-policy` check run for one pull request event. The merge queue is
- * deliberately not routed here: the workflow answers `merge_group` inline, so the queue's path
- * needs neither a checkout nor this module, and a commit added to the queue before this file
- * reached the default branch still gets its context.
+ * Applies the review policy to one pull request event.
+ *
+ * The pull request is re-read from the API rather than trusted from the webhook payload, so the
+ * author login and head commit come from GitHub rather than from the event that woke the workflow.
+ * A failure here fails the job: nothing is approved, and the native requirement leaves the pull
+ * request blocked, which is the safe direction.
  */
 export const enforce = async ({ github, context, core }: EnforceInput): Promise<void> => {
-	const pullRequest = context.payload.pull_request;
-	if (!pullRequest) {
+	const eventPullRequest = context.payload.pull_request;
+	if (!eventPullRequest) {
 		core.setFailed(`A ${context.eventName} event carried no pull request to evaluate.`);
 		return;
 	}
 
-	// The webhook's own head SHA, kept only so a failure that happens before the pull request is
-	// read still has a commit to report against.
-	let headSha = pullRequest.head?.sha;
 	try {
 		const { data: pull } = await github.rest.pulls.get({
 			...context.repo,
-			pull_number: pullRequest.number,
+			pull_number: eventPullRequest.number,
 		});
-		headSha = pull.head.sha;
-		await publish(github, context, core, headSha, await evaluate(github, context, pull));
+
+		const maintainers = parseMaintainers(process.env.MAINTAINERS);
+		if (maintainers.size === 0) {
+			// Fail-safe, and quietly so: with nobody allow-listed every pull request simply needs a
+			// human approval, which is what the native requirement asks for anyway. It is worth saying
+			// out loud because a maintainer whose own pull request stopped self-approving would
+			// otherwise have to guess why.
+			core.warning(
+				"REVIEW_POLICY_MAINTAINERS is empty or unset, so no pull request is auto-approved. " +
+					"Every pull request now needs an approval from someone with write access.",
+			);
+		}
+
+		const reviews = await github.paginate(github.rest.pulls.listReviews, {
+			...context.repo,
+			pull_number: pull.number,
+			per_page: 100,
+		});
+
+		const decision = decide({
+			author: pull.user.login,
+			baseRef: pull.base.ref,
+			headSha: pull.head.sha,
+			maintainers,
+			reviews,
+		});
+		core.info(decision.reason);
+		if (decision.kind !== "approve") return;
+
+		// `commit_id` pins the approval to the commit the decision was made against. If a push landed
+		// between the read and this call, the approval attaches to the commit that was evaluated and
+		// the ruleset treats it as stale for the new head — and the push's own `synchronize` event
+		// produces a fresh one.
+		await github.rest.pulls.createReview({
+			...context.repo,
+			pull_number: pull.number,
+			commit_id: pull.head.sha,
+			event: "APPROVE",
+			body: approvalBody(pull.user.login),
+		});
+		core.info(`Approved ${shortSha(pull.head.sha)} on pull request #${pull.number}.`);
 	} catch (error) {
 		const reason = error instanceof Error ? error.message : String(error);
-		// A policy that cannot be evaluated is broken rather than waiting, and says so in red. If
-		// even that cannot be published the context stays unreported, which leaves the pull request
-		// blocked on a context nothing has answered — still not mergeable.
-		try {
-			if (headSha) {
-				await publish(github, context, core, headSha, {
-					kind: "misconfigured",
-					title: "The review policy could not be evaluated",
-					summary: `Re-run the \`Review policy\` workflow. GitHub reported: ${reason}`,
-				});
-			}
-		} catch {
-			core.info("The review policy verdict could not be published as a check run.");
-		}
-		core.setFailed(`Review policy evaluation failed: ${reason}`);
+		core.setFailed(`The review policy could not be applied: ${reason}`);
 	}
 };


### PR DESCRIPTION
## Summary

Replaces the custom `review-policy` check run with GitHub's own required-approval rule, plus a
workflow that supplies the approval for authors on the maintainer allow-list.

Today the ruleset requires zero native approvals and instead requires a check named `review-policy`,
which is deliberately left `in_progress` (yellow) while an approval is outstanding. That works, but
every pull request awaiting review carries a permanently pending required context, which reads as
"something is still running" rather than "someone has to look at this".

After this change:

- `review-policy.yml` submits an approving review with `GITHUB_TOKEN` when the pull request author is
  listed in `REVIEW_POLICY_MAINTAINERS`, and does nothing otherwise.
- A maintainer's own pull request self-satisfies and enqueues normally, with the checks list fully
  green and no ruleset bypass involved.
- Anyone else's pull request sits in GitHub's native **Review required** state, which blocks the
  merge button, blocks merge-queue entry, and holds an armed auto-merge.

## Evidence

The one thing this depends on — that a `GITHUB_TOKEN` review counts toward
`required_approving_review_count` — was settled empirically on this repository before anything was
written, on a throwaway pull request that has since been closed and its branch deleted:

- Review recorded as `user.login: github-actions[bot]`, `state: APPROVED`,
  `author_association: CONTRIBUTOR`, pinned to the head commit.
- With `required_approving_review_count: 1` and that bot review as the only review, GraphQL reported
  `reviewDecision: APPROVED` and `mergeStateStatus: CLEAN`.
- `enqueuePullRequest` **succeeded** — `{"mergeQueueEntry":{"position":1,"state":"QUEUED"}}` — and the
  entry was dequeued immediately. `main` never moved.
- For contrast, the same mutation attempted while a required check was still pending returned only
  `Required status check "CI Status Gate" is expected.`; the review requirement was not among the
  blockers.

The ruleset was restored byte-for-byte afterwards and is **unchanged by this pull request**.

## Follow-up the maintainer has to do, after this merges

This pull request deliberately does not touch ruleset `1290597`. Flipping it before the workflow is
on `main` would deadlock every open pull request. Once this is merged:

1. Set `required_approving_review_count: 1` on the `pull_request` rule.
2. Remove `review-policy` from the required status check contexts.

## Notes

- `synchronize` is load-bearing: the ruleset sets `dismiss_stale_reviews_on_push`, so each push has to
  earn a fresh approval. A run that finds its own approval standing on the head commit submits
  nothing, so re-runs do not stack duplicate reviews.
- The hardening posture is unchanged: `pull_request_target`, `sparse-checkout: scripts` from the
  default branch, `persist-credentials: false`, and a decision taken from the pull request author
  login alone — never from pull-request content.
- `scripts/review-policy.test.ts` keeps covering the allow-list logic; the suite is 32 cases.
- The docs say plainly that auto-approval is not a review: it encodes the same policy the old
  allow-list did, and it exists only because the repository has one write-access collaborator. It
  should be deleted the moment a second reviewer exists.
- **No changeset.** `verify-changesets` scopes the release-note requirement to `server`, `webapp` and
  `docker`; this touches `.github/`, `scripts/` and `docs/` only.
- `pnpm run format` and `pnpm run check` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
