### PR TITLE
fix(ci): approve stacked pull requests before they are retargeted

### DIFF
--- a/.github/workflows/review-policy.yml
+++ b/.github/workflows/review-policy.yml
@@ -2,8 +2,7 @@ name: Review policy
 
 on:
   pull_request_target: # zizmor: ignore[dangerous-triggers] API reads only; no pull-request code is executed.
-    branches: [main]
-    types: [opened, reopened, synchronize, ready_for_review]
+    types: [opened, reopened, synchronize, ready_for_review, edited]
 
 permissions: {}
 
@@ -20,7 +19,11 @@ jobs:
   # GitHub's own "Review required" state, which blocks merging, merge-queue entry and auto-merge.
   #
   # `synchronize` is load-bearing: the ruleset dismisses stale approvals on push, so every push has
-  # to earn a fresh one.
+  # to earn a fresh one. `edited` is load-bearing for stacked pull requests: merging a lower layer
+  # retargets the upper one onto `main`, which fires no other event here — without it the layer
+  # arrives at the queue unapproved and cannot enter. For the same reason there is no `branches:`
+  # filter: a layer must already hold its approval when it is retargeted, and an approval on a pull
+  # request targeting anything but `main` satisfies no rule and is inert.
   approve:
     name: Approve a maintainer's pull request
     runs-on: ubuntu-latest

--- a/docs/contributor/ci-cd.mdx
+++ b/docs/contributor/ci-cd.mdx
@@ -99,6 +99,13 @@ create and approve pull requests*, which governs whether `GITHUB_TOKEN` may appr
 is pinned to the head commit it was decided against, and a run that finds its own approval already
 standing on that commit submits nothing, so re-runs do not stack duplicate reviews.
 
+The workflow deliberately carries no `branches:` filter, and runs on `edited` too, because of
+stacked pull requests (`CONTRIBUTING.md` § Stacked Pull Requests). Merging a lower layer
+retargets the upper one onto `main`, and that retarget fires no event a base-filtered workflow would
+see — the layer would reach the merge queue unapproved and be refused entry. So every layer earns
+its approval while it still points at the layer below. An approval on a pull request targeting
+anything but `main` satisfies no rule and is inert.
+
 [`scripts/review-policy.ts`](https://github.com/ls1intum/Hephaestus/blob/main/scripts/review-policy.ts)
 holds the decision, and it reads the author login and nothing else — never the diff, the title or
 the body. That is what makes it safe under `pull_request_target` with `pull-requests: write`: the
@@ -222,7 +229,7 @@ why the label is the authority, and which alternatives were priced and declined,
 | Workflow               | Trigger               | Purpose                                            |
 | ---------------------- | --------------------- | -------------------------------------------------- |
 | `cicd.yml`             | PR, merge group, push to main | Validates changes before merge and builds final-SHA images after merge |
-| `review-policy.yml`    | PR opened, reopened, synchronized, ready for review | Approves a listed maintainer's pull request so the ruleset's required approval is met; does nothing for anyone else |
+| `review-policy.yml`    | PR opened, reopened, synchronized, ready for review, edited | Approves a listed maintainer's pull request so the ruleset's required approval is met; does nothing for anyone else |
 | `ci-quality-gates.yml` | Called by cicd.yml    | Code quality, formatting, schema validation        |
 | `ci-tests.yml`         | Called by cicd.yml    | Unit, integration, visual tests                    |
 | `ci-docker-build.yml`  | Called by cicd.yml    | Docker image builds per component                  |

--- a/scripts/review-policy.test.ts
+++ b/scripts/review-policy.test.ts
@@ -41,7 +41,6 @@ const theirs = (over: Partial<Review> & Pick<Review, "id">): Review => ({
 
 const pull: PullRequest = {
 	number: 7,
-	base: { ref: "main" },
 	head: { sha: HEAD },
 	user: { login: "MaIntAiner" },
 };
@@ -168,7 +167,6 @@ void describe("review policy", () => {
 	void describe("decide", () => {
 		const base = {
 			author: "MaIntAiner",
-			baseRef: "main",
 			headSha: HEAD,
 			reviews: [] as readonly Review[],
 		};
@@ -223,14 +221,11 @@ void describe("review policy", () => {
 			assert.equal(decision.kind, "approve");
 		});
 
-		void it("stays out of the way of a pull request that does not target main", () => {
-			const decision = decide({
-				...base,
-				baseRef: "release",
-				maintainers: new Set(["maintainer"]),
-			});
-			assert.equal(decision.kind, "skip");
-			assert.match(decision.reason, /release/);
+		void it("approves a stacked pull request that targets another branch", () => {
+			// A layer must already hold its approval when merging the layer below retargets it onto
+			// main: that retarget fires no event that could earn one, so declining here would strand
+			// the stack at the merge queue.
+			assert.equal(decide({ ...base, maintainers: new Set(["maintainer"]) }).kind, "approve");
 		});
 	});
 
@@ -273,13 +268,12 @@ void describe("review policy", () => {
 			assert.deepEqual(submitted, []);
 		});
 
-		void it("submits nothing for a pull request that does not target main", async () => {
-			const { submitted, github } = makeGitHub({
-				resolvedPull: { ...pull, base: { ref: "release" } },
-			});
+		void it("approves a stacked pull request, so it survives being retargeted onto main", async () => {
+			const { submitted, github } = makeGitHub();
 			await enforce({ github, context, core: makeCore() });
 
-			assert.deepEqual(submitted, []);
+			assert.equal(submitted.length, 1);
+			assert.equal(submitted[0]?.event, "APPROVE");
 		});
 
 		void it("warns, and approves nobody, when the allow-list is unset", async () => {
@@ -367,7 +361,13 @@ void describe("review policy", () => {
 		});
 
 		void it("re-runs on every push, because the ruleset dismisses stale approvals", () => {
-			assert.match(workflow, /types: \[opened, reopened, synchronize, ready_for_review\]/);
+			assert.match(workflow, /types: \[opened, reopened, synchronize, ready_for_review, edited\]/);
+		});
+
+		void it("runs for a stacked pull request, whatever branch it targets", () => {
+			// A `branches:` filter would strand every stack: the retarget onto main that follows the
+			// lower layer's merge fires only `edited`, and only on a workflow that runs off main.
+			assert.doesNotMatch(workflow, /^\s+branches:/m);
 		});
 
 		void it("publishes no check run, now that the ruleset requires a native approval", () => {

--- a/scripts/review-policy.ts
+++ b/scripts/review-policy.ts
@@ -36,7 +36,6 @@ export interface Review {
 
 export interface PullRequest {
 	readonly number: number;
-	readonly base: { readonly ref: string };
 	readonly head: { readonly sha: string };
 	readonly user: { readonly login: string };
 }
@@ -87,7 +86,12 @@ export interface EnforceInput {
 	readonly core: ActionsCore;
 }
 
-/** The policy guards the branch the ruleset guards. */
+/**
+ * The branch whose ruleset requires the approval this module supplies. Nothing here filters on it:
+ * an approval on a pull request targeting any other branch satisfies no rule and is inert, whereas
+ * filtering strands every stacked pull request — the lower layer merges, GitHub retargets the upper
+ * one onto `main`, and a base-filtered policy has already declined to approve it.
+ */
 export const POLICY_BASE_REF = "main";
 
 /**
@@ -138,24 +142,16 @@ export interface Decision {
 
 export interface DecisionInput {
 	readonly author: string;
-	readonly baseRef: string;
 	readonly headSha: string;
 	readonly maintainers: ReadonlySet<string>;
 	readonly reviews: readonly Review[];
 }
 
 /**
- * What this module should do about one pull request. Purely a function of the author login, the base
- * branch, the head commit and the approvals already on record — never of anything the author wrote.
+ * What this module should do about one pull request. Purely a function of the author login, the head
+ * commit and the approvals already on record — never of anything the author wrote.
  */
 export const decide = (input: DecisionInput): Decision => {
-	if (input.baseRef !== POLICY_BASE_REF) {
-		return {
-			kind: "skip",
-			reason: `The review policy guards pull requests that target ${POLICY_BASE_REF}, not ${input.baseRef}.`,
-		};
-	}
-
 	if (!input.maintainers.has(input.author.toLowerCase())) {
 		return {
 			kind: "skip",
@@ -227,7 +223,6 @@ export const enforce = async ({ github, context, core }: EnforceInput): Promise<
 
 		const decision = decide({
 			author: pull.user.login,
-			baseRef: pull.base.ref,
 			headSha: pull.head.sha,
 			maintainers,
 			reviews,


### PR DESCRIPTION
## Problem

`#1698` is a stacked pull request — it targets `feat/practice-area-webapp` (the `#1487` branch), not `main`. The review policy never approved it, so the stack cannot be enqueued.

Two compounding causes, both in the trigger:

```yaml
pull_request_target:
    branches: [main]                                          # never runs for a stacked layer
    types: [opened, reopened, synchronize, ready_for_review]  # no `edited`
```

The second is the worse one. When the lower layer merges, GitHub retargets the upper layer onto `main` — and that retarget fires **only** `edited`. With `edited` absent and a `branches:` filter in place, the layer arrives at the merge queue unapproved and is refused entry, with no event left that could earn it an approval. Every future stack would have hit this.

## Fix

- Drop the `branches:` filter and add `edited`, so a layer earns its approval while it still points at the layer below and survives the retarget.
- Remove the base-ref guard from `decide()`, along with the now-dead `baseRef`/`base` fields. An approval on a pull request targeting anything but `main` satisfies no rule and is inert, so filtering bought nothing and cost the stack.

The security boundary is unchanged: the decision still reads the author login and nothing else, under the same `pull_request_target` containment.

## Verification

- `scripts/review-policy.test.ts` — **33 cases pass**. The two base-ref cases are replaced by cases pinning the new behaviour, plus a workflow-contract assertion that no `branches:` filter returns and that `edited` is present.
- `pnpm run format` and `pnpm run check` both pass.

No changeset: `verify-changesets` scopes `SHIPPED_PATHS` to `server`, `webapp`, `docker`; this touches `.github/`, `scripts/` and `docs/`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Review policy approvals now apply consistently to pull requests targeting any branch.
  * Retargeted stacked pull requests are now re-evaluated automatically.

* **Documentation**
  * Updated contribution guidance to explain review-policy behavior and supported trigger events.

* **Tests**
  * Added coverage for approvals on non-main targets and pull requests retargeted through edits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->