### PR TITLE
fix(ci): scan images against the vulnerability policy where they are built

### DIFF
--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -442,3 +442,117 @@ jobs:
             --certificate-github-workflow-repository "${{ github.repository }}" \
             > /dev/null
           gh attestation verify "oci://$IMAGE_REF" --owner "${{ github.repository_owner }}"
+
+  # The release vulnerability gate, run where the image is built. Until this job existed the
+  # policy's first execution was at `tag-images`, so a release was the first thing it could
+  # fail — a tripwire, not a safety net (issue #1703). It calls the same script and the same
+  # security/vulnerability-policy.json the release and the scheduled rescan call; a second
+  # copy of the policy is precisely the failure this prevents.
+  #
+  # linux/amd64 only: Alpine and Debian ship the same package versions across architectures,
+  # and the release still scans both, where the evidence bundle has to be complete.
+  scan:
+    name: Scan linux/amd64 Image
+    needs: [build, merge]
+    # `merge` is skipped for single-architecture builds, which would skip this job too
+    # without a status-check function to suppress the implicit success() over every need.
+    if: >-
+      ${{ !cancelled() && needs.build.result == 'success' &&
+      needs.merge.result != 'failure' && needs.merge.result != 'cancelled' }}
+    timeout-minutes: 20
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - uses: ./.github/actions/setup-node-pnpm
+        with:
+          install: "none"
+
+      - uses: ./.github/actions/setup-release-security-tools
+        with:
+          install-syft: "false"
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ${{ inputs.registry }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve the linux/amd64 subject
+        id: subject
+        env:
+          # The run tag both build paths already publish; it names this run's image whether
+          # `build` pushed it directly or `merge` assembled an index from the per-arch pushes.
+          IMAGE_REF: ${{ inputs.registry }}/${{ inputs.image-name }}:run-${{ github.run_id }}-${{ github.run_attempt }}
+          INPUT_IMAGE_NAME: ${{ inputs.image-name }}
+        run: |
+          set -euo pipefail
+          # First, so the artifact below is still named after the image if the lookup fails.
+          echo "image=${INPUT_IMAGE_NAME##*/}" >> "$GITHUB_OUTPUT"
+          raw=$(docker buildx imagetools inspect "$IMAGE_REF" --raw)
+          if jq -e 'has("manifests")' <<< "$raw" > /dev/null; then
+            digest=$(jq -er 'first(.manifests[]
+              | select(.platform.os == "linux" and .platform.architecture == "amd64")
+              | .digest)' <<< "$raw")
+          else
+            digest=$(docker buildx imagetools inspect --format '{{.Manifest.Digest}}' "$IMAGE_REF")
+          fi
+          if [[ ! "$digest" =~ ^sha256:[a-f0-9]{64}$ ]]; then
+            echo "::error::No linux/amd64 digest for $IMAGE_REF (got: ${digest:-<empty>})"
+            exit 1
+          fi
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
+
+      - name: Download the Trivy database
+        env:
+          # A blocking gate inherits Trivy's database availability as a hard dependency, and
+          # GHCR answers TOOMANYREQUESTS often enough that Harbor, Rancher and New Relic all
+          # override this. Trivy walks the list in order. The `:2` tag is the database schema
+          # version and is pinned to the Trivy version in setup-release-security-tools; a
+          # schema bump fails this step loudly rather than silently fetching the wrong DB.
+          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db:2,public.ecr.aws/aquasecurity/trivy-db:2
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            trivy image --timeout 90s --download-db-only && break
+            if [ "$attempt" -eq 3 ]; then
+              echo "::error::Trivy database download failed after $attempt attempts"
+              exit 1
+            fi
+            sleep $((attempt * 5))
+          done
+
+      - name: Enforce the release vulnerability policy
+        env:
+          IMAGE: ${{ steps.subject.outputs.image }}
+          REPOSITORY: ${{ inputs.registry }}/${{ inputs.image-name }}
+          SUBJECT_DIGEST: ${{ steps.subject.outputs.digest }}
+          TRIVY_USERNAME: ${{ github.actor }}
+          TRIVY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          mkdir -p reports
+          trivy image --skip-db-update --scanners vuln --format json \
+            --output "reports/$IMAGE-linux-amd64.json" "$REPOSITORY@$SUBJECT_DIGEST"
+          node scripts/check-release-vulnerabilities.ts "$IMAGE" linux/amd64 "$SUBJECT_DIGEST" \
+            "$REPOSITORY" "reports/$IMAGE-linux-amd64.json" security/vulnerability-policy.json \
+            "reports/$IMAGE-linux-amd64.policy.json"
+
+      # The policy result names the CVEs; without it the gate says only that the image failed,
+      # and diagnosing v0.75.0 meant rebuilding and rescanning the base image by hand.
+      - name: Upload the vulnerability policy result
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: vulnerability-policy-${{ steps.subject.outputs.image }}-linux-amd64
+          path: reports
+          if-no-files-found: warn
+          retention-days: 7

--- a/docs/contributor/ci-cd.mdx
+++ b/docs/contributor/ci-cd.mdx
@@ -233,6 +233,7 @@ why the label is the authority, and which alternatives were priced and declined,
 | `ci-quality-gates.yml` | Called by cicd.yml    | Code quality, formatting, schema validation        |
 | `ci-tests.yml`         | Called by cicd.yml    | Unit, integration, visual tests                    |
 | `ci-docker-build.yml`  | Called by cicd.yml    | Docker image builds per component                  |
+| `reusable-docker-build.yml` | Called by ci-docker-build.yml | Builds, signs, attests, and blocks on the release vulnerability policy for the `linux/amd64` image |
 | `ci-security-scan.yml` | Called by cicd.yml    | Dependency scanning (Trivy), secret detection      |
 | `ci-profile.yml` | Weekly, manual | Profiles server integration tests and Spring contexts |
 | `ci-server-clean-reference.yml` | Weekly, manual | Records cold server phases and compares generated JARs |

--- a/docs/contributor/release-management.mdx
+++ b/docs/contributor/release-management.mdx
@@ -92,10 +92,20 @@ Compose topology. They receive the same per-platform SBOM, license, vulnerabilit
 evidence as first-party images. Hephaestus requires its own signatures and build provenance only for
 images it builds; it does not misrepresent observed upstream images as Hephaestus-built artifacts.
 
-The version-controlled policy rejects every HIGH or CRITICAL finding. A residual finding requires an
-exception scoped to its image, vulnerability, package, and installed version, with an owner, justification,
-evidence URL, and expiry no more than 90 days away. Each exception and policy report records the scanned
-platform and digest.
+The version-controlled policy rejects every HIGH or CRITICAL finding **for which upstream has published
+a fix**. An unfixable finding is still counted and still appears in the signed evidence, but it does not
+block: the pinned upstream images cannot be patched at all, so failing on one removes no risk and leaves
+nobody an action. A residual fixable finding requires an exception scoped to its image, platform,
+vulnerability, package, and installed version, with an owner, justification, evidence URL, and expiry no
+more than 90 days away. Each exception and policy report records the scanned digest, but an exception is
+not matched on it — the release digest does not exist until the images are tagged, so a digest-keyed
+exception could only ever be written after the gate had already failed a release.
+
+The same policy runs on every image build, against the `linux/amd64` image the run just pushed, so a
+pull request fails before a release can. The release scans both architectures, where the evidence bundle
+has to be complete. Both call `scripts/check-release-vulnerabilities.ts` with
+`security/vulnerability-policy.json`; there is no second copy of either. A failing gate names the
+rejected CVEs in the run summary and uploads its `.policy.json`.
 
 The latest release is rescanned weekly. A policy violation or scan failure is reported on
 [the vulnerability response issue](https://github.com/ls1intum/Hephaestus/issues/1369); scanner failure

--- a/scripts/check-release-vulnerabilities.test.ts
+++ b/scripts/check-release-vulnerabilities.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import { evaluate } from "./check-release-vulnerabilities.ts";
+import { evaluate, renderSummary } from "./check-release-vulnerabilities.ts";
 
 const finding = {
 	FixedVersion: "2",
@@ -19,14 +19,53 @@ await test("rejects a high vulnerability without a disposition", () => {
 	assert.deepEqual(evaluate("server", report, policy).rejected, ["server|CVE-1|lib|1"]);
 });
 
-await test("requires a disposition even when no fixed version exists", () => {
-	assert.deepEqual(
-		evaluate(
-			"server",
-			{ Results: [{ Vulnerabilities: [{ ...finding, FixedVersion: "" }] }] },
-			policy,
-		).rejected,
-		["server|CVE-1|lib|1"],
+await test("reports but does not reject a high vulnerability with no upstream fix", () => {
+	// The four upstream images in security/release-images.json cannot be patched at all, so
+	// an unfixable finding blocks a release without offering anyone an action. It still has
+	// to be counted, because the evidence bundle is signed and must stay complete.
+	for (const unfixable of [
+		{ ...finding, FixedVersion: "" },
+		{ ...finding, FixedVersion: "   " },
+		Object.fromEntries(Object.entries(finding).filter(([field]) => field !== "FixedVersion")),
+	]) {
+		const result = evaluate("server", { Results: [{ Vulnerabilities: [unfixable] }] }, policy);
+		assert.deepEqual(result.rejected, []);
+		assert.deepEqual(result.highCritical, ["server|CVE-1|lib|1"]);
+		assert.deepEqual(result.errors, []);
+	}
+	// A mixed report rejects only the half upstream has published a fix for.
+	const mixed = evaluate(
+		"server",
+		{
+			Results: [
+				{
+					Vulnerabilities: [
+						finding,
+						{ ...finding, PkgName: "other", VulnerabilityID: "CVE-2", FixedVersion: "" },
+						{ ...finding, PkgName: "third", VulnerabilityID: "CVE-3", Severity: "CRITICAL" },
+					],
+				},
+			],
+		},
+		policy,
+	);
+	assert.deepEqual(mixed.rejected, ["server|CVE-1|lib|1", "server|CVE-3|third|1"]);
+	assert.deepEqual(mixed.highCritical, [
+		"server|CVE-1|lib|1",
+		"server|CVE-2|other|1",
+		"server|CVE-3|third|1",
+	]);
+});
+
+await test("rejects a report whose fixed version is not a string", () => {
+	assert.throws(
+		() =>
+			evaluate(
+				"server",
+				{ Results: [{ Vulnerabilities: [{ ...finding, FixedVersion: 2 }] }] },
+				policy,
+			),
+		/FixedVersion must be a string/,
 	);
 });
 
@@ -66,15 +105,56 @@ await test("accepts an owned, justified, unexpired exception", () => {
 		).rejected,
 		["server|CVE-1|lib|1"],
 	);
-	assert.deepEqual(
+});
+
+await test("matches an exception without its digest, but still on every other field", () => {
+	const exception = {
+		digest,
+		evidence: "https://github.com/example/project/issues/1",
+		expires: "2026-10-01T00:00:00Z",
+		image: "server",
+		installedVersion: "1",
+		justification: "not reachable in the deployed configuration",
+		owner: "@security",
+		package: "lib",
+		platform: "linux/amd64",
+		status: "not_affected",
+		vulnerability: "CVE-1",
+	};
+	const rejectedWith = (override: Partial<typeof exception>): string[] =>
 		evaluate(
 			"server",
 			{ ...report, ArtifactName: subject.reference },
-			{ ...policy, exceptions: [{ ...exceptions[0], digest: `sha256:${"b".repeat(64)}` }] },
+			{ ...policy, exceptions: [{ ...exception, ...override }] },
 			now,
 			subject,
-		).rejected,
-		["server|CVE-1|lib|1"],
+		).rejected;
+	// The release digest does not exist until the images are tagged, so matching on it made a
+	// pre-release exception impossible to author. An exception reviewed against one digest now
+	// covers the same package at the same version wherever it is scanned.
+	assert.deepEqual(rejectedWith({ digest: `sha256:${"b".repeat(64)}` }), []);
+	// Every other field still binds.
+	for (const override of [
+		{ image: "other" },
+		{ platform: "linux/arm64" },
+		{ package: "other" },
+		{ installedVersion: "0" },
+		{ vulnerability: "CVE-2" },
+	] satisfies Partial<typeof exception>[])
+		assert.deepEqual(rejectedWith(override), ["server|CVE-1|lib|1"], JSON.stringify(override));
+	// Two exceptions that differ only by digest are now one exception, twice.
+	assert.match(
+		evaluate(
+			"server",
+			{ ...report, ArtifactName: subject.reference },
+			{
+				...policy,
+				exceptions: [exception, { ...exception, digest: `sha256:${"b".repeat(64)}` }],
+			},
+			now,
+			subject,
+		).errors.join("\n"),
+		/duplicate exception: server\|linux\/amd64\|CVE-1\|lib\|1/,
 	);
 });
 
@@ -132,4 +212,32 @@ await test("rejects expired and malformed exceptions", () => {
 		).errors.join("\n"),
 		/Trivy report is for/,
 	);
+});
+
+await test("names the rejected findings in the run summary", () => {
+	const rendered = renderSummary(
+		{ digest, image: "server", platform: "linux/amd64" },
+		evaluate(
+			"server",
+			{
+				Results: [
+					{
+						Vulnerabilities: [finding, { ...finding, VulnerabilityID: "CVE-2", FixedVersion: "" }],
+					},
+				],
+			},
+			policy,
+		),
+	);
+	assert.match(rendered, /server \(linux\/amd64\): fail/);
+	assert.match(rendered, /2 HIGH\/CRITICAL, 1 rejected/);
+	assert.match(rendered, /\| CVE-1 \| lib \| 1 \|/);
+	assert.doesNotMatch(rendered, /\| CVE-2 \|/);
+
+	const clean = renderSummary(
+		{ digest, image: "server", platform: "linux/amd64" },
+		evaluate("server", { Results: [] }, policy),
+	);
+	assert.match(clean, /server \(linux\/amd64\): pass/);
+	assert.doesNotMatch(clean, /\| Vulnerability \|/);
 });

--- a/scripts/check-release-vulnerabilities.ts
+++ b/scripts/check-release-vulnerabilities.ts
@@ -1,12 +1,18 @@
-import { readFileSync, writeFileSync } from "node:fs";
+import { appendFileSync, readFileSync, writeFileSync } from "node:fs";
 
 type Finding = {
+	FixedVersion?: string;
 	InstalledVersion?: string;
 	PkgName?: string;
 	Severity?: string;
 	VulnerabilityID?: string;
 };
 
+// `digest` is recorded so an exception names the artefact it was reviewed against, but it is
+// deliberately not part of the match key: the release digest does not exist until `tag-images`
+// runs, so a digest-keyed exception could only ever be authored after the gate had already
+// failed a release, and would die on the next rebuild. `installedVersion` already gives the
+// "this exception expires when the package moves" property that digest matching was there for.
 type Exception = {
 	digest: string;
 	evidence: string;
@@ -93,7 +99,7 @@ export function evaluate(
 			);
 			continue;
 		}
-		const key = `${exception.image}|${exception.platform}|${exception.digest}|${exception.vulnerability}|${exception.package}|${exception.installedVersion}`;
+		const key = `${exception.image}|${exception.platform}|${exception.vulnerability}|${exception.package}|${exception.installedVersion}`;
 		if (exceptionKeys.has(key)) errors.push(`duplicate exception: ${key}`);
 		exceptionKeys.add(key);
 		if (!/^sha256:[a-f0-9]{64}$/.test(exception.digest))
@@ -130,7 +136,12 @@ export function evaluate(
 			for (const field of ["InstalledVersion", "PkgName", "Severity", "VulnerabilityID"])
 				if (typeof value[field] !== "string" || value[field].length === 0)
 					throw new Error(`malformed Trivy vulnerability: missing ${field}`);
+			// Trivy omits FixedVersion entirely when upstream has published no fix, so its
+			// absence is data rather than corruption; only a non-string is malformed.
+			if (value.FixedVersion !== undefined && typeof value.FixedVersion !== "string")
+				throw new Error("malformed Trivy vulnerability: FixedVersion must be a string");
 			findings.push({
+				FixedVersion: typeof value.FixedVersion === "string" ? value.FixedVersion : undefined,
 				InstalledVersion:
 					typeof value.InstalledVersion === "string" ? value.InstalledVersion : undefined,
 				PkgName: typeof value.PkgName === "string" ? value.PkgName : undefined,
@@ -143,14 +154,18 @@ export function evaluate(
 	const highCritical = findings.filter(
 		(finding) => finding.Severity === "HIGH" || finding.Severity === "CRITICAL",
 	);
-	const subjectDigest = subject?.digest;
 	const subjectPlatform = subject?.platform;
+	// Only a finding upstream has published a fix for can block: the upstream images in
+	// security/release-images.json cannot be patched at all, so failing on an unfixable
+	// finding removes no risk and leaves nobody an action. The filter lives here rather than
+	// on Trivy's command line (`--ignore-unfixed`) so unfixable findings stay counted in
+	// `highCritical` and visible in the signed evidence bundle.
 	const rejected = highCritical.filter((finding) => {
+		if (!finding.FixedVersion?.trim()) return false;
 		return !policy.exceptions.some(
 			(exception) =>
 				exception.image === image &&
 				exception.platform === subjectPlatform &&
-				exception.digest === subjectDigest &&
 				exception.package === finding.PkgName &&
 				exception.installedVersion === finding.InstalledVersion &&
 				exception.vulnerability === finding.VulnerabilityID &&
@@ -162,6 +177,34 @@ export function evaluate(
 		errors,
 		rejected: rejected.map((finding) => fingerprint(image, finding)),
 	};
+}
+
+export type Evaluation = ReturnType<typeof evaluate>;
+
+/**
+ * A run summary naming what was rejected. The gate used to fail with nothing but
+ * `<image> does not satisfy vulnerability policy`, so diagnosing it meant rebuilding and
+ * rescanning the base image by hand.
+ */
+export function renderSummary(
+	subject: { digest: string; image: string; platform: string },
+	result: Evaluation,
+): string {
+	const status = result.errors.length === 0 && result.rejected.length === 0 ? "pass" : "fail";
+	const lines = [
+		`### Vulnerability policy — ${subject.image} (${subject.platform}): ${status}`,
+		"",
+		`Subject \`${subject.digest}\` — ${result.highCritical.length} HIGH/CRITICAL, ${result.rejected.length} rejected.`,
+	];
+	if (result.rejected.length > 0) {
+		lines.push("", "| Vulnerability | Package | Installed |", "| --- | --- | --- |");
+		for (const finding of result.rejected) {
+			const [, vulnerability = "", packageName = "", installedVersion = ""] = finding.split("|");
+			lines.push(`| ${vulnerability} | ${packageName} | ${installedVersion} |`);
+		}
+	}
+	if (result.errors.length > 0) lines.push("", ...result.errors.map((message) => `- ${message}`));
+	return `${lines.join("\n")}\n`;
 }
 
 if (import.meta.main) {
@@ -183,6 +226,8 @@ if (import.meta.main) {
 		outputPath,
 		`${JSON.stringify({ image, platform, digest, status: result.errors.length === 0 && result.rejected.length === 0 ? "pass" : "fail", ...result }, null, 2)}\n`,
 	);
+	const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+	if (summaryPath) appendFileSync(summaryPath, renderSummary({ digest, image, platform }, result));
 	if (result.errors.length > 0 || result.rejected.length > 0) {
 		for (const message of [
 			...result.errors,

--- a/scripts/ci-contract.test.ts
+++ b/scripts/ci-contract.test.ts
@@ -249,6 +249,45 @@ void describe("CI contract", () => {
 		);
 	});
 
+	void test("enforces the release vulnerability policy where images are built", async () => {
+		const reusable = await readFile(".github/workflows/reusable-docker-build.yml", "utf8");
+		const scan = job(reusable, "scan");
+		// Blocking, and after the push: it needs both build paths, and a skipped `merge`
+		// (single-architecture builds) must not skip it.
+		assert.match(scan, /needs: \[build, merge\]/);
+		assert.match(scan, /!cancelled\(\)/);
+		assert.match(scan, /needs\.build\.result == 'success'/);
+		// The same script and the same policy file the release and the rescan call. A second
+		// copy of the policy is the failure this gate exists to prevent.
+		assert.match(
+			scan,
+			/node scripts\/check-release-vulnerabilities\.ts[\s\S]*security\/vulnerability-policy\.json/,
+		);
+		assert.match(scan, /run-\${{ github\.run_id }}-\${{ github\.run_attempt }}/);
+		assert.match(scan, /linux\/amd64/);
+		assert.doesNotMatch(scan, /linux\/arm64/);
+		// A gate that cannot say what it rejected is not finished.
+		assert.match(scan, /uses: actions\/upload-artifact@/);
+		assert.match(scan, /public\.ecr\.aws\/aquasecurity\/trivy-db/);
+
+		let callSites = 0;
+		for (const [file, source] of await workflowSources()) {
+			for (const call of source.match(
+				/node scripts\/check-release-vulnerabilities\.ts[\s\S]*?\.policy\.json"/g,
+			) ?? []) {
+				callSites += 1;
+				assert.match(
+					call,
+					/(?<![\w./-])security\/vulnerability-policy\.json/,
+					`${file} must evaluate the one release vulnerability policy`,
+				);
+			}
+		}
+		// The blocking build gate and the scheduled rescan; the release path goes through
+		// verify-release-evidence.ts, which imports evaluate() directly.
+		assert.equal(callSites, 2);
+	});
+
 	void test("pins every external action to a full commit SHA with a version comment", async () => {
 		const invalid: string[] = [];
 		const files = await Array.fromAsync(glob(".github/{actions,workflows}/**/*.{yml,yaml}"));


### PR DESCRIPTION
## Description

The v0.75.0 release failed at `tag-images` with `webapp does not satisfy vulnerability policy`.
Main was green because **no container image is scanned anywhere before release**:
`ci-security-scan.yml` runs Trivy with `scan-type: "fs"` and `continue-on-error: true`, so it
never sees an image. This fixes both defects behind that, in one PR because both rewrite
`evaluate()` in `scripts/check-release-vulnerabilities.ts`.

**#1704 — unfixable findings no longer block.** `evaluate()` rejected any HIGH or CRITICAL
whether or not upstream had published a fix, and `security/release-images.json` runs four
*upstream* images — alpine, nats, nginx, traefik — through the same gate. Those cannot be
patched at all, so failing on them removes no risk and leaves nobody an action. `Finding` now
carries `FixedVersion`, and a finding needs a non-empty one to reach `rejected`. The filter is
in the evaluator, **not** on Trivy's command line (`--ignore-unfixed`), so unfixable findings
stay counted in `highCritical` and visible in the signed evidence bundle. On this run that
distinction is doing most of the work: `agent-pi` reports 59 HIGH/CRITICAL and rejects 1,
`postgres` reports 99 and rejects 23.

**#1703 — the gate runs where images are built.** That needed the exception schema fixed first.
Exceptions matched on `image | platform | digest | vulnerability | package | installedVersion`,
including the release image digest — which does not exist until `tag-images` runs. A
pull-request-time exception could therefore never match a release-time digest, and an exception
could only be authored *after* the gate had already failed a release. `digest` is dropped from
the match key (and from the duplicate key) and kept in the recorded exception for auditability;
`installedVersion` already gives the "dies when the package moves" property.

A new `scan` job in `reusable-docker-build.yml` then blocks after the push, on the `linux/amd64`
image behind the `run-<run_id>-<run_attempt>` tag the workflow already produces. It calls **the
same script and the same `security/vulnerability-policy.json`** the release and the weekly
rescan call; `ci-contract.test.ts` now asserts there is no second copy. Both architectures are
still scanned at release, where the evidence bundle has to be complete.

Also: a failing gate names the rejected CVEs in `$GITHUB_STEP_SUMMARY` and uploads its
`.policy.json` — diagnosing v0.75.0 required rebuilding and rescanning the base image by hand.
And `public.ecr.aws/aquasecurity/trivy-db` is added as a `TRIVY_DB_REPOSITORY` fallback, because
a blocking gate inherits Trivy's database availability as a hard dependency and GHCR returns
`TOOMANYREQUESTS` often enough that Harbor, Rancher and New Relic all override it. The existing
3× retry stays.

Closes #1703
Closes #1704

## ⚠️ This PR cannot pass its own CI, and #1702 is not enough

The gate is blocking on a policy that has never run at build time, so this PR fails on the
images it is meant to protect. The mechanism itself works end to end — subject resolution,
database download, scan, evaluation, step summary and artifact upload all succeeded on every
image; the four `Scan linux/amd64 Image` jobs failed **on the policy**, which is the point.
Measured on this run's images:

| Image | HIGH/CRITICAL | Rejected | What is rejected | Fixed by |
|---|---:|---:|---|---|
| `webapp` | 4 | 4 | `libcrypto3`/`libssl3` 3.5.7-r0 (CVE-2026-14456), `libexpat` 2.8.2-r0 (CVE-2026-66046, CVE-2026-76641) | **#1702** |
| `agent-pi` | 59 | 1 | `libexpat1` 2.5.0-1+deb12u2 (CVE-2026-56408) | **#1702** |
| `postgres` | 99 | 23 | `libexpat1` (same CVE) — and 22 Go `stdlib` CVEs in `usr/local/bin/gosu`, built with Go 1.24.6 | #1702 covers only the `libexpat1` one, and only if it includes `docker/postgres/` |
| `application-server` | 6 | 6 | `org.bouncycastle:bcprov-jdk18on` 1.82 — CVE-2025-14813 (CRITICAL) and CVE-2026-5598 (HIGH), both fixed in 1.84 | **nothing yet** |

So the dependency is: **#1702 first** (it clears `webapp` and `agent-pi` outright), and then two
things no issue covers today:

1. **`application-server`**: bump Bouncy Castle 1.82 → 1.84. This is an ordinary dependency
   bump in the server's tree, not an image concern.
2. **`postgres`**: `gosu` is a Go binary baked into the upstream `postgres:*-bookworm` image and
   is not reachable by `apt-get upgrade`; the fix has to come from a docker-library rebuild, a
   base-image bump that carries one, or dropping/replacing `gosu`. If none of those lands in
   time, this is exactly the case the exception mechanism exists for — and *because* of this
   PR's match-key fix, such an exception can now be authored before a release instead of only
   after one has already failed.

I have deliberately **not** weakened the gate, added `--ignore-unfixed`, or written exceptions
on someone else's behalf to get this green.

Worth noting what this measurement already bought: `application-server` and `postgres` were
*both* going to block the very next release attempt, behind `webapp` in the manifest order, with
no warning anywhere. That is the invisibility this PR removes.

## How to test

CI covers this once the blockers above clear. Locally:

- `pnpm run format && pnpm run check` — both pass.
- Tooling tests 270 → 274. `scripts/check-release-vulnerabilities.test.ts` goes 4 → 7 and covers
  the fixable/unfixable split (including a HIGH with no `FixedVersion` that appears in
  `highCritical` but not in `rejected`, a whitespace-only `FixedVersion`, an absent field, and a
  mixed report), the exception match key with and without `digest` (every other field still
  binds, and two exceptions differing only by digest are now a duplicate), and the run summary.
- `scripts/ci-contract.test.ts` gains an assertion that the scan job is blocking, amd64-only,
  scans the run tag, uploads its result, and that every workflow call site evaluates
  `security/vulnerability-policy.json` — there is no second copy.
- `scripts/verify-release-evidence.ts` still consumes `evaluate()` unchanged, and its own tests
  pass. The result **keeps its exact shape**, which matters: the weekly rescan re-derives a
  published release's `.policy.json` and fails on any difference. `rejected` can only shrink and
  a published release had `rejected: []`, so older evidence still re-derives byte for byte.

## Checklist

- [x] No changeset. `verify-changesets.yml` scopes `SHIPPED_PATHS` to `server`, `webapp` and
      `docker`; this PR touches `.github/`, `scripts/` and `docs/` only, so `shipped_changed` is
      empty and the release-note check does not fire. Confirmed by reading the workflow, and by
      the `Verify changesets` job passing on this PR.
- [x] If operators must act, the changeset and migration entry give actionable upgrade
      instructions — n/a, no operator-visible change.
- [x] I did not commit generated-artifact changes that this PR did not cause.

## Deliberately not changed

`release.yml` and `rescan-release-images.yml` did **not** get the ECR fallback. In both, the
Trivy database download shares one `run:` block — and therefore one `env:` — with the image
scan, which sets `TRIVY_USERNAME`/`TRIVY_PASSWORD` for GHCR. Trivy applies those credentials to
every registry, so a fallback to `public.ecr.aws` would present a GHCR token and fail auth
instead of pulling anonymously. Giving those two workflows a real fallback means splitting the
database download into its own credential-free step, a separate change to a release-critical
path. The new job here is already structured that way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
