### PR TITLE
fix(ci): gate the release before the draft exists

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,9 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     permissions:
+      # No release is created here — tag-images creates the draft once the evidence gate has
+      # passed. Draft releases are invisible to tokens without push access, so the resume and
+      # parent-version preconditions below still need write.
       contents: write
     outputs:
       released: ${{ steps.cut.outputs.released }}
@@ -36,6 +39,7 @@ jobs:
       tag_name: ${{ steps.cut.outputs.tag_name }}
       previous_version: ${{ steps.cut.outputs.previous_version }}
       sha: ${{ steps.cut.outputs.sha }}
+      migrations: ${{ steps.cut.outputs.migrations }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -44,7 +48,13 @@ jobs:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
 
-      - name: Cut release if this commit bumped the version
+      # Decides whether this commit cuts a release, and creates nothing.
+      # The draft is created in tag-images, after the evidence gate, so a gate failure leaves no
+      # release behind: release images are promoted by digest and never rebuilt, so a draft cut at
+      # a commit the gate rejected can never pass, and it would then block the next version too
+      # (the parent-version precondition below). Nothing survives a failed attempt, and the same
+      # version re-cuts from a commit that carries the fix.
+      - name: Plan the release for this commit
         id: cut
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -63,7 +73,8 @@ jobs:
             echo "released=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          RESUME=false
+          # A draft can only exist here if an earlier attempt cleared the evidence gate and failed
+          # later; it is resumed rather than recreated.
           if existing=$(gh release view "$TAG" --repo "${{ github.repository }}" --json isDraft,targetCommitish 2>/dev/null); then
             if [ "$(jq -r .isDraft <<< "$existing")" != true ]; then
               echo "Release $TAG is already published."
@@ -72,7 +83,6 @@ jobs:
             fi
             [ "$(jq -r .targetCommitish <<< "$existing")" = "$SHA" ] || {
               echo "::error::Draft $TAG targets a different commit"; exit 1; }
-            RESUME=true
           fi
           echo "Cutting $TAG at $SHA (was $PARENT_VERSION)"
 
@@ -82,33 +92,17 @@ jobs:
           jq -e '.isDraft == false and .isPrerelease == false' <<< "$previous" >/dev/null || {
             echo "::error::$PREV_TAG is not a stable published release"; exit 1; }
 
-          NOTES=$(mktemp)
-          if [ -n "$PREV_TAG" ] && ! git diff --quiet "$PREV_TAG" "$SHA" -- server/application/src/main/resources/db/changelog/; then
-            {
-              echo "> [!WARNING]"
-              echo "> This release contains **schema migrations**. They run automatically on startup — back up your database before upgrading. See the [migration guide](${{ github.server_url }}/${{ github.repository }}/blob/main/MIGRATION.md)."
-              echo ""
-            } >> "$NOTES"
-          fi
-          # Materialise the changelog first: awk exits at the next section
-          # heading, which would SIGPIPE (exit 141) the still-writing `git show`
-          # once CHANGELOG.md outgrew the 64 KiB pipe buffer.
-          CHANGELOG_SNAPSHOT=$(mktemp)
-          git show "$SHA:CHANGELOG.md" > "$CHANGELOG_SNAPSHOT"
-          awk -v ver="## $VERSION" '
-                $0 == ver { on=1; next }
-                on && /^## / { exit }
-                on { print }
-              ' "$CHANGELOG_SNAPSHOT" >> "$NOTES"
-          echo "----- release notes -----"; cat "$NOTES"; echo "-------------------------"
-
-          if [ "$RESUME" = false ]; then
-            gh release create "$TAG" --draft \
-              --title "$TAG" \
-              --notes-file "$NOTES" \
-              --target "$SHA" \
-              --repo "${{ github.repository }}"
-          fi
+          # The notes are assembled where the draft is created, in tag-images, from the CHANGELOG.md
+          # it checks out. Only this job has the tags to tell whether the release carries schema
+          # migrations, so that one bit travels as an output.
+          status=0
+          git diff --quiet "$PREV_TAG" "$SHA" -- server/application/src/main/resources/db/changelog/ || status=$?
+          case "$status" in
+            0) MIGRATIONS=false ;;
+            1) MIGRATIONS=true ;;
+            # Anything else is git failing, not a verdict — never stamp the warning by accident.
+            *) echo "::error::Could not diff $PREV_TAG..$SHA for schema migrations"; exit 1 ;;
+          esac
 
           {
             echo "released=true"
@@ -118,13 +112,14 @@ jobs:
             echo "tag_name=$TAG"
             echo "sha=$SHA"
             echo "previous_version=$PARENT_VERSION"
+            echo "migrations=$MIGRATIONS"
           } >> "$GITHUB_OUTPUT"
 
       - name: Summary
         if: steps.cut.outputs.released == 'true'
         run: |
           echo "## Preparing ${{ steps.cut.outputs.tag_name }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "Evidence verification is in progress." >> "$GITHUB_STEP_SUMMARY"
+          echo "Evidence verification is in progress; the draft is created once it passes." >> "$GITHUB_STEP_SUMMARY"
 
   tag-images:
     needs: release
@@ -135,7 +130,7 @@ jobs:
       packages: write
       id-token: write
       attestations: write
-      contents: write # gh release upload (release image lock)
+      contents: write # gh release create/upload, once the evidence gate has passed
     outputs:
       agent-pi-digest: ${{ steps.retag.outputs.agent-pi-digest }}
       application-server-digest: ${{ steps.retag.outputs.application-server-digest }}
@@ -368,6 +363,46 @@ jobs:
             --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
             "$ASSET"
 
+      # First and only write to the release surface: every step above fails without creating one,
+      # so a rejected release leaves no draft to delete and no tag — a draft materialises none —
+      # and the version re-cuts unchanged from a commit that carries the fix.
+      - name: Create the draft release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ needs.release.outputs.tag_name }}
+          VERSION: ${{ needs.release.outputs.version }}
+          SHA: ${{ needs.release.outputs.sha }}
+          MIGRATIONS: ${{ needs.release.outputs.migrations }}
+        run: |
+          set -euo pipefail
+          # The release job has already proved that any existing release is a draft at this commit.
+          if gh release view "$TAG_NAME" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            echo "Resuming the existing draft $TAG_NAME."
+            exit 0
+          fi
+
+          NOTES=$(mktemp)
+          if [ "$MIGRATIONS" = true ]; then
+            {
+              echo "> [!WARNING]"
+              echo "> This release contains **schema migrations**. They run automatically on startup — back up your database before upgrading. See the [migration guide](${{ github.server_url }}/${{ github.repository }}/blob/main/MIGRATION.md)."
+              echo ""
+            } >> "$NOTES"
+          fi
+          # CHANGELOG.md as checked out at the released commit; awk exits at the next section.
+          awk -v ver="## $VERSION" '
+                $0 == ver { on=1; next }
+                on && /^## / { exit }
+                on { print }
+              ' CHANGELOG.md >> "$NOTES"
+          echo "----- release notes -----"; cat "$NOTES"; echo "-------------------------"
+
+          gh release create "$TAG_NAME" --draft \
+            --title "$TAG_NAME" \
+            --notes-file "$NOTES" \
+            --target "$SHA" \
+            --repo "${{ github.repository }}"
+
       - name: Upload release image lock to GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -375,8 +410,11 @@ jobs:
           ASSET: ${{ steps.pin.outputs.asset-path }}
         run: |
           set -euo pipefail
+          # --clobber so a re-run over a resumed draft replaces its assets instead of failing on
+          # every name that already exists.
           gh release upload "$TAG_NAME" \
             "$ASSET" "${ASSET}.sigstore.json" evidence/* \
+            --clobber \
             --repo "${{ github.repository }}"
 
   upgrade-test:
@@ -608,7 +646,7 @@ jobs:
           TAG_NAME: ${{ needs.release.outputs.tag_name }}
         run: |
           set -euo pipefail
-          gh release upload "$TAG_NAME" host-smoke/*.json --repo "${{ github.repository }}"
+          gh release upload "$TAG_NAME" host-smoke/*.json --clobber --repo "${{ github.repository }}"
           gh release edit "$TAG_NAME" --repo "${{ github.repository }}" --draft=false
           [ "$(gh release view "$TAG_NAME" --repo "${{ github.repository }}" --json isImmutable --jq .isImmutable)" = true ] || {
             echo "::error::Repository immutable releases must be enabled before publishing"; exit 1; }

--- a/.github/workflows/verify-changesets.yml
+++ b/.github/workflows/verify-changesets.yml
@@ -25,8 +25,22 @@ jobs:
       - name: Test changeset and version-sync policies
         run: pnpm run check:changesets
 
-      - name: Check release-note presence
+      # A revert of a release commit restores MIGRATION.md, the consumed changesets and the pending
+      # migration fragments by construction, so it can never satisfy the rules below — the release
+      # reverts so far each needed an administrator bypass. The exemption is structural, never
+      # lexical: scripts/verify-revert.ts ignores the title and requires every commit the pull
+      # request adds to be the exact inverse, by patch id, of a commit already on the base.
+      - name: Detect a verified revert
+        id: revert
         if: ${{ !github.event.pull_request.draft && github.event.pull_request.user.type != 'Bot' }}
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: node scripts/verify-revert.ts "$BASE_SHA" HEAD
+
+      - name: Check release-note presence
+        if: >-
+          ${{ !github.event.pull_request.draft && github.event.pull_request.user.type != 'Bot'
+            && steps.revert.outputs.verified-revert != 'true' }}
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |

--- a/docs/contributor/release-management.mdx
+++ b/docs/contributor/release-management.mdx
@@ -32,8 +32,9 @@ sequenceDiagram
     M->>VP: changesets action folds pending changesets into the accumulating Version PR
     Note over VP: CHANGELOG.md + version bump preview
     VP->>M: Maintainer merges when the release is ready
-    M->>R: Create draft vX.Y.Z release
+    M->>R: Plan vX.Y.Z and assemble its notes
     R->>R: Generate and verify digest-bound evidence
+    R->>R: Create the draft vX.Y.Z release and attach its evidence
     R->>R: Upgrade seeded data from the previous stable release
     R->>R: Qualify supported hosts
     R->>R: Promote X.Y.Z / X.Y / latest image tags
@@ -56,10 +57,31 @@ sequenceDiagram
    `main`, and a release is only cut if that run succeeds. Versioning also moves any
    migration fragments at the existing `### Next release` anchor in `MIGRATION.md`, creates the
    versioned section beneath it, and consumes the fragments.
-3. **Merging the Version PR cuts the release.** The workflow creates a draft release at the merge
-   commit. After its evidence, seeded-upgrade, and supported-host gates pass, it promotes the CI-built images to
-   `X.Y.Z`, `X.Y`, and `latest`, publishes the release, deploys staging, and requests production
-   approval.
+3. **Merging the Version PR cuts the release.** The workflow resolves the release image digests and
+   runs the evidence gate first, and only then creates the draft release at the merge commit and
+   attaches the evidence to it. After the seeded-upgrade and supported-host gates pass too, it
+   promotes the CI-built images to `X.Y.Z`, `X.Y`, and `latest`, publishes the release, deploys
+   staging, and requests production approval.
+
+### When a release fails
+
+Release images are promoted **by digest and never rebuilt**, so a commit the evidence gate rejects
+can never pass on a retry — only a new commit can. The gate therefore runs before anything is
+created: a rejected release leaves no draft and no tag behind (a draft materialises no tag), so
+there is nothing to clean up and the version number is not consumed.
+
+Recovering is a revert and a re-cut: revert the version commit, which restores the pending
+changesets, land the fix, and let the Version PR re-cut the same version from a commit that carries
+it. The `verify-changesets` freeze rules — `MIGRATION.md` is not editable in a feature PR, pending
+changesets and migration fragments are not deletable — are lifted for a **verified revert**, which
+`scripts/verify-revert.ts` decides structurally rather than by title: every commit the pull request
+adds must record `This reverts commit <sha>.`, name a commit that is already an ancestor of the
+base, and carry that commit's patch exactly reversed. Anything else leaves the rules in force.
+
+A failure *after* the draft exists — the seeded-upgrade or supported-host gate, or publication
+itself — is the case the resume path covers: re-running the workflow at the same commit reuses the
+existing draft, regenerates the evidence, and replaces its assets. A draft that can never pass is
+deleted by hand, and the version re-cuts from the fixed commit as above.
 
 ## Supported-host qualification
 
@@ -72,9 +94,9 @@ clean boot; the seeded-upgrade gate separately proves the supported migration pa
 
 ## Supply-chain evidence
 
-A release remains a draft until every first-party and upstream production image in
+No release exists at all until every first-party and upstream production image in
 `security/release-images.json` has passed the evidence
-gate. The gate resolves each image index and its `linux/amd64` and `linux/arm64` manifests to immutable
+gate, and it remains a draft until the gates after it pass too. The gate resolves each image index and its `linux/amd64` and `linux/arm64` manifests to immutable
 digests. It generates a lossless Syft inventory plus SPDX and CycloneDX SBOMs for each deployed platform,
 scanning the registry manifest directly rather than a local Docker daemon copy, which would re-serialize
 the manifest and digest to something the release never published. The gate proves that all three documents

--- a/scripts/ci-contract.test.ts
+++ b/scripts/ci-contract.test.ts
@@ -307,6 +307,39 @@ void describe("CI contract", () => {
 		assert.doesNotMatch(release, /node scripts\/check-release-(?:sbom|vulnerabilities)\.ts/);
 	});
 
+	void test("creates the draft release only once the evidence gate has passed", async () => {
+		const source = await readFile(".github/workflows/release.yml", "utf8");
+		const decide = job(source, "release");
+		const gate = job(source, "tag-images");
+		// Release images are promoted by digest and never rebuilt, so a draft cut before the gate
+		// can never pass at that commit — and it blocks the next version too, because the
+		// precondition below requires the previous version to be published.
+		assert.doesNotMatch(decide, /gh release create/);
+		assert.match(decide, /is not a published release/);
+		assert.match(decide, /is not a stable published release/);
+		const created = gate.indexOf('gh release create "$TAG_NAME"');
+		const gated = gate.lastIndexOf("node scripts/verify-release-evidence.ts");
+		const uploaded = gate.indexOf('gh release upload "$TAG_NAME"');
+		assert.ok(gated >= 0, "tag-images must run the evidence verifier");
+		assert.ok(created > gated, "the draft must be created after the evidence gate");
+		assert.ok(uploaded > created, "release assets need a draft to upload to");
+		// A re-run resumes the draft, so uploads must replace assets instead of failing on names.
+		for (const upload of source.matchAll(/gh release upload[\s\S]*?\n\n/g)) {
+			assert.match(upload[0], /--clobber/);
+		}
+	});
+
+	void test("exempts a verified revert from the changeset freeze rules", async () => {
+		const source = await readFile(".github/workflows/verify-changesets.yml", "utf8");
+		const detect = source.indexOf("- name: Detect a verified revert");
+		const guard = source.indexOf("- name: Check release-note presence");
+		assert.ok(detect >= 0 && guard > detect, "the revert check must precede the freeze guard");
+		assert.match(source, /run: node scripts\/verify-revert\.ts "\$BASE_SHA" HEAD/);
+		assert.match(source, /steps\.revert\.outputs\.verified-revert != 'true'/);
+		// The exemption is structural: a title or branch name is attacker-chosen and never read.
+		assert.doesNotMatch(source, /pull_request\.title|github\.head_ref/);
+	});
+
 	void test("never invokes a repository-local action before checkout", async () => {
 		for (const [file, source] of await workflowSources()) {
 			for (const jobSource of source.split(/^ {2}(?=[A-Za-z][\w-]*:\s*$)/m).slice(1)) {

--- a/scripts/verify-revert.test.ts
+++ b/scripts/verify-revert.test.ts
@@ -1,0 +1,262 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { after, test } from "node:test";
+
+import { verifyRevert } from "./verify-revert.ts";
+
+const SCRIPT = join(import.meta.dirname, "verify-revert.ts");
+
+/**
+ * Git hooks export GIT_DIR, GIT_INDEX_FILE and friends, which would point every command below at
+ * the repository being pushed instead of at the fixture.
+ */
+const cleanGitEnv = (): NodeJS.ProcessEnv =>
+	Object.fromEntries(Object.entries(process.env).filter(([key]) => !key.startsWith("GIT_")));
+
+type Git = (...args: string[]) => string;
+
+const repositories: string[] = [];
+
+after(() => {
+	for (const repo of repositories) rmSync(repo, { recursive: true, force: true });
+});
+
+/** A repository whose `main` carries a release-shaped commit, with a branch checked out from it. */
+function fixture(): { repo: string; git: Git; write: (file: string, content: string) => void } {
+	const repo = mkdtempSync(join(tmpdir(), "verify-revert-"));
+	repositories.push(repo);
+	const git: Git = (...args) =>
+		execFileSync("git", args, {
+			cwd: repo,
+			encoding: "utf8",
+			stdio: ["ignore", "pipe", "pipe"],
+			env: cleanGitEnv(),
+		}).trim();
+	const write = (file: string, content: string): void => writeFileSync(join(repo, file), content);
+	git("init", "--quiet", "--initial-branch=main");
+	git("config", "user.email", "test@example.invalid");
+	git("config", "user.name", "Test");
+	write("package.json", '{"version":"0.74.0"}\n');
+	write("MIGRATION.md", "# Migration\n");
+	write("changeset.md", "---\nhephaestus: minor\n---\n\nA pending note.\n");
+	git("add", "-A");
+	git("commit", "--quiet", "-m", "base");
+	return { repo, git, write };
+}
+
+/** The shape the release reverts have: bump the version, stamp MIGRATION.md, consume changesets. */
+function versionCommit(git: Git, write: (file: string, content: string) => void): string {
+	write("package.json", '{"version":"0.75.0"}\n');
+	write("MIGRATION.md", "# Migration\n\n## 0.75.0\n\nDo the thing.\n");
+	git("rm", "--quiet", "changeset.md");
+	git("add", "-A");
+	git("commit", "--quiet", "-m", "chore(release): version packages");
+	return git("rev-parse", "HEAD");
+}
+
+void test("verifies a git revert of a commit already on the base", () => {
+	const { repo, git, write } = fixture();
+	const released = versionCommit(git, write);
+	const base = git("rev-parse", "HEAD");
+	git("checkout", "--quiet", "-b", "revert/version");
+	git("revert", "--no-edit", released);
+
+	const verdict = verifyRevert(base, "HEAD", repo);
+	assert.equal(verdict.verified, true);
+	assert.deepEqual(
+		verdict.commits.map((entry) => entry.reverted),
+		[released],
+	);
+	// The revert restores exactly what the guard freezes.
+	assert.equal(readFileSync(join(repo, "MIGRATION.md"), "utf8"), "# Migration\n");
+});
+
+void test("verifies a revert taken after unrelated work landed on the base", () => {
+	const { repo, git, write } = fixture();
+	const released = versionCommit(git, write);
+	write("feature.ts", "export const feature = true;\n");
+	write("changeset-later.md", "---\nhephaestus: patch\n---\n\nA later note.\n");
+	git("add", "-A");
+	git("commit", "--quiet", "-m", "feat: land more work");
+	const base = git("rev-parse", "HEAD");
+	git("checkout", "--quiet", "-b", "revert/version");
+	git("revert", "--no-edit", released);
+
+	assert.equal(verifyRevert(base, "HEAD", repo).verified, true);
+	// The changesets that landed after the release are untouched by the revert.
+	assert.equal(readFileSync(join(repo, "changeset-later.md"), "utf8").includes("later note"), true);
+});
+
+void test("rejects a claimed revert that smuggles an extra change", () => {
+	const { repo, git, write } = fixture();
+	const released = versionCommit(git, write);
+	const base = git("rev-parse", "HEAD");
+	git("checkout", "--quiet", "-b", "revert/version");
+	git("revert", "--no-edit", "--no-commit", released);
+	write("backdoor.ts", "export const shipped = true;\n");
+	git("add", "-A");
+	git("commit", "--quiet", "-m", `revert with a rider\n\nThis reverts commit ${released}.`);
+
+	const verdict = verifyRevert(base, "HEAD", repo);
+	assert.equal(verdict.verified, false);
+	assert.match(verdict.reason, /not the exact inverse/);
+});
+
+void test("rejects a revert commit paired with an unrelated commit", () => {
+	const { repo, git, write } = fixture();
+	const released = versionCommit(git, write);
+	const base = git("rev-parse", "HEAD");
+	git("checkout", "--quiet", "-b", "revert/version");
+	git("revert", "--no-edit", released);
+	write("backdoor.ts", "export const shipped = true;\n");
+	git("add", "-A");
+	git("commit", "--quiet", "-m", "feat: ship something under cover of a revert");
+
+	const verdict = verifyRevert(base, "HEAD", repo);
+	assert.equal(verdict.verified, false);
+	assert.match(verdict.reason, /does not record exactly one/);
+});
+
+void test("rejects a trailer that names a commit which is not on the base", () => {
+	const { repo, git, write } = fixture();
+	versionCommit(git, write);
+	const base = git("rev-parse", "HEAD");
+	git("checkout", "--quiet", "-b", "revert/version");
+	write("private.ts", "export const value = 1;\n");
+	git("add", "-A");
+	git("commit", "--quiet", "-m", "chore: a commit only this branch has");
+	const branchOnly = git("rev-parse", "HEAD");
+	git("revert", "--no-edit", branchOnly);
+
+	const verdict = verifyRevert(base, "HEAD", repo);
+	assert.equal(verdict.verified, false);
+	assert.match(verdict.reason, /is not an ancestor of the base/);
+});
+
+void test("rejects a fabricated trailer naming an unknown commit", () => {
+	const { repo, git, write } = fixture();
+	versionCommit(git, write);
+	const base = git("rev-parse", "HEAD");
+	git("checkout", "--quiet", "-b", "revert/version");
+	write("MIGRATION.md", "# Migration\n");
+	git("add", "-A");
+	const unknown = "0".repeat(40);
+	git("commit", "--quiet", "-m", `revert: restore MIGRATION.md\n\nThis reverts commit ${unknown}.`);
+
+	const verdict = verifyRevert(base, "HEAD", repo);
+	assert.equal(verdict.verified, false);
+	assert.match(verdict.reason, /reverts unknown commit/);
+});
+
+void test("rejects a revert whose title says revert but whose body does not", () => {
+	const { repo, git, write } = fixture();
+	versionCommit(git, write);
+	const base = git("rev-parse", "HEAD");
+	git("checkout", "--quiet", "-b", "revert/version");
+	write("MIGRATION.md", "# Migration\n");
+	git("add", "-A");
+	git("commit", "--quiet", "-m", "revert(release): defer the release");
+
+	const verdict = verifyRevert(base, "HEAD", repo);
+	assert.equal(verdict.verified, false);
+	assert.match(verdict.reason, /does not record exactly one/);
+});
+
+void test("rejects a binary payload swapped under a revert trailer", () => {
+	const { repo, git } = fixture();
+	writeFileSync(join(repo, "logo.png"), Buffer.from([0, 1, 2, 65]));
+	git("add", "-A");
+	git("commit", "--quiet", "-m", "add a binary");
+	writeFileSync(join(repo, "logo.png"), Buffer.from([0, 1, 2, 66, 66]));
+	git("add", "-A");
+	git("commit", "--quiet", "-m", "change the binary");
+	const released = git("rev-parse", "HEAD");
+	const base = git("rev-parse", "HEAD");
+	git("checkout", "--quiet", "-b", "revert/binary");
+	writeFileSync(join(repo, "logo.png"), Buffer.from([9, 9, 9, 67, 67, 67]));
+	git("add", "-A");
+	git("commit", "--quiet", "-m", `revert the binary\n\nThis reverts commit ${released}.`);
+
+	const verdict = verifyRevert(base, "HEAD", repo);
+	assert.equal(verdict.verified, false);
+	assert.match(verdict.reason, /not the exact inverse/);
+});
+
+void test("rejects a branch that adds nothing over the base", () => {
+	const { repo, git, write } = fixture();
+	versionCommit(git, write);
+	const base = git("rev-parse", "HEAD");
+
+	const verdict = verifyRevert(base, "HEAD", repo);
+	assert.equal(verdict.verified, false);
+	assert.match(verdict.reason, /adds no commit/);
+});
+
+void test("rejects a revert of a merge commit", () => {
+	const { repo, git, write } = fixture();
+	git("checkout", "--quiet", "-b", "side");
+	write("side.ts", "export const side = true;\n");
+	git("add", "-A");
+	git("commit", "--quiet", "-m", "feat: side");
+	git("checkout", "--quiet", "main");
+	versionCommit(git, write);
+	git("merge", "--quiet", "--no-ff", "-m", "merge side", "side");
+	const base = git("rev-parse", "HEAD");
+	git("checkout", "--quiet", "-b", "revert/merge");
+	// `git revert -m 1` writes "…, reversing changes made to <sha>." instead, which the trailer
+	// pattern already refuses; this is the hand-written form that reaches the parent check.
+	git("revert", "--no-edit", "-m", "1", base);
+	git("commit", "--quiet", "--amend", "-m", `revert the merge\n\nThis reverts commit ${base}.`);
+
+	const verdict = verifyRevert(base, "HEAD", repo);
+	assert.equal(verdict.verified, false);
+	assert.match(verdict.reason, /which has 2 parents/);
+});
+
+void test("rejects the trailer git writes for a reverted merge", () => {
+	const { repo, git, write } = fixture();
+	git("checkout", "--quiet", "-b", "side");
+	write("side.ts", "export const side = true;\n");
+	git("add", "-A");
+	git("commit", "--quiet", "-m", "feat: side");
+	git("checkout", "--quiet", "main");
+	versionCommit(git, write);
+	git("merge", "--quiet", "--no-ff", "-m", "merge side", "side");
+	const base = git("rev-parse", "HEAD");
+	git("checkout", "--quiet", "-b", "revert/merge");
+	git("revert", "--no-edit", "-m", "1", base);
+
+	const verdict = verifyRevert(base, "HEAD", repo);
+	assert.equal(verdict.verified, false);
+	assert.match(verdict.reason, /does not record exactly one/);
+});
+
+void test("reports the verdict to GITHUB_OUTPUT", () => {
+	const { repo, git, write } = fixture();
+	const released = versionCommit(git, write);
+	const base = git("rev-parse", "HEAD");
+	git("checkout", "--quiet", "-b", "revert/version");
+	git("revert", "--no-edit", released);
+	const output = join(repo, "github-output");
+	writeFileSync(output, "");
+
+	const stdout = execFileSync(process.execPath, [SCRIPT, base, "HEAD"], {
+		cwd: repo,
+		encoding: "utf8",
+		env: { ...cleanGitEnv(), GITHUB_OUTPUT: output },
+	});
+	assert.match(stdout, /::notice::Verified revert of/);
+	assert.equal(readFileSync(output, "utf8"), "verified-revert=true\n");
+
+	git("reset", "--quiet", "--hard", base);
+	const denied = execFileSync(process.execPath, [SCRIPT, base, "HEAD"], {
+		cwd: repo,
+		encoding: "utf8",
+		env: { ...cleanGitEnv(), GITHUB_OUTPUT: output },
+	});
+	assert.match(denied, /Not a verified revert/);
+	assert.equal(readFileSync(output, "utf8"), "verified-revert=true\nverified-revert=false\n");
+});

--- a/scripts/verify-revert.ts
+++ b/scripts/verify-revert.ts
@@ -1,0 +1,163 @@
+/**
+ * Decides whether a pull request is a *verified revert*.
+ *
+ * The changeset freeze rules — MIGRATION.md is not editable, pending changesets and migration
+ * fragments are not deletable — describe how a feature moves forward. A revert of a release
+ * commit necessarily restores every one of them, so it can never satisfy the guard, and the three
+ * release reverts so far each needed an administrator bypass. A guard that has to be bypassed on a
+ * known-good path teaches people to bypass it.
+ *
+ * The exemption is deliberately structural rather than lexical: the pull request title and branch
+ * name are never read, because both are attacker-chosen. A pull request qualifies only when *every*
+ * non-merge commit it adds over the base
+ *
+ *   1. carries exactly one `This reverts commit <sha>.` line, the trailer `git revert` writes,
+ *   2. names a commit that exists and is an ancestor of the base — already reviewed and merged,
+ *   3. names a commit with a single parent — reverting a merge is out of scope, and
+ *   4. has a patch identical to that commit's patch reversed, compared by `git patch-id --stable`
+ *      over a `--binary` diff, so neither an extra hunk nor an altered binary payload can ride
+ *      along.
+ *
+ * Anything else — an unrelated commit in the range, a fabricated trailer, a conflict-resolved
+ * revert whose patch no longer matches — leaves the guard fully in force. The check fails closed.
+ */
+
+import { execFileSync } from "node:child_process";
+import { appendFileSync } from "node:fs";
+
+/** `git revert` writes exactly this line; a revert of a merge adds `, reversing changes …`. */
+const REVERT_TRAILER = /^This reverts commit ([0-9a-f]{7,40})\.$/gm;
+
+const MAX_BUFFER = 64 * 1024 * 1024;
+
+export interface RevertedCommit {
+	/** A commit the pull request adds. */
+	readonly commit: string;
+	/** The already-merged commit it undoes. */
+	readonly reverted: string;
+}
+
+export type RevertVerdict =
+	| { readonly verified: true; readonly commits: readonly RevertedCommit[] }
+	| { readonly verified: false; readonly reason: string };
+
+const short = (sha: string): string => sha.slice(0, 8);
+
+export function verifyRevert(baseSha: string, head = "HEAD", cwd?: string): RevertVerdict {
+	// Git hooks export GIT_DIR and GIT_INDEX_FILE, which would silently redirect every command
+	// below at whichever repository invoked the hook.
+	const env = Object.fromEntries(
+		Object.entries(process.env).filter(([key]) => !key.startsWith("GIT_")),
+	);
+	const git = (...args: string[]): string =>
+		execFileSync("git", args, {
+			cwd,
+			env,
+			encoding: "utf8",
+			maxBuffer: MAX_BUFFER,
+			stdio: ["ignore", "pipe", "pipe"],
+		}).trim();
+	const succeeds = (...args: string[]): boolean => {
+		try {
+			git(...args);
+			return true;
+		} catch {
+			return false;
+		}
+	};
+	const commit = (revision: string): string | undefined => {
+		try {
+			return git("rev-parse", "--verify", "--end-of-options", `${revision}^{commit}`);
+		} catch {
+			return undefined;
+		}
+	};
+	/** The identity of the change between two commits, independent of where it applies. */
+	const patchId = (from: string, to: string): string => {
+		const diff = execFileSync("git", ["diff", "--binary", from, to], {
+			cwd,
+			env,
+			maxBuffer: MAX_BUFFER,
+			stdio: ["ignore", "pipe", "pipe"],
+		});
+		const identity = execFileSync("git", ["patch-id", "--stable"], {
+			cwd,
+			env,
+			input: diff,
+			encoding: "utf8",
+			maxBuffer: MAX_BUFFER,
+			stdio: ["pipe", "pipe", "pipe"],
+		});
+		return identity.trim().split(" ")[0] ?? "";
+	};
+
+	const base = commit(baseSha);
+	if (!base) return { verified: false, reason: `base ${baseSha} is not a commit in this clone` };
+	const tip = commit(head);
+	if (!tip) return { verified: false, reason: `head ${head} is not a commit in this clone` };
+
+	// Merge commits carry no patch of their own; a branch that merged the base back in adds one.
+	const added = git("rev-list", "--no-merges", `${base}..${tip}`).split("\n").filter(Boolean);
+	if (added.length === 0) return { verified: false, reason: "adds no commit over the base" };
+
+	const commits: RevertedCommit[] = [];
+	for (const candidate of added) {
+		const message = git("log", "-1", "--format=%B", candidate);
+		const trailers = [...message.matchAll(REVERT_TRAILER)];
+		const trailer = trailers[0]?.[1];
+		if (trailers.length !== 1 || !trailer) {
+			return {
+				verified: false,
+				reason: `${short(candidate)} does not record exactly one "This reverts commit <sha>." line`,
+			};
+		}
+		const reverted = commit(trailer);
+		if (!reverted) {
+			return { verified: false, reason: `${short(candidate)} reverts unknown commit ${trailer}` };
+		}
+		if (!succeeds("merge-base", "--is-ancestor", reverted, base)) {
+			return {
+				verified: false,
+				reason: `${short(candidate)} reverts ${short(reverted)}, which is not an ancestor of the base`,
+			};
+		}
+		const parents = git("rev-list", "--parents", "-n", "1", reverted).split(" ").length - 1;
+		if (parents !== 1) {
+			return {
+				verified: false,
+				reason: `${short(candidate)} reverts ${short(reverted)}, which has ${parents} parents`,
+			};
+		}
+		const applied = patchId(`${candidate}^`, candidate);
+		const inverse = patchId(reverted, `${reverted}^`);
+		if (applied === "" || applied !== inverse) {
+			return {
+				verified: false,
+				reason: `${short(candidate)} is not the exact inverse of ${short(reverted)}`,
+			};
+		}
+		commits.push({ commit: candidate, reverted });
+	}
+	return { verified: true, commits };
+}
+
+if (import.meta.main) {
+	const [baseSha, head] = process.argv.slice(2);
+	if (!baseSha) {
+		console.error("::error::usage: verify-revert.ts <base-sha> [head]");
+		process.exitCode = 1;
+	} else {
+		const verdict = verifyRevert(baseSha, head);
+		if (verdict.verified) {
+			const reverted = verdict.commits.map((entry) => short(entry.reverted)).join(", ");
+			console.log(
+				`::notice::Verified revert of ${reverted}; the changeset freeze rules do not apply.`,
+			);
+		} else {
+			console.log(`Not a verified revert (${verdict.reason}); the changeset rules apply in full.`);
+		}
+		if (process.env.GITHUB_OUTPUT) {
+			appendFileSync(process.env.GITHUB_OUTPUT, `verified-revert=${verdict.verified}\n`);
+		}
+	}
+}


### PR DESCRIPTION
## Description

The v0.75.0 evidence gate failed after the draft release already existed, and because release images
are promoted by digest and never rebuilt, that draft could never pass — escaping it took a manual
draft deletion plus an admin-bypassed revert (#1701). This takes the **reorder**, not the cleanup
job: the gate now runs before anything is created, so a rejected release leaves no state at all.

Fixes #1705

### Which approach, and why

**Reorder — the preferred option.** `tag-images` already resolved digests, generated and verified the
evidence, wrote the image lock, attested and signed it before touching the release; only
`gh release upload` needed a release to exist. Creating the draft immediately before that upload was
a local change, so the fallback cleanup job was not needed:

- `release` no longer creates anything. It decides whether this commit cuts a version, enforces the
  preconditions, and publishes the same outputs as before.
- `tag-images` creates the draft as its second-to-last step, then uploads the evidence to it.
- Release notes are assembled where the draft is created, from the `CHANGELOG.md` that job already
  checks out. Only the schema-migration flag still travels as a job output, because deciding it needs
  tags and history that `tag-images` (depth 1) does not have. A job output, not an artifact: outputs
  survive a partial re-run in which `release` is not replayed, and the notes themselves would be a
  ~120 KB output at current release sizes, close enough to the per-output limit to be worth avoiding.
- Both `gh release upload` calls gained `--clobber`, so a re-run over a resumed draft replaces assets
  instead of failing on every name that already exists.

**The `PARENT_VERSION must be published` precondition is untouched**, including its "draft targets a
different commit" sibling. Both are good invariants; they only bit us because failure left state
behind. `scripts/ci-contract.test.ts` now asserts both are still there, that the draft is created
after the evidence verifier runs, that assets are uploaded after the draft exists, and that every
release upload clobbers.

### Failure modes considered

`release.yml` cannot be rehearsed, so these are argued rather than tested:

| Failure | Before | After |
|---|---|---|
| Evidence gate rejects an image | Draft exists at a commit that can never pass; blocks the next version too, needs a manual delete + admin-bypassed revert | Nothing was created. No draft, no tag, no assets. The version is not consumed |
| Same-commit re-run of a gate failure | Same digests, same verdict, plus a stale draft | Same verdict, no residue |
| Failure *after* the draft exists (upgrade test, host smoke, publish) | Resume path | Unchanged: the `release` job still resumes a draft that targets this commit, `tag-images` reuses it instead of recreating, and the uploads clobber. This is the window the resume path was designed for — a flake at the same digests. A draft that genuinely can never pass still needs deleting by hand, but that window is now three jobs wide instead of the whole pipeline, and I deliberately did **not** add an `if: failure()` cleanup, because deleting the draft is exactly what would break the resume path for the flake case |
| Full workflow re-run after success | — | `release` sees a published release, sets `released=false`, everything downstream skips |
| Full re-run after the draft was created | `gh release upload` fails on existing asset names | `--clobber` replaces them |
| Draft creation itself fails | — | No assets uploaded; the run fails with an empty draft at worst, which the resume path picks up |
| `git diff` against the previous tag errors while deciding the migration warning | Silently treated as "has migrations" | Distinguishes exit 1 (differences) from any other status, which now fails loudly |

Reordering does not weaken any gate: nothing between the digest resolution and the draft creation
reads the release, and the draft is still published only after the seeded-upgrade and supported-host
gates pass. Attestations and image promotion are unchanged.

### Revert exemption, and its threat model

`verify-changesets` freeze-guards `MIGRATION.md`, `.migration/*.md` and pending changesets. A revert
of a version commit restores all three by construction, so the guard cannot pass on that path — it
has been admin-bypassed three times (#1686, #1691, #1701), and a guard that must be bypassed on a
known-good path teaches people to bypass it.

`scripts/verify-revert.ts` decides the exemption **structurally**. The title and branch name are
never read. Every non-merge commit the PR adds over the base must:

1. record exactly one `This reverts commit <sha>.` line — the trailer `git revert` writes;
2. name a commit that exists and is an **ancestor of the base**, so it is already reviewed and merged;
3. name a commit with a single parent — reverting a merge is out of scope; and
4. have a patch equal to that commit's patch reversed, by `git patch-id --stable` over a `--binary`
   diff.

Threat model:

- **Spoofing by title** (`revert: …`, `revert/x` branch): impossible, neither is an input.
- **Fabricated trailer**: the named commit must resolve and be an ancestor of the base.
- **Smuggling a change into the revert commit**: any extra hunk changes the patch id.
- **Smuggling a change in a second commit**: every commit in the range is checked, and a non-revert
  commit denies the exemption for the whole PR.
- **Binary payload swap** under a real trailer: `--binary` puts the payload in the hashed diff, so a
  different blob is a different patch id. Covered by a test.
- **Reverting a merge**, where "the inverse" is ambiguous: refused twice over — git's merge-revert
  trailer does not match the pattern, and the parent count is checked.
- **Residual risk, accepted**: the exemption trusts that the reverted commit satisfied policy when it
  landed. It is an ancestor of the base, so it passed this same guard or was bypassed by an admin.
- **Fails closed**: a conflict-resolved revert whose patch no longer matches, a commit whose trailer
  git did not write, a shallow clone that cannot see the reverted commit — all leave the guard in
  full force, and the admin bypass remains as the escape hatch.

The check runs with `contents: read`, no secrets and no network; it only reads git objects from the
already-checked-out clone (`fetch-depth: 0`).

It is verified against the real case: `verifyRevert("8ff1a912a", "27a698954")` — the base and head of
#1701 — returns verified, and the squash-merged commit on `main` (whose body lost the trailer) does
not.

### Changeset

None. `verify-changesets` scopes `SHIPPED_PATHS` to `server`, `webapp` and `docker`, excluding
`**/*.md` and tests. This PR touches `.github/`, `scripts/` and `docs/` only, so no changeset is
required and none is added.

## How to test

CI covers this: `pnpm run format && pnpm run check` pass locally, `scripts/verify-revert.test.ts`
adds 12 `node:test` cases over throwaway git fixtures (release-shaped reverts, reverts taken after
later work landed, riders, unrelated commits, fabricated trailers, binary swaps, merge reverts, empty
ranges, and the `GITHUB_OUTPUT` contract), and `scripts/ci-contract.test.ts` pins the new release job
wiring. `release.yml` itself cannot be exercised without cutting a release — the reasoning above is
the substitute.

## Checklist

- [x] My changeset summary reads as an operator/user-facing note — n/a, no changeset required
- [x] If operators must act, the changeset and migration entry give actionable upgrade instructions — n/a
- [x] I did not commit generated-artifact changes that this PR did not cause
