### PR TITLE
feat(ci): rescan main's images weekly and route drift to a tracking issue

### DIFF
--- a/.github/actions/download-trivy-db/action.yml
+++ b/.github/actions/download-trivy-db/action.yml
@@ -1,0 +1,54 @@
+name: Download the Trivy database
+description: >-
+  Fetches the Trivy vulnerability database once, with the retries and registry fallback a gate
+  needs, and optionally asserts its freshness and records its metadata.
+inputs:
+  max-age-hours:
+    description: >-
+      Fail when the downloaded database is older than this many whole hours. Empty skips the
+      assertion; evidence-producing scans set it so a stale mirror cannot be signed as a scan.
+    required: false
+    default: ""
+  metadata-path:
+    description: >-
+      Copy the database metadata to this path, creating parent directories. Empty skips the copy.
+    required: false
+    default: ""
+runs:
+  using: composite
+  steps:
+    - name: Download the Trivy database
+      shell: bash
+      env:
+        MAX_AGE_HOURS: ${{ inputs.max-age-hours }}
+        METADATA_PATH: ${{ inputs.metadata-path }}
+        # GHCR answers TOOMANYREQUESTS often enough that Harbor, Rancher and New Relic all
+        # override this; Trivy walks the list in order. The `:2` tag is the database schema
+        # version, pinned to the Trivy version in setup-release-security-tools, so a schema bump
+        # fails loudly rather than silently fetching the wrong database.
+        TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db:2,public.ecr.aws/aquasecurity/trivy-db:2
+      run: |
+        set -euo pipefail
+        if [ -n "$MAX_AGE_HOURS" ] && ! [[ "$MAX_AGE_HOURS" =~ ^[0-9]+$ ]]; then
+          echo "::error::max-age-hours must be a whole number of hours"
+          exit 1
+        fi
+        for attempt in 1 2 3; do
+          trivy image --timeout 90s --download-db-only && break
+          if [ "$attempt" -eq 3 ]; then
+            echo "::error::Trivy database download failed after $attempt attempts"
+            exit 1
+          fi
+          sleep $((attempt * 5))
+        done
+        db_metadata="${TRIVY_CACHE_DIR:-$HOME/.cache/trivy}/db/metadata.json"
+        if [ -n "$MAX_AGE_HOURS" ]; then
+          jq -e --argjson max "$((MAX_AGE_HOURS * 3600))" \
+            '(.UpdatedAt | sub("\\.[0-9]+Z$"; "Z") | fromdateiso8601) as $updated |
+              ((now - $updated) >= 0) and ((now - $updated) <= $max)' \
+            "$db_metadata" >/dev/null
+        fi
+        if [ -n "$METADATA_PATH" ]; then
+          mkdir -p "$(dirname "$METADATA_PATH")"
+          cp "$db_metadata" "$METADATA_PATH"
+        fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -218,6 +218,13 @@ jobs:
         with:
           install: "none"
 
+      # The database the whole evidence bundle is scanned against: recorded into the bundle, and
+      # refused if it is over a day old, so a stale mirror cannot be signed as a fresh scan.
+      - uses: ./.github/actions/download-trivy-db
+        with:
+          max-age-hours: "24"
+          metadata-path: evidence/trivy-db.json
+
       - name: Generate and enforce release evidence
         env:
           TRIVY_USERNAME: ${{ github.actor }}
@@ -227,19 +234,6 @@ jobs:
           mkdir -p evidence
           : > release-platforms.tsv
           started=$SECONDS
-          for attempt in 1 2 3; do
-            trivy image --timeout 90s --download-db-only && break
-            if [ "$attempt" -eq 3 ]; then
-              echo "::error::Trivy database download failed after $attempt attempts"
-              exit 1
-            fi
-            sleep $((attempt * 5))
-          done
-          db_metadata="${TRIVY_CACHE_DIR:-$HOME/.cache/trivy}/db/metadata.json"
-          jq -e '(.UpdatedAt | sub("\\.[0-9]+Z$"; "Z") | fromdateiso8601) as $updated |
-            ((now - $updated) >= 0) and ((now - $updated) <= 86400)' \
-            "$db_metadata" >/dev/null
-          cp "$db_metadata" evidence/trivy-db.json
           jq -n --arg syft "$(syft version -o json | jq -r .version)" \
             --arg trivy "$(trivy version --format json | jq -r .Version)" \
             --arg cosign "$(cosign version --json | jq -r .gitVersion)" \

--- a/.github/workflows/rescan-main-images.yml
+++ b/.github/workflows/rescan-main-images.yml
@@ -1,0 +1,87 @@
+# Rescans the images built from main's HEAD against the release vulnerability policy.
+#
+# The gate in reusable-docker-build.yml runs where an image is built, so it catches a change that
+# introduces a finding and cannot catch a finding that appears with no change at all. That is the
+# common case: v0.75.0 was blocked by CVEs published after the code merged clean, and nothing
+# noticed until the release failed. rescan-release-images.yml already covers published releases on
+# this cadence; this covers what main would release today.
+#
+# Non-blocking by design. Findings go to a tracking issue, updated in place, because a red status on
+# a schedule nobody triggered — for a regression no commit caused and no revert fixes — is how a team
+# learns to ignore the gate.
+name: Rescan main images
+
+on:
+  schedule:
+    # Weekly, twenty minutes after the supported-release rescan, so the two never contend for the
+    # Trivy database. Monday also puts findings in front of the same review Renovate's PRs land for.
+    - cron: "37 4 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: read
+
+concurrency:
+  group: rescan-main-images
+  cancel-in-progress: false
+
+jobs:
+  rescan:
+    name: Rescan main's images
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      issues: write
+      packages: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - uses: ./.github/actions/setup-node-pnpm
+        with:
+          install: "none"
+
+      - uses: ./.github/actions/setup-release-security-tools
+        with:
+          install-syft: "false"
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # A day old at most: an older mirror would report last week's drift as this week's.
+      - uses: ./.github/actions/download-trivy-db
+        with:
+          max-age-hours: "24"
+          metadata-path: reports/trivy-db.json
+
+      # Resolves each image's `:main` tag to its linux/amd64 digest, scans it, and evaluates the one
+      # security/vulnerability-policy.json through the one scripts/check-release-vulnerabilities.ts.
+      # A finding does not fail this step; an unreachable registry or a broken scanner does.
+      - name: Scan the images built from main
+        env:
+          TRIVY_USERNAME: ${{ github.actor }}
+          TRIVY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        run: node scripts/scan-main-images.ts reports
+
+      - name: Upload the vulnerability policy results
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: main-image-rescan-${{ github.run_id }}
+          path: reports
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Route findings to the tracking issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node scripts/report-vulnerability-drift.ts reports

--- a/.github/workflows/rescan-release-images.yml
+++ b/.github/workflows/rescan-release-images.yml
@@ -46,26 +46,16 @@ jobs:
           node scripts/release-image-lock.ts "release-evidence/$lock" \
             release-evidence/manifest.json "$tag" /tmp/release-lock.env
           node scripts/verify-release-evidence.ts release-evidence
+      - uses: ./.github/actions/download-trivy-db
+        with:
+          max-age-hours: "24"
+          metadata-path: reports/trivy-db.json
       - name: Rescan immutable subjects
         env:
           TRIVY_USERNAME: ${{ github.actor }}
           TRIVY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          mkdir reports
-          for attempt in 1 2 3; do
-            trivy image --timeout 90s --download-db-only && break
-            if [ "$attempt" -eq 3 ]; then
-              echo "::error::Trivy database download failed after $attempt attempts"
-              exit 1
-            fi
-            sleep $((attempt * 5))
-          done
-          db_metadata="${TRIVY_CACHE_DIR:-$HOME/.cache/trivy}/db/metadata.json"
-          jq -e '(.UpdatedAt | sub("\\.[0-9]+Z$"; "Z") | fromdateiso8601) as $updated |
-            ((now - $updated) >= 0) and ((now - $updated) <= 86400)' \
-            "$db_metadata" >/dev/null
-          cp "$db_metadata" reports/trivy-db.json
           jq -er '.subjects[] | [.image, .platform, .digest, .repository] | @tsv' release-evidence/manifest.json |
           while IFS=$'\t' read -r image platform digest repository; do
             suffix=${platform//\//-}

--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -511,24 +511,9 @@ jobs:
           fi
           echo "digest=$digest" >> "$GITHUB_OUTPUT"
 
-      - name: Download the Trivy database
-        env:
-          # A blocking gate inherits Trivy's database availability as a hard dependency, and
-          # GHCR answers TOOMANYREQUESTS often enough that Harbor, Rancher and New Relic all
-          # override this. Trivy walks the list in order. The `:2` tag is the database schema
-          # version and is pinned to the Trivy version in setup-release-security-tools; a
-          # schema bump fails this step loudly rather than silently fetching the wrong DB.
-          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db:2,public.ecr.aws/aquasecurity/trivy-db:2
-        run: |
-          set -euo pipefail
-          for attempt in 1 2 3; do
-            trivy image --timeout 90s --download-db-only && break
-            if [ "$attempt" -eq 3 ]; then
-              echo "::error::Trivy database download failed after $attempt attempts"
-              exit 1
-            fi
-            sleep $((attempt * 5))
-          done
+      # A blocking gate inherits Trivy's database availability as a hard dependency, so the
+      # retries and the mirror fallback live in one action rather than in each caller.
+      - uses: ./.github/actions/download-trivy-db
 
       - name: Enforce the release vulnerability policy
         env:

--- a/docs/contributor/ci-cd.mdx
+++ b/docs/contributor/ci-cd.mdx
@@ -235,6 +235,7 @@ why the label is the authority, and which alternatives were priced and declined,
 | `ci-docker-build.yml`  | Called by cicd.yml    | Docker image builds per component                  |
 | `reusable-docker-build.yml` | Called by ci-docker-build.yml | Builds, signs, attests, and blocks on the release vulnerability policy for the `linux/amd64` image |
 | `ci-security-scan.yml` | Called by cicd.yml    | Dependency scanning (Trivy), secret detection      |
+| `rescan-main-images.yml` | Weekly, manual | Rescans main's published images against the release vulnerability policy and keeps one tracking issue in step with the findings |
 | `ci-profile.yml` | Weekly, manual | Profiles server integration tests and Spring contexts |
 | `ci-server-clean-reference.yml` | Weekly, manual | Records cold server phases and compares generated JARs |
 | `verify-changesets.yml`| Called by cicd.yml    | Tests changeset/version-sync policy and enforces release-note presence |
@@ -255,6 +256,7 @@ why the label is the authority, and which alternatives were priced and declined,
 | `setup-caches` | Restores Maven and generated-client caches for one validated `cache-type` |
 | `setup-browsers` | Restores the exact Playwright browser version and installs Chromium system dependencies |
 | `setup-release-security-tools` | Installs Cosign, Trivy, and optionally Syft for release-evidence jobs |
+| `download-trivy-db` | Fetches the vulnerability database with retries and a mirror fallback; optionally refuses one over `max-age-hours` old and records its metadata |
 | `ghcr-login` | Authenticates Docker to GHCR |
 
 Repository-local actions require checkout first. Jobs without checkout use the external SHA-pinned

--- a/docs/contributor/release-management.mdx
+++ b/docs/contributor/release-management.mdx
@@ -133,6 +133,20 @@ The latest release is rescanned weekly. A policy violation or scan failure is re
 [the vulnerability response issue](https://github.com/ls1intum/Hephaestus/issues/1369); scanner failure
 is never treated as no findings.
 
+`main`'s images are rescanned on the same weekly cadence, by `rescan-main-images.yml`. Container
+vulnerabilities are time-dependent, not commit-dependent: the build gate can only catch a finding some
+change introduced, and the finding that blocked v0.75.0 was published after the code had merged clean.
+The scheduled run resolves each image's `:main` tag to its `linux/amd64` digest and evaluates the same
+policy through the same script, so nothing about the verdict differs from a release.
+
+That run is **not** blocking, and no scheduled run should be. Nobody triggered it, no commit caused the
+finding and no revert removes it — the remedy is to rebuild `main` against a patched base image, which
+the next merge does anyway. So `scripts/report-vulnerability-drift.ts` keeps a single tracking issue in
+step with the findings instead: opened when they appear, edited in place and commented when the set
+changes, silent when it has not, and closed when it clears. It recognises its own issue by an HTML
+marker on the first line of the body, not by the title, so the issue can be retitled and triaged freely;
+delete that line and the next run opens a new one.
+
 ## Browser source maps
 
 Image builds upload hidden source maps through Sentry's debug-ID integration when the repository

--- a/scripts/ci-contract.test.ts
+++ b/scripts/ci-contract.test.ts
@@ -268,7 +268,7 @@ void describe("CI contract", () => {
 		assert.doesNotMatch(scan, /linux\/arm64/);
 		// A gate that cannot say what it rejected is not finished.
 		assert.match(scan, /uses: actions\/upload-artifact@/);
-		assert.match(scan, /public\.ecr\.aws\/aquasecurity\/trivy-db/);
+		assert.match(scan, /uses: \.\/\.github\/actions\/download-trivy-db/);
 
 		let callSites = 0;
 		for (const [file, source] of await workflowSources()) {
@@ -283,9 +283,90 @@ void describe("CI contract", () => {
 				);
 			}
 		}
-		// The blocking build gate and the scheduled rescan; the release path goes through
-		// verify-release-evidence.ts, which imports evaluate() directly.
+		// The blocking build gate and the scheduled release rescan; the release path goes through
+		// verify-release-evidence.ts and the main rescan through scan-main-images.ts, both of which
+		// reach the same evaluator without a workflow-level call site.
 		assert.equal(callSites, 2);
+	});
+
+	void test("keeps one release vulnerability policy behind every scan", async () => {
+		// Every path that evaluates the policy — the build gate, the release, the release rescan and
+		// the main rescan — must name this one file. A second copy is the failure the whole effort
+		// removes, and it would be invisible: two policies both pass until they disagree.
+		const files = [
+			...(await Array.fromAsync(glob(".github/workflows/*.{yml,yaml}"))),
+			...(await Array.fromAsync(glob("scripts/*.ts"))),
+		];
+		for (const [file, source] of await readSources(files)) {
+			if (file.endsWith(".test.ts")) continue;
+			for (const reference of source.match(/[\w./-]*vulnerability-polic[\w-]*\.json/g) ?? [])
+				assert.ok(
+					// The evidence bundle carries a copy so a release can be re-audited against the
+					// policy it was cut under; release.yml is asserted below to copy, not author, it.
+					["security/vulnerability-policy.json", "evidence/vulnerability-policy.json"].includes(
+						reference,
+					) || reference === "vulnerability-policy.json",
+					`${file} must evaluate the one release vulnerability policy, not ${reference}`,
+				);
+		}
+		assert.match(
+			await readFile(".github/workflows/release.yml", "utf8"),
+			/cp security\/vulnerability-policy\.json evidence\/vulnerability-policy\.json/,
+		);
+		// One committed policy, so "the same policy" is a fact rather than a convention.
+		assert.deepEqual(await Array.fromAsync(glob("security/*vulnerability*.json")), [
+			"security/vulnerability-policy.json",
+		]);
+	});
+
+	void test("rescans main's images weekly and reports drift to an issue, not a status", async () => {
+		const source = await readFile(".github/workflows/rescan-main-images.yml", "utf8");
+		// Weekly, matching the supported-release rescan: the remedy for drift is a rebuild of main,
+		// which the next merge performs anyway, so a nightly run would report the same finding six
+		// more times before anything could have changed.
+		assert.match(source, /^ {4}- cron: "\d+ \d+ \* \* 1"$/m);
+		assert.match(source, /workflow_dispatch:/);
+		assert.match(source, /group: rescan-main-images/);
+		// Writing an issue is the whole point; nothing else here needs a write.
+		assert.match(source, /issues: write/);
+		assert.doesNotMatch(source, /contents: write|packages: write|id-token: write/);
+		// The scan and the reporting are tested TypeScript, not inline bash: the upsert in
+		// particular has to not open a duplicate every week, which no eyeball review establishes.
+		assert.match(source, /run: node scripts\/scan-main-images\.ts reports/);
+		assert.match(source, /run: node scripts\/report-vulnerability-drift\.ts reports/);
+		assert.match(source, /uses: \.\/\.github\/actions\/download-trivy-db/);
+		assert.match(source, /uses: actions\/upload-artifact@/);
+		// Nothing may turn a finding into a red status: no `continue-on-error` fig leaf, and no
+		// second evaluator inline.
+		assert.doesNotMatch(source, /continue-on-error/);
+		assert.doesNotMatch(source, /trivy image/);
+	});
+
+	void test("fetches the Trivy database through one action", async () => {
+		const action = await readFile(".github/actions/download-trivy-db/action.yml", "utf8");
+		// GHCR answers TOOMANYREQUESTS often enough that a gate needs the mirror; stating it once
+		// is why this action exists at all.
+		assert.match(action, /public\.ecr\.aws\/aquasecurity\/trivy-db/);
+		assert.match(action, /--download-db-only/);
+		for (const [file, source] of await workflowSources())
+			assert.doesNotMatch(
+				source,
+				/--download-db-only/,
+				`${file} must download the Trivy database through .github/actions/download-trivy-db`,
+			);
+		// Everything that signs or publishes a scan result asserts the database is not stale.
+		for (const file of [
+			".github/workflows/release.yml",
+			".github/workflows/rescan-release-images.yml",
+			".github/workflows/rescan-main-images.yml",
+		]) {
+			const source = await readFile(file, "utf8");
+			assert.match(
+				source,
+				/uses: \.\/\.github\/actions\/download-trivy-db\n\s+with:\n\s+max-age-hours: "24"/,
+				`${file} must refuse a stale Trivy database`,
+			);
+		}
 	});
 
 	void test("pins every external action to a full commit SHA with a version comment", async () => {

--- a/scripts/report-vulnerability-drift.test.ts
+++ b/scripts/report-vulnerability-drift.test.ts
@@ -1,0 +1,282 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+
+import {
+	applyPlan,
+	fingerprint,
+	hasFindings,
+	ISSUE_LABELS,
+	ISSUE_TITLE,
+	MARKER,
+	markerFingerprint,
+	parsePolicyResult,
+	planIssueAction,
+	renderIssueBody,
+	type CommandRunner,
+	type PolicyResult,
+	type ReportContext,
+} from "./report-vulnerability-drift.ts";
+
+const context: ReportContext = {
+	registry: "ghcr.io/hephaestus-build",
+	runUrl: "https://github.com/owner/repo/actions/runs/42",
+	scannedAt: "2026-09-01T04:37:00Z",
+	tag: "main",
+};
+
+const clean = (image: string): PolicyResult => ({
+	digest: `sha256:${"a".repeat(64)}`,
+	errors: [],
+	highCritical: [],
+	image,
+	platform: "linux/amd64",
+	rejected: [],
+	status: "pass",
+});
+
+const failing = (image: string, rejected: readonly string[]): PolicyResult => ({
+	...clean(image),
+	highCritical: [...rejected],
+	rejected,
+	status: "fail",
+});
+
+const tracked = (
+	number: number,
+	results: readonly PolicyResult[],
+): { body: string; number: number } => ({
+	body: renderIssueBody(results, context),
+	number,
+});
+
+const recorder = (): { calls: string[][]; gh: CommandRunner } => {
+	const calls: string[][] = [];
+	return {
+		calls,
+		gh: (args) => {
+			calls.push([...args]);
+			return Promise.resolve();
+		},
+	};
+};
+
+void describe("parsePolicyResult", () => {
+	void test("accepts what check-release-vulnerabilities.ts writes", () => {
+		const written = {
+			digest: `sha256:${"a".repeat(64)}`,
+			errors: [],
+			highCritical: ["webapp|CVE-2026-1|openssl|3.1.0"],
+			image: "webapp",
+			platform: "linux/amd64",
+			rejected: ["webapp|CVE-2026-1|openssl|3.1.0"],
+			status: "fail",
+		};
+		assert.deepEqual(parsePolicyResult(written, "result"), written);
+	});
+
+	void test("names the field that changed shape rather than failing later", () => {
+		assert.throws(
+			() => parsePolicyResult({ ...clean("webapp"), rejected: "none" }, "result"),
+			/result\.rejected must be an array/,
+		);
+	});
+});
+
+void describe("fingerprint", () => {
+	void test("is stable across scan order and finding order", () => {
+		const left = [
+			failing("webapp", ["webapp|CVE-2|b|1"]),
+			failing("postgres", ["postgres|CVE-1|a|2"]),
+		];
+		const right = [
+			failing("postgres", ["postgres|CVE-1|a|2"]),
+			failing("webapp", ["webapp|CVE-2|b|1"]),
+		];
+		assert.equal(fingerprint(left), fingerprint(right));
+	});
+
+	void test("ignores images with nothing wrong, so a passing image joining changes nothing", () => {
+		const findings = [failing("webapp", ["webapp|CVE-1|a|1"])];
+		assert.equal(fingerprint(findings), fingerprint([...findings, clean("postgres")]));
+	});
+
+	void test("changes when a finding appears, disappears, or moves image", () => {
+		const base = fingerprint([failing("webapp", ["webapp|CVE-1|a|1"])]);
+		assert.notEqual(
+			base,
+			fingerprint([failing("webapp", ["webapp|CVE-1|a|1", "webapp|CVE-2|b|1"])]),
+		);
+		assert.notEqual(base, fingerprint([failing("postgres", ["postgres|CVE-1|a|1"])]));
+		assert.notEqual(base, fingerprint([clean("webapp")]));
+	});
+
+	void test("distinguishes a policy error from a rejected finding", () => {
+		const error: PolicyResult = {
+			...clean("webapp"),
+			errors: ["exception expired"],
+			status: "fail",
+		};
+		assert.notEqual(fingerprint([error]), fingerprint([failing("webapp", ["exception expired"])]));
+	});
+});
+
+void describe("hasFindings", () => {
+	void test("counts a policy error, not only a rejected CVE", () => {
+		assert.equal(hasFindings([clean("webapp")]), false);
+		assert.equal(hasFindings([failing("webapp", ["webapp|CVE-1|a|1"])]), true);
+		assert.equal(hasFindings([{ ...clean("webapp"), errors: ["exception expired"] }]), true);
+	});
+});
+
+void describe("renderIssueBody", () => {
+	void test("carries a marker the next run can recognise", () => {
+		const results = [failing("webapp", ["webapp|CVE-2026-1|openssl|3.1.0"])];
+		const body = renderIssueBody(results, context);
+		assert.match(body, new RegExp(`^<!-- ${MARKER} [0-9a-f]{16} -->`));
+		assert.equal(markerFingerprint(body), fingerprint(results));
+	});
+
+	void test("tabulates every rejected finding and names the passing images too", () => {
+		const body = renderIssueBody(
+			[failing("webapp", ["webapp|CVE-2026-1|openssl|3.1.0"]), clean("postgres")],
+			context,
+		);
+		assert.match(body, /### webapp \(linux\/amd64\)/);
+		assert.match(body, /\| CVE-2026-1 \| openssl \| 3\.1\.0 \|/);
+		assert.match(body, /### postgres \(linux\/amd64\)/);
+		assert.match(body, /No findings the policy rejects/);
+		assert.match(body, /\[this run\]\(https:\/\/github\.com\/owner\/repo\/actions\/runs\/42\)/);
+	});
+
+	void test("lists policy errors separately from CVEs, since they need a commit", () => {
+		const body = renderIssueBody(
+			[{ ...clean("webapp"), errors: ["exception expired: CVE-2026-1"], status: "fail" }],
+			context,
+		);
+		assert.match(body, /Policy errors:\n- exception expired: CVE-2026-1/);
+	});
+
+	void test("is byte-identical for the same findings scanned in a different order", () => {
+		const one = renderIssueBody(
+			[failing("webapp", ["webapp|CVE-2|b|1", "webapp|CVE-1|a|1"])],
+			context,
+		);
+		const two = renderIssueBody(
+			[failing("webapp", ["webapp|CVE-1|a|1", "webapp|CVE-2|b|1"])],
+			context,
+		);
+		assert.equal(one, two);
+	});
+});
+
+void describe("markerFingerprint", () => {
+	void test("ignores an issue that is not this workflow's", () => {
+		assert.equal(markerFingerprint("A hand-written security issue"), undefined);
+		assert.equal(markerFingerprint(`<!-- ${MARKER} not-a-fingerprint -->`), undefined);
+	});
+});
+
+void describe("planIssueAction", () => {
+	const findings = [failing("webapp", ["webapp|CVE-2026-1|openssl|3.1.0"])];
+
+	void test("does nothing when there is nothing to report and nothing open", () => {
+		assert.deepEqual(planIssueAction([], [clean("webapp")], context), { kind: "none" });
+	});
+
+	void test("opens an issue the first time findings appear", () => {
+		const plan = planIssueAction([], findings, context);
+		assert.equal(plan.kind, "create");
+		assert.equal(plan.title, ISSUE_TITLE);
+		assert.equal(markerFingerprint(plan.body), fingerprint(findings));
+	});
+
+	void test("does not open a second issue the following week", () => {
+		const plan = planIssueAction([tracked(7, findings)], findings, context);
+		assert.deepEqual(plan, { issue: 7, kind: "unchanged" });
+	});
+
+	void test("updates in place, with a comment, when the finding set changes", () => {
+		const grown = [
+			failing("webapp", ["webapp|CVE-2026-1|openssl|3.1.0", "webapp|CVE-2026-2|zlib|1.3"]),
+		];
+		const plan = planIssueAction([tracked(7, findings)], grown, context);
+		assert.equal(plan.kind, "update");
+		assert.equal(plan.issue, 7);
+		assert.equal(markerFingerprint(plan.body), fingerprint(grown));
+		assert.match(plan.comment, /finding set changed/);
+	});
+
+	void test("closes every tracking issue once the policy is satisfied again", () => {
+		const plan = planIssueAction(
+			[tracked(9, findings), tracked(7, findings)],
+			[clean("webapp")],
+			context,
+		);
+		assert.equal(plan.kind, "close");
+		assert.deepEqual(plan.issues, [7, 9]);
+	});
+
+	void test("takes over the oldest tracking issue, not the newest", () => {
+		const other = [failing("postgres", ["postgres|CVE-2026-9|musl|1.2"])];
+		const plan = planIssueAction([tracked(9, findings), tracked(7, other)], findings, context);
+		assert.ok(plan.kind === "update");
+		assert.equal(plan.issue, 7);
+	});
+
+	void test("never adopts an unrelated open security issue", () => {
+		const plan = planIssueAction(
+			[{ body: "Rotate the signing key", number: 3 }],
+			findings,
+			context,
+		);
+		assert.equal(plan.kind, "create");
+		const cleared = planIssueAction(
+			[{ body: "Rotate the signing key", number: 3 }],
+			[clean("webapp")],
+			context,
+		);
+		assert.deepEqual(cleared, { kind: "none" });
+	});
+});
+
+void describe("applyPlan", () => {
+	void test("writes nothing to GitHub when the findings are unchanged", async () => {
+		const { calls, gh } = recorder();
+		await applyPlan({ issue: 7, kind: "unchanged" }, gh);
+		await applyPlan({ kind: "none" }, gh);
+		assert.deepEqual(calls, []);
+	});
+
+	void test("creates the issue with labels that already exist in the repository", async () => {
+		const { calls, gh } = recorder();
+		await applyPlan({ body: "body", kind: "create", title: ISSUE_TITLE }, gh);
+		assert.equal(calls.length, 1);
+		const [call = []] = calls;
+		assert.equal(call[0], "issue");
+		assert.equal(call[1], "create");
+		for (const label of ISSUE_LABELS) assert.ok(call.includes(label), `missing --label ${label}`);
+		// A body long enough to blow the argument limit goes through a file, not argv.
+		assert.ok(call.includes("--body-file"));
+	});
+
+	void test("edits the body and then comments, so the change is notified once", async () => {
+		const { calls, gh } = recorder();
+		await applyPlan({ body: "body", comment: "changed", issue: 7, kind: "update" }, gh);
+		assert.deepEqual(
+			calls.map((call) => call.slice(0, 3)),
+			[
+				["issue", "edit", "7"],
+				["issue", "comment", "7"],
+			],
+		);
+	});
+
+	void test("closes each tracking issue with the reason", async () => {
+		const { calls, gh } = recorder();
+		await applyPlan({ comment: "cleared", issues: [7, 9], kind: "close" }, gh);
+		assert.deepEqual(calls, [
+			["issue", "close", "7", "--comment", "cleared"],
+			["issue", "close", "9", "--comment", "cleared"],
+		]);
+	});
+});

--- a/scripts/report-vulnerability-drift.ts
+++ b/scripts/report-vulnerability-drift.ts
@@ -1,0 +1,290 @@
+/**
+ * Routes a scheduled image rescan to a tracking issue instead of a red status.
+ *
+ * A drift finding is not a regression anyone can revert: no commit introduced it, and the repository
+ * is exactly as correct as it was yesterday. A second blocking gate on that is how a team learns to
+ * ignore the gate, so this reads the `.policy.json` files `scan-main-images.ts` wrote and keeps one
+ * issue in step with them — created when findings appear, edited in place when the finding set
+ * changes, silent when it has not, and closed when it clears. Kyverno's `sync-trivy-issues` has the
+ * same shape.
+ *
+ * The issue is identified by an HTML marker carrying a fingerprint of the finding set, not by its
+ * title: a title is editable, and a run that cannot recognise its own issue opens a duplicate every
+ * week until someone turns the schedule off.
+ */
+import { createHash } from "node:crypto";
+import { glob, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { asArray, asRecord, asString, asStringArray, parseJson } from "./lib/json.ts";
+import { output, run } from "./lib/process.ts";
+
+export const MARKER = "hephaestus:main-image-vulnerability-drift";
+export const ISSUE_TITLE = "Container vulnerability drift in main's images";
+/** Both already exist in the repository; `gh issue create` fails on a label that does not. */
+export const ISSUE_LABELS = ["security", "ci"] as const;
+
+export interface PolicyResult {
+	readonly digest: string;
+	readonly errors: readonly string[];
+	readonly highCritical: readonly string[];
+	readonly image: string;
+	readonly platform: string;
+	readonly rejected: readonly string[];
+	readonly status: string;
+}
+
+export interface ReportContext {
+	readonly registry: string;
+	readonly runUrl: string;
+	readonly scannedAt: string;
+	readonly tag: string;
+}
+
+export interface TrackingIssue {
+	readonly body: string;
+	readonly number: number;
+}
+
+export type IssuePlan =
+	| { readonly kind: "none" }
+	| { readonly body: string; readonly kind: "create"; readonly title: string }
+	| {
+			readonly body: string;
+			readonly comment: string;
+			readonly issue: number;
+			readonly kind: "update";
+	  }
+	| { readonly issue: number; readonly kind: "unchanged" }
+	| { readonly comment: string; readonly issues: readonly number[]; readonly kind: "close" };
+
+export function parsePolicyResult(value: unknown, label: string): PolicyResult {
+	const result = asRecord(value, label);
+	return {
+		digest: asString(result.digest, `${label}.digest`),
+		errors: asStringArray(result.errors, `${label}.errors`),
+		highCritical: asStringArray(result.highCritical, `${label}.highCritical`),
+		image: asString(result.image, `${label}.image`),
+		platform: asString(result.platform, `${label}.platform`),
+		rejected: asStringArray(result.rejected, `${label}.rejected`),
+		status: asString(result.status, `${label}.status`),
+	};
+}
+
+export const hasFindings = (results: readonly PolicyResult[]): boolean =>
+	results.some((result) => result.rejected.length > 0 || result.errors.length > 0);
+
+/**
+ * A stable digest of what is wrong, and of nothing else. The body also carries a scan timestamp and a
+ * run link; folding those in would make every week's fingerprint differ and turn "update in place"
+ * back into a weekly notification.
+ */
+export function fingerprint(results: readonly PolicyResult[]): string {
+	const canonical = results
+		.map((result) => ({
+			errors: [...result.errors].toSorted(),
+			image: result.image,
+			platform: result.platform,
+			rejected: [...result.rejected].toSorted(),
+		}))
+		.filter((result) => result.errors.length > 0 || result.rejected.length > 0)
+		.toSorted((left, right) =>
+			`${left.image}|${left.platform}`.localeCompare(`${right.image}|${right.platform}`),
+		);
+	return createHash("sha256").update(JSON.stringify(canonical)).digest("hex").slice(0, 16);
+}
+
+/** The fingerprint this run's own marker records, or `undefined` when the body is not one of ours. */
+export function markerFingerprint(body: string): string | undefined {
+	return new RegExp(`<!-- ${MARKER} ([0-9a-f]{16}) -->`).exec(body)?.[1];
+}
+
+// `image|CVE-…|package|installed`, the shape check-release-vulnerabilities.ts emits.
+const cell = (finding: string, index: number): string => finding.split("|")[index] ?? "";
+
+export function renderIssueBody(results: readonly PolicyResult[], context: ReportContext): string {
+	const lines = [
+		`<!-- ${MARKER} ${fingerprint(results)} -->`,
+		"",
+		`The images built from \`main\` no longer satisfy \`security/vulnerability-policy.json\`.`,
+		"",
+		"Container vulnerabilities are time-dependent, not commit-dependent: no change introduced these,",
+		"and no revert removes them. Rebuilding `main` against a patched base image does — which the next",
+		"merge already does — so the usual remedy is to bump the base image or simply wait for a merge and",
+		"let the next scheduled run close this. Anything still listed after that needs a real fix or a",
+		"dispositioned exception in `security/vulnerability-policy.json`.",
+		"",
+		`Scanned \`${context.registry}/<image>:${context.tag}\` on ${context.scannedAt}. Findings last changed by [this run](${context.runUrl}).`,
+	];
+	for (const result of results) {
+		lines.push("", `### ${result.image} (${result.platform})`, "", `Subject \`${result.digest}\`.`);
+		if (result.rejected.length === 0 && result.errors.length === 0) {
+			lines.push(
+				"",
+				`No findings the policy rejects (${result.highCritical.length} HIGH/CRITICAL total).`,
+			);
+			continue;
+		}
+		if (result.rejected.length > 0) {
+			lines.push("", "| Vulnerability | Package | Installed |", "| --- | --- | --- |");
+			for (const finding of [...result.rejected].toSorted())
+				lines.push(`| ${cell(finding, 1)} | ${cell(finding, 2)} | ${cell(finding, 3)} |`);
+		}
+		// A policy error is an expired or malformed exception, not a CVE; it needs a commit, not a rebuild.
+		if (result.errors.length > 0)
+			lines.push(
+				"",
+				"Policy errors:",
+				...[...result.errors].toSorted().map((error) => `- ${error}`),
+			);
+	}
+	lines.push(
+		"",
+		"---",
+		"",
+		"Maintained by `.github/workflows/rescan-main-images.yml`, which edits this issue in place when the",
+		"finding set changes and closes it when it clears. Retitle or annotate it freely, but keep the HTML",
+		"comment on the first line: it is how the next run recognises this issue instead of opening another.",
+		"",
+	);
+	return lines.join("\n");
+}
+
+/**
+ * @param open every open issue that could be the tracking issue; non-tracking issues are ignored.
+ */
+export function planIssueAction(
+	open: readonly TrackingIssue[],
+	results: readonly PolicyResult[],
+	context: ReportContext,
+): IssuePlan {
+	const tracked = open
+		.filter((issue) => markerFingerprint(issue.body) !== undefined)
+		.toSorted((left, right) => left.number - right.number);
+	if (!hasFindings(results)) {
+		if (tracked.length === 0) return { kind: "none" };
+		return {
+			comment: `Every image built from \`main\` satisfies the vulnerability policy again as of ${context.scannedAt}. Closed by [this run](${context.runUrl}).`,
+			issues: tracked.map((issue) => issue.number),
+			kind: "close",
+		};
+	}
+	const body = renderIssueBody(results, context);
+	// The oldest, so a duplicate opened by hand cannot take over the tracking history.
+	const [current] = tracked;
+	if (!current) return { body, kind: "create", title: ISSUE_TITLE };
+	if (markerFingerprint(current.body) === fingerprint(results))
+		return { issue: current.number, kind: "unchanged" };
+	return {
+		body,
+		comment: `The finding set changed as of ${context.scannedAt}; the description above now lists what [this run](${context.runUrl}) found.`,
+		issue: current.number,
+		kind: "update",
+	};
+}
+
+export type CommandRunner = (args: readonly string[]) => Promise<void>;
+
+async function bodyFile(content: string, name: string): Promise<string> {
+	const directory = await mkdtemp(path.join(tmpdir(), "vulnerability-drift-"));
+	const file = path.join(directory, name);
+	await writeFile(file, content);
+	return file;
+}
+
+export async function applyPlan(plan: IssuePlan, gh: CommandRunner): Promise<string> {
+	switch (plan.kind) {
+		case "none":
+			return "No findings and no tracking issue; nothing to do.";
+		case "unchanged":
+			return `Findings unchanged since issue #${plan.issue} was last updated; left alone.`;
+		case "create":
+			await gh([
+				"issue",
+				"create",
+				"--title",
+				plan.title,
+				...ISSUE_LABELS.flatMap((label) => ["--label", label]),
+				"--body-file",
+				await bodyFile(plan.body, "body.md"),
+			]);
+			return "Opened a tracking issue for the new findings.";
+		case "update":
+			await gh([
+				"issue",
+				"edit",
+				String(plan.issue),
+				"--body-file",
+				await bodyFile(plan.body, "body.md"),
+			]);
+			await gh([
+				"issue",
+				"comment",
+				String(plan.issue),
+				"--body-file",
+				await bodyFile(plan.comment, "comment.md"),
+			]);
+			return `Updated issue #${plan.issue} with the changed finding set.`;
+		default:
+			for (const issue of plan.issues)
+				await gh(["issue", "close", String(issue), "--comment", plan.comment]);
+			return `Closed ${plan.issues.map((issue) => `#${issue}`).join(", ")}; the policy is satisfied again.`;
+	}
+}
+
+export async function readPolicyResults(directory: string): Promise<PolicyResult[]> {
+	const files = (await Array.fromAsync(glob(path.join(directory, "*.policy.json")))).toSorted();
+	const results: PolicyResult[] = [];
+	for (const file of files)
+		results.push(parsePolicyResult(parseJson(await readFile(file, "utf8")), file));
+	return results;
+}
+
+if (import.meta.main) {
+	const [directory = "reports"] = process.argv.slice(2);
+	const repository = process.env.GITHUB_REPOSITORY;
+	if (!repository) throw new Error("GITHUB_REPOSITORY is required");
+	const results = await readPolicyResults(directory);
+	if (results.length === 0) throw new Error(`no policy results under ${directory}`);
+	const context: ReportContext = {
+		registry: process.env.IMAGE_REGISTRY ?? "ghcr.io/hephaestus-build",
+		runUrl: `${process.env.GITHUB_SERVER_URL ?? "https://github.com"}/${repository}/actions/runs/${process.env.GITHUB_RUN_ID ?? ""}`,
+		scannedAt: new Date().toISOString().replace(/\.\d+Z$/, "Z"),
+		tag: process.env.IMAGE_TAG ?? "main",
+	};
+	const listed = asArray(
+		parseJson(
+			await output("gh", [
+				"issue",
+				"list",
+				"--repo",
+				repository,
+				"--state",
+				"open",
+				"--label",
+				ISSUE_LABELS[0],
+				"--json",
+				"body,number",
+				"--limit",
+				"100",
+			]),
+		),
+		"gh issue list",
+	);
+	const open = listed.map((value, index) => {
+		const issue = asRecord(value, `gh issue list[${index}]`);
+		return {
+			body: asString(issue.body, `gh issue list[${index}].body`),
+			number: Number(issue.number),
+		};
+	});
+	const plan = planIssueAction(open, results, context);
+	const summary = await applyPlan(plan, (args) => run("gh", [...args, "--repo", repository]));
+	process.stdout.write(`${summary}\n`);
+	const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+	if (summaryPath)
+		await writeFile(summaryPath, `### Container vulnerability drift\n\n${summary}\n`, {
+			flag: "a",
+		});
+}

--- a/scripts/scan-main-images.test.ts
+++ b/scripts/scan-main-images.test.ts
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { describe, test } from "node:test";
+
+import { PLATFORM, planSubjects, reportStem, selectPlatformDigest } from "./scan-main-images.ts";
+
+const DIGEST = `sha256:${"a".repeat(64)}`;
+const ARM_DIGEST = `sha256:${"b".repeat(64)}`;
+
+void describe("planSubjects", () => {
+	void test("names every inventory image at the requested registry and tag", () => {
+		const subjects = planSubjects(
+			{ images: ["webapp", "postgres"] },
+			"ghcr.io/hephaestus-build",
+			"main",
+		);
+		assert.deepEqual(subjects, [
+			{
+				image: "webapp",
+				reference: "ghcr.io/hephaestus-build/webapp:main",
+				repository: "ghcr.io/hephaestus-build/webapp",
+			},
+			{
+				image: "postgres",
+				reference: "ghcr.io/hephaestus-build/postgres:main",
+				repository: "ghcr.io/hephaestus-build/postgres",
+			},
+		]);
+	});
+
+	void test("covers the committed release image inventory", async () => {
+		const inventory: unknown = JSON.parse(await readFile("security/release-images.json", "utf8"));
+		const subjects = planSubjects(inventory, "ghcr.io/hephaestus-build", "main");
+		// The four first-party images the release promotes. The upstream images in the same file are
+		// not built here and have no `:main` tag, so they are deliberately not subjects.
+		assert.deepEqual(subjects.map((subject) => subject.image).toSorted(), [
+			"agent-pi",
+			"application-server",
+			"postgres",
+			"webapp",
+		]);
+	});
+
+	void test("rejects an inventory that could name something other than an image", () => {
+		assert.throws(() => planSubjects({ images: ["web app"] }, "ghcr.io/x", "main"), /malformed/);
+		assert.throws(() => planSubjects({ images: [] }, "ghcr.io/x", "main"), /no images/);
+		assert.throws(() => planSubjects({ images: [7] }, "ghcr.io/x", "main"), /must be a string/);
+		assert.throws(() => planSubjects({}, "ghcr.io/x", "main"), /must be an array/);
+	});
+});
+
+void describe("selectPlatformDigest", () => {
+	void test("picks the requested architecture out of a multi-architecture index", () => {
+		const raw = {
+			manifests: [
+				{ digest: ARM_DIGEST, platform: { architecture: "arm64", os: "linux" } },
+				{ digest: DIGEST, platform: { architecture: "amd64", os: "linux" } },
+			],
+		};
+		assert.equal(selectPlatformDigest(raw, PLATFORM), DIGEST);
+	});
+
+	void test("ignores the attestation manifest a multi-architecture push also publishes", () => {
+		const raw = {
+			manifests: [
+				{
+					digest: `sha256:${"c".repeat(64)}`,
+					platform: { architecture: "unknown", os: "unknown" },
+				},
+				{ digest: DIGEST, platform: { architecture: "amd64", os: "linux" } },
+			],
+		};
+		assert.equal(selectPlatformDigest(raw, PLATFORM), DIGEST);
+	});
+
+	void test("returns undefined for a single manifest so the caller asks for its digest", () => {
+		assert.equal(selectPlatformDigest({ config: {}, layers: [] }, PLATFORM), undefined);
+	});
+
+	void test("returns undefined rather than a wrong architecture when the index lacks one", () => {
+		const raw = {
+			manifests: [{ digest: ARM_DIGEST, platform: { architecture: "arm64", os: "linux" } }],
+		};
+		assert.equal(selectPlatformDigest(raw, PLATFORM), undefined);
+	});
+
+	void test("skips entries that carry no usable platform", () => {
+		const raw = {
+			manifests: [
+				null,
+				{ digest: ARM_DIGEST },
+				{ platform: { architecture: "amd64", os: "linux" } },
+				{ digest: DIGEST, platform: { architecture: "amd64", os: "linux" } },
+			],
+		};
+		assert.equal(selectPlatformDigest(raw, PLATFORM), DIGEST);
+	});
+
+	void test("rejects a document that is not a manifest at all", () => {
+		assert.throws(() => selectPlatformDigest("nope", PLATFORM), /must be a JSON object/);
+	});
+});
+
+void test("reportStem names files after the image and platform", () => {
+	assert.equal(reportStem("webapp", PLATFORM), "webapp-linux-amd64");
+});

--- a/scripts/scan-main-images.ts
+++ b/scripts/scan-main-images.ts
@@ -1,0 +1,169 @@
+/**
+ * Rescans the images built from `main` against the release vulnerability policy.
+ *
+ * Container CVEs are time-dependent, not commit-dependent: the commit that was clean when it merged
+ * becomes vulnerable days later with nothing in the repository having changed. The build-time gate in
+ * `reusable-docker-build.yml` catches change-driven regressions and cannot catch this, so v0.75.0 was
+ * blocked by findings whose first appearance was the release itself.
+ *
+ * This walks `security/release-images.json`, resolves each image's `:main` tag to its `linux/amd64`
+ * digest, scans it, and hands the report to `check-release-vulnerabilities.ts` — the same evaluator and
+ * the same `security/vulnerability-policy.json` the build gate and the release use. A second copy of
+ * either is precisely the failure this whole effort removes, so the policy is evaluated by invoking
+ * that script rather than by reimplementing it.
+ *
+ * A finding never fails this run. `report-vulnerability-drift.ts` reads the `.policy.json` files
+ * written here and routes them to a tracking issue; only an infrastructure failure — a missing tag, an
+ * unreachable registry, a Trivy crash — is worth a red status on a schedule nobody triggered.
+ */
+import { existsSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import { asArray, asRecord, asString, isRecord, readJsonFile } from "./lib/json.ts";
+import { output, run, succeeds } from "./lib/process.ts";
+
+/** The one platform scanned. Alpine and Debian ship the same package versions across
+ * architectures, and the release still scans both, where the evidence bundle must be complete. */
+export const PLATFORM = "linux/amd64";
+
+const DIGEST = /^sha256:[a-f0-9]{64}$/;
+
+export interface Subject {
+	/** Short image name, as `security/release-images.json` and the policy exceptions spell it. */
+	readonly image: string;
+	readonly reference: string;
+	readonly repository: string;
+}
+
+export interface ScanOutcome {
+	readonly image: string;
+	/** `false` when the policy evaluator rejected something; never throws the run. */
+	readonly passed: boolean;
+}
+
+/**
+ * The first-party images to scan, in inventory order.
+ *
+ * `reusable-docker-build.yml` tags every push with `github.ref_name`, so `<registry>/<owner>/<image>:main`
+ * already names main's HEAD build and nothing new has to be published for this to have a subject.
+ */
+export function planSubjects(inventory: unknown, registry: string, tag: string): Subject[] {
+	const images = asArray(asRecord(inventory, "release image inventory").images, "images");
+	if (images.length === 0) throw new Error("release image inventory lists no images");
+	return images.map((value, index) => {
+		const image = asString(value, `images[${index}]`);
+		if (!/^[a-z0-9-]+$/.test(image)) throw new Error(`malformed release image name: ${image}`);
+		const repository = `${registry}/${image}`;
+		return { image, reference: `${repository}:${tag}`, repository };
+	});
+}
+
+/**
+ * The `linux/amd64` digest inside `docker buildx imagetools inspect --raw` output, or `undefined`
+ * when the document is a single manifest rather than an index and the caller must ask for its digest
+ * directly. Multi-architecture builds also push an attestation manifest, whose platform is
+ * `unknown/unknown`, so the architecture has to be matched rather than the position assumed.
+ */
+export function selectPlatformDigest(raw: unknown, platform: string): string | undefined {
+	const document = asRecord(raw, "imagetools manifest");
+	if (!Array.isArray(document.manifests)) return undefined;
+	const [os, architecture] = platform.split("/");
+	for (const entry of document.manifests) {
+		if (!isRecord(entry) || !isRecord(entry.platform)) continue;
+		if (entry.platform.os !== os || entry.platform.architecture !== architecture) continue;
+		if (typeof entry.digest === "string") return entry.digest;
+	}
+	return undefined;
+}
+
+async function resolveDigest(subject: Subject, platform: string): Promise<string> {
+	const raw: unknown = JSON.parse(
+		await output("docker", ["buildx", "imagetools", "inspect", subject.reference, "--raw"]),
+	);
+	const digest =
+		selectPlatformDigest(raw, platform) ??
+		(
+			await output("docker", [
+				"buildx",
+				"imagetools",
+				"inspect",
+				"--format",
+				"{{.Manifest.Digest}}",
+				subject.reference,
+			])
+		).trim();
+	if (!DIGEST.test(digest))
+		throw new Error(`no ${platform} digest for ${subject.reference} (got: ${digest || "<empty>"})`);
+	return digest;
+}
+
+/** `webapp-linux-amd64`, the stem both report files and the uploaded artifact are named by. */
+export function reportStem(image: string, platform: string): string {
+	return `${image}-${platform.replaceAll("/", "-")}`;
+}
+
+async function scan(subject: Subject, directory: string, platform: string): Promise<ScanOutcome> {
+	const digest = await resolveDigest(subject, platform);
+	const stem = reportStem(subject.image, platform);
+	const report = path.join(directory, `${stem}.json`);
+	await run("trivy", [
+		"image",
+		"--skip-db-update",
+		"--scanners",
+		"vuln",
+		"--format",
+		"json",
+		"--output",
+		report,
+		`${subject.repository}@${digest}`,
+	]);
+	const result = path.join(directory, `${stem}.policy.json`);
+	const evaluator = [
+		path.join(import.meta.dirname, "check-release-vulnerabilities.ts"),
+		subject.image,
+		platform,
+		digest,
+		subject.repository,
+		report,
+		"security/vulnerability-policy.json",
+		result,
+	];
+	// Silenced, not ignored: the evaluator writes `::error::` per rejected finding, and a green job
+	// carrying error annotations is how a team learns to read past them. The result file it wrote
+	// names every finding, and report-vulnerability-drift.ts routes them to a human from there.
+	if (await succeeds("node", evaluator)) return { image: subject.image, passed: true };
+	if (!existsSync(result)) {
+		// It threw before writing anything — a malformed report or policy, not a finding. Re-run so
+		// the reason reaches the log, then fail: this is an infrastructure failure, and unlike a CVE
+		// it is fixed by a commit.
+		await run("node", evaluator);
+		throw new Error(`vulnerability policy evaluation produced no result for ${subject.image}`);
+	}
+	return { image: subject.image, passed: false };
+}
+
+export async function scanAll(
+	subjects: readonly Subject[],
+	directory: string,
+	platform = PLATFORM,
+): Promise<ScanOutcome[]> {
+	await mkdir(directory, { recursive: true });
+	const outcomes: ScanOutcome[] = [];
+	for (const subject of subjects) outcomes.push(await scan(subject, directory, platform));
+	return outcomes;
+}
+
+if (import.meta.main) {
+	const [directory = "reports"] = process.argv.slice(2);
+	const registry = process.env.IMAGE_REGISTRY ?? "ghcr.io/hephaestus-build";
+	const tag = process.env.IMAGE_TAG ?? "main";
+	const subjects = planSubjects(await readJsonFile("security/release-images.json"), registry, tag);
+	const outcomes = await scanAll(subjects, directory);
+	await writeFile(
+		path.join(directory, "scan.json"),
+		`${JSON.stringify({ platform: PLATFORM, registry, scannedAt: new Date().toISOString(), subjects, tag }, null, 2)}\n`,
+	);
+	for (const outcome of outcomes)
+		process.stdout.write(`${outcome.image}: ${outcome.passed ? "pass" : "fail"}\n`);
+}


### PR DESCRIPTION
## Description

Adds `rescan-main-images.yml`: a weekly, **non-blocking** rescan of the images built from `main`'s
HEAD against the release vulnerability policy, with findings routed to a single tracking issue.

Container vulnerabilities are time-dependent, not commit-dependent. The gate #1710 added runs where
an image is built, so it catches a finding some change introduced and cannot catch one published
after the code merged clean — which is exactly what blocked v0.75.0, and what nothing notices today
until a release fails. `rescan-release-images.yml` already covers *published releases* on this
cadence; this covers what `main` would release today.

Fixes #1706

## What is reused, and what is new

Reused as-is, not re-derived:

- **`scripts/check-release-vulnerabilities.ts` and `security/vulnerability-policy.json`.** One
  evaluator, one policy. `scan-main-images.ts` invokes that script rather than importing or
  reimplementing it, so the `.policy.json` result files this run produces are byte-shaped exactly
  like the build gate's and the release rescan's.
- **#1710's `linux/amd64` digest resolution** — index first, single-manifest fallback, digest shape
  asserted — lifted into `selectPlatformDigest`, where it is now tested against a real index, a
  single manifest, and the `unknown/unknown` attestation manifest a multi-arch push also publishes.
- **`rescan-release-images.yml`'s shape**: weekly cron, `workflow_dispatch`, non-cancelling
  concurrency group, `setup-release-security-tools` without Syft, artifact upload of the reports.

New:

- `scripts/scan-main-images.ts` — resolves each inventory image's `:main` tag to its `linux/amd64`
  digest, scans it, evaluates the policy. A finding never fails the run; an unreachable registry, a
  missing tag or a malformed report does. The evaluator is run silenced, because a green job
  carrying `::error::` annotations is how a team learns to read past them — but if it exits without
  writing a result file (a malformed report or policy, not a finding) it is re-run with output and
  the run fails, since unlike a CVE that is fixed by a commit.
- `scripts/report-vulnerability-drift.ts` — the issue upsert, in kyverno `sync-trivy-issues` shape.
  Creates when findings appear, edits in place and comments when the finding set changes, **writes
  nothing when it has not**, and closes when it clears. It identifies its own issue by an HTML
  marker carrying a fingerprint of the finding set, not by title: a title is editable, and a run
  that cannot recognise its own issue opens a duplicate every week until someone turns the schedule
  off. The fingerprint deliberately excludes the scan timestamp and run link, or every week would
  look like a change.

## Composite action: yes, and why

The Trivy database fetch — retry loop, mirror fallback, freshness assertion, metadata copy — was
about to exist in a **fourth** copy, and only #1710's carried the
`public.ecr.aws/aquasecurity/trivy-db` fallback and the note that the `:2` schema tag tracks the
Trivy version in `setup-release-security-tools`. That is the same class of drift this whole effort
is removing, so it is now `.github/actions/download-trivy-db` with two optional inputs
(`max-age-hours`, `metadata-path`) covering all four call sites. `release.yml` and
`rescan-release-images.yml` adopt it and gain the mirror fallback; `reusable-docker-build.yml`'s
`scan` job loses ten lines. It is roughly line-neutral — the win is that the fallback and the schema
pin are stated once instead of in one place out of four.

## Changeset

None. `verify-changesets` scopes `SHIPPED_PATHS` to `server`, `webapp` and `docker`; this PR touches
only `.github/`, `scripts/` and `docs/`, so `git diff --name-only ... -- server webapp docker` is
empty and the check does not require one.

## How to test

CI covers this. 46 `node:test` cases across `scripts/scan-main-images.test.ts` (13),
`scripts/report-vulnerability-drift.test.ts` (20) and the new/extended `scripts/ci-contract.test.ts`
assertions (3 new tests, existing one updated), including:

- the upsert does not open a second issue when the findings are unchanged, takes over the *oldest*
  tracking issue rather than the newest, closes every tracking issue when the policy clears, and
  never adopts an unrelated open `security` issue;
- the rendered body is byte-identical for the same findings scanned in a different order;
- every path that evaluates the policy names `security/vulnerability-policy.json`, and exactly one
  such file is committed;
- no workflow downloads the Trivy database outside the composite action, and every workflow that
  publishes or signs a scan result refuses a database over 24 h old.

`pnpm run format` and `pnpm run check` both pass.

The workflow can be exercised before the first Monday with `workflow_dispatch`.

## Checklist

- [x] My changeset summary reads as an operator/user-facing note — n/a, no shipped code changed
- [x] If operators must act, the changeset and migration entry give actionable upgrade instructions
- [x] I did not commit generated-artifact changes that this PR did not cause
