### PR TITLE
fix(docker): patch OS packages in digest-pinned images

### DIFF
--- a/.changeset/images-carry-current-security-updates.md
+++ b/.changeset/images-carry-current-security-updates.md
@@ -1,0 +1,8 @@
+---
+"hephaestus": patch
+---
+
+Hephaestus container images now install the operating-system security updates published since their
+base image was built, instead of shipping whatever the base image happened to contain. The web
+application image carries no known high or critical operating-system vulnerabilities as of this
+release. No action is needed to upgrade.

--- a/.github/workflows/ci-docker-build.yml
+++ b/.github/workflows/ci-docker-build.yml
@@ -113,6 +113,9 @@ jobs:
       docker-file: "./docker/agents/pi/Dockerfile"
       docker-context: "./docker/agents"
       registry: "ghcr.io"
+      # Cache-busts the OS-package upgrade layer; this build imports the `cache-main` registry cache.
+      build-args: |
+        SOURCE_COMMIT=${{ github.sha }}
       single-arch: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
       labels: |
         org.opencontainers.image.title=Hephaestus Agent - Pi
@@ -137,6 +140,9 @@ jobs:
       docker-file: "./docker/postgres/Dockerfile"
       docker-context: "./docker/postgres"
       registry: "ghcr.io"
+      # Cache-busts the OS-package upgrade layer; this build imports the `cache-main` registry cache.
+      build-args: |
+        SOURCE_COMMIT=${{ github.sha }}
       single-arch: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
       labels: |
         org.opencontainers.image.title=Hephaestus Postgres

--- a/docker/agents/pi/Dockerfile
+++ b/docker/agents/pi/Dockerfile
@@ -5,7 +5,15 @@ FROM node:${NODE_VERSION}-slim@sha256:a9f5f7c91a432850b2a8a7797adf5eadb6c733ceed
 
 # The base digest is pinned, so Debian security updates published after the upstream image was
 # built can reach it only here; Renovate bumps the digest only when upstream republishes one.
-RUN apt-get update -qq && apt-get upgrade -y -qq && \
+#
+# SOURCE_COMMIT is what makes that upgrade actually run. The builder imports the `cache-main`
+# registry cache and nothing else in this layer changes between builds, so without a per-build
+# input BuildKit would replay a weeks-old package set and the upgrade would silently stop
+# happening — the exact failure this layer exists to prevent. webapp/Dockerfile gets the same
+# argument, one instruction ahead of its own upgrade.
+ARG SOURCE_COMMIT
+RUN echo "source commit: ${SOURCE_COMMIT:-<unset — local build>}" && \
+    apt-get update -qq && apt-get upgrade -y -qq && \
     apt-get install -y --no-install-recommends git findutils tree jq ca-certificates grep && \
     rm -rf /var/lib/apt/lists/*
 

--- a/docker/agents/pi/Dockerfile
+++ b/docker/agents/pi/Dockerfile
@@ -3,7 +3,10 @@
 ARG NODE_VERSION=24.19.0
 FROM node:${NODE_VERSION}-slim@sha256:a9f5f7c91a432850b2a8a7797adf5eadb6c733ceed61167806cee7ea7fbc29df
 
-RUN apt-get update -qq && apt-get install -y --no-install-recommends git findutils tree jq ca-certificates grep && \
+# The base digest is pinned, so Debian security updates published after the upstream image was
+# built can reach it only here; Renovate bumps the digest only when upstream republishes one.
+RUN apt-get update -qq && apt-get upgrade -y -qq && \
+    apt-get install -y --no-install-recommends git findutils tree jq ca-certificates grep && \
     rm -rf /var/lib/apt/lists/*
 
 RUN groupmod --new-name agent node && \

--- a/docker/postgres/Dockerfile
+++ b/docker/postgres/Dockerfile
@@ -9,7 +9,12 @@ ARG PARTMAN_VERSION=5.5.0-1.pgdg12+1
 # The tag floats, so docker-library rebuilds already carry most OS updates here; the upgrade closes
 # the window between a Debian security publication and the next upstream rebuild. Same posture as
 # webapp/Dockerfile and docker/agents/pi/Dockerfile so no image is the one that blocks a release.
+#
+# SOURCE_COMMIT is what makes that upgrade actually run: the builder imports the `cache-main`
+# registry cache, and a layer with no per-build input would replay a stale package set instead.
+ARG SOURCE_COMMIT
 RUN set -eux; \
+    echo "source commit: ${SOURCE_COMMIT:-<unset — local build>}"; \
     apt-get update; \
     apt-get upgrade -y; \
     apt-get install -y --no-install-recommends "postgresql-${PG_MAJOR}-partman=${PARTMAN_VERSION}"; \

--- a/docker/postgres/Dockerfile
+++ b/docker/postgres/Dockerfile
@@ -6,7 +6,11 @@ FROM postgres:${PG_MAJOR}-bookworm
 ARG PG_MAJOR=18
 # Pinned for reproducibility (PGDG bookworm pool). Bump deliberately.
 ARG PARTMAN_VERSION=5.5.0-1.pgdg12+1
+# The tag floats, so docker-library rebuilds already carry most OS updates here; the upgrade closes
+# the window between a Debian security publication and the next upstream rebuild. Same posture as
+# webapp/Dockerfile and docker/agents/pi/Dockerfile so no image is the one that blocks a release.
 RUN set -eux; \
     apt-get update; \
+    apt-get upgrade -y; \
     apt-get install -y --no-install-recommends "postgresql-${PG_MAJOR}-partman=${PARTMAN_VERSION}"; \
     rm -rf /var/lib/apt/lists/*

--- a/webapp/Dockerfile
+++ b/webapp/Dockerfile
@@ -25,7 +25,12 @@ FROM nginx:stable-alpine@sha256:97d490c12ba55b4946b01546d1c3ed324e8d41ab1c9fcb2a
 ARG COOLIFY_BRANCH
 ARG SOURCE_COMMIT
 ENV BUILD_GIT_BRANCH=$COOLIFY_BRANCH BUILD_GIT_COMMIT=$SOURCE_COMMIT
-RUN apk add --no-cache bash sed grep curl
+# The base digest is pinned, so Alpine security updates published after the upstream image was
+# built can reach it only here — `nginx:stable-alpine` keeps resolving to the same digest, so
+# Renovate has nothing to bump. `apk add` is already unversioned against the live index, so this
+# costs no reproducibility. nginx itself comes from a one-shot `apk add -X <nginx.org repo>` that
+# the upstream image never persists to /etc/apk/repositories, so this upgrades OS packages only.
+RUN apk upgrade --no-cache && apk add --no-cache bash sed grep curl
 COPY --from=build /repo/webapp/dist /usr/share/nginx/html
 COPY webapp/docker/entrypoint.sh /entrypoint.sh
 COPY webapp/docker/nginx.conf /etc/nginx/conf.d/default.conf


### PR DESCRIPTION
Closes #1713

## What

`gosu` is a static Go binary the official postgres image bakes in for exactly one purpose: both upstream entrypoints (`docker-entrypoint.sh`, `docker-ensure-initdb.sh`) call `gosu postgres "$BASH_SOURCE" "$@"` once, as root, to step down to the postgres user. apt cannot reach it, so its Go stdlib CVEs cannot leave the image while the binary is in it.

The image now deletes the binary and puts a `setpriv` (util-linux) stand-in at the same path. `setpriv --reuid postgres --regid <gid> --init-groups` makes the identical switch and then execs, and it is an ordinary Debian package the OS updates keep patched — so these findings do not come back on the next rebuild the way a freshly rebuilt `gosu` would.

Two details worth reviewing:

- **The removal is its own layer.** Trivy reads a path a later layer merely *overwrote* as the file the lower layer put there. Copying the stand-in over `gosu` left all 22 findings reported (`Number of language-specific files num=1`). Deleting first writes a whiteout, and the scan then reports `num=0`. This is the whole difference between 22 rejected and 0.
- **The stand-in only accepts `gosu <user> <command> [args...]`.** A `user:group` spec or an option exits 1 rather than guessing at gosu's semantics and running a command with privileges nobody asked for. The build asserts the resulting identity — uid, primary gid *and* supplementary groups, since postgres is also in `ssl-cert` — instead of trusting the script.

## Options considered

| # | Option | Outcome |
|---|---|---|
| 1 | Newer upstream base | **No.** `docker/postgres/Dockerfile` already floats on `postgres:${PG_MAJOR}-bookworm`; a fresh pull today (`sha256:1c59e2c3…`) still ships `gosu 1.19 (go1.24.6 on linux/amd64; gc)`. There is no rebuild to wait for. |
| 2 | Run as the postgres user and delete `gosu` | **Measured and rejected.** `server/compose.yaml` bind-mounts `./postgres-data`, which Docker creates root-owned on the host; a non-root container cannot create `PGDATA` inside it, so every contributor's `pnpm run dev` would break. `docker/preview/compose.app.yaml` likewise documents the root step-down in its `cap_add` list. The root path has to keep working. |
| 3 | Replace the binary | **Taken, in the form that ends the problem.** Rebuilding `gosu` against a current Go would clear today's 22 and start accruing tomorrow's; `setpriv` moves the privilege drop onto the OS package set that `apt` already maintains. |
| 4 | Time-boxed exceptions | Not needed. `security/vulnerability-policy.json` is untouched, and no entry expires into a re-cut. |

## Vulnerability scans

Trivy `--severity HIGH,CRITICAL --scanners vuln` on locally built images, evaluated through `evaluate()` from `scripts/check-release-vulnerabilities.ts` **on `ci/scan-images-at-build-time` (#1710)** against this branch's `security/vulnerability-policy.json`, so the numbers are what the gate will say and not a raw count:

| | HIGH/CRITICAL | **Rejected** |
|---|---:|---:|
| before | 98 | **22** |
| after | 76 | **0** |

All 22 rejected findings were `stdlib v1.24.6` in `usr/local/bin/gosu` (CVE-2025-68121 CRITICAL, 21 HIGH). The remaining 76 are unfixed in Debian 12 (`affected` / `will_not_fix`), which the gate does not reject.

### `libexpat1`

Already resolved, and not by this PR. #1710 measured `libexpat1 2.5.0-1+deb12u2` / CVE-2026-56408 as rejected; a build against today's index installs **`2.5.0-1+deb12u3`**, which fixes it. The four `libexpat1` findings that remain (CVE-2025-59375, CVE-2026-25210, CVE-2026-45186, CVE-2026-66046) all carry no fix in Debian 12, so none is rejected. Nothing to do here — the Dockerfile's `apt-get update` already picks it up, and #1709's `apt-get upgrade` keeps it that way.

## Verification

Built and smoke-tested the real image. The fresh-init run used the preview stack's confinement (`--security-opt no-new-privileges:true`, `--cap-drop ALL`, `--cap-add CHOWN,DAC_OVERRIDE,FOWNER,SETGID,SETUID`) to prove `setpriv` drops privileges under exactly the capability set the deployed stack grants:

**Fresh `initdb` on an empty volume**

```
PostgreSQL 18.6 (Debian 18.6-1.pgdg12+2) on x86_64-pc-linux-gnu
CREATE EXTENSION pg_partman -> 5.5.0
/proc/1/status: Name: postgres   Uid: 999 999 999 999   Gid: 999 999 999 999
LOG:  database system is ready to accept connections
```

PID 1 is the server running as uid 999 — the step-down happened *and* `setpriv` exec'd rather than forked, so PostgreSQL keeps PID 1 and its signal handling.

**Restart on an existing data directory**

```
PostgreSQL Database directory appears to contain a database; Skipping initialization
LOG:  database system is ready to accept connections
pg_partman still 5.5.0
```

**`docker stop`** → `LOG:  database system is shut down` after a complete checkpoint, so SIGTERM still reaches PID 1.

**Root-owned bind mount** (the `server/compose.yaml` shape, and the case that rules out option 2): container starts, chowns the directory, steps down, `PGDATA` initialises at `18/docker` owned by uid 999.

**Stand-in refuses what it does not implement**

```
gosu postgres id -u        -> 999
gosu --version             -> usage, rc=1
gosu postgres:postgres id  -> usage, rc=1
gosu postgres              -> usage, rc=1
```

## Overlap with #1709

#1709 adds `apt-get upgrade -y` **inside the existing `RUN`** in `docker/postgres/Dockerfile`. This PR appends a new `RUN` + `COPY` **below** that block and does not touch it, so the two should merge without a conflict; whichever lands second needs no rework. They are complementary: #1709 keeps the OS packages patched, which is now the mechanism that keeps the privilege drop patched too. `libexpat1` is covered under either.

## Quality gates

`pnpm run format` then `pnpm run check` — both pass.

## Cache-busting the upgrade layer (review follow-up)

An upgrade layer with no changing build input is cache-stable forever, and the reusable builder imports `cache-main` unconditionally (`cache-from: type=registry,...:cache-main-<platform>`, with neither `no-cache` nor `pull` set). BuildKit would therefore replay a stale package layer and the upgrade would silently stop happening — the exact failure this PR exists to prevent.

`webapp` was already covered: `ENV BUILD_GIT_COMMIT=$SOURCE_COMMIT` lands one instruction ahead of its `apk upgrade`. The other two jobs received no `build-args` at all, so `SOURCE_COMMIT=${{ github.sha }}` is now passed to `agent-pi-build` and `postgres-build` too and consumed in the upgrade layer. One mechanism for all three; no `--no-cache`, so dependency layers stay cached when the commit is unchanged.

Verified by three consecutive `postgres` builds — `aaaa1111` executes the upgrade, `aaaa1111` again reports `#5 CACHED`, `bbbb2222` re-executes `apt-get update` / `apt-get upgrade -y`. Same result for `agent-pi`, and `webapp` re-confirmed (`Upgrading libapk (3.0.6-r0 -> 3.0.8-r0)` on a changed commit).

In `agent-pi` the upgrade sits second, so busting it also rebuilds the Pi SDK `npm install` below it. Accepted: that job only runs when `agent_images_changed == 'true'`, and a correct agent image beats a fast one that ships stale packages.
