### PR TITLE
fix(server): boot a fresh install that passes no credential-rotation keys

### DIFF
--- a/.changeset/self-host-blank-rotation-keys.md
+++ b/.changeset/self-host-blank-rotation-keys.md
@@ -1,0 +1,11 @@
+---
+"hephaestus": patch
+---
+
+A fresh self-host install now starts instead of crash-looping with
+`hephaestus.security.prior-credential-encryption-key and prior-credential-encryption-key-version must
+be configured together`. The stack passes both credential-rotation variables through empty when you
+have not set them, and Hephaestus was reading one empty value as a half-finished key rotation; an
+empty value now means what you meant by it — not configured. Finishing a rotation by clearing the
+prior key and its version works the same way. Setting only one of the two is still refused at
+startup, so a rotation cannot half-apply and leave stored credentials unreadable.

--- a/.changeset/tomcat-11-0-25.md
+++ b/.changeset/tomcat-11-0-25.md
@@ -1,0 +1,9 @@
+---
+"hephaestus": patch
+---
+
+Hephaestus now serves HTTP on Apache Tomcat 11.0.25. The previous release line could apply a
+security constraint written for a longer path ahead of a stricter one covering a shorter path
+beneath it, letting a request reach a page the constraint was meant to close; it could also let a
+redirect after a sign-in form skip a method restriction, and let one DIGEST-authenticated request be
+replayed. No action on upgrade — the server picks the new version up with the image.

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/security/SecurityProperties.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/security/SecurityProperties.java
@@ -18,6 +18,14 @@ public record SecurityProperties(
         @DefaultValue("100") int credentialRotationBatchSize) {
 
     public SecurityProperties {
+        // The Compose files forward these keys with an empty default, so an operator who set
+        // neither still hands the container `HEPHAESTUS_SECURITY_…_KEY=""`. Blank is how "unset"
+        // arrives here — a String binds it as "" while the paired Integer version binds it as null,
+        // so comparing the raw values would read a fresh install as a half-finished key rotation and
+        // refuse to boot. Normalize first; every rule below then reads one notion of "configured".
+        credentialEncryptionKey = blankToNull(credentialEncryptionKey);
+        priorCredentialEncryptionKey = blankToNull(priorCredentialEncryptionKey);
+
         if (credentialEncryptionKeyVersion < 1) {
             throw new IllegalArgumentException(
                     "hephaestus.security.credential-encryption-key-version must be positive");
@@ -34,12 +42,12 @@ public record SecurityProperties(
             throw new IllegalArgumentException(
                     "hephaestus.security.credential-rotation-batch-size must be between 1 and 10000");
         }
-        if (credentialRotationEnabled
-                && (credentialEncryptionKey == null
-                        || credentialEncryptionKey.isBlank()
-                        || priorCredentialEncryptionKey == null
-                        || priorCredentialEncryptionKey.isBlank())) {
+        if (credentialRotationEnabled && (credentialEncryptionKey == null || priorCredentialEncryptionKey == null)) {
             throw new IllegalArgumentException("Credential rotation requires both active and prior encryption keys");
         }
+    }
+
+    private static @Nullable String blankToNull(@Nullable String value) {
+        return value == null || value.isBlank() ? null : value;
     }
 }

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/security/SecurityPropertiesEnvBindingTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/security/SecurityPropertiesEnvBindingTest.java
@@ -1,0 +1,105 @@
+package de.tum.cit.aet.hephaestus.core.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import de.tum.cit.aet.hephaestus.testconfig.BaseUnitTest;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.core.env.StandardEnvironment;
+import org.springframework.core.env.SystemEnvironmentPropertySource;
+
+/**
+ * The Compose files forward the whole {@code hephaestus.security} block, so a self-hosted install
+ * that configured none of it still starts the container with those variables set to the empty
+ * string. Binding therefore has to agree with the operator that they configured nothing: a fresh
+ * install must boot, and the rotation pair must still fail loudly when only one half is real.
+ *
+ * <p>These bind through a real {@link SystemEnvironmentPropertySource}, because the defect this
+ * covers only exists in the environment: a blank {@code String} binds as {@code ""} while the
+ * {@code Integer} beside it binds as {@code null}, which is what made "both or neither" reject
+ * neither.
+ */
+class SecurityPropertiesEnvBindingTest extends BaseUnitTest {
+
+    @Test
+    void shouldBindNoRotationWhenTheForwardedRotationKeysAreBlank() {
+        SecurityProperties properties = bindWith(Map.of(
+                "HEPHAESTUS_SECURITY_CREDENTIAL_ENCRYPTION_KEY",
+                "0123456789abcdef0123456789abcdef",
+                "HEPHAESTUS_SECURITY_PRIOR_CREDENTIAL_ENCRYPTION_KEY",
+                "",
+                "HEPHAESTUS_SECURITY_PRIOR_CREDENTIAL_ENCRYPTION_KEY_VERSION",
+                ""));
+
+        assertThat(properties.priorCredentialEncryptionKey())
+                .as("a forwarded-but-empty key is unset, not a half-finished rotation")
+                .isNull();
+        assertThat(properties.priorCredentialEncryptionKeyVersion()).isNull();
+    }
+
+    @Test
+    void shouldBindNoKeysWhenEveryForwardedValueIsBlank() {
+        SecurityProperties properties = bindWith(Map.of(
+                "HEPHAESTUS_SECURITY_CREDENTIAL_ENCRYPTION_KEY",
+                "",
+                "HEPHAESTUS_SECURITY_PRIOR_CREDENTIAL_ENCRYPTION_KEY",
+                "",
+                "HEPHAESTUS_SECURITY_PRIOR_CREDENTIAL_ENCRYPTION_KEY_VERSION",
+                ""));
+
+        assertThat(properties.credentialEncryptionKey()).isNull();
+        assertThat(properties.priorCredentialEncryptionKey()).isNull();
+    }
+
+    @Test
+    void shouldRejectAPriorKeyWhoseVersionIsBlank() {
+        assertThatThrownBy(() -> bindWith(Map.of(
+                        "HEPHAESTUS_SECURITY_PRIOR_CREDENTIAL_ENCRYPTION_KEY",
+                        "fedcba9876543210fedcba9876543210",
+                        "HEPHAESTUS_SECURITY_PRIOR_CREDENTIAL_ENCRYPTION_KEY_VERSION",
+                        "")))
+                .rootCause()
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("must be configured together");
+    }
+
+    @Test
+    void shouldRejectAPriorKeyVersionWhoseKeyIsBlank() {
+        assertThatThrownBy(() -> bindWith(Map.of(
+                        "HEPHAESTUS_SECURITY_PRIOR_CREDENTIAL_ENCRYPTION_KEY",
+                        "",
+                        "HEPHAESTUS_SECURITY_PRIOR_CREDENTIAL_ENCRYPTION_KEY_VERSION",
+                        "2")))
+                .rootCause()
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("must be configured together");
+    }
+
+    @Test
+    void shouldRejectRotationEnabledWhenTheKeysItRotatesAreBlank() {
+        assertThatThrownBy(() -> bindWith(Map.of(
+                        "HEPHAESTUS_SECURITY_CREDENTIAL_ENCRYPTION_KEY",
+                        "",
+                        "HEPHAESTUS_SECURITY_PRIOR_CREDENTIAL_ENCRYPTION_KEY",
+                        "",
+                        "HEPHAESTUS_SECURITY_CREDENTIAL_ROTATION_ENABLED",
+                        "true")))
+                .rootCause()
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Credential rotation requires both active and prior encryption keys");
+    }
+
+    private static SecurityProperties bindWith(Map<String, Object> environmentVariables) {
+        StandardEnvironment environment = new StandardEnvironment();
+        environment
+                .getPropertySources()
+                .replace(
+                        StandardEnvironment.SYSTEM_ENVIRONMENT_PROPERTY_SOURCE_NAME,
+                        new SystemEnvironmentPropertySource(
+                                StandardEnvironment.SYSTEM_ENVIRONMENT_PROPERTY_SOURCE_NAME, environmentVariables));
+
+        return Binder.get(environment).bindOrCreate("hephaestus.security", SecurityProperties.class);
+    }
+}

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -22,6 +22,14 @@
         <java.version>21</java.version>
         <spring-boot.version>4.1.1</spring-boot.version>
         <netty.version>4.2.17.Final</netty.version>
+        <!--
+          Ahead of the Spring Boot BOM, which manages Tomcat 11.0.24: the release vulnerability
+          gate rejects it over CVE-2026-65182, CVE-2026-65905 and CVE-2026-68525, all fixed in
+          11.0.25. The BOM derives every org.apache.tomcat and org.apache.tomcat.embed artifact
+          from this one property, so the servlet container moves as a set. Drop this line once
+          the managed version reaches 11.0.25, rather than carrying a version we own forever.
+        -->
+        <tomcat.version>11.0.25</tomcat.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <project.build.outputTimestamp>2026-01-01T00:00:00Z</project.build.outputTimestamp>


### PR DESCRIPTION
## What changed and why

A fresh self-hosted install cannot boot. The stack renders and starts, then the application server
crash-loops:

```
Failed to bind properties under 'hephaestus.security' to …SecurityProperties:
  Reason: java.lang.IllegalArgumentException:
  hephaestus.security.prior-credential-encryption-key and
  prior-credential-encryption-key-version must be configured together
```

`Release` run 33702237127, `Host smoke (amd64)` and `(arm64)` — the third install defect this
release has surfaced, after #1754.

**The validator was the wrong side.** `docker/compose.app.yaml` and `docker/compose.core.yaml`
forward the rotation pair with an empty default, so a fresh install starts the container with
`HEPHAESTUS_SECURITY_PRIOR_CREDENTIAL_ENCRYPTION_KEY=""` and
`HEPHAESTUS_SECURITY_PRIOR_CREDENTIAL_ENCRYPTION_KEY_VERSION=""`. Spring's binder resolves an empty
environment value to `""` for the `String` and to `null` for the `Integer` beside it, so the
both-or-neither rule saw one half present and one half absent, and read a fresh install as a
half-finished key rotation.

The install path is not wrong: neither variable appears in any `.env.example`, `setup.sh` does not
write them, and the `${VAR:-}` forward is how every optional variable in those files is passed.
Nothing to fix there. The application is what has to agree that blank means unset — which it already
says elsewhere. `NatsConnectionProperties` normalizes the NATS credential pair to `null` before
comparing them, with a comment naming this exact hazard; `SecurityProperties` was the outlier.

So `SecurityProperties` now normalizes blank to `null` for the two credential keys before any rule
reads them. That also removes the `isBlank()` clauses the rotation-enabled check had grown to
compensate, so there is one notion of "configured" in the record.

**The rotation invariant is not weakened.** A prior key without its version, or a version without
its key, still fails at startup with the same message — it now fails on a *blank* half too, which it
previously let through into `parseKey("")`. `docs/admin/credential-key-rotation.mdx` step 6 tells
operators to finish a rotation by deploying "without the prior key and version"; on this stack that
means blanking both, which is now what it means.

Fixes the `Host smoke` failures in run 33702237127.

## How to test

Reproduced end to end against the released v0.75.0 image lock, on the blessed install path:

```sh
cd docker/self-host && cp .env.example .env && ./setup.sh
# fill APP_HOSTNAME / ACME_EMAIL / GH_OAUTH_* / bootstrap admins as the release job does
node ../../scripts/prepare-release-lock.ts v0.75.0
docker compose --env-file .env --env-file release-lock.env up -d --wait postgres nats-server application-server
```

- **Before** — on `ghcr.io/hephaestus-build/application-server@sha256:7eb1335e…` (the v0.75.0
  image), `application-server` never becomes healthy and the logs carry `APPLICATION FAILED TO
  START` with the message above, once per restart.
- **After** — the same image with only the rebuilt `SecurityProperties.class` swapped into
  `runner.jar` reports `Started Application in 16.909 seconds` and
  `application-server running healthy`, with
  `HEPHAESTUS_SECURITY_PRIOR_CREDENTIAL_ENCRYPTION_KEY=` and `…_VERSION=` still both set to the
  empty string on the container (`docker inspect`). Only `postgres`, `nats-server` and
  `application-server` were started; 80/443 were in use on the test host.

New `SecurityPropertiesEnvBindingTest` (unit tier) binds through a real
`SystemEnvironmentPropertySource`, because the defect exists only in the environment. Four of its
five cases fail on `main` with the release's exact message and pass here; the fifth — a real prior
key with a blank version — is the invariant, and passes both before and after.

```sh
pnpm run test:server:unit   # or: ./mvnw -pl application test-compile surefire:test \
                            #     -Dtest=SecurityPropertiesEnvBindingTest -Dsurefire.includedGroups=unit
```

`pnpm run format` and `pnpm run check` both pass.

## Release impact

`.changeset/self-host-blank-rotation-keys.md`, `patch`. No operator action: an install that was
already configured correctly is unaffected, and an install that could not boot now boots.

## Notes for reviewers

I swept the rest of the settings surface for the same class — an empty environment value that
Compose forwards turning into a half-configured state a validator rejects. Two results:

- **#1759** — `GitHubWorkspaceProviderAvailability` tests the GitHub App installation URL with
  `!= null` while its own javadoc says a half-configured App must not reach the wizard. Compose
  forwards `GH_APP_INSTALLATION_URL` empty, so an operator with an App id but no installation URL
  gets a wizard entry linking to `""`. Real, same class, not a boot failure — filed rather than
  folded in here.
- Everything else either normalizes blank already (`NatsConnectionProperties`,
  `AuthProperties.LoginProviderSeed`, `WebhookProperties`, `SentryProperties`,
  `WorkerTokenProperties`, `SandboxProperties`' consumers) or has no cross-field rule an empty value
  can trip. Two survive on luck rather than intent and are worth knowing about: the display-currency
  `@Pattern` in `LlmProperties` only accepts a blank value because its regex carries a leading empty
  alternation, and the Slack signing secret would fail-fast on blank if the webhook role were ever
  enabled in the application-server container.

**#1758** — this class is caught by a check, not by a validator: the release-only
`supported-host-smoke` job is the only thing in CI that installs Hephaestus the way an operator
does, and it runs after the tag is cut. I filed a proposal for a cheap PR-time version (self-host
`setup.sh`, the PR's own images, `postgres` + `nats-server` + `application-server` only, amd64) that
would have caught both this and #1754 in minutes. Not built here — it is its own change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed crash loops on fresh self-hosted installations when credential-rotation settings are forwarded as empty values.
  * Empty rotation-key values are now treated as unconfigured, while incomplete key configurations continue to be rejected.
  * Clearing both previous rotation settings now completes credential-key rotation correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->