### PR TITLE
fix(scripts): complete the transparency notice in the API test harnesses

### DIFF
--- a/scripts/e2e-setup.ts
+++ b/scripts/e2e-setup.ts
@@ -207,6 +207,15 @@ async function main(): Promise<void> {
 			},
 			path,
 		);
+	// A signed-in person may not read anything else until they complete the current transparency
+	// notice, so the seeding account completes it through the endpoint the interstitial uses.
+	const consent = object(await api("GET", "/user/consent"), "consent status");
+	if (consent.completed !== true)
+		await api("PUT", "/user/consent", {
+			noticeVersion: textField(consent, "noticeVersion", "consent status"),
+			termsAccepted: true,
+			participateInResearch: false,
+		});
 	const accountId = idField(object(await api("GET", "/user"), "user"), "user");
 	const scmOrigin = config.provider === "github" ? "https://github.com" : config.serverUrl;
 	const scmHeaders: Record<string, string> =

--- a/scripts/release-upgrade-test.ts
+++ b/scripts/release-upgrade-test.ts
@@ -101,6 +101,40 @@ async function login(port: number, username: string): Promise<string> {
 	return cookie;
 }
 
+/**
+ * A signed-in person may not read anything else until they complete the current transparency
+ * notice, so the drill completes it through the endpoint the first-login interstitial uses. The
+ * notice arrived after some of the releases this runs against, and those have no consent endpoint.
+ */
+async function completeTransparencyNotice(port: number, cookie: string): Promise<void> {
+	const status = await fetch(`http://127.0.0.1:${port}/user/consent`, { headers: { cookie } });
+	if (status.status === 404) return;
+	if (!status.ok)
+		throw new Error(`Consent status returned ${status.status}: ${await status.text()}`);
+	const statusBody: unknown = await status.json();
+	if (
+		typeof statusBody !== "object" ||
+		statusBody === null ||
+		!("noticeVersion" in statusBody) ||
+		typeof statusBody.noticeVersion !== "string"
+	)
+		throw new Error("Consent status did not return the current notice version");
+	if ("completed" in statusBody && statusBody.completed === true) return;
+	const completed = await fetch(`http://127.0.0.1:${port}/user/consent`, {
+		method: "PUT",
+		headers: { "content-type": "application/json", cookie },
+		body: JSON.stringify({
+			noticeVersion: statusBody.noticeVersion,
+			termsAccepted: true,
+			participateInResearch: false,
+		}),
+	});
+	if (!completed.ok)
+		throw new Error(
+			`Completing the transparency notice returned ${completed.status}: ${await completed.text()}`,
+		);
+}
+
 async function assertCoreReads(port: number, cookie: string): Promise<void> {
 	const user = await fetch(`http://127.0.0.1:${port}/user`, { headers: { cookie } });
 	if (!user.ok) throw new Error(`Core read /user returned ${user.status}: ${await user.text()}`);
@@ -290,6 +324,7 @@ try {
 	let port = startApplication(application, previousImage);
 	await waitUntilReady(application, port);
 	const previousCookie = await login(port, "alice");
+	await completeTransparencyNotice(port, previousCookie);
 	await login(port, "root");
 	linkWorkspaceIdentity();
 	await seedWorkspace(port, previousCookie);
@@ -321,6 +356,7 @@ try {
 			`Liquibase history shrank during upgrade: before=${previousChanges}, after=${candidateChanges}`,
 		);
 	const candidateCookie = await login(port, "alice");
+	await completeTransparencyNotice(port, candidateCookie);
 	await assertCoreReads(port, candidateCookie);
 
 	console.log("Seeded previous-release upgrade passed.");


### PR DESCRIPTION
## What changed and why

`upgrade-test / upgrade` fails in the v0.75.0 release run with

```
Error: Core read /workspaces returned 428:
{"detail":"Complete the current transparency notice first","instance":"/workspaces",
 "status":428,"title":"Precondition Required"}
```

The server is right and the harness is wrong. The consent gate applies only to a request whose token
subject is an account — a person's session — and lets `GET /user`, `GET|PUT /user/consent`, logout and
refresh through; machine callers (webhook ingest, worker registration, the agent callbacks) carry no
account subject and are not gated at all. The drill signs in through `/auth/dev-login`, which mints
exactly the session the OAuth success path mints, and then does the reads a browser does. It is a
first login, and it was skipping the step every first login takes. After the upgrade, the account
seeded on v0.74.0 has no decision recorded against the new notice, which is the intended re-prompt.

So the harness completes the notice the way the interstitial does: read `GET /user/consent` for the
current version, then `PUT /user/consent` with the terms accepted and research participation
declined. Nothing about the gate changes.

`scripts/e2e-setup.ts` seeds a live instance over the same dev-login session and hits the same
gated endpoints, so it gets the same step. The browser suite already handled this — `loginAsDevAdmin`
in `webapp/e2e/fixtures.ts` walks the real interstitial — and both additions follow it in tolerating
an account that has already accepted.

The drill runs against released images as well as the candidate, so it treats a 404 from
`/user/consent` as "this release predates the notice" and a `completed` status as "already accepted"
rather than assuming either.

## How to test

Reproduced against the exact images from the failing run:

```bash
node scripts/release-upgrade-test.ts \
  ghcr.io/ls1intum/hephaestus/application-server@sha256:45a0df4115ed89b292a1db21977fe002b3d502af3b35591a9612d484b9cff7cd \
  ghcr.io/hephaestus-build/application-server@sha256:e15239825906263e62b08ff53e9f72fa0fedcb1c111c42371927eb0249ccd283 \
  ghcr.io/hephaestus-build/postgres@sha256:6f891a185fa72325e37f7a07839d6464be15f6a1b94e718cbde85539f644d359
```

With the script from `main` this fails with the 428 above at the post-upgrade read; with this change
it prints `Seeded previous-release upgrade passed.` `pnpm run format` and `pnpm run check` are green.

## Release impact

No changeset: this changes release and E2E tooling only, no shipped code and no operator-visible
behaviour. The consent gate is untouched — the point of the change is that CI now satisfies it
instead of avoiding it.

## Notes for reviewers

The interesting question is which side was wrong; the reasoning is above, and the short version is
that the drill authenticates as a person, so the gate applies to it correctly. If you disagree —
i.e. if the drill should be a machine path — the fix would belong in the harness anyway, since the
gate keys off the session type rather than the endpoint.

Model: Claude Fable 5. Harness: Claude Code.
