### PR TITLE
fix(deps): upgrade Bouncy Castle past CVE-2025-14813 (critical) and CVE-2026-5598

### DIFF
--- a/.changeset/patched-server-image-crypto-library.md
+++ b/.changeset/patched-server-image-crypto-library.md
@@ -1,0 +1,5 @@
+---
+"hephaestus": patch
+---
+
+The server image no longer ships a cryptography library with a known critical vulnerability, so it passes a high- and critical-severity image scan with nothing left to disposition. Deployments that talk to a TLS-protected Docker daemon keep working unchanged.

--- a/server/application/pom.xml
+++ b/server/application/pom.xml
@@ -62,6 +62,12 @@
         <nullaway.version>0.14.0</nullaway.version>
         <shedlock.version>7.9.0</shedlock.version>
         <bucket4j.version>8.19.0</bucket4j.version>
+        <!-- Transitive only, via docker-java-core: bcpkix -> bcutil -> bcprov. Not managed by the
+             Spring Boot BOM, so the version it resolves to is docker-java's, and 1.82 carries
+             CVE-2025-14813 (critical) and CVE-2026-5598, both fixed in 1.84. Managed here so the
+             image scan stays clean and Renovate keeps it current; drop it once docker-java ships a
+             fixed floor of its own. -->
+        <bouncycastle.version>1.84</bouncycastle.version>
         <maven.build.cache.skipCache>true</maven.build.cache.skipCache>
         <maven.build.cache.skipSave>true</maven.build.cache.skipSave>
     </properties>
@@ -402,6 +408,25 @@
                 <version>${okhttp.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
+            </dependency>
+            <!-- All three move together: Bouncy Castle only supports a matched provider, util and
+                 PKIX set. docker-java's TLS path (CertificateUtils, LocalDirectorySSLConfig) is the
+                 only consumer, and it links against PEMParser, JcaPEMKeyConverter,
+                 JcaX509CertificateConverter and BouncyCastleProvider, all unchanged in 1.84. -->
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcprov-jdk18on</artifactId>
+                <version>${bouncycastle.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcutil-jdk18on</artifactId>
+                <version>${bouncycastle.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcpkix-jdk18on</artifactId>
+                <version>${bouncycastle.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
## Description

`application-server` shipped `org.bouncycastle:bcprov-jdk18on` 1.82, which the release evidence gate rejects for CVE-2025-14813 (critical) and CVE-2026-5598 (high), both fixed in 1.84. This manages the Bouncy Castle set at 1.84 in `server/application/pom.xml`, which clears every high/critical finding on the image.

Fixes #1712

### The dependency path

Bouncy Castle is transitive and was unversioned by us. `mvn dependency:tree -Dincludes=org.bouncycastle` on `main`:

```
de.tum.cit.aet:hephaestus-application:jar:0.0.0-development
+- io.nats:jnats:jar:2.26.2:compile
|  \- org.bouncycastle:bcprov-lts8on:jar:2.73.10:compile
\- com.github.docker-java:docker-java-core:jar:3.7.1:compile
   \- org.bouncycastle:bcpkix-jdk18on:jar:1.82:compile
      \- org.bouncycastle:bcutil-jdk18on:jar:1.82:compile
         \- org.bouncycastle:bcprov-jdk18on:jar:1.82:compile
```

The flagged artifact arrives through **docker-java-core**, not through jnats — jnats pulls the separate `bcprov-lts8on` 2.73.10 LTS line, which the scanner does not flag. docker-java 3.7.1 is the newest release and still floors at 1.82, so waiting on the dependency was not an option.

### How it is pinned, and why

Spring Boot 4.1.1's BOM manages **no** `org.bouncycastle` artifact — the only bouncycastle-named entries in the effective POM's dependency management are Jetty's `jetty-alpn-bouncycastle-{client,server}`. So the preferred "override a BOM-managed version" route does not exist here. The next least surprising thing is a `<dependencyManagement>` entry rather than a new direct `<dependency>`: it constrains the version of something already on the classpath instead of declaring a compile dependency we do not use, and Renovate's maven manager tracks it like any other version.

All three artifacts move together behind one `${bouncycastle.version}` property — Bouncy Castle only supports a matched provider/util/PKIX set, and pinning `bcprov` alone would leave `bcpkix`/`bcutil` at 1.82 against a 1.84 provider. Resolution afterwards:

```
\- com.github.docker-java:docker-java-core:jar:3.7.1:compile
   \- org.bouncycastle:bcpkix-jdk18on:jar:1.84:compile
      \- org.bouncycastle:bcutil-jdk18on:jar:1.84:compile
         \- org.bouncycastle:bcprov-jdk18on:jar:1.84:compile
```

1.84 rather than the newest 1.85: 1.84 is the fixed floor Trivy names, the rebuilt image scans clean at it, and `bcprov` alone has a 1.85.2 patch that `bcpkix`/`bcutil` do not, so 1.85 would have meant either a split set or an unnecessary jump. Renovate carries it forward from here.

### Compatibility evidence

The pin only matters if docker-java survives it, so the consumer was checked before forcing the version:

- **Nothing in Hephaestus touches Bouncy Castle.** No `org.bouncycastle` import, no `Security.addProvider`; JWT signing, webhook HMAC verification and column encryption all use JDK/Nimbus providers.
- **The only consumer is docker-java's TLS path** — `CertificateUtils` and `LocalDirectorySSLConfig` are the two classes in `docker-java-core-3.7.1.jar` that reference `org/bouncycastle`, reached when an operator sets `tlsVerify`/`certPath` on the sandbox Docker host. Everything they link against is: `PEMParser(Reader)`, `PEMParser.readObject`, `PEMKeyPair.getPrivateKeyInfo`, `JcaPEMKeyConverter()`/`.getPrivateKey(PrivateKeyInfo)`, `JcaX509CertificateConverter()`/`.setProvider(String)`/`.getCertificate(X509CertificateHolder)` and `new BouncyCastleProvider()`. Every one of those classes and signatures is present and unchanged in 1.84 (`javap` against the 1.84 jars).
- **Executed, not just inspected**: `LocalDirectorySSLConfig.getSSLContext()` was run against a generated `ca.pem`/`cert.pem`/`key.pem` trio with 1.82 and then with 1.84 on the classpath. Both parse the PEM material and return a working `TLSv1.2` `SSLContext`.
- The image build's CDS training run boots the full Spring context with 1.84 on the classpath and completes.

### Before / after on the built image

Built with `./mvnw -f application/pom.xml spring-boot:build-image` and scanned with
`docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v /tmp/trivy-cache:/root/.cache/ aquasec/trivy:latest image --severity HIGH,CRITICAL --scanners vuln <image>`, then the JSON report was evaluated through `scripts/check-release-vulnerabilities.ts` against `security/vulnerability-policy.json` (which holds no exceptions, so every high/critical finding is rejected):

| | HIGH/CRITICAL | rejected |
|---|---|---|
| before (`main`) | 6 | **6** |
| after (this PR) | 0 | **0** |

The six were three copies each of CVE-2025-14813 and CVE-2026-5598 — the scanner sees `bcprov-jdk18on-1.82.jar` in the Spring Boot runner layer, in `workspace/lib`, and via the image SBOM. The rebuilt image reports `bcprov/bcutil/bcpkix-jdk18on 1.84` (plus the untouched `bcprov-lts8on 2.73.10`) and no high or critical findings at all.

## How to test

Build the image and rescan it with the command above; the report is empty at HIGH,CRITICAL.

Test tiers run locally, all green: unit (6885 tests), architecture (259), integration (1470, Testcontainers) — the tiers that cover the JWT, webhook-signature and TLS-adjacent code. `live` needs GitHub App credentials and touches no crypto path. `pnpm run format` and `pnpm run check` both pass.

## Checklist

- [x] My changeset summary reads as an operator/user-facing note (it becomes the changelog entry) — see `.changeset/README.md`
- [x] If operators must act, the changeset and migration entry give actionable upgrade instructions — no operator action; the pin is internal
- [x] I did not commit generated-artifact changes that this PR did not cause

🤖 Generated with [Claude Code](https://claude.com/claude-code)
