### PR TITLE
fix(server): account for prompt cache writes

### DIFF
--- a/.changeset/accurate-cache-write-costs.md
+++ b/.changeset/accurate-cache-write-costs.md
@@ -1,0 +1,5 @@
+---
+"hephaestus": patch
+---
+
+LLM usage reports and budget enforcement now record and price prompt-cache writes separately from ordinary input tokens.

--- a/docs/contributor/erd/schema.mmd
+++ b/docs/contributor/erd/schema.mmd
@@ -155,6 +155,7 @@ erDiagram
         BIGINT llm_total_output_tokens "NOT NULL"
         BIGINT llm_total_reasoning_tokens "NOT NULL"
         BIGINT llm_cache_read_tokens "NOT NULL"
+        BIGINT llm_cache_write_tokens "NOT NULL"
     }
 
     ChatMessageVote {

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobLlmUsageDelta.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobLlmUsageDelta.java
@@ -1,0 +1,4 @@
+package de.tum.cit.aet.hephaestus.agent.job;
+
+public record AgentJobLlmUsageDelta(
+        int inputTokens, int outputTokens, int reasoningTokens, int cacheReadTokens, int cacheWriteTokens) {}

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobRepository.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobRepository.java
@@ -275,9 +275,6 @@ public interface AgentJobRepository extends JpaRepository<AgentJob, UUID> {
      * columns) while the proxy is still waiting on the provider, and a late write would otherwise bill
      * one attempt's tokens at another attempt's frozen price and funding source.
      *
-     * <p>{@code llm_cache_write_tokens} is not touched: the OpenAI-compatible usage shapes the proxy
-     * parses do not report cache writes, so only the runner's end-of-run report fills that column.
-     *
      * @param attempt the {@code retry_count} the caller observed when it authenticated the call
      * @return 1 if the attempt still owns the row, 0 if it has been superseded (a safe no-op)
      */
@@ -287,7 +284,8 @@ public interface AgentJobRepository extends JpaRepository<AgentJob, UUID> {
             + "j.llmTotalInputTokens = COALESCE(j.llmTotalInputTokens, 0) + :input, "
             + "j.llmTotalOutputTokens = COALESCE(j.llmTotalOutputTokens, 0) + :output, "
             + "j.llmTotalReasoningTokens = COALESCE(j.llmTotalReasoningTokens, 0) + :reasoning, "
-            + "j.llmCacheReadTokens = COALESCE(j.llmCacheReadTokens, 0) + :cacheRead "
+            + "j.llmCacheReadTokens = COALESCE(j.llmCacheReadTokens, 0) + :cacheRead, "
+            + "j.llmCacheWriteTokens = COALESCE(j.llmCacheWriteTokens, 0) + :cacheWrite "
             + "WHERE j.id = :id AND j.retryCount = :attempt AND j.status = 'RUNNING'")
     int accumulateLlmUsage(
             @Param("id") UUID id,
@@ -295,7 +293,8 @@ public interface AgentJobRepository extends JpaRepository<AgentJob, UUID> {
             @Param("input") int input,
             @Param("output") int output,
             @Param("reasoning") int reasoning,
-            @Param("cacheRead") int cacheRead);
+            @Param("cacheRead") int cacheRead,
+            @Param("cacheWrite") int cacheWrite);
 
     /**
      * Reads the totals straight from the row rather than from a possibly stale in-memory entity, so

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobRepository.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobRepository.java
@@ -281,20 +281,14 @@ public interface AgentJobRepository extends JpaRepository<AgentJob, UUID> {
     @WorkspaceAgnostic("ID-based per-call usage accumulation from the worker-local proxy")
     @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Query("UPDATE AgentJob j SET " + "j.llmTotalCalls = COALESCE(j.llmTotalCalls, 0) + 1, "
-            + "j.llmTotalInputTokens = COALESCE(j.llmTotalInputTokens, 0) + :input, "
-            + "j.llmTotalOutputTokens = COALESCE(j.llmTotalOutputTokens, 0) + :output, "
-            + "j.llmTotalReasoningTokens = COALESCE(j.llmTotalReasoningTokens, 0) + :reasoning, "
-            + "j.llmCacheReadTokens = COALESCE(j.llmCacheReadTokens, 0) + :cacheRead, "
-            + "j.llmCacheWriteTokens = COALESCE(j.llmCacheWriteTokens, 0) + :cacheWrite "
+            + "j.llmTotalInputTokens = COALESCE(j.llmTotalInputTokens, 0) + :#{#usage.inputTokens()}, "
+            + "j.llmTotalOutputTokens = COALESCE(j.llmTotalOutputTokens, 0) + :#{#usage.outputTokens()}, "
+            + "j.llmTotalReasoningTokens = COALESCE(j.llmTotalReasoningTokens, 0) + :#{#usage.reasoningTokens()}, "
+            + "j.llmCacheReadTokens = COALESCE(j.llmCacheReadTokens, 0) + :#{#usage.cacheReadTokens()}, "
+            + "j.llmCacheWriteTokens = COALESCE(j.llmCacheWriteTokens, 0) + :#{#usage.cacheWriteTokens()} "
             + "WHERE j.id = :id AND j.retryCount = :attempt AND j.status = 'RUNNING'")
     int accumulateLlmUsage(
-            @Param("id") UUID id,
-            @Param("attempt") int attempt,
-            @Param("input") int input,
-            @Param("output") int output,
-            @Param("reasoning") int reasoning,
-            @Param("cacheRead") int cacheRead,
-            @Param("cacheWrite") int cacheWrite);
+            @Param("id") UUID id, @Param("attempt") int attempt, @Param("usage") AgentJobLlmUsageDelta usage);
 
     /**
      * Reads the totals straight from the row rather than from a possibly stale in-memory entity, so

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/job/TerminalUsage.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/job/TerminalUsage.java
@@ -12,37 +12,8 @@ import java.util.Objects;
 import org.jspecify.annotations.Nullable;
 
 /**
- * The token counts one ending attempt of an {@code AgentJob} is billed for, and whether they can be
- * trusted. Every terminal accounting path resolves its numbers here, so all of them answer "what did
- * this attempt spend?" the same way.
- *
- * <p>Two independent records of the same spend exist and <b>neither is complete</b>:
- *
- * <ul>
- *   <li>the runner's {@code usage.json}, which covers streamed calls the proxy never parses, but is
- *       derived by walking the agent session's surviving messages — and compaction is on for every
- *       session, so every message it drops takes its tokens out of the report with it;
- *   <li>the LLM proxy's per-call accumulation onto the {@code agent_job} row, which never forgets a call
- *       it forwarded, but sees no streamed call and no cache write.
- * </ul>
- *
- * <p>So the attempt is billed the <b>per-bucket maximum</b> of the two. Preferring the runner outright
- * — which this did — meant a compacted session was billed only for what survived compaction, and a
- * live 29-practice review booked 26 of the 143 calls the proxy had already watched go upstream. Since
- * the budget cap reads this ledger, that is a cap computed from a quarter of the spend, not an
- * accounting nit.
- *
- * <p>The maximum is safe in both directions. Neither source double-counts within itself, so no bucket
- * can exceed the truth; and each covers calls the other misses, so the larger of the two is always at
- * least as close. Where only one source exists for a bucket — {@code cacheWriteTokens}, which the proxy
- * never accumulates — the maximum simply is that source's value. It can still under-bill, when both
- * sources lost the same call, which is why {@link #provenance()} is recorded rather than inferred.
- *
- * @param verifiable whether these numbers are real observed spend, or an admission that the attempt's
- *     spend is unknown — which the ledger records UNPRICED so the month reads unverifiable rather than
- *     cheap
- * @param provenance which record the billed numbers came from, so a later reader can tell a merged row
- *     from either source's own
+ * Reconciles an ending job attempt's runner and proxy observations. Each bucket uses the larger
+ * observed value; {@link #provenance()} records whether the result matches either source.
  */
 record TerminalUsage(
         long inputTokens,

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/mentor/chat/MentorInFlightAccounting.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/mentor/chat/MentorInFlightAccounting.java
@@ -56,7 +56,7 @@ public class MentorInFlightAccounting {
                 observed.inputTokens(),
                 observed.outputTokens(),
                 observed.cacheReadTokens(),
-                0,
+                observed.cacheWriteTokens(),
                 observed.reasoningTokens(),
                 Math.max(1, observed.totalCalls()),
                 price,

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/mentor/chat/MentorTurnPersistence.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/mentor/chat/MentorTurnPersistence.java
@@ -324,7 +324,7 @@ public class MentorTurnPersistence {
                         viaProxy.inputTokens(),
                         viaProxy.outputTokens(),
                         viaProxy.cacheReadTokens(),
-                        /* cacheWrite — no OpenAI-compatible usage block reports one per call */ 0);
+                        viaProxy.cacheWriteTokens());
                 calls = viaProxy.totalCalls();
                 reasoning = viaProxy.reasoningTokens();
                 provenance = UsageProvenance.PROXY;

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/proxy/LlmProxyController.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/proxy/LlmProxyController.java
@@ -186,7 +186,11 @@ class LlmProxyController {
             ProxyStreamingUtils.streamSseToResponse(
                     upstream.sseBody(), upstream.headers(), response, upstream.status(), tap);
             if (tap != null) {
-                accounting.recordUsage(attempt, tap.observed());
+                if (tap.hasMalformedUsage()) {
+                    accounting.recordMalformedUsage(attempt);
+                } else {
+                    accounting.recordUsage(attempt, tap.observed());
+                }
             }
             return null;
         }

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/proxy/MentorTurnMeter.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/proxy/MentorTurnMeter.java
@@ -25,11 +25,16 @@ public final class MentorTurnMeter {
      * @param reasoningTokens already inside {@link #outputTokens}; reported, never priced twice
      */
     public record ObservedUsage(
-            long inputTokens, long outputTokens, long reasoningTokens, long cacheReadTokens, int calls) {
-        static final ObservedUsage NONE = new ObservedUsage(0, 0, 0, 0, 0);
+            long inputTokens,
+            long outputTokens,
+            long reasoningTokens,
+            long cacheReadTokens,
+            long cacheWriteTokens,
+            int calls) {
+        static final ObservedUsage NONE = new ObservedUsage(0, 0, 0, 0, 0, 0);
 
         public boolean isEmpty() {
-            return inputTokens <= 0 && outputTokens <= 0 && cacheReadTokens <= 0;
+            return inputTokens <= 0 && outputTokens <= 0 && cacheReadTokens <= 0 && cacheWriteTokens <= 0;
         }
 
         ObservedUsage plus(ProxyTokenUsage call) {
@@ -38,6 +43,7 @@ public final class MentorTurnMeter {
                     outputTokens + call.outputTokens(),
                     reasoningTokens + call.reasoningTokens(),
                     cacheReadTokens + call.cacheReadTokens(),
+                    cacheWriteTokens + call.cacheWriteTokens(),
                     calls + 1);
         }
     }
@@ -75,7 +81,10 @@ public final class MentorTurnMeter {
         }
         ObservedUsage snapshot = Objects.requireNonNull(observed.get());
         BigDecimal cost = price.calculateCost(
-                        snapshot.inputTokens(), snapshot.outputTokens(), snapshot.cacheReadTokens(), 0)
+                        snapshot.inputTokens(),
+                        snapshot.outputTokens(),
+                        snapshot.cacheReadTokens(),
+                        snapshot.cacheWriteTokens())
                 .usd();
         return cost != null ? cost : BigDecimal.ZERO;
     }

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/proxy/MentorTurnUsageAccumulator.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/proxy/MentorTurnUsageAccumulator.java
@@ -60,7 +60,8 @@ public class MentorTurnUsageAccumulator {
                     usage.billableInputTokens(),
                     usage.outputTokens(),
                     usage.reasoningTokens(),
-                    usage.cacheReadTokens());
+                    usage.cacheReadTokens(),
+                    usage.cacheWriteTokens());
             if (rows == 0) {
                 recordSuperseded(turnId);
                 return;

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/proxy/ProxyAccounting.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/proxy/ProxyAccounting.java
@@ -75,16 +75,10 @@ public class ProxyAccounting {
             recordUsage(attempt, ProxyTokenUsage.from(parsed, responsesProtocol));
         } catch (Exception e) {
             log.warn("Could not parse upstream usage for {} — this call's tokens go unbilled", attempt.sourceId(), e);
-            meterRegistry
-                    .counter(
-                            "llm.proxy.usage.unparseable",
-                            "sourceType",
-                            attempt.sourceType().name())
-                    .increment();
+            recordMalformedUsage(attempt);
         }
     }
 
-    /** The shared tail of the buffered and streamed paths. */
     public void recordUsage(ProxyRouting.BilledAttempt attempt, @Nullable ProxyTokenUsage usage) {
         if (usage == null) {
             return;
@@ -93,6 +87,15 @@ public class ProxyAccounting {
             case AGENT_JOB -> usageAccumulator.accumulate(attempt, usage);
             case MENTOR_TURN -> mentorTurnUsageAccumulator.accumulate(attempt, usage);
         }
+    }
+
+    public void recordMalformedUsage(ProxyRouting.BilledAttempt attempt) {
+        meterRegistry
+                .counter(
+                        "llm.proxy.usage.unparseable",
+                        "sourceType",
+                        attempt.sourceType().name())
+                .increment();
     }
 
     public Timer.Sample startTimer() {

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/proxy/ProxyStreamUsageTap.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/proxy/ProxyStreamUsageTap.java
@@ -43,6 +43,8 @@ final class ProxyStreamUsageTap implements Consumer<byte[]> {
     @Nullable
     private ProxyTokenUsage observed;
 
+    private boolean malformedUsage;
+
     ProxyStreamUsageTap(ObjectMapper objectMapper, boolean responsesProtocol) {
         this.objectMapper = objectMapper;
         this.responsesProtocol = responsesProtocol;
@@ -96,7 +98,7 @@ final class ProxyStreamUsageTap implements Consumer<byte[]> {
                 observed = parsed;
             }
         } catch (RuntimeException e) {
-            // Only the billing is lost; the client already has the frame verbatim.
+            malformedUsage = true;
             log.debug("Unparseable SSE frame while looking for usage: {}", e.toString());
         }
     }
@@ -105,6 +107,10 @@ final class ProxyStreamUsageTap implements Consumer<byte[]> {
     @Nullable
     ProxyTokenUsage observed() {
         return observed;
+    }
+
+    boolean hasMalformedUsage() {
+        return malformedUsage;
     }
 
     private static boolean startsWith(byte[] line, byte[] prefix) {

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/proxy/ProxyTokenUsage.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/proxy/ProxyTokenUsage.java
@@ -27,14 +27,14 @@ public record ProxyTokenUsage(
         int cacheRead;
         int cacheWrite;
         if (responsesProtocol) {
-            input = count(usage, "input_tokens");
-            output = count(usage, "output_tokens");
+            input = requiredCount(usage, "input_tokens");
+            output = requiredCount(usage, "output_tokens");
             cacheRead = count(usage.path("input_tokens_details"), "cached_tokens");
             cacheWrite = cacheWriteTokens(usage.path("input_tokens_details"));
             reasoning = count(usage.path("output_tokens_details"), "reasoning_tokens");
         } else {
-            input = count(usage, "prompt_tokens");
-            output = count(usage, "completion_tokens");
+            input = requiredCount(usage, "prompt_tokens");
+            output = requiredCount(usage, "completion_tokens");
             cacheRead = count(usage.path("prompt_tokens_details"), "cached_tokens");
             cacheWrite = cacheWriteTokens(usage.path("prompt_tokens_details"));
             reasoning = count(usage.path("completion_tokens_details"), "reasoning_tokens");
@@ -57,6 +57,14 @@ public record ProxyTokenUsage(
     private static int count(JsonNode owner, String field) {
         Integer value = optionalCount(owner, field);
         return value != null ? value : 0;
+    }
+
+    private static int requiredCount(JsonNode owner, String field) {
+        Integer value = optionalCount(owner, field);
+        if (value == null) {
+            throw new IllegalArgumentException("Missing token count: " + field);
+        }
+        return value;
     }
 
     private static @Nullable Integer optionalCount(JsonNode owner, String field) {

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/proxy/ProxyTokenUsage.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/proxy/ProxyTokenUsage.java
@@ -4,20 +4,15 @@ import org.jspecify.annotations.Nullable;
 import tools.jackson.databind.JsonNode;
 
 /**
- * One proxied call's token counts, read off an OpenAI-compatible {@code usage} block — the single
- * parser for both API shapes and both transports, so the buffered and streamed billing paths cannot
- * drift apart on which bucket a token belongs in.
+ * Normalized token buckets for one proxied response.
  *
- * @param billableInputTokens prompt tokens MINUS the cached ones, because upstream reports the prompt
- *     count inclusive of cache reads and a cache read must not be billed at both rates
+ * @param billableInputTokens prompt tokens MINUS cache reads and writes, because OpenAI-compatible
+ *     providers report both as details of the inclusive prompt total
  * @param reasoningTokens already counted inside {@link #outputTokens}; reported, never priced twice
  */
-public record ProxyTokenUsage(int billableInputTokens, int outputTokens, int reasoningTokens, int cacheReadTokens) {
-    /**
-     * @param usageOwner the node that CONTAINS a {@code usage} field
-     * @return {@code null} when there is no usage block to read, which is not an error: the caller
-     *     records nothing rather than guessing
-     */
+public record ProxyTokenUsage(
+        int billableInputTokens, int outputTokens, int reasoningTokens, int cacheReadTokens, int cacheWriteTokens) {
+    /** @return {@code null} when no usage block is present */
     static @Nullable ProxyTokenUsage from(@Nullable JsonNode usageOwner, boolean responsesProtocol) {
         if (usageOwner == null) {
             return null;
@@ -30,21 +25,48 @@ public record ProxyTokenUsage(int billableInputTokens, int outputTokens, int rea
         int output;
         int reasoning;
         int cacheRead;
+        int cacheWrite;
         if (responsesProtocol) {
-            input = usage.path("input_tokens").asInt(0);
-            output = usage.path("output_tokens").asInt(0);
-            cacheRead = usage.path("input_tokens_details").path("cached_tokens").asInt(0);
-            reasoning =
-                    usage.path("output_tokens_details").path("reasoning_tokens").asInt(0);
+            input = count(usage, "input_tokens");
+            output = count(usage, "output_tokens");
+            cacheRead = count(usage.path("input_tokens_details"), "cached_tokens");
+            cacheWrite = cacheWriteTokens(usage.path("input_tokens_details"));
+            reasoning = count(usage.path("output_tokens_details"), "reasoning_tokens");
         } else {
-            input = usage.path("prompt_tokens").asInt(0);
-            output = usage.path("completion_tokens").asInt(0);
-            cacheRead =
-                    usage.path("prompt_tokens_details").path("cached_tokens").asInt(0);
-            reasoning = usage.path("completion_tokens_details")
-                    .path("reasoning_tokens")
-                    .asInt(0);
+            input = count(usage, "prompt_tokens");
+            output = count(usage, "completion_tokens");
+            cacheRead = count(usage.path("prompt_tokens_details"), "cached_tokens");
+            cacheWrite = cacheWriteTokens(usage.path("prompt_tokens_details"));
+            reasoning = count(usage.path("completion_tokens_details"), "reasoning_tokens");
         }
-        return new ProxyTokenUsage(Math.max(0, input - cacheRead), output, reasoning, cacheRead);
+        if ((long) cacheRead + cacheWrite > input) {
+            throw new IllegalArgumentException("Cache token details exceed input tokens");
+        }
+        return new ProxyTokenUsage(input - cacheRead - cacheWrite, output, reasoning, cacheRead, cacheWrite);
+    }
+
+    private static int cacheWriteTokens(JsonNode details) {
+        Integer standard = optionalCount(details, "cache_write_tokens");
+        Integer logos = optionalCount(details, "created_cache_tokens");
+        if (standard != null && logos != null && !standard.equals(logos)) {
+            throw new IllegalArgumentException("Conflicting cache-write token details");
+        }
+        return standard != null ? standard : logos != null ? logos : 0;
+    }
+
+    private static int count(JsonNode owner, String field) {
+        Integer value = optionalCount(owner, field);
+        return value != null ? value : 0;
+    }
+
+    private static @Nullable Integer optionalCount(JsonNode owner, String field) {
+        JsonNode value = owner.get(field);
+        if (value == null || value.isNull()) {
+            return null;
+        }
+        if (!value.isIntegralNumber() || !value.canConvertToInt() || value.intValue() < 0) {
+            throw new IllegalArgumentException("Invalid token count: " + field);
+        }
+        return value.intValue();
     }
 }

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/proxy/ProxyUsageAccumulator.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/proxy/ProxyUsageAccumulator.java
@@ -1,5 +1,6 @@
 package de.tum.cit.aet.hephaestus.agent.proxy;
 
+import de.tum.cit.aet.hephaestus.agent.job.AgentJobLlmUsageDelta;
 import de.tum.cit.aet.hephaestus.agent.job.AgentJobRepository;
 import de.tum.cit.aet.hephaestus.agent.proxy.ProxyRouting.BilledAttempt;
 import de.tum.cit.aet.hephaestus.core.runtime.RuntimeRole;
@@ -48,11 +49,12 @@ public class ProxyUsageAccumulator {
             int rows = agentJobRepository.accumulateLlmUsage(
                     jobId,
                     attempt.number(),
-                    usage.billableInputTokens(),
-                    usage.outputTokens(),
-                    usage.reasoningTokens(),
-                    usage.cacheReadTokens(),
-                    usage.cacheWriteTokens());
+                    new AgentJobLlmUsageDelta(
+                            usage.billableInputTokens(),
+                            usage.outputTokens(),
+                            usage.reasoningTokens(),
+                            usage.cacheReadTokens(),
+                            usage.cacheWriteTokens()));
             if (rows == 0) {
                 recordSuperseded(attempt);
             }

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/proxy/ProxyUsageAccumulator.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/proxy/ProxyUsageAccumulator.java
@@ -51,7 +51,8 @@ public class ProxyUsageAccumulator {
                     usage.billableInputTokens(),
                     usage.outputTokens(),
                     usage.reasoningTokens(),
-                    usage.cacheReadTokens());
+                    usage.cacheReadTokens(),
+                    usage.cacheWriteTokens());
             if (rows == 0) {
                 recordSuperseded(attempt);
             }

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/usage/UsageProvenance.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/usage/UsageProvenance.java
@@ -1,20 +1,6 @@
 package de.tum.cit.aet.hephaestus.agent.usage;
 
-/**
- * Where a ledger row's token counts came from.
- *
- * <p>Two independent records of the same spend exist and neither is complete. The runner's
- * {@code usage.json} is derived by walking the agent session's surviving messages, so compaction — on
- * by default for every session — silently deletes the tokens of every call it drops. The LLM proxy
- * counts each forwarded HTTP call as it happens and never forgets one, but it does not see streamed
- * calls at all, and no OpenAI-compatible usage block it parses reports a cache write.
- *
- * <p>A row is therefore billed per bucket from whichever source saw more, and this says which that was.
- * Without it the amount on a row cannot be interpreted at all: {@link #MERGED} rows match neither
- * source's own number, and a run of {@link #PROXY} where {@link #RUNNER} is expected is the visible
- * signature of a compaction losing calls — the exact failure that made the ledger read 4× low before
- * the maximum was taken.
- */
+/** Which observation source supplied a ledger row's per-bucket maxima. */
 public enum UsageProvenance {
     /** Every non-zero bucket came from the runner's own report; the proxy saw no more than it did. */
     RUNNER,

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/mentor/ChatMessage.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/mentor/ChatMessage.java
@@ -153,6 +153,10 @@ public class ChatMessage {
     @Column(name = "llm_cache_read_tokens", nullable = false, insertable = false, updatable = false)
     private long llmCacheReadTokens;
 
+    @org.hibernate.annotations.ColumnDefault("0")
+    @Column(name = "llm_cache_write_tokens", nullable = false, insertable = false, updatable = false)
+    private long llmCacheWriteTokens;
+
     /**
      * Optimistic-lock version — Hibernate bumps it on every managed write, including the reaper's.
      * Stale-snapshot writers (reaper-vs-finalise, finalise-vs-interrupt) get

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/mentor/ChatMessageRepository.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/mentor/ChatMessageRepository.java
@@ -60,7 +60,8 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, UUID> 
                llm_total_input_tokens = llm_total_input_tokens + :input,
                llm_total_output_tokens = llm_total_output_tokens + :output,
                llm_total_reasoning_tokens = llm_total_reasoning_tokens + :reasoning,
-               llm_cache_read_tokens = llm_cache_read_tokens + :cacheRead
+               llm_cache_read_tokens = llm_cache_read_tokens + :cacheRead,
+               llm_cache_write_tokens = llm_cache_write_tokens + :cacheWrite
          WHERE id = :id
            AND status = 'in_flight'
         """, nativeQuery = true)
@@ -69,7 +70,8 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, UUID> 
             @Param("input") long input,
             @Param("output") long output,
             @Param("reasoning") long reasoning,
-            @Param("cacheRead") long cacheRead);
+            @Param("cacheRead") long cacheRead,
+            @Param("cacheWrite") long cacheWrite);
 
     /**
      * The turn's accumulated proxy usage read straight from the row rather than from a possibly stale
@@ -78,7 +80,7 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, UUID> 
      */
     @Query("SELECT new de.tum.cit.aet.hephaestus.mentor.MentorTurnLlmUsage("
             + "m.llmTotalCalls, m.llmTotalInputTokens, m.llmTotalOutputTokens, "
-            + "m.llmTotalReasoningTokens, m.llmCacheReadTokens) "
+            + "m.llmTotalReasoningTokens, m.llmCacheReadTokens, m.llmCacheWriteTokens) "
             + "FROM ChatMessage m WHERE m.id = :id")
     Optional<MentorTurnLlmUsage> findLlmUsageById(@Param("id") UUID id);
 }

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/mentor/MentorTurnLlmUsage.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/mentor/MentorTurnLlmUsage.java
@@ -5,11 +5,16 @@ package de.tum.cit.aet.hephaestus.mentor;
  * than read off a loaded entity, so it reflects every proxy call that has committed.
  */
 public record MentorTurnLlmUsage(
-        int totalCalls, long inputTokens, long outputTokens, long reasoningTokens, long cacheReadTokens) {
-    public static final MentorTurnLlmUsage NONE = new MentorTurnLlmUsage(0, 0, 0, 0, 0);
+        int totalCalls,
+        long inputTokens,
+        long outputTokens,
+        long reasoningTokens,
+        long cacheReadTokens,
+        long cacheWriteTokens) {
+    public static final MentorTurnLlmUsage NONE = new MentorTurnLlmUsage(0, 0, 0, 0, 0, 0);
 
     /** True when at least one proxied call was recorded — i.e. there is real spend to bill. */
     public boolean hasBillableUsage() {
-        return totalCalls > 0 && (inputTokens > 0 || outputTokens > 0 || cacheReadTokens > 0);
+        return totalCalls > 0 && (inputTokens > 0 || outputTokens > 0 || cacheReadTokens > 0 || cacheWriteTokens > 0);
     }
 }

--- a/server/application/src/main/resources/db/changelog/1788356611818_changelog.xml
+++ b/server/application/src/main/resources/db/changelog/1788356611818_changelog.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+    <changeSet id="1788356611818-1" author="hephaestus">
+        <preConditions onFail="HALT">
+            <not><columnExists tableName="chat_message" columnName="llm_cache_write_tokens"/></not>
+        </preConditions>
+        <comment>Record cache-write usage for mentor turns that end before the runner reports totals.</comment>
+        <addColumn tableName="chat_message">
+            <column defaultValueNumeric="0" name="llm_cache_write_tokens" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+        <rollback><dropColumn tableName="chat_message" columnName="llm_cache_write_tokens"/></rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/server/application/src/main/resources/db/master.xml
+++ b/server/application/src/main/resources/db/master.xml
@@ -102,4 +102,5 @@
     <include file="./changelog/1788095708139_changelog.xml" relativeToChangelogFile="true"/>
     <include file="./changelog/1788071342079_changelog.xml" relativeToChangelogFile="true"/>
     <include file="./changelog/1788330977174_changelog.xml" relativeToChangelogFile="true"/>
+    <include file="./changelog/1788356611818_changelog.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/job/TerminalUsageTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/job/TerminalUsageTest.java
@@ -75,15 +75,13 @@ class TerminalUsageTest extends BaseUnitTest {
         assertThat(usage.provenance()).isEqualTo(UsageProvenance.MERGED);
     }
 
-    // The proxy never accumulates a cache write, so a maximum against it must not read the missing
-    // column as a zero that beats the only source that has the number.
     @Test
-    @DisplayName("cache writes survive the maximum even though the proxy never counts them")
-    void cacheWritesSurviveTheMaximum() {
+    @DisplayName("cache writes use the larger observation like every other bucket")
+    void cacheWritesUseTheLargerObservation() {
         TerminalUsage usage = TerminalUsage.resolve(
-                new LlmUsage("m", 100, 200, 0, 0, 12_345, 0.0, 2), new AgentJobLlmUsage(9, 8_000, 900, 0, 0, 0));
+                new LlmUsage("m", 100, 200, 0, 0, 12_345, 0.0, 2), new AgentJobLlmUsage(9, 8_000, 900, 0, 0, 20_000));
 
-        assertThat(usage.cacheWriteTokens()).isEqualTo(12_345);
+        assertThat(usage.cacheWriteTokens()).isEqualTo(20_000);
     }
 
     // Neither source double-counts within itself, so no bucket of the maximum can exceed what was really
@@ -92,7 +90,7 @@ class TerminalUsageTest extends BaseUnitTest {
     @DisplayName("no bucket is ever billed above the larger of the two records")
     void neverBillsAboveEitherRecord() {
         LlmUsage runnerUsage = new LlmUsage("m", 100, 4_000, 7, 50, 900, 0.0, 3);
-        AgentJobLlmUsage proxy = new AgentJobLlmUsage(9, 8_000, 200, 11, 20, 0);
+        AgentJobLlmUsage proxy = new AgentJobLlmUsage(9, 8_000, 200, 11, 20, 1_000);
 
         TerminalUsage usage = TerminalUsage.resolve(runnerUsage, proxy);
 
@@ -100,7 +98,7 @@ class TerminalUsageTest extends BaseUnitTest {
         assertThat(usage.outputTokens()).isEqualTo(Math.max(4_000, 200));
         assertThat(usage.reasoningTokens()).isEqualTo(Math.max(7, 11));
         assertThat(usage.cacheReadTokens()).isEqualTo(Math.max(50, 20));
-        assertThat(usage.cacheWriteTokens()).isEqualTo(Math.max(900, 0));
+        assertThat(usage.cacheWriteTokens()).isEqualTo(Math.max(900, 1_000));
         assertThat(usage.totalCalls()).isEqualTo(Math.max(3, 9));
     }
 

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/mentor/chat/MentorChatServiceTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/mentor/chat/MentorChatServiceTest.java
@@ -720,7 +720,7 @@ class MentorChatServiceTest extends BaseUnitTest {
                         proxyCredentialRegistry.validate(token).orElseThrow().attempt();
                 if (attempt != null) {
                     // 100k input tokens at the fixture's $10/M — a whole dollar of this turn's own spend.
-                    proxyCredentialRegistry.accumulate(attempt.sourceId(), new ProxyTokenUsage(100_000, 0, 0, 0));
+                    proxyCredentialRegistry.accumulate(attempt.sourceId(), new ProxyTokenUsage(100_000, 0, 0, 0, 0));
                 }
                 seen.set(Objects.requireNonNull(
                         proxyCredentialRegistry.validate(token).orElseThrow().attempt()));

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/mentor/chat/MentorTurnCrashBillingTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/mentor/chat/MentorTurnCrashBillingTest.java
@@ -113,7 +113,7 @@ class MentorTurnCrashBillingTest extends BaseUnitTest {
     @Test
     @DisplayName("a turn that dies before the runner reports anything is billed for the calls the proxy saw")
     void aCrashedTurnIsBilledForWhatTheProxyObserved() {
-        proxyRecorded(new MentorTurnLlmUsage(3, 6_000, 900, 50, 100));
+        proxyRecorded(new MentorTurnLlmUsage(3, 6_000, 900, 50, 100, 0));
 
         persistence.interrupt(cookie(), startedTurnWithNoRunnerReport(), new IllegalStateException("runner died"));
 

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/mentor/chat/MentorTurnPersistenceIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/mentor/chat/MentorTurnPersistenceIntegrationTest.java
@@ -619,8 +619,8 @@ class MentorTurnPersistenceIntegrationTest extends BaseIntegrationTest {
 
     private void accumulateProxyCall(UUID turnId, long input, long output, long reasoning, long cacheRead) {
         new TransactionTemplate(transactionManager)
-                .executeWithoutResult(ignored -> assertThat(
-                                chatMessageRepository.accumulateLlmUsage(turnId, input, output, reasoning, cacheRead))
+                .executeWithoutResult(ignored -> assertThat(chatMessageRepository.accumulateLlmUsage(
+                                turnId, input, output, reasoning, cacheRead, 0))
                         .isEqualTo(1));
     }
 

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/mentor/chat/MentorTurnPersistenceIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/mentor/chat/MentorTurnPersistenceIntegrationTest.java
@@ -579,8 +579,8 @@ class MentorTurnPersistenceIntegrationTest extends BaseIntegrationTest {
     @DisplayName("a turn abandoned by a crashed worker is billed for the calls the proxy recorded")
     void accountingReaper_billsACrashedTurnFromItsProxyRecordedUsage() throws Exception {
         UUID crashedTurn = persistInFlightTurn("crashed-turn");
-        accumulateProxyCall(crashedTurn, 40_000, 1_000, 250, 5_000);
-        accumulateProxyCall(crashedTurn, 60_000, 2_000, 250, 5_000);
+        accumulateProxyCall(crashedTurn, 40_000, 1_000, 250, 5_000, 1_000);
+        accumulateProxyCall(crashedTurn, 60_000, 2_000, 250, 5_000, 2_000);
         setCreatedAt(crashedTurn, Instant.now().minus(Duration.ofMinutes(200)));
 
         reaperWithAnUnsafeWindow().reap();
@@ -594,6 +594,7 @@ class MentorTurnPersistenceIntegrationTest extends BaseIntegrationTest {
         assertThat(event.getInputTokens()).isEqualTo(100_000);
         assertThat(event.getOutputTokens()).isEqualTo(3_000);
         assertThat(event.getCacheReadTokens()).isEqualTo(10_000);
+        assertThat(event.getCacheWriteTokens()).isEqualTo(3_000);
         assertThat(event.getReasoningTokens()).isEqualTo(500);
         assertThat(event.getTotalCalls()).isEqualTo(2);
         assertThat(event.getPricingState()).isEqualTo(PricingState.PRICED);
@@ -617,10 +618,11 @@ class MentorTurnPersistenceIntegrationTest extends BaseIntegrationTest {
         assertThat(event.getCostUsd()).isNull();
     }
 
-    private void accumulateProxyCall(UUID turnId, long input, long output, long reasoning, long cacheRead) {
+    private void accumulateProxyCall(
+            UUID turnId, long input, long output, long reasoning, long cacheRead, long cacheWrite) {
         new TransactionTemplate(transactionManager)
                 .executeWithoutResult(ignored -> assertThat(chatMessageRepository.accumulateLlmUsage(
-                                turnId, input, output, reasoning, cacheRead, 0))
+                                turnId, input, output, reasoning, cacheRead, cacheWrite))
                         .isEqualTo(1));
     }
 

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/proxy/LlmProxyControllerTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/proxy/LlmProxyControllerTest.java
@@ -363,11 +363,13 @@ class LlmProxyControllerTest extends BaseUnitTest {
 
         private MockWebServer upstream;
         private LlmProxyController streamingController;
+        private SimpleMeterRegistry streamingMeterRegistry;
 
         @BeforeEach
         void startUpstream() throws IOException {
             upstream = new MockWebServer();
             upstream.start();
+            streamingMeterRegistry = new SimpleMeterRegistry();
             streamingController = new LlmProxyController(
                     WebClient.builder().build(),
                     resolver,
@@ -377,7 +379,7 @@ class LlmProxyControllerTest extends BaseUnitTest {
                             budgetGate,
                             usageAccumulator,
                             mentorTurnUsageAccumulator,
-                            new SimpleMeterRegistry(),
+                            streamingMeterRegistry,
                             OBJECT_MAPPER));
         }
 
@@ -453,10 +455,6 @@ class LlmProxyControllerTest extends BaseUnitTest {
             assertThat(usage.getValue().cacheReadTokens()).isEqualTo(25);
         }
 
-        /**
-         * A stream that ends before its usage frame bills what it observed — which is nothing. Recording
-         * a zero-token call instead would put a fabricated event in the ledger.
-         */
         @Test
         @DisplayName("a stream that terminates before the usage frame records nothing")
         void aTruncatedStreamRecordsNothing() throws Exception {
@@ -467,10 +465,17 @@ class LlmProxyControllerTest extends BaseUnitTest {
             verifyNoInteractions(usageAccumulator);
         }
 
-        /**
-         * The request-side half of the fix, proven on the wire: without the flag the provider sends no
-         * usage at all and there is nothing for the tap to read.
-         */
+        @Test
+        void malformedStreamUsageIsCounted() throws Exception {
+            proxyStream("{\"usage\":{\"prompt_tokens\":1,\"prompt_tokens_details\":{\"cached_tokens\":2}}}");
+
+            assertThat(streamingMeterRegistry
+                            .counter("llm.proxy.usage.unparseable", "sourceType", "AGENT_JOB")
+                            .count())
+                    .isEqualTo(1.0);
+            verifyNoInteractions(usageAccumulator);
+        }
+
         @Test
         @DisplayName("the outgoing streaming request asks the provider to report usage")
         void theOutgoingRequestAsksForUsage() throws Exception {

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/proxy/MentorProxyCredentialRegistryTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/proxy/MentorProxyCredentialRegistryTest.java
@@ -118,12 +118,10 @@ class MentorProxyCredentialRegistryTest extends BaseUnitTest {
             assertThat(registry.bindTurn(sessionId, meter)).isTrue();
 
             // Two completed calls of 100k input tokens each, at $10 per million = $1.00 each.
-            registry.accumulate(turnId, new ProxyTokenUsage(100_000, 0, 0, 0));
-            registry.accumulate(turnId, new ProxyTokenUsage(100_000, 0, 0, 0));
+            registry.accumulate(turnId, new ProxyTokenUsage(100_000, 0, 0, 0, 0));
+            registry.accumulate(turnId, new ProxyTokenUsage(100_000, 0, 0, 0, 0));
 
             var attempt = registry.validate(token).orElseThrow().attempt();
-            org.junit.jupiter.api.Assertions.assertNotNull(attempt);
-            org.junit.jupiter.api.Assertions.assertNotNull(attempt);
             assertThat(attempt).isNotNull();
             assertThat(attempt.sourceType()).isEqualTo(LlmUsageSourceType.MENTOR_TURN);
             assertThat(attempt.sourceId()).isEqualTo(turnId);
@@ -145,7 +143,7 @@ class MentorProxyCredentialRegistryTest extends BaseUnitTest {
             registry.unbindTurn(sessionId, turnA);
             registry.bindTurn(sessionId, turnB);
 
-            boolean applied = registry.accumulate(turnA.turnId(), new ProxyTokenUsage(999, 0, 0, 0));
+            boolean applied = registry.accumulate(turnA.turnId(), new ProxyTokenUsage(999, 0, 0, 0, 0));
 
             assertThat(applied).as("the fence rejects it").isFalse();
             assertThat(turnB.observed().isEmpty()).as("turn B is untouched").isTrue();
@@ -157,7 +155,7 @@ class MentorProxyCredentialRegistryTest extends BaseUnitTest {
             String token = mint(sessionId);
             MentorTurnMeter meter = new MentorTurnMeter(UUID.randomUUID(), TEN_DOLLARS_PER_MILLION);
             registry.bindTurn(sessionId, meter);
-            registry.accumulate(meter.turnId(), new ProxyTokenUsage(50_000, 10, 0, 0));
+            registry.accumulate(meter.turnId(), new ProxyTokenUsage(50_000, 10, 0, 0, 0));
 
             registry.unbindTurn(sessionId, meter);
 
@@ -195,7 +193,7 @@ class MentorProxyCredentialRegistryTest extends BaseUnitTest {
 
             registry.bindTurn(sessionId, new MentorTurnMeter(UUID.randomUUID(), TEN_DOLLARS_PER_MILLION));
 
-            assertThat(registry.accumulate(turnA.turnId(), new ProxyTokenUsage(10, 0, 0, 0)))
+            assertThat(registry.accumulate(turnA.turnId(), new ProxyTokenUsage(10, 0, 0, 0, 0)))
                     .isFalse();
             assertThat(registry.boundTurns()).isEqualTo(1);
         }
@@ -223,7 +221,7 @@ class MentorProxyCredentialRegistryTest extends BaseUnitTest {
             registry.revoke(sessionId);
 
             assertThat(registry.boundTurns()).isZero();
-            assertThat(registry.accumulate(meter.turnId(), new ProxyTokenUsage(10, 0, 0, 0)))
+            assertThat(registry.accumulate(meter.turnId(), new ProxyTokenUsage(10, 0, 0, 0, 0)))
                     .isFalse();
         }
 
@@ -233,7 +231,7 @@ class MentorProxyCredentialRegistryTest extends BaseUnitTest {
             String token = mint(sessionId);
             MentorTurnMeter meter = new MentorTurnMeter(UUID.randomUUID(), null);
             registry.bindTurn(sessionId, meter);
-            registry.accumulate(meter.turnId(), new ProxyTokenUsage(1_000_000, 0, 0, 0));
+            registry.accumulate(meter.turnId(), new ProxyTokenUsage(1_000_000, 0, 0, 0, 0));
 
             var attempt = registry.validate(token).orElseThrow().attempt();
             org.junit.jupiter.api.Assertions.assertNotNull(attempt);

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/proxy/MentorTurnMeterCommitOrderingTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/proxy/MentorTurnMeterCommitOrderingTest.java
@@ -47,7 +47,7 @@ class MentorTurnMeterCommitOrderingTest extends BaseUnitTest {
         TransactionSynchronizationManager.initSynchronization();
         UUID turnId = UUID.randomUUID();
         ProxyTokenUsage usage = usageOf(turnId);
-        when(chatMessageRepository.accumulateLlmUsage(any(), anyLong(), anyLong(), anyLong(), anyLong()))
+        when(chatMessageRepository.accumulateLlmUsage(any(), anyLong(), anyLong(), anyLong(), anyLong(), anyLong()))
                 .thenReturn(1);
 
         accumulator.accumulate(attempt(turnId), usage);
@@ -64,7 +64,7 @@ class MentorTurnMeterCommitOrderingTest extends BaseUnitTest {
     void shouldNotMirrorASupersededWrite() {
         TransactionSynchronizationManager.initSynchronization();
         UUID turnId = UUID.randomUUID();
-        when(chatMessageRepository.accumulateLlmUsage(any(), anyLong(), anyLong(), anyLong(), anyLong()))
+        when(chatMessageRepository.accumulateLlmUsage(any(), anyLong(), anyLong(), anyLong(), anyLong(), anyLong()))
                 .thenReturn(0);
 
         accumulator.accumulate(attempt(turnId), usageOf(turnId));
@@ -80,6 +80,6 @@ class MentorTurnMeterCommitOrderingTest extends BaseUnitTest {
     }
 
     private static ProxyTokenUsage usageOf(UUID turnId) {
-        return new ProxyTokenUsage(100, 50, 10, 5);
+        return new ProxyTokenUsage(100, 50, 10, 5, 0);
     }
 }

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/proxy/MentorTurnMeterTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/proxy/MentorTurnMeterTest.java
@@ -1,0 +1,32 @@
+package de.tum.cit.aet.hephaestus.agent.proxy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import de.tum.cit.aet.hephaestus.agent.usage.FundingSource;
+import de.tum.cit.aet.hephaestus.agent.usage.LlmPriceSnapshot;
+import de.tum.cit.aet.hephaestus.agent.usage.PricingState;
+import de.tum.cit.aet.hephaestus.testconfig.BaseUnitTest;
+import java.math.BigDecimal;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class MentorTurnMeterTest extends BaseUnitTest {
+
+    @Test
+    void cacheWritesUseTheirOwnRate() {
+        var price = new LlmPriceSnapshot(
+                FundingSource.INSTANCE,
+                PricingState.PRICED,
+                1L,
+                null,
+                BigDecimal.ONE,
+                BigDecimal.ZERO,
+                BigDecimal.ZERO,
+                BigDecimal.TEN);
+        var meter = new MentorTurnMeter(UUID.randomUUID(), price);
+
+        meter.add(new ProxyTokenUsage(0, 0, 0, 0, 100_000));
+
+        assertThat(meter.spentUsd()).isEqualByComparingTo("1.00");
+    }
+}

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/proxy/MentorTurnUsageAccumulatorIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/proxy/MentorTurnUsageAccumulatorIntegrationTest.java
@@ -107,9 +107,9 @@ class MentorTurnUsageAccumulatorIntegrationTest extends AbstractWorkspaceIntegra
     void repeatedCallsAccumulateOntoTheSameRow() {
         UUID turnId = turn(ChatMessage.Status.in_flight);
 
-        accumulate(turnId, new ProxyTokenUsage(100, 40, 10, 25));
-        accumulate(turnId, new ProxyTokenUsage(200, 60, 5, 0));
-        accumulate(turnId, new ProxyTokenUsage(300, 80, 0, 0));
+        accumulate(turnId, new ProxyTokenUsage(100, 40, 10, 25, 15));
+        accumulate(turnId, new ProxyTokenUsage(200, 60, 5, 0, 0));
+        accumulate(turnId, new ProxyTokenUsage(300, 80, 0, 0, 0));
 
         MentorTurnLlmUsage usage = usageOf(turnId);
         assertThat(usage.totalCalls()).isEqualTo(3);
@@ -117,6 +117,7 @@ class MentorTurnUsageAccumulatorIntegrationTest extends AbstractWorkspaceIntegra
         assertThat(usage.outputTokens()).isEqualTo(180);
         assertThat(usage.reasoningTokens()).isEqualTo(15);
         assertThat(usage.cacheReadTokens()).isEqualTo(25);
+        assertThat(usage.cacheWriteTokens()).isEqualTo(15);
         assertThat(usage.hasBillableUsage()).isTrue();
     }
 
@@ -124,14 +125,14 @@ class MentorTurnUsageAccumulatorIntegrationTest extends AbstractWorkspaceIntegra
     @DisplayName("a call that lands after the turn ended is dropped, not added to a turn already billed")
     void aLateCallAfterTheTurnEndedIsDropped() {
         UUID turnId = turn(ChatMessage.Status.in_flight);
-        accumulate(turnId, new ProxyTokenUsage(100, 40, 0, 0));
+        accumulate(turnId, new ProxyTokenUsage(100, 40, 0, 0, 0));
 
         transactionTemplate.executeWithoutResult(tx -> {
             ChatMessage message = chatMessageRepository.findById(turnId).orElseThrow();
             message.setStatus(ChatMessage.Status.completed);
             chatMessageRepository.saveAndFlush(message);
         });
-        accumulate(turnId, new ProxyTokenUsage(999, 999, 0, 0));
+        accumulate(turnId, new ProxyTokenUsage(999, 999, 0, 0, 0));
 
         MentorTurnLlmUsage usage = usageOf(turnId);
         assertThat(usage.totalCalls()).isEqualTo(1);
@@ -156,7 +157,7 @@ class MentorTurnUsageAccumulatorIntegrationTest extends AbstractWorkspaceIntegra
         MentorTurnMeter meter = new MentorTurnMeter(inFlight, TEN_DOLLARS_PER_MILLION);
         credentials.bindTurn(sessionId, meter);
 
-        accumulate(inFlight, new ProxyTokenUsage(100_000, 0, 0, 0));
+        accumulate(inFlight, new ProxyTokenUsage(100_000, 0, 0, 0, 0));
 
         assertThat(credentials.validate(token).orElseThrow().inFlightSpendUsd()).isEqualByComparingTo("1.00");
 
@@ -165,7 +166,7 @@ class MentorTurnUsageAccumulatorIntegrationTest extends AbstractWorkspaceIntegra
             message.setStatus(ChatMessage.Status.interrupted);
             chatMessageRepository.saveAndFlush(message);
         });
-        accumulate(inFlight, new ProxyTokenUsage(100_000, 0, 0, 0));
+        accumulate(inFlight, new ProxyTokenUsage(100_000, 0, 0, 0, 0));
 
         assertThat(credentials.validate(token).orElseThrow().inFlightSpendUsd()).isEqualByComparingTo("1.00");
         assertThat(usageOf(inFlight).inputTokens()).isEqualTo(100_000);
@@ -182,7 +183,7 @@ class MentorTurnUsageAccumulatorIntegrationTest extends AbstractWorkspaceIntegra
 
         transactionTemplate.executeWithoutResult(tx -> {
             ChatMessage stale = chatMessageRepository.findById(turnId).orElseThrow();
-            accumulator.accumulate(attempt(turnId), new ProxyTokenUsage(4_242, 99, 0, 0));
+            accumulator.accumulate(attempt(turnId), new ProxyTokenUsage(4_242, 99, 0, 0, 0));
             stale.setMetadata(JsonNodeFactory.instance.objectNode().put("finishReason", "stop"));
             chatMessageRepository.saveAndFlush(stale);
         });
@@ -198,14 +199,14 @@ class MentorTurnUsageAccumulatorIntegrationTest extends AbstractWorkspaceIntegra
     @DisplayName("a failed write is swallowed, but counted so the under-billing is visible")
     void failedAccumulationIsCountedNotSilent() {
         ChatMessageRepository failing = mock(ChatMessageRepository.class);
-        when(failing.accumulateLlmUsage(any(), anyLong(), anyLong(), anyLong(), anyLong()))
+        when(failing.accumulateLlmUsage(any(), anyLong(), anyLong(), anyLong(), anyLong(), anyLong()))
                 .thenThrow(new IllegalStateException("connection reset"));
         SimpleMeterRegistry registry = new SimpleMeterRegistry();
         MentorTurnUsageAccumulator failingAccumulator =
                 new MentorTurnUsageAccumulator(failing, new MentorProxyCredentialRegistry(), registry);
 
         assertThatCode(() ->
-                        failingAccumulator.accumulate(attempt(UUID.randomUUID()), new ProxyTokenUsage(10, 1, 0, 0)))
+                        failingAccumulator.accumulate(attempt(UUID.randomUUID()), new ProxyTokenUsage(10, 1, 0, 0, 0)))
                 .doesNotThrowAnyException();
 
         assertThat(registry.counter("llm.proxy.usage.mentor.failure").count()).isEqualTo(1.0);

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/proxy/ProxyAccountingUnparseableUsageTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/proxy/ProxyAccountingUnparseableUsageTest.java
@@ -17,11 +17,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import tools.jackson.databind.ObjectMapper;
 
-/**
- * The tokens of an unreadable 2xx body are gone either way — there is nothing to parse. What matters is
- * that the loss is OBSERVABLE: without a counter, the first symptom of a gateway that starts wrapping
- * responses is a suspiciously cheap month.
- */
 class ProxyAccountingUnparseableUsageTest extends BaseUnitTest {
 
     private final ProxyBudgetGate budgetGate = mock(ProxyBudgetGate.class);
@@ -56,8 +51,6 @@ class ProxyAccountingUnparseableUsageTest extends BaseUnitTest {
     void shouldNotCountAParseableBody() {
         ProxyRouting.BilledAttempt attempt =
                 new ProxyRouting.BilledAttempt(LlmUsageSourceType.AGENT_JOB, UUID.randomUUID(), 1, BigDecimal.ZERO);
-        // Every bucket distinct and non-zero: with cache-read and reasoning left at 0 the assertion
-        // below cannot tell the correct mapping from any permutation of it.
         byte[] body = ("""
             {"usage":{"prompt_tokens":10,"completion_tokens":5,\
             "prompt_tokens_details":{"cached_tokens":4},\
@@ -71,9 +64,23 @@ class ProxyAccountingUnparseableUsageTest extends BaseUnitTest {
                         .count())
                 .as("the counter must mean 'unbilled', not 'a call happened'")
                 .isZero();
-        // Component order is (billableInput, output, reasoning, cacheRead), and the input bucket is the
-        // NON-cached remainder: 10 prompt tokens of which 4 were cache reads bills 6 at the input rate,
-        // not 10 — the intuitive (in, out, cacheRead, reasoning) reading mis-asserts and still passes.
-        verify(usageAccumulator).accumulate(attempt, new ProxyTokenUsage(6, 5, 2, 4));
+        verify(usageAccumulator).accumulate(attempt, new ProxyTokenUsage(6, 5, 2, 4, 0));
+    }
+
+    @Test
+    void shouldCountInvalidTokenTotals() {
+        ProxyRouting.BilledAttempt attempt =
+                new ProxyRouting.BilledAttempt(LlmUsageSourceType.AGENT_JOB, UUID.randomUUID(), 1, BigDecimal.ZERO);
+        byte[] body = ("""
+            {"usage":{"prompt_tokens":3,"prompt_tokens_details":{"cached_tokens":4}}}
+            """).getBytes(StandardCharsets.UTF_8);
+
+        accounting.recordUsage(attempt, body, false);
+
+        assertThat(meterRegistry
+                        .counter("llm.proxy.usage.unparseable", "sourceType", "AGENT_JOB")
+                        .count())
+                .isEqualTo(1.0);
+        verify(usageAccumulator, never()).accumulate(any(), any());
     }
 }

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/proxy/ProxyBudgetGateTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/proxy/ProxyBudgetGateTest.java
@@ -160,7 +160,7 @@ class ProxyBudgetGateTest extends BaseUnitTest {
             MentorTurnMeter meter = new MentorTurnMeter(UUID.randomUUID(), TEN_DOLLARS_PER_MILLION_INPUT);
             credentials.bindTurn(sessionId, meter);
             if (inputTokens > 0) {
-                credentials.accumulate(meter.turnId(), new ProxyTokenUsage(inputTokens, 0, 0, 0));
+                credentials.accumulate(meter.turnId(), new ProxyTokenUsage(inputTokens, 0, 0, 0, 0));
             }
             return credentials.validate(token).orElseThrow();
         }

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/proxy/ProxyStreamUsageTapTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/proxy/ProxyStreamUsageTapTest.java
@@ -53,6 +53,7 @@ class ProxyStreamUsageTapTest extends BaseUnitTest {
             assertThat(observed.cacheReadTokens()).isEqualTo(20);
             assertThat(observed.outputTokens()).isEqualTo(50);
             assertThat(observed.reasoningTokens()).isEqualTo(10);
+            assertThat(observed.cacheWriteTokens()).isZero();
         }
 
         @Test
@@ -92,6 +93,16 @@ class ProxyStreamUsageTapTest extends BaseUnitTest {
             feed(tap, "data: {\"choices\":[{\"delta\":{\"content\":\"partial answ\"}}],\"usage\":null}\n\n");
 
             assertThat(tap.observed()).isNull();
+        }
+
+        @Test
+        void marksInvalidUsage() {
+            ProxyStreamUsageTap tap = completionsTap();
+
+            feed(tap, "data: {\"usage\":{\"prompt_tokens\":1,\"prompt_tokens_details\":{\"cached_tokens\":2}}}\n");
+
+            assertThat(tap.observed()).isNull();
+            assertThat(tap.hasMalformedUsage()).isTrue();
         }
 
         @Test

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/proxy/ProxyTokenUsageTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/proxy/ProxyTokenUsageTest.java
@@ -50,6 +50,15 @@ class ProxyTokenUsageTest extends BaseUnitTest {
     }
 
     @Test
+    void rejectsIncompleteUsage() throws Exception {
+        var chat = MAPPER.readTree("{\"usage\":{\"prompt_tokens\":10}}");
+        var responses = MAPPER.readTree("{\"usage\":{\"output_tokens\":2}}");
+
+        assertThatIllegalArgumentException().isThrownBy(() -> ProxyTokenUsage.from(chat, false));
+        assertThatIllegalArgumentException().isThrownBy(() -> ProxyTokenUsage.from(responses, true));
+    }
+
+    @Test
     void missingUsageReturnsNull() throws Exception {
         assertThat(ProxyTokenUsage.from(MAPPER.readTree("{}"), false)).isNull();
     }

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/proxy/ProxyTokenUsageTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/proxy/ProxyTokenUsageTest.java
@@ -1,0 +1,56 @@
+package de.tum.cit.aet.hephaestus.agent.proxy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+import de.tum.cit.aet.hephaestus.testconfig.BaseUnitTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import tools.jackson.databind.ObjectMapper;
+
+class ProxyTokenUsageTest extends BaseUnitTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @ParameterizedTest
+    @ValueSource(strings = {"cache_write_tokens", "created_cache_tokens"})
+    void readsSupportedChatCacheWriteFields(String field) throws Exception {
+        var body = MAPPER.readTree("""
+                {"usage":{"prompt_tokens":100,"completion_tokens":2,
+                "prompt_tokens_details":{"cached_tokens":20,"%s":30}}}
+                """.formatted(field));
+
+        assertThat(ProxyTokenUsage.from(body, false)).isEqualTo(new ProxyTokenUsage(50, 2, 0, 20, 30));
+    }
+
+    @Test
+    void readsResponsesCacheWrites() throws Exception {
+        var body = MAPPER.readTree("""
+                {"usage":{"input_tokens":100,"output_tokens":2,
+                "input_tokens_details":{"cached_tokens":20,"cache_write_tokens":30}}}
+                """);
+
+        assertThat(ProxyTokenUsage.from(body, true)).isEqualTo(new ProxyTokenUsage(50, 2, 0, 20, 30));
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                "{\"prompt_tokens\":-1}",
+                "{\"prompt_tokens\":1.5}",
+                "{\"prompt_tokens\":2147483648}",
+                "{\"prompt_tokens\":10,\"prompt_tokens_details\":{\"cached_tokens\":11}}",
+                "{\"prompt_tokens\":10,\"prompt_tokens_details\":{\"cache_write_tokens\":2,\"created_cache_tokens\":3}}"
+            })
+    void rejectsInvalidUsage(String usage) throws Exception {
+        var body = MAPPER.readTree("{\"usage\":" + usage + "}");
+
+        assertThatIllegalArgumentException().isThrownBy(() -> ProxyTokenUsage.from(body, false));
+    }
+
+    @Test
+    void missingUsageReturnsNull() throws Exception {
+        assertThat(ProxyTokenUsage.from(MAPPER.readTree("{}"), false)).isNull();
+    }
+}

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/proxy/ProxyUsageAccumulatorIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/proxy/ProxyUsageAccumulatorIntegrationTest.java
@@ -214,7 +214,7 @@ class ProxyUsageAccumulatorIntegrationTest extends AbstractWorkspaceIntegrationT
     @DisplayName("a failed write is swallowed, but counted so the under-billing is visible")
     void failedAccumulationIsCountedNotSilent() {
         AgentJobRepository failing = mock(AgentJobRepository.class);
-        when(failing.accumulateLlmUsage(any(), anyInt(), anyInt(), anyInt(), anyInt(), anyInt(), anyInt()))
+        when(failing.accumulateLlmUsage(any(), anyInt(), any()))
                 .thenThrow(new IllegalStateException("connection reset"));
         SimpleMeterRegistry registry = new SimpleMeterRegistry();
         ProxyUsageAccumulator accumulator = new ProxyUsageAccumulator(failing, registry);

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/proxy/ProxyUsageAccumulatorIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/proxy/ProxyUsageAccumulatorIntegrationTest.java
@@ -130,7 +130,7 @@ class ProxyUsageAccumulatorIntegrationTest extends AbstractWorkspaceIntegrationT
     void nullJobIdIsANoOp() {
         AgentJob job = persistedJob("proxy-usage-null-target");
 
-        accumulate(null, json("{\"usage\":{\"prompt_tokens\":10}}"), false);
+        accumulate(null, json("{\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":0}}"), false);
 
         assertThat(usageOf(job).totalCalls()).isZero();
     }
@@ -189,7 +189,7 @@ class ProxyUsageAccumulatorIntegrationTest extends AbstractWorkspaceIntegrationT
         job.setLlmTotalCalls(4);
         jobRepository.saveAndFlush(job);
 
-        accumulate(job.getId(), json("{\"usage\":{\"prompt_tokens\":25}}"), false);
+        accumulate(job.getId(), json("{\"usage\":{\"prompt_tokens\":25,\"completion_tokens\":0}}"), false);
 
         AgentJobLlmUsage usage = usageOf(job);
         assertThat(usage.inputTokens()).isEqualTo(500);
@@ -222,7 +222,8 @@ class ProxyUsageAccumulatorIntegrationTest extends AbstractWorkspaceIntegrationT
         assertThatCode(() -> accumulator.accumulate(
                         new ProxyRouting.BilledAttempt(
                                 LlmUsageSourceType.AGENT_JOB, UUID.randomUUID(), 0, BigDecimal.ZERO),
-                        ProxyTokenUsage.from(json("{\"usage\":{\"prompt_tokens\":10}}"), false)))
+                        ProxyTokenUsage.from(
+                                json("{\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":0}}"), false)))
                 .doesNotThrowAnyException();
 
         assertThat(registry.counter("llm.proxy.usage.accumulate.failure").count())

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/proxy/ProxyUsageAccumulatorIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/proxy/ProxyUsageAccumulatorIntegrationTest.java
@@ -97,7 +97,7 @@ class ProxyUsageAccumulatorIntegrationTest extends AbstractWorkspaceIntegrationT
     void repeatedCallsAccumulateOntoTheSameRow() {
         AgentJob job = persistedJob("proxy-usage-adds");
         String body = "{\"usage\":{\"prompt_tokens\":30,\"completion_tokens\":10,"
-                + "\"prompt_tokens_details\":{\"cached_tokens\":5},"
+                + "\"prompt_tokens_details\":{\"cached_tokens\":5,\"cache_write_tokens\":7},"
                 + "\"completion_tokens_details\":{\"reasoning_tokens\":2}}}";
 
         accumulate(job.getId(), json(body), false);
@@ -106,8 +106,9 @@ class ProxyUsageAccumulatorIntegrationTest extends AbstractWorkspaceIntegrationT
 
         AgentJobLlmUsage usage = usageOf(job);
         assertThat(usage.totalCalls()).isEqualTo(3);
-        assertThat(usage.inputTokens()).isEqualTo(75); // 3 × (30 − 5)
+        assertThat(usage.inputTokens()).isEqualTo(54); // 3 × (30 − 5 − 7)
         assertThat(usage.cacheReadTokens()).isEqualTo(15);
+        assertThat(usage.cacheWriteTokens()).isEqualTo(21);
         assertThat(usage.outputTokens()).isEqualTo(30);
         assertThat(usage.reasoningTokens()).isEqualTo(6);
     }
@@ -213,7 +214,7 @@ class ProxyUsageAccumulatorIntegrationTest extends AbstractWorkspaceIntegrationT
     @DisplayName("a failed write is swallowed, but counted so the under-billing is visible")
     void failedAccumulationIsCountedNotSilent() {
         AgentJobRepository failing = mock(AgentJobRepository.class);
-        when(failing.accumulateLlmUsage(any(), anyInt(), anyInt(), anyInt(), anyInt(), anyInt()))
+        when(failing.accumulateLlmUsage(any(), anyInt(), anyInt(), anyInt(), anyInt(), anyInt(), anyInt()))
                 .thenThrow(new IllegalStateException("connection reset"));
         SimpleMeterRegistry registry = new SimpleMeterRegistry();
         ProxyUsageAccumulator accumulator = new ProxyUsageAccumulator(failing, registry);

--- a/webapp/src/components/admin/usage/LlmUsageBreakdownTables.test.tsx
+++ b/webapp/src/components/admin/usage/LlmUsageBreakdownTables.test.tsx
@@ -45,8 +45,8 @@ const report: WorkspaceLlmUsageReport = {
 			unpricedEventCount: 1,
 			inputTokens: 1000,
 			outputTokens: 200,
-			cacheReadTokens: 0,
-			cacheWriteTokens: 0,
+			cacheReadTokens: 600,
+			cacheWriteTokens: 50,
 			totalCalls: 12,
 			events: 10,
 		},
@@ -57,8 +57,8 @@ const report: WorkspaceLlmUsageReport = {
 			unpricedEventCount: 2,
 			inputTokens: 3000,
 			outputTokens: 400,
-			cacheReadTokens: 0,
-			cacheWriteTokens: 0,
+			cacheReadTokens: 1400,
+			cacheWriteTokens: 150,
 			totalCalls: 24,
 			events: 20,
 		},
@@ -88,9 +88,33 @@ describe("usage breakdown totals", () => {
 		render(<LlmUsageByJobTypeTable report={report} />);
 
 		const footer = totalsRowOf("AI spend by run type");
-		// Reads as: the server's two money figures, a dash where a blended average would be (two
-		// purses), then the counts this table adds up itself.
-		expect(footer.textContent).toBe("Total$4.25$1.75—34,0006003630");
+		const cells = within(footer).getAllByRole("cell");
+		expect(cells.map((cell) => cell.textContent)).toStrictEqual([
+			"Total",
+			"$4.25",
+			"$1.75",
+			"—",
+			"3",
+			"4,000",
+			"2,000",
+			"200",
+			"600",
+			"36",
+			"30",
+		]);
+	});
+
+	it("shows cache reads and writes separately", () => {
+		render(<LlmUsageByJobTypeTable report={report} />);
+
+		const table = screen.getByRole("table", { name: "AI spend by run type" });
+		within(table).getByRole("columnheader", { name: "Cache reads" });
+		within(table).getByRole("columnheader", { name: "Cache writes" });
+		const cells = within(within(table).getByRole("row", { name: /PR review/ })).getAllByRole(
+			"cell",
+		);
+		expect(cells[6]?.textContent).toBe("600");
+		expect(cells[7]?.textContent).toBe("50");
 	});
 
 	it("drops the footer for a single row rather than restating the line above it", () => {

--- a/webapp/src/components/admin/usage/LlmUsageBreakdownTables.tsx
+++ b/webapp/src/components/admin/usage/LlmUsageBreakdownTables.tsx
@@ -16,7 +16,6 @@ import { formatCostUsd, formatRateUsd } from "@/lib/money";
 import { type Fx, FxSpendLine } from "./fx";
 import { formatUsageDay, JOB_TYPE_LABELS } from "./usage-utils";
 
-/** Counts only — integers, so adding them is exact. Money never goes through here: see the footers. */
 function sumBy<T>(rows: T[], pick: (row: T) => number): number {
 	return rows.reduce((total, row) => total + pick(row), 0);
 }
@@ -29,24 +28,20 @@ const JOB_TYPE_SKELETON_COLUMNS = [
 	"w-16",
 	"w-20",
 	"w-20",
+	"w-20",
+	"w-20",
 	"w-12",
 	"w-12",
 ];
 const DAY_SKELETON_COLUMNS = ["w-16", "w-16", "w-16", "w-16", "w-12"];
 
 export interface LlmUsageByJobTypeTableProps {
-	/**
-	 * The whole report, not a bare `rows` array: re-adding the row costs in float would drift from the
-	 * exact total the server put on the same payload, which is what the budget gate enforces against.
-	 */
 	report?: WorkspaceLlmUsageReport;
-	/** Totals row only. Body cells stay USD-only — an estimate on each would cost the column width. */
 	fx?: Fx;
 }
 
 export function LlmUsageByJobTypeTable({ report, fx }: LlmUsageByJobTypeTableProps) {
 	const rows = report?.byJobType;
-	// One row earns no footer.
 	const totals =
 		report == null || rows == null || rows.length < 2
 			? null
@@ -55,6 +50,8 @@ export function LlmUsageByJobTypeTable({ report, fx }: LlmUsageByJobTypeTablePro
 					ownProvider: report.ownProviderTotalCostUsd,
 					unpriced: sumBy(rows, (row) => row.unpricedEventCount),
 					inputTokens: sumBy(rows, (row) => row.inputTokens),
+					cacheReadTokens: sumBy(rows, (row) => row.cacheReadTokens),
+					cacheWriteTokens: sumBy(rows, (row) => row.cacheWriteTokens),
 					outputTokens: sumBy(rows, (row) => row.outputTokens),
 					calls: sumBy(rows, (row) => row.totalCalls),
 					events: sumBy(rows, (row) => row.events),
@@ -79,6 +76,12 @@ export function LlmUsageByJobTypeTable({ report, fx }: LlmUsageByJobTypeTablePro
 					</TableHead>
 					<TableHead scope="col" className="text-right">
 						Input tokens
+					</TableHead>
+					<TableHead scope="col" className="text-right">
+						Cache reads
+					</TableHead>
+					<TableHead scope="col" className="text-right">
+						Cache writes
 					</TableHead>
 					<TableHead scope="col" className="text-right">
 						Output tokens
@@ -114,6 +117,12 @@ export function LlmUsageByJobTypeTable({ report, fx }: LlmUsageByJobTypeTablePro
 								{formatTokens(row.inputTokens)}
 							</TableCell>
 							<TableCell className="text-right tabular-nums">
+								{formatTokens(row.cacheReadTokens)}
+							</TableCell>
+							<TableCell className="text-right tabular-nums">
+								{formatTokens(row.cacheWriteTokens)}
+							</TableCell>
+							<TableCell className="text-right tabular-nums">
 								{formatTokens(row.outputTokens)}
 							</TableCell>
 							<TableCell className="text-right tabular-nums">
@@ -138,13 +147,18 @@ export function LlmUsageByJobTypeTable({ report, fx }: LlmUsageByJobTypeTablePro
 							<MoneyCell>{formatCostUsd(totals.ownProvider)}</MoneyCell>
 							<FxSpendLine usd={totals.ownProvider} fx={fx} />
 						</TableCell>
-						{/* No blended average: the two money streams are different money. */}
 						<TableCell className="text-right text-muted-foreground">—</TableCell>
 						<TableCell className="text-right tabular-nums">
 							{totals.unpriced.toLocaleString()}
 						</TableCell>
 						<TableCell className="text-right tabular-nums">
 							{formatTokens(totals.inputTokens)}
+						</TableCell>
+						<TableCell className="text-right tabular-nums">
+							{formatTokens(totals.cacheReadTokens)}
+						</TableCell>
+						<TableCell className="text-right tabular-nums">
+							{formatTokens(totals.cacheWriteTokens)}
 						</TableCell>
 						<TableCell className="text-right tabular-nums">
 							{formatTokens(totals.outputTokens)}
@@ -162,11 +176,6 @@ export function LlmUsageByJobTypeTable({ report, fx }: LlmUsageByJobTypeTablePro
 	);
 }
 
-/**
- * An average is a rate, not an amount spent, so it renders through `formatRateUsd`: rounding to cents
- * destroys the number this column exists to give. And no `≈` — on this page that means "converted".
- * The two money streams are never blended into one figure.
- */
 function AvgPerRun({ row }: { row: LlmUsageByJobType }) {
 	const parts = [
 		{ key: "shared", label: "shared models", total: row.instanceTotalCostUsd },
@@ -194,9 +203,7 @@ function AvgPerRun({ row }: { row: LlmUsageByJobType }) {
 }
 
 export interface LlmUsageByDayTableProps {
-	/** The whole report: the footer reads the server's exact total rather than re-adding floats. */
 	report?: WorkspaceLlmUsageReport;
-	/** Display-only conversion for the totals row; per-day cells stay USD-only. */
 	fx?: Fx;
 }
 


### PR DESCRIPTION
## What changed and why

OpenAI-compatible providers can report prompt-cache writes separately from ordinary input and cache reads. Hephaestus previously had no end-to-end cache-write bucket, so those tokens could be priced as ordinary input or omitted from mentor crash accounting and usage reports.

This change normalizes the observed OpenAI-compatible fields (`cache_write_tokens` and Logos' `created_cache_tokens`), validates provider totals at the proxy boundary, and carries cache writes through live budget enforcement, persistence, crash reconciliation, and workspace reporting. The usage table now shows cache reads and writes in separate columns so operators can understand the cost split without decoding a combined value.

## How to test

```bash
pnpm run check
pnpm --dir webapp run test:storybook
pnpm exec mvn -f server/pom.xml -pl application \
  -Dtest='ProxyTokenUsageTest,ProxyStreamUsageTapTest,ProxyAccountingUnparseableUsageTest,LlmProxyControllerTest,MentorTurnMeterTest' \
  test
```

The focused server run passed 52 tests. The webapp suite passed 1,037 tests, and the Storybook browser suite passed 1,683 tests across 279 story files.

To exercise the behavior manually, send an OpenAI-compatible response whose inclusive input total contains cache-read and cache-write details. Confirm that ordinary input excludes both cache buckets, each bucket uses its own configured rate, and the workspace usage table displays independent **Cache reads** and **Cache writes** totals.

## Release impact

[The patch changeset](https://github.com/hephaestus-build/Hephaestus/blob/logos-cached-token-cost-tracking/.changeset/accurate-cache-write-costs.md) records the user-visible accounting improvement.

The Liquibase migration adds a non-null `llm_cache_write_tokens` column with a zero default to `chat_message`; existing rows require no operator action. The migration includes a precondition and rollback, and the contributor ERD is regenerated.

## Notes for reviewers

Start with `ProxyTokenUsage`: it owns the provider boundary and guarantees that ordinary input, cache reads, and cache writes are mutually exclusive. Invalid, negative, fractional, overflowing, or contradictory totals are rejected and counted by `llm.proxy.usage.unparseable` rather than silently corrupting cost data.

The supported aliases are intentionally limited to response shapes observed from OpenAI-compatible providers. When both aliases appear, differing values are treated as malformed instead of guessing which provider field is authoritative.

## Visual evidence

**Before:** the table exposed only ordinary input and output totals.

**After:** cache reads and cache writes are distinct, accessible columns with independent totals.

![Before: usage table without cache token columns](https://github.com/user-attachments/assets/31d87c1e-f29b-455c-933c-c58258d0c3d6)

![After: usage table with separate cache read and cache write columns](https://github.com/user-attachments/assets/9335a48c-ab70-498b-8e8f-ce0f8f29949e)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Usage reporting now tracks prompt-cache writes separately from regular input and cache-read tokens.
  * Budget enforcement and cost calculations apply dedicated pricing to cache-write tokens.
  * Admin usage tables display cache-read and cache-write token totals by job type and day.

* **Bug Fixes**
  * Invalid or inconsistent usage data is now rejected and reported instead of being incorrectly recorded.
  * Streaming usage accounting preserves cache-write values from observed and fallback usage data.

* **Documentation**
  * Updated the schema documentation to include cache-write token tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->