### PR TITLE
fix(docker): drop the postgres image's Go privilege-drop binary

### DIFF
--- a/.changeset/postgres-image-sheds-its-go-helper.md
+++ b/.changeset/postgres-image-sheds-its-go-helper.md
@@ -1,0 +1,5 @@
+---
+"hephaestus": patch
+---
+
+Clears 22 high and critical vulnerabilities from the PostgreSQL image. The image no longer carries the bundled Go helper that dropped privileges at start-up — the same step now uses a tool the operating-system updates keep patched, so the vulnerabilities cannot come back with the next rebuild. The database initialises, restarts and runs exactly as before, and no configuration changes.

--- a/docker/postgres/Dockerfile
+++ b/docker/postgres/Dockerfile
@@ -10,3 +10,23 @@ RUN set -eux; \
     apt-get update; \
     apt-get install -y --no-install-recommends "postgresql-${PG_MAJOR}-partman=${PARTMAN_VERSION}"; \
     rm -rf /var/lib/apt/lists/*
+
+# The only Go binary in the image is upstream's gosu, which the entrypoints run once as root to step
+# down to the postgres user. apt cannot reach it, so its Go stdlib CVEs — 22 HIGH/CRITICAL against
+# Go 1.24.6 when this was written — leave the image only when the binary does. setpriv (util-linux)
+# makes the identical switch and is patched by ordinary OS updates. The entrypoints hardcode the
+# command name, so the stand-in takes the same path; gosu-setpriv.sh explains the argument handling.
+#
+# The removal is its own layer on purpose: an image scanner reads a path that a later layer merely
+# overwrote as the file the lower layer put there, so the Go binary has to be deleted — which writes
+# a whiteout — before the stand-in is copied over the same path.
+#
+# The build asserts the identity the entrypoints actually depend on — uid, primary gid and the
+# supplementary groups, postgres being in ssl-cert too — rather than trusting the stand-in.
+RUN rm /usr/local/bin/gosu
+COPY gosu-setpriv.sh /usr/local/bin/gosu
+RUN set -eux; \
+    chmod 0755 /usr/local/bin/gosu; \
+    expected="$(id -u postgres):$(id -g postgres):$(id -G postgres)"; \
+    actual="$(gosu postgres sh -c 'echo "$(id -u):$(id -g):$(id -G)"')"; \
+    [ "${expected}" = "${actual}" ]

--- a/docker/postgres/gosu-setpriv.sh
+++ b/docker/postgres/gosu-setpriv.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+# Installed over /usr/local/bin/gosu in the image built by the Dockerfile beside this file.
+#
+# The official postgres entrypoints (docker-entrypoint.sh, docker-ensure-initdb.sh) each call
+# `gosu postgres "$BASH_SOURCE" "$@"` exactly once, as root, to drop to the postgres user before
+# re-running themselves. Upstream's gosu is a static Go binary, so every Go stdlib CVE lands in this
+# image with nothing apt can do about it. setpriv (util-linux) makes the same uid/gid/supplementary
+# -group switch and then execs, and it is an ordinary Debian package that OS updates keep patched.
+#
+# Only the `gosu <user> <command> [args...]` form those entrypoints use is supported. A `user:group`
+# spec or an option fails loudly, because guessing at gosu's semantics would mean running a command
+# with privileges nobody asked for.
+set -eu
+
+if [ "$#" -lt 2 ] || [ "${1#-}" != "$1" ] || [ "${1#*:}" != "$1" ]; then
+	echo "gosu (setpriv stand-in): usage: gosu <user> <command> [args...]" >&2
+	exit 1
+fi
+
+user="$1"
+shift
+
+# --init-groups reproduces gosu's supplementary groups (postgres is also in ssl-cert); the primary
+# group is read from the passwd entry rather than assumed to share the user's name.
+exec setpriv --reuid "$user" --regid "$(id -g "$user")" --init-groups -- "$@"


### PR DESCRIPTION
Closes #1713

## What

`gosu` is a static Go binary the official postgres image bakes in for exactly one purpose: both upstream entrypoints (`docker-entrypoint.sh`, `docker-ensure-initdb.sh`) call `gosu postgres "$BASH_SOURCE" "$@"` once, as root, to step down to the postgres user. apt cannot reach it, so its Go stdlib CVEs cannot leave the image while the binary is in it.

The image now deletes the binary and puts a `setpriv` (util-linux) stand-in at the same path. `setpriv --reuid postgres --regid <gid> --init-groups` makes the identical switch and then execs, and it is an ordinary Debian package the OS updates keep patched — so these findings do not come back on the next rebuild the way a freshly rebuilt `gosu` would.

Two details worth reviewing:

- **The removal is its own layer.** Trivy reads a path a later layer merely *overwrote* as the file the lower layer put there. Copying the stand-in over `gosu` left all 22 findings reported (`Number of language-specific files num=1`). Deleting first writes a whiteout, and the scan then reports `num=0`. This is the whole difference between 22 rejected and 0.
- **The stand-in only accepts `gosu <user> <command> [args...]`.** A `user:group` spec or an option exits 1 rather than guessing at gosu's semantics and running a command with privileges nobody asked for. The build asserts the resulting identity — uid, primary gid *and* supplementary groups, since postgres is also in `ssl-cert` — instead of trusting the script.

## Options considered

| # | Option | Outcome |
|---|---|---|
| 1 | Newer upstream base | **No.** `docker/postgres/Dockerfile` already floats on `postgres:${PG_MAJOR}-bookworm`; a fresh pull today (`sha256:1c59e2c3…`) still ships `gosu 1.19 (go1.24.6 on linux/amd64; gc)`. There is no rebuild to wait for. |
| 2 | Run as the postgres user and delete `gosu` | **Measured and rejected.** `server/compose.yaml` bind-mounts `./postgres-data`, which Docker creates root-owned on the host; a non-root container cannot create `PGDATA` inside it, so every contributor's `pnpm run dev` would break. `docker/preview/compose.app.yaml` likewise documents the root step-down in its `cap_add` list. The root path has to keep working. |
| 3 | Replace the binary | **Taken, in the form that ends the problem.** Rebuilding `gosu` against a current Go would clear today's 22 and start accruing tomorrow's; `setpriv` moves the privilege drop onto the OS package set that `apt` already maintains. |
| 4 | Time-boxed exceptions | Not needed. `security/vulnerability-policy.json` is untouched, and no entry expires into a re-cut. |

## Vulnerability scans

Trivy `--severity HIGH,CRITICAL --scanners vuln` on locally built images, evaluated through `evaluate()` from `scripts/check-release-vulnerabilities.ts` **on `ci/scan-images-at-build-time` (#1710)** against this branch's `security/vulnerability-policy.json`, so the numbers are what the gate will say and not a raw count:

| | HIGH/CRITICAL | **Rejected** |
|---|---:|---:|
| before | 98 | **22** |
| after | 76 | **0** |

All 22 rejected findings were `stdlib v1.24.6` in `usr/local/bin/gosu` (CVE-2025-68121 CRITICAL, 21 HIGH). The remaining 76 are unfixed in Debian 12 (`affected` / `will_not_fix`), which the gate does not reject.

### `libexpat1`

Already resolved, and not by this PR. #1710 measured `libexpat1 2.5.0-1+deb12u2` / CVE-2026-56408 as rejected; a build against today's index installs **`2.5.0-1+deb12u3`**, which fixes it. The four `libexpat1` findings that remain (CVE-2025-59375, CVE-2026-25210, CVE-2026-45186, CVE-2026-66046) all carry no fix in Debian 12, so none is rejected. Nothing to do here — the Dockerfile's `apt-get update` already picks it up, and #1709's `apt-get upgrade` keeps it that way.

## Verification

Built and smoke-tested the real image. The fresh-init run used the preview stack's confinement (`--security-opt no-new-privileges:true`, `--cap-drop ALL`, `--cap-add CHOWN,DAC_OVERRIDE,FOWNER,SETGID,SETUID`) to prove `setpriv` drops privileges under exactly the capability set the deployed stack grants:

**Fresh `initdb` on an empty volume**

```
PostgreSQL 18.6 (Debian 18.6-1.pgdg12+2) on x86_64-pc-linux-gnu
CREATE EXTENSION pg_partman -> 5.5.0
/proc/1/status: Name: postgres   Uid: 999 999 999 999   Gid: 999 999 999 999
LOG:  database system is ready to accept connections
```

PID 1 is the server running as uid 999 — the step-down happened *and* `setpriv` exec'd rather than forked, so PostgreSQL keeps PID 1 and its signal handling.

**Restart on an existing data directory**

```
PostgreSQL Database directory appears to contain a database; Skipping initialization
LOG:  database system is ready to accept connections
pg_partman still 5.5.0
```

**`docker stop`** → `LOG:  database system is shut down` after a complete checkpoint, so SIGTERM still reaches PID 1.

**Root-owned bind mount** (the `server/compose.yaml` shape, and the case that rules out option 2): container starts, chowns the directory, steps down, `PGDATA` initialises at `18/docker` owned by uid 999.

**Stand-in refuses what it does not implement**

```
gosu postgres id -u        -> 999
gosu --version             -> usage, rc=1
gosu postgres:postgres id  -> usage, rc=1
gosu postgres              -> usage, rc=1
```

## Overlap with #1709

#1709 adds `apt-get upgrade -y` **inside the existing `RUN`** in `docker/postgres/Dockerfile`. This PR appends a new `RUN` + `COPY` **below** that block and does not touch it, so the two should merge without a conflict; whichever lands second needs no rework. They are complementary: #1709 keeps the OS packages patched, which is now the mechanism that keeps the privilege drop patched too. `libexpat1` is covered under either.

## Quality gates

`pnpm run format` then `pnpm run check` — both pass.
