### PR TITLE
fix(ci): re-cut a release whose version was never published

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,8 +28,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       # No release is created here — tag-images creates the draft once the evidence gate has
-      # passed. Draft releases are invisible to tokens without push access, so the resume and
-      # parent-version preconditions below still need write.
+      # passed. Draft releases are invisible to tokens without push access, and the plan turns on
+      # whether this version's release is a draft, so listing them still needs write.
       contents: write
     outputs:
       released: ${{ steps.cut.outputs.released }}
@@ -47,12 +47,16 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      # Decides whether this commit cuts a release, and creates nothing.
-      # The draft is created in tag-images, after the evidence gate, so a gate failure leaves no
-      # release behind: release images are promoted by digest and never rebuilt, so a draft cut at
-      # a commit the gate rejected can never pass, and it would then block the next version too
-      # (the parent-version precondition below). Nothing survives a failed attempt, and the same
-      # version re-cuts from a commit that carries the fix.
+      - uses: ./.github/actions/setup-node-pnpm
+        with:
+          install: "none"
+
+      # Decides whether this commit cuts a release, and creates nothing. The rule — a version with
+      # no published release is cut, from whichever commit carries it — and the four cases it
+      # decides between are documented in scripts/plan-release.ts. The draft is created in
+      # tag-images, after the evidence gate, so a gate failure leaves nothing behind: release images
+      # are promoted by digest and never rebuilt, so a draft cut at a commit the gate rejected can
+      # never pass. The same version then re-cuts from the commit that carries the fix.
       - name: Plan the release for this commit
         id: cut
         env:
@@ -61,62 +65,11 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Read the commit CI/CD built, not main's tip, which may already carry a newer version bump.
+          # The commit CI/CD built has to be one of ours; everything downstream checks it out.
           git merge-base --is-ancestor "$SHA" origin/main || {
             echo "::error::Commit $SHA is not on main"; exit 1; }
 
-          VERSION=$(git show "$SHA:package.json" | jq -r .version)
-          PARENT_VERSION=$(git show "${SHA}^:package.json" | jq -r .version)
-          TAG="v$VERSION"
-
-          # Only the Version PR merge changes the root version. Feature merges add
-          # changesets, not version bumps, so they no-op here.
-          if [ "$VERSION" = "$PARENT_VERSION" ]; then
-            echo "Version unchanged at $VERSION — no release to cut."
-            echo "released=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          # A draft can only exist here if an earlier attempt cleared the evidence gate and failed
-          # later; it is resumed rather than recreated.
-          if existing=$(gh release view "$TAG" --repo "${{ github.repository }}" --json isDraft,targetCommitish 2>/dev/null); then
-            if [ "$(jq -r .isDraft <<< "$existing")" != true ]; then
-              echo "Release $TAG is already published."
-              echo "released=false" >> "$GITHUB_OUTPUT"
-              exit 0
-            fi
-            [ "$(jq -r .targetCommitish <<< "$existing")" = "$SHA" ] || {
-              echo "::error::Draft $TAG targets a different commit"; exit 1; }
-          fi
-          echo "Cutting $TAG at $SHA (was $PARENT_VERSION)"
-
-          PREV_TAG="v$PARENT_VERSION"
-          previous=$(gh release view "$PREV_TAG" --repo "${{ github.repository }}" --json isDraft,isPrerelease 2>/dev/null) || {
-            echo "::error::Previous package version $PARENT_VERSION is not a published release"; exit 1; }
-          jq -e '.isDraft == false and .isPrerelease == false' <<< "$previous" >/dev/null || {
-            echo "::error::$PREV_TAG is not a stable published release"; exit 1; }
-
-          # The notes are assembled where the draft is created, in tag-images, from the CHANGELOG.md
-          # it checks out. Only this job has the tags to tell whether the release carries schema
-          # migrations, so that one bit travels as an output.
-          status=0
-          git diff --quiet "$PREV_TAG" "$SHA" -- server/application/src/main/resources/db/changelog/ || status=$?
-          case "$status" in
-            0) MIGRATIONS=false ;;
-            1) MIGRATIONS=true ;;
-            # Anything else is git failing, not a verdict — never stamp the warning by accident.
-            *) echo "::error::Could not diff $PREV_TAG..$SHA for schema migrations"; exit 1 ;;
-          esac
-
-          {
-            echo "released=true"
-            echo "version=$VERSION"
-            echo "major=${VERSION%%.*}"
-            MINOR="${VERSION#*.}"; echo "minor=${MINOR%%.*}"
-            echo "tag_name=$TAG"
-            echo "sha=$SHA"
-            echo "previous_version=$PARENT_VERSION"
-            echo "migrations=$MIGRATIONS"
-          } >> "$GITHUB_OUTPUT"
+          node scripts/plan-release.ts "$SHA"
 
       - name: Summary
         if: steps.cut.outputs.released == 'true'

--- a/docs/contributor/release-management.mdx
+++ b/docs/contributor/release-management.mdx
@@ -61,20 +61,28 @@ sequenceDiagram
 Release images are promoted **by digest and never rebuilt**, so a commit the evidence gate rejects
 can never pass on a retry — only a new commit can. The gate therefore runs before anything is
 created: a rejected release leaves no draft and no tag behind (a draft materialises no tag), so
-there is nothing to clean up and the version number is not consumed.
+there is nothing to clean up.
 
-Recovering is a revert and a re-cut: revert the version commit, which restores the pending
-changesets, land the fix, and let the Version PR re-cut the same version from a commit that carries
-it. The `verify-changesets` freeze rules — `MIGRATION.md` is not editable in a feature PR, pending
-changesets and migration fragments are not deletable — are lifted for a **verified revert**, which
-`scripts/verify-revert.ts` decides structurally: every commit the pull request
-adds must record `This reverts commit <sha>.`, name a commit that is already an ancestor of the
-base, and carry that commit's patch exactly reversed. Anything else leaves the rules in force.
+Recovering is fixing forward. `scripts/plan-release.ts` cuts the version `main` carries whenever
+that version has **no published release**, from whichever commit carries it, so landing the fix is
+the whole recovery: the next successful CI run on `main` re-cuts the same version from the commit
+that fixes it. Merging the next Version PR instead works just as well — a release follows the
+latest *published* release rather than the version its parent commit carried, so a version that
+never published is simply skipped. An ordinary merge decides nothing either way: it carries a
+version that is already published, which is the one and only no-op.
 
 A failure *after* the draft exists — the seeded-upgrade or supported-host gate, or publication
 itself — is the case the resume path covers: re-running the workflow at the same commit reuses the
-existing draft, regenerates the evidence, and replaces its assets. A draft that can never pass is
-deleted by hand, and the version re-cuts from the fixed commit as above.
+existing draft, regenerates the evidence, and replaces its assets. A draft pins its version to its
+commit, so a later commit refuses to re-cut over it: a draft that can never pass is deleted by
+hand, and the version then re-cuts from the fixed commit.
+
+Reverting the version commit is therefore no longer part of recovery, but the exemption that made
+it possible stands. The `verify-changesets` freeze rules — `MIGRATION.md` is not editable in a
+feature PR, pending changesets and migration fragments are not deletable — are lifted for a
+**verified revert**, which `scripts/verify-revert.ts` decides structurally: every commit the pull
+request adds must record `This reverts commit <sha>.`, name a commit that is already an ancestor of
+the base, and carry that commit's patch exactly reversed. Anything else leaves the rules in force.
 
 ## Supported-host qualification
 

--- a/scripts/ci-contract.test.ts
+++ b/scripts/ci-contract.test.ts
@@ -4,6 +4,8 @@ import { describe, test } from "node:test";
 
 import { type Document, isMap, isSeq, parseDocument, type YAMLMap } from "yaml";
 
+import { planRelease, releaseOutputs } from "./plan-release.ts";
+
 function job(source: string, name: string): string {
 	const match = source.match(
 		new RegExp(`^  ${name}:\\n([\\s\\S]*?)(?=^  [A-Za-z][\\w-]*:\\s*$|(?![\\s\\S]))`, "m"),
@@ -534,11 +536,8 @@ void describe("CI contract", () => {
 		const decide = job(source, "release");
 		const gate = job(source, "tag-images");
 		// Release images are promoted by digest and never rebuilt, so a draft cut before the gate
-		// can never pass at that commit — and it blocks the next version too, because the
-		// precondition below requires the previous version to be published.
+		// can never pass at that commit.
 		assert.doesNotMatch(decide, /gh release create/);
-		assert.match(decide, /is not a published release/);
-		assert.match(decide, /is not a stable published release/);
 		const created = gate.indexOf('gh release create "$TAG_NAME"');
 		const gated = gate.lastIndexOf("node scripts/verify-release-evidence.ts");
 		const uploaded = gate.indexOf('gh release upload "$TAG_NAME"');
@@ -549,6 +548,28 @@ void describe("CI contract", () => {
 		for (const upload of source.matchAll(/gh release upload[\s\S]*?\n\n/g)) {
 			assert.match(upload[0], /--clobber/);
 		}
+	});
+
+	void test("decides what to release in tested TypeScript, on outputs the workflow reads", async () => {
+		const source = await readFile(".github/workflows/release.yml", "utf8");
+		const decide = job(source, "release");
+		// Four branches over the release listing, one of them "cut a release on this push"; inline
+		// bash cannot be tested, and the ordinary feature merge is the case that must not regress.
+		assert.match(decide, /node scripts\/plan-release\.ts "\$SHA"/);
+		assert.doesNotMatch(decide, /PARENT_VERSION|gh release view/);
+		// Every output the workflow reads is one the planner writes, and nothing it writes is dead.
+		const plan = planRelease("cafe", "0.75.0", [
+			{ isDraft: false, isPrerelease: false, tag: "v0.74.0", targetCommitish: "main" },
+		]);
+		const read = [...source.matchAll(/steps\.cut\.outputs\.([\w-]+)/g)].map((match) => {
+			const name = match[1];
+			assert.ok(name);
+			return name;
+		});
+		assert.deepEqual(
+			[...new Set(read)].toSorted(),
+			Object.keys(releaseOutputs(plan, true)).toSorted(),
+		);
 	});
 
 	void test("exempts a verified revert from the changeset freeze rules", async () => {

--- a/scripts/plan-release.test.ts
+++ b/scripts/plan-release.test.ts
@@ -1,0 +1,186 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { after, test } from "node:test";
+
+import {
+	hasSchemaMigrations,
+	planRelease,
+	type ReleaseRef,
+	releaseOutputs,
+} from "./plan-release.ts";
+
+const SHA = "1111111111111111111111111111111111111111";
+const OTHER_SHA = "2222222222222222222222222222222222222222";
+
+const published = (tag: string): ReleaseRef => ({
+	isDraft: false,
+	isPrerelease: false,
+	tag,
+	targetCommitish: "main",
+});
+
+const draft = (tag: string, targetCommitish: string): ReleaseRef => ({
+	isDraft: true,
+	isPrerelease: false,
+	tag,
+	targetCommitish,
+});
+
+/** What main looks like today: everything up to 0.74.0 released, 0.75.0 never published. */
+const RELEASED = [published("v0.73.2"), published("v0.74.0")];
+
+void test("cuts nothing on an ordinary feature merge", () => {
+	// The non-deferrable case: every push to main carries a version that is already published, and a
+	// planner that cut one here would cut a release on every merge.
+	const plan = planRelease(SHA, "0.74.0", RELEASED);
+	assert.equal(plan.kind, "skip");
+	assert.match(plan.reason, /v0\.74\.0 is already published/);
+	assert.deepEqual(releaseOutputs(plan), { released: "false" });
+});
+
+void test("cuts the version the Version PR merge introduced", () => {
+	const plan = planRelease(SHA, "0.75.0", RELEASED);
+	assert.equal(plan.kind, "cut");
+	assert.equal(plan.previousVersion, "0.74.0");
+	assert.equal(plan.resumesDraft, false);
+	assert.deepEqual(releaseOutputs(plan, true), {
+		major: "0",
+		migrations: "true",
+		minor: "75",
+		previous_version: "0.74.0",
+		released: "true",
+		sha: SHA,
+		tag_name: "v0.75.0",
+		version: "0.75.0",
+	});
+});
+
+void test("re-cuts an unpublished version from a later commit that did not change it", () => {
+	// The wedge this exists to remove: the version commit is consumed, the fix lands on top, and the
+	// same version cuts again from the commit that carries it.
+	const plan = planRelease(OTHER_SHA, "0.75.0", RELEASED);
+	assert.equal(plan.kind, "cut");
+	assert.equal(plan.sha, OTHER_SHA);
+	assert.equal(plan.tag, "v0.75.0");
+	assert.equal(plan.previousVersion, "0.74.0");
+});
+
+void test("follows the latest published release, not the version the parent commit carried", () => {
+	// On a re-cut the parent carries the same unpublished version; comparing against it would refuse
+	// the retry. 0.75.0 having failed, 0.75.1 follows 0.74.0.
+	const plan = planRelease(SHA, "0.75.1", RELEASED);
+	assert.equal(plan.kind, "cut");
+	assert.equal(plan.previousVersion, "0.74.0");
+});
+
+void test("resumes a draft that targets this commit", () => {
+	const plan = planRelease(SHA, "0.75.0", [...RELEASED, draft("v0.75.0", SHA)]);
+	assert.equal(plan.kind, "cut");
+	assert.equal(plan.resumesDraft, true);
+	assert.equal(plan.previousVersion, "0.74.0");
+});
+
+void test("refuses a draft that targets another commit", () => {
+	const plan = planRelease(SHA, "0.75.0", [...RELEASED, draft("v0.75.0", OTHER_SHA)]);
+	assert.equal(plan.kind, "refuse");
+	assert.match(plan.reason, /delete the draft to re-cut v0\.75\.0 here/);
+});
+
+void test("cuts nothing once the release publishes, whatever it targets", () => {
+	// A re-run at the same commit after publication, and every merge after it.
+	const plan = planRelease(SHA, "0.75.0", [
+		...RELEASED,
+		{ isDraft: false, isPrerelease: false, tag: "v0.75.0", targetCommitish: OTHER_SHA },
+	]);
+	assert.equal(plan.kind, "skip");
+});
+
+void test("refuses a version that is not newer than the latest published release", () => {
+	// A rollback of package.json cannot promote X.Y and latest back onto older code.
+	const plan = planRelease(SHA, "0.73.5", RELEASED);
+	assert.equal(plan.kind, "refuse");
+	assert.match(plan.reason, /not newer than the latest published release v0\.74\.0/);
+});
+
+void test("refuses when nothing published exists to follow", () => {
+	const plan = planRelease(SHA, "0.75.0", [draft("v0.75.0", SHA)]);
+	assert.equal(plan.kind, "refuse");
+	assert.match(plan.reason, /no published release to follow/);
+});
+
+void test("refuses a version that is not a released version shape", () => {
+	const plan = planRelease(SHA, "0.75.0-rc.1", RELEASED);
+	assert.equal(plan.kind, "refuse");
+	assert.match(plan.reason, /is not major\.minor\.patch/);
+});
+
+void test("ignores prereleases and drafts when picking the release to follow", () => {
+	const plan = planRelease(SHA, "0.75.0", [
+		published("v0.74.0"),
+		{ isDraft: false, isPrerelease: true, tag: "v0.74.1-rc.1", targetCommitish: "main" },
+		draft("v0.74.2", "main"),
+		published("not-a-version"),
+	]);
+	assert.equal(plan.kind, "cut");
+	assert.equal(plan.previousVersion, "0.74.0");
+});
+
+void test("orders the published releases by version, not by listing order", () => {
+	const plan = planRelease(SHA, "0.75.0", [
+		published("v0.9.1"),
+		published("v0.74.0"),
+		published("v0.10.6"),
+	]);
+	assert.equal(plan.kind, "cut");
+	assert.equal(plan.previousVersion, "0.74.0");
+});
+
+const repositories: string[] = [];
+
+after(() => {
+	for (const repo of repositories) rmSync(repo, { recursive: true, force: true });
+});
+
+void test("reads schema migrations from the diff between the two releases", async () => {
+	const repo = mkdtempSync(join(tmpdir(), "plan-release-"));
+	repositories.push(repo);
+	const git = (...args: string[]): string =>
+		execFileSync("git", args, {
+			cwd: repo,
+			encoding: "utf8",
+			env: Object.fromEntries(
+				Object.entries(process.env).filter(([key]) => !key.startsWith("GIT_")),
+			),
+			stdio: ["ignore", "pipe", "pipe"],
+		}).trim();
+	const changelog = "server/application/src/main/resources/db/changelog";
+	git("init", "--quiet", "--initial-branch=main");
+	git("config", "user.email", "test@example.invalid");
+	git("config", "user.name", "Test");
+	mkdirSync(join(repo, changelog), { recursive: true });
+	writeFileSync(join(repo, changelog, "master.xml"), "<databaseChangeLog/>\n");
+	git("add", "-A");
+	git("commit", "--quiet", "-m", "release");
+	git("tag", "v0.74.0");
+	writeFileSync(join(repo, "README.md"), "# Nothing schema-shaped\n");
+	git("add", "-A");
+	git("commit", "--quiet", "-m", "docs");
+	// A git hook exports GIT_DIR at the repository being pushed. Leaking it here would read that
+	// repository's history instead of this one's, and git fails outright when it names nothing.
+	process.env.GIT_DIR = join(repo, "not-a-git-directory");
+	try {
+		assert.equal(await hasSchemaMigrations("v0.74.0", "HEAD", repo), false);
+	} finally {
+		delete process.env.GIT_DIR;
+	}
+
+	writeFileSync(join(repo, changelog, "0.75.0.xml"), "<databaseChangeLog/>\n");
+	git("add", "-A");
+	git("commit", "--quiet", "-m", "feat: a migration");
+	assert.equal(await hasSchemaMigrations("v0.74.0", "HEAD", repo), true);
+	// A git failure is an error, never a verdict: neither true nor false is stamped by accident.
+	await assert.rejects(hasSchemaMigrations("v0.99.0", "HEAD", repo));
+});

--- a/scripts/plan-release.ts
+++ b/scripts/plan-release.ts
@@ -1,0 +1,243 @@
+/**
+ * Decides whether a commit on `main` cuts a release, and which release it follows.
+ *
+ * The question is *does the version on `main` have a published release yet*, not *did this commit
+ * change the version*. A release that fails leaves the version consumed — the Version PR is merged
+ * and the changesets it folded in are gone — so a decision keyed on the version commit can only be
+ * retried by reverting that commit, which the changeset freeze rules block by construction and which
+ * needed an administrator bypass all three times it was done (issues #1686, #1691, #1701). Keyed on
+ * the version, the same release re-cuts from the next commit that carries the fix, which is how
+ * everything else here recovers.
+ *
+ * That leaves four cases, in this order:
+ *
+ *   1. the version's release is published — the ordinary feature merge, and the only no-op;
+ *   2. a draft of it targets another commit — refused, because resuming it would publish that
+ *      commit's images under this tag; the operator deletes the draft to re-cut here;
+ *   3. a draft of it targets this commit — cut, resuming the draft an attempt left behind;
+ *   4. no release of it exists — cut, whether or not this commit changed the version.
+ *
+ * The precondition that a release must follow a published one compares against the latest published
+ * release rather than the parent commit's version: on a re-cut the parent carries the same
+ * unpublished version, and a parent comparison would refuse the very retry this exists to allow. It
+ * is also what keeps the promotion of `X.Y`, `latest` and the staging deploy moving forward — a
+ * version that is not newer than the latest published release is refused rather than cut.
+ */
+import { appendFile } from "node:fs/promises";
+
+import { asRecord, asString, parseJson } from "./lib/json.ts";
+import { output } from "./lib/process.ts";
+
+/** Only a stable version counts; `0.9.0-rc.4` and friends are not part of the released line. */
+const RELEASE_VERSION = /^(\d+)\.(\d+)\.(\d+)$/;
+
+const MIGRATION_PATH = "server/application/src/main/resources/db/changelog/";
+
+/**
+ * Git hooks export `GIT_DIR` and `GIT_INDEX_FILE`, which would point every git command below at
+ * whichever repository invoked the hook instead of at the checkout being planned.
+ */
+const withoutGitEnvironment = (): Record<string, undefined> =>
+	Object.fromEntries(
+		Object.keys(process.env)
+			.filter((key) => key.startsWith("GIT_"))
+			.map((key) => [key, undefined]),
+	);
+
+export interface ReleaseRef {
+	readonly isDraft: boolean;
+	readonly isPrerelease: boolean;
+	readonly tag: string;
+	/** The commit a draft was targeted at; a branch name for a release published from one. */
+	readonly targetCommitish: string;
+}
+
+export interface ReleaseCut {
+	readonly kind: "cut";
+	readonly major: number;
+	readonly minor: number;
+	/** The latest published release, which the upgrade gate seeds from. */
+	readonly previousVersion: string;
+	/** A draft left by an attempt that cleared the evidence gate at this same commit. */
+	readonly resumesDraft: boolean;
+	readonly sha: string;
+	readonly tag: string;
+	readonly version: string;
+}
+
+export type ReleasePlan =
+	| ReleaseCut
+	| { readonly kind: "refuse"; readonly reason: string }
+	| { readonly kind: "skip"; readonly reason: string };
+
+interface Version {
+	readonly major: number;
+	readonly minor: number;
+	readonly patch: number;
+}
+
+const parseVersion = (value: string): Version | undefined => {
+	const match = RELEASE_VERSION.exec(value);
+	if (!match) return undefined;
+	return { major: Number(match[1]), minor: Number(match[2]), patch: Number(match[3]) };
+};
+
+const compareVersions = (left: Version, right: Version): number =>
+	left.major - right.major || left.minor - right.minor || left.patch - right.patch;
+
+const formatVersion = (version: Version): string =>
+	`${version.major}.${version.minor}.${version.patch}`;
+
+/** The highest published stable release: the one a new release follows and upgrades from. */
+const latestPublished = (releases: readonly ReleaseRef[]): Version | undefined => {
+	let latest: Version | undefined;
+	for (const release of releases) {
+		if (release.isDraft || release.isPrerelease || !release.tag.startsWith("v")) continue;
+		const version = parseVersion(release.tag.slice(1));
+		if (version && (!latest || compareVersions(version, latest) > 0)) latest = version;
+	}
+	return latest;
+};
+
+export function planRelease(
+	sha: string,
+	version: string,
+	releases: readonly ReleaseRef[],
+): ReleasePlan {
+	const parsed = parseVersion(version);
+	if (!parsed) {
+		return { kind: "refuse", reason: `package version "${version}" is not major.minor.patch` };
+	}
+	const tag = `v${version}`;
+	const existing = releases.find((release) => release.tag === tag);
+
+	// The ordinary case and the only no-op: a feature merge carries a version published long ago, as
+	// does a re-run of a workflow that already finished.
+	if (existing && !existing.isDraft) return { kind: "skip", reason: `${tag} is already published` };
+
+	// A draft exists only where an earlier attempt cleared the evidence gate and failed after it.
+	if (existing && existing.targetCommitish !== sha) {
+		return {
+			kind: "refuse",
+			reason: `draft ${tag} targets ${existing.targetCommitish}, not ${sha}; delete the draft to re-cut ${tag} here`,
+		};
+	}
+
+	const previous = latestPublished(releases);
+	if (!previous) return { kind: "refuse", reason: `${tag} has no published release to follow` };
+	if (compareVersions(parsed, previous) <= 0) {
+		return {
+			kind: "refuse",
+			reason: `${tag} is not newer than the latest published release v${formatVersion(previous)}`,
+		};
+	}
+
+	return {
+		kind: "cut",
+		major: parsed.major,
+		minor: parsed.minor,
+		previousVersion: formatVersion(previous),
+		resumesDraft: existing !== undefined,
+		sha,
+		tag,
+		version,
+	};
+}
+
+/**
+ * The step outputs the rest of `release.yml` reads. A plan that cuts nothing writes only `released`,
+ * which is what every downstream job is gated on.
+ */
+export function releaseOutputs(plan: ReleasePlan, migrations = false): Record<string, string> {
+	if (plan.kind !== "cut") return { released: "false" };
+	return {
+		major: String(plan.major),
+		migrations: String(migrations),
+		minor: String(plan.minor),
+		previous_version: plan.previousVersion,
+		released: "true",
+		sha: plan.sha,
+		tag_name: plan.tag,
+		version: plan.version,
+	};
+}
+
+/** Every release, drafts included — which the listing carries only for a token with push access. */
+async function listReleases(repository: string): Promise<ReleaseRef[]> {
+	const listed = await output("gh", [
+		"api",
+		"--paginate",
+		`repos/${repository}/releases?per_page=100`,
+		// Projected rather than slurped whole: the release bodies are the changelog, and the full
+		// listing already outgrows the default subprocess buffer.
+		"--jq",
+		".[] | {tag: .tag_name, draft: .draft, prerelease: .prerelease, commitish: .target_commitish}",
+	]);
+	return listed
+		.split("\n")
+		.filter((line) => line.trim() !== "")
+		.map((line, index) => {
+			const release = asRecord(parseJson(line), `gh api releases[${index}]`);
+			return {
+				isDraft: release.draft === true,
+				isPrerelease: release.prerelease === true,
+				tag: asString(release.tag, `gh api releases[${index}].tag_name`),
+				targetCommitish: asString(release.commitish, `gh api releases[${index}].target_commitish`),
+			};
+		});
+}
+
+/**
+ * Whether the release carries schema migrations, which the notes warn about. `--name-only` reports
+ * the difference on success, so a git failure is an error here rather than a verdict — the warning
+ * is never stamped, or omitted, by accident.
+ */
+export async function hasSchemaMigrations(
+	from: string,
+	to: string,
+	cwd?: string,
+): Promise<boolean> {
+	const changed = await output("git", ["diff", "--name-only", from, to, "--", MIGRATION_PATH], {
+		cwd,
+		env: withoutGitEnvironment(),
+	});
+	return changed.trim() !== "";
+}
+
+if (import.meta.main) {
+	const [sha] = process.argv.slice(2);
+	const repository = process.env.GITHUB_REPOSITORY;
+	if (!sha || !repository) {
+		console.log("::error::usage: GITHUB_REPOSITORY=<owner/repo> plan-release.ts <sha>");
+		process.exitCode = 1;
+	} else {
+		// The version at the commit CI/CD built, not main's tip, which may carry a newer one.
+		const manifest = asRecord(
+			parseJson(
+				await output("git", ["show", `${sha}:package.json`], { env: withoutGitEnvironment() }),
+			),
+			`${sha}:package.json`,
+		);
+		const plan = planRelease(
+			sha,
+			asString(manifest.version, `${sha}:package.json version`),
+			await listReleases(repository),
+		);
+		if (plan.kind === "refuse") {
+			console.log(`::error::${plan.reason}`);
+			process.exitCode = 1;
+		} else {
+			const migrations =
+				plan.kind === "cut" && (await hasSchemaMigrations(`v${plan.previousVersion}`, sha));
+			console.log(
+				plan.kind === "cut"
+					? `Cutting ${plan.tag} at ${sha} after v${plan.previousVersion}${plan.resumesDraft ? ", resuming its draft" : ""}`
+					: `${plan.reason} — no release to cut.`,
+			);
+			const outputs = Object.entries(releaseOutputs(plan, migrations))
+				.map(([name, value]) => `${name}=${value}\n`)
+				.join("");
+			if (process.env.GITHUB_OUTPUT) await appendFile(process.env.GITHUB_OUTPUT, outputs);
+		}
+	}
+}


### PR DESCRIPTION
## What changed and why

A release that fails consumes its version. `release.yml` cut a release only when the version
changed *at that exact commit*, so after the v0.75.0 attempt failed at the evidence gate, every fix
that lands carries an unchanged version and cuts nothing — and 0.75.1 could not help either, because
the precondition required the previous version to be a *published* release. The only way out was
reverting the version commit, which the changeset freeze rules block by construction and which has
needed an administrator bypass three times (#1686, #1691, #1701).

The decision now asks whether the version `main` carries has a **published release**, from whichever
commit carries it, so a failed release is retried by the next push — fix forward, like everything
else here. Four cases, in this order:

1. **published** — skip. Every ordinary feature merge lands here, and so does a re-run after the
   release publishes. This is the only no-op.
2. **a draft targets another commit** — refuse, and say to delete the draft. Resuming it would
   publish that commit's images under this tag.
3. **a draft targets this commit** — cut, resuming the draft the earlier attempt left.
4. **no release** — cut, whether or not this commit changed the version.

The precondition that a release follows a published one now compares against the **latest published
release**, not the parent commit's version: on a re-cut the parent carries the same unpublished
version and a parent comparison would refuse the retry it exists to allow. It also refuses a version
that is not newer than the latest published release, so no rollback of `package.json` can promote
`X.Y` and `latest` back onto older code. `previous_version` — what the seeded-upgrade gate upgrades
from — is that latest published release, so a version that never published is simply skipped over.

That is four branches over a release listing, which inline bash cannot test, so the decision moved
into `scripts/plan-release.ts` behind a pure `planRelease(sha, version, releases)`. The workflow
step keeps only the guard that the commit is on `main` and calls the script; the step's outputs are
unchanged, so no downstream job moved. `scripts/plan-release.test.ts` covers all four cases plus the
version ordering, and `scripts/ci-contract.test.ts` now asserts that every `steps.cut.outputs.*` the
workflow reads is exactly what the planner writes.

Fixes #1742

## How to test

- `node --test scripts/plan-release.test.ts scripts/ci-contract.test.ts`
- `pnpm run format` then `pnpm run check` — both pass.
- Read-only dry run against this repository, which is in exactly the wedged state:
  - main's tip `ab2348dfe` (0.75.0, never published) → `Cutting v0.75.0 at ab2348dfe after v0.74.0`,
    `released=true migrations=true previous_version=0.74.0`. The old logic cut nothing here.
  - the feature merge before it `239b63f45` (0.74.0, published) → `v0.74.0 is already published — no
    release to cut.`, `released=false`.

## Release impact

No changeset: `verify-changesets` scopes shipped code to `server`, `webapp` and `docker`, and this
touches `.github/`, `scripts/` and `docs/` only.

## Notes for reviewers

`release.yml` cannot be rehearsed, so here is the reasoning per failure mode:

- **Ordinary feature merge.** Its version is published, so case 1 skips before anything else is
  consulted. A bug here would cut a release on every push to `main`; it is the first unit test, and
  the planner is also proved against the real listing above.
- **Re-cut after a failed release.** Case 4 cuts the same version at the fixed commit. Every push to
  `main` retries until it publishes, which is the intended trade: the full release pipeline runs on
  each of those pushes, and a persistently failing gate (say an unfixed CVE) will fail loudly on
  each one rather than going quiet.
- **Re-run at the same SHA.** Failed before the draft: cuts again identically. Failed after: case 3
  resumes the draft, as today. Already published: case 1 skips — the run is a no-op, unchanged
  behaviour.
- **Two pushes racing.** `concurrency: group: release` (no cancellation) serialises whole runs, so
  the second push plans after the first finishes: it sees either a published release (skip) or a
  draft left by a failure (refuse, naming the draft to delete). It never plans against a draft the
  first run is mid-way through creating.
- **A draft at another commit.** Kept as a hard error, per the issue; it is now reachable more often
  (any later push, not just a re-cut of a changed version), so the message says what to do.
- **Once the release publishes.** Every subsequent push sees a published version and skips, which is
  the same steady state as before this change.
- **A version out of order** — a rollback, or a hand-edited `package.json` — is refused rather than
  cut, which the old parent-version precondition only caught by accident.
- **The listing itself.** `gh api --paginate` fails the step rather than returning a short list, so a
  transient API failure can never be read as "this version has no release". Drafts are only visible
  to a token with push access, which is why the job keeps `contents: write`. The listing is
  projected to four fields per release because the full bodies are the changelog and already exceed
  the default subprocess buffer.
- **Git environment.** `plan-release.ts` strips `GIT_*` before shelling out, so a hook's `GIT_DIR`
  cannot redirect the version read or the migration diff at another repository — caught by the
  pre-push hook while writing this, and now covered by a test.
- **Migration detection** moved with it and is now read from `git diff --name-only`, which reports
  the difference on success, so a git failure is an error instead of one of the two verdicts.

The release job gains `setup-node-pnpm` with `install: "none"` (no install; the script imports only
`scripts/lib/*` and Node built-ins).

Overlaps with the in-flight #1741 work on `scripts/ci-contract.test.ts`: this adds one test and
edits three lines of the existing draft-release test, so a conflict there should be mechanical.

---

Claude Fable 5 via Claude Code.
