### PR TITLE
docs(config): teach PR workflow to attach visual evidence

### DIFF
--- a/.agents/skills/land-pr/SKILL.md
+++ b/.agents/skills/land-pr/SKILL.md
@@ -105,8 +105,14 @@ the changeset, not the header.
 ## 9. Open the PR
 
 ```bash
-PAGER=cat gh pr view --json number,url 2>/dev/null || PAGER=cat gh pr create --base main --title "<type>(<scope>): <description>" --body "$(cat <<'BODY'
-## Description
+PAGER=cat gh pr view --json number,url
+```
+
+If that reports that the current branch has no pull request, create it:
+
+```bash
+PAGER=cat gh pr create --base main --title "<type>(<scope>): <description>" --body "$(cat <<'BODY'
+## What changed and why
 
 <1-2 sentences: what and why>
 
@@ -114,15 +120,40 @@ PAGER=cat gh pr view --json number,url 2>/dev/null || PAGER=cat gh pr create --b
 
 <manual steps, or "CI covers this">
 
-## Checklist
+## Release impact
 
-<the items from .github/PULL_REQUEST_TEMPLATE.md that apply>
+<link the changeset and state operator action, or explain why neither applies>
+
+## Notes for reviewers
+
+<risks, tradeoffs, follow-up work, or delete this section>
+
+## Visual evidence
+
+<UI: before and after. Motion or timing: a short video. Otherwise delete this section.>
 BODY
 )"
 ```
 
-## 10. Verify
+## 10. Upload visual evidence
+
+For a UI change, save PR-only evidence under the ignored `tmp/` directory and inspect it for
+secrets, personal data, and unrelated content. Give each image alt text that describes the visible
+state. For a video, describe the demonstrated behavior in the PR body.
+
+```bash
+mkdir -p tmp
+gh pr edit --attach './tmp/before.png#Settings before the change' --attach './tmp/after.png#Settings after the change'
+```
+
+An upload can add earlier files before a later file fails. Inspect the PR before retrying, then
+attach only the missing files.
+
+## 11. Verify
 
 ```bash
 PAGER=cat gh pr view --json url,title -q '"PR: \(.title)\nURL: \(.url)"'
 ```
+
+Open the URL and check that every attachment renders, describes the intended state, and contains no
+sensitive or unrelated content.

--- a/.claude/skills/land-pr/SKILL.md
+++ b/.claude/skills/land-pr/SKILL.md
@@ -105,8 +105,14 @@ the changeset, not the header.
 ## 9. Open the PR
 
 ```bash
-PAGER=cat gh pr view --json number,url 2>/dev/null || PAGER=cat gh pr create --base main --title "<type>(<scope>): <description>" --body "$(cat <<'BODY'
-## Description
+PAGER=cat gh pr view --json number,url
+```
+
+If that reports that the current branch has no pull request, create it:
+
+```bash
+PAGER=cat gh pr create --base main --title "<type>(<scope>): <description>" --body "$(cat <<'BODY'
+## What changed and why
 
 <1-2 sentences: what and why>
 
@@ -114,15 +120,40 @@ PAGER=cat gh pr view --json number,url 2>/dev/null || PAGER=cat gh pr create --b
 
 <manual steps, or "CI covers this">
 
-## Checklist
+## Release impact
 
-<the items from .github/PULL_REQUEST_TEMPLATE.md that apply>
+<link the changeset and state operator action, or explain why neither applies>
+
+## Notes for reviewers
+
+<risks, tradeoffs, follow-up work, or delete this section>
+
+## Visual evidence
+
+<UI: before and after. Motion or timing: a short video. Otherwise delete this section.>
 BODY
 )"
 ```
 
-## 10. Verify
+## 10. Upload visual evidence
+
+For a UI change, save PR-only evidence under the ignored `tmp/` directory and inspect it for
+secrets, personal data, and unrelated content. Give each image alt text that describes the visible
+state. For a video, describe the demonstrated behavior in the PR body.
+
+```bash
+mkdir -p tmp
+gh pr edit --attach './tmp/before.png#Settings before the change' --attach './tmp/after.png#Settings after the change'
+```
+
+An upload can add earlier files before a later file fails. Inspect the PR before retrying, then
+attach only the missing files.
+
+## 11. Verify
 
 ```bash
 PAGER=cat gh pr view --json url,title -q '"PR: \(.title)\nURL: \(.url)"'
 ```
+
+Open the URL and check that every attachment renders, describes the intended state, and contains no
+sensitive or unrelated content.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,43 +1,23 @@
-<!--
-TITLE FORMAT (required):
-  <type>(<scope>): <description>
+<!-- Thanks for contributing. Use the title format in CONTRIBUTING.md and delete sections that do not apply. -->
 
-  Types and scopes: CONTRIBUTING.md § Pull Request Title Guidelines (validated by commitlint.config.ts).
-  Breaking changes are carried by the changeset (pre-1.0: minor + **Operators:** + .migration/<slug>.md), not the title.
+## What changed and why
 
-  ✓ Good: feat(leaderboard): add weekly ranking filter
-  ✓ Good: fix(ci): update workflow configuration
-  ✗ Bad:  Added weekly ranking filter to leaderboard
+<!-- Start with the problem, then explain the solution and why this approach is appropriate. -->
 
-BEFORE PUSHING:
-  pnpm run format && pnpm run check     # Apply formatting, then run the local quality gate
-
-AFTER API CHANGES:
-  pnpm run generate:api                # Rewrites server/openapi.yaml and webapp/src/api
-
-AFTER DATABASE/ENTITY CHANGES:
-  pnpm run db:draft-changelog          # Writes this branch's changelog (needs Docker); prune it, add preconditions and rollbacks
-  pnpm run db:generate-erd-docs        # After pruning
--->
-
-## Description
-
-<!-- 1-2 sentences: what changed, and why. -->
-
-Fixes # <!-- Link issue if applicable, or delete this line -->
+<!-- Link related work with "Fixes #123" when merging this PR should close it. -->
 
 ## How to test
 
-<!-- Manual steps to verify, OR "CI covers this" for config/docs changes. -->
+<!-- List the behavior you exercised and the exact steps or commands needed to reproduce it. -->
 
-## Checklist
+## Release impact
 
-<!-- Only what CI can't check for you. Changeset presence is enforced by `verify-changesets`. -->
+<!-- Link the changeset and state any operator action. If neither applies, explain why. -->
 
-- [ ] My changeset summary reads as an operator/user-facing note (it becomes the changelog entry) — see `.changeset/README.md`
-- [ ] If operators must act, the changeset and migration fragment state what the operator must do
-- [ ] I did not commit generated-artifact changes that this PR did not cause
+## Notes for reviewers
 
-## Screenshots
+<!-- Call out risks, tradeoffs, follow-up work, or the best place to begin reviewing. Delete if unnecessary. -->
 
-<!-- For UI changes. Delete section if not applicable. -->
+## Visual evidence
+
+<!-- UI changes: show before and after. Motion or timing changes: add a short video. Delete otherwise. -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,8 +203,8 @@ Oxlint lints; oxfmt formats and sorts imports. Each tree states its rule set in 
   change is carried by the changeset.
 - Body: the problem in a sentence or two, then how you fixed it and how you verified it. End with
   the model and harness that did the work. `.github/PULL_REQUEST_TEMPLATE.md` is the shape.
-- UI changes need before/after images; motion or timing needs a short video. Upload evidence to
-  GitHub; never commit screenshots or PR-only assets.
+- UI changes need before/after images; motion or timing needs a short video. Never commit PR-only
+  evidence; `/land-pr` owns its preparation and upload.
 - One concern per PR. If the description says "also", split it.
 - A PR that changes shipped code ships a changeset — `.changeset/README.md` is the contract. With no
   TTY, hand-write `.changeset/<slug>.md` in the shape shown there; `verify-changesets` fails the PR


### PR DESCRIPTION
## What changed and why

Pull requests that change the UI need durable visual evidence, but the contribution workflow did not explain how to publish local images or videos without committing them. This update integrates GitHub CLI's native `--attach` support into `/land-pr`, keeps PR-only files in the ignored `tmp/` directory, and separates PR creation from upload so the same path works for new and existing pull requests.

The root guide now states only the evidence policy and leaves mechanics to `/land-pr`. The pull request template is also shorter and asks directly for the problem, verification, release impact, reviewer context, and visual evidence without duplicating commands already enforced elsewhere.

## How to test

1. Run `pnpm run format && pnpm run check`.
2. Run `pnpm run check:instructions` and confirm both `/land-pr` copies remain identical.
3. Run `mkdir -p tmp && git check-ignore -v tmp/proof.png` and confirm Git ignores PR-only evidence.
4. Run `gh pr edit --help | grep -q -- --attach` and confirm the installed CLI supports the documented upload command.

The local quality gate and pre-push quality gate pass. No attachment was uploaded to this documentation-only PR because it has no UI change or meaningful visual evidence.

## Release impact

No changeset is needed: this changes contributor documentation and tooling only, not shipped product behavior. Operators do not need to take action.

## Notes for reviewers

The key design choice is to create or locate the pull request first, then upload evidence with `gh pr edit`. This avoids skipping uploads on an existing PR and prevents an upload failure from being mistaken for a failed PR creation.

Authored by OpenAI Codex in Jean.
