### PR TITLE
fix(ci): bound the release evidence subprocess capture

### DIFF
--- a/scripts/verify-release-evidence.test.ts
+++ b/scripts/verify-release-evidence.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import { describe, it } from "node:test";
 
 import {
@@ -161,6 +162,18 @@ void describe("release evidence manifest", () => {
 				),
 			/one index digest/,
 		);
+	});
+});
+
+void describe("subprocess capture", () => {
+	void it("bounds every captured subprocess above Node's 1 MiB default", () => {
+		// A cosign attestation carries the whole SPDX SBOM base64-encoded. Under the default cap the
+		// capture raises ENOBUFS, which failed a release after the images were already tagged.
+		const source = readFileSync(new URL("./verify-release-evidence.ts", import.meta.url), "utf8");
+		assert.match(source, /maxBuffer: CAPTURE_LIMIT_BYTES/);
+		const limit = /const CAPTURE_LIMIT_BYTES = (\d+) \* 1024 \* 1024;/.exec(source);
+		assert.ok(limit, "CAPTURE_LIMIT_BYTES must be declared in MiB");
+		assert.ok(Number(limit[1]) >= 64, "an SBOM attestation needs far more than the 1 MiB default");
 	});
 });
 

--- a/scripts/verify-release-evidence.ts
+++ b/scripts/verify-release-evidence.ts
@@ -182,10 +182,19 @@ export function validateManifest(
 	return { schemaVersion: 1, subjects };
 }
 
+/**
+ * Node caps a captured subprocess at 1 MiB and raises ENOBUFS past it. A `cosign verify-attestation`
+ * envelope carries the whole SPDX SBOM base64-encoded, so the webapp's exceeds that cap and failed a
+ * release mid-verification. The bound belongs here rather than at a call site: every capture in this
+ * file reads an SBOM, an attestation or an image index, and none of them has a useful size limit.
+ */
+const CAPTURE_LIMIT_BYTES = 256 * 1024 * 1024;
+
 function command(commandName: string, args: string[], capture = false): string {
 	const result = spawnSync(commandName, args, {
 		encoding: "utf8",
 		stdio: capture ? "pipe" : "inherit",
+		maxBuffer: CAPTURE_LIMIT_BYTES,
 	});
 	if (result.error) throw result.error;
 	if (result.status !== 0) {


### PR DESCRIPTION
## Problem

The v0.75.0 release failed during `Verify evidence from registry subjects`:

```
errno: -105, code: 'ENOBUFS', syscall: 'spawnSync cosign',
spawnargs: [ 'verify-attestation', '--type', 'spdxjson', ... ]
```

`readJsonFromCommand` captures through `spawnSync` with `stdio: "pipe"` and Node's **default 1 MiB `maxBuffer`**. A `cosign verify-attestation` envelope carries the whole SPDX SBOM base64-encoded, so the webapp's exceeds that cap.

This fired after the images were already tagged, in one of the two checks that are *structurally* release-only (the attestation does not exist until `cosign attest` runs during the release), so no preflight could have caught it.

## Fix

`maxBuffer` set once in the shared `command()` helper rather than at the call site — every capture in this file reads an SBOM, an attestation or an image index, and none has a useful size limit. A test pins both the wiring and the floor.

## The wider class

This is the second time the 1 MiB default has bitten: #1744 had to project `gh api` release listings to four fields because full bodies overflow it too. Several other scripts capture without a bound — `check-package-manager.ts` reads `git ls-files -z` over the whole tree, `check-affected.ts` reads diff name lists. None is release-critical, so they are **not** in this PR; they are filed separately so this one can land while a release is waiting on it.

## Verification

`node --test scripts/verify-release-evidence.test.ts` → 8/8. `pnpm run format` then `pnpm run check` both pass.

No changeset: `verify-changesets` scopes `SHIPPED_PATHS` to `server`, `webapp`, `docker`; this touches `scripts/` only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented release evidence verification from failing when subprocess output exceeds Node’s default capture limit.
  - Ensured large SBOMs, attestations, and image indexes are captured without truncation during verification.

- **Tests**
  - Added coverage confirming subprocess captures use an appropriate buffer size for large outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->