### PR TITLE
fix(docker): give the webhook receiver the release lock's agent image

### DIFF
--- a/.changeset/self-host-webhook-agent-image.md
+++ b/.changeset/self-host-webhook-agent-image.md
@@ -1,0 +1,11 @@
+---
+"hephaestus": patch
+---
+
+The webhook receiver in a self-host install now starts instead of crash-looping with
+`hephaestus.agent.image.reference must be digest-pinned`, so incoming pull request, issue and chat
+events are received again. The stack was handing the verified release lock's agent image digest to
+the API server and the worker but not to the receiver, which fell back to naming that image by tag —
+and Hephaestus refuses a tag there, because the tag can move to an image built from a different
+commit than the one you installed. Every container now reads the same digest from the lock. Nothing
+to set: reinstall or upgrade as usual.

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -276,11 +276,11 @@ GITLAB_WORKSPACE_CREATION=false
 # AGENT SANDBOX (Practice Review)
 # -----------------------------------------------------------------------------
 
-# Agent sandbox image. Left unset it follows IMAGE_TAG above on a deploy tracking main, and the
-# release's cosign-verified digest on a release deploy — so setting it is an override of both, for
-# when neither names the image you mean. A digest is immutable and therefore reproducible; never a
-# release channel, which names whatever released most recently. See docs/admin/agent-image-digests.md.
-# HEPHAESTUS_AGENT_IMAGE_REFERENCE=ghcr.io/hephaestus-build/agent-pi@sha256:<digest>
+# Agent sandbox image. Not a knob here: Compose hands every application container — the API server,
+# the worker and the webhook receiver alike — the HEPHAESTUS_IMAGE_AGENT_PI digest from the verified
+# release lock, because the server and the agent image are one runtime contract and a container that
+# disagreed about which image that is would be describing a deployment nobody is running. Naming a
+# different image means writing it into release-lock.env. See docs/admin/release-image-lock.md.
 
 # A deploy that tracks main rather than a release sets BOTH of these: there is no signed pin asset
 # for a main commit, so the fetcher must be told to skip it and the digest requirement must come off.

--- a/docker/compose.core.yaml
+++ b/docker/compose.core.yaml
@@ -89,10 +89,12 @@ services:
       HEPHAESTUS_TRUSTED_PROXIES: ${HEPHAESTUS_TRUSTED_PROXIES:-}
       # AgentImagePinGuard loads in any prod pod; set false for non-release deploys that skip the pin.
       HEPHAESTUS_AGENT_IMAGE_REQUIRE_DIGEST: ${HEPHAESTUS_AGENT_IMAGE_REQUIRE_DIGEST:-true}
-      # AgentImageReferenceGuard is deliberately not role-gated (ADR 0031), so a reference the workers
-      # cannot run crash-loops this pod too — and the override has to reach here to fix it. Valueless,
-      # as in docker/compose.app.yaml.
-      HEPHAESTUS_AGENT_IMAGE_REFERENCE:
+      # Both agent image guards are deliberately not role-gated (ADR 0031): the server and the agent
+      # image are one runtime contract, so a reference the workers cannot run has to fail this pod
+      # too rather than let it boot on a deployment the rest of the stack rejects. That makes the
+      # lock's digest a setting this pod is owed, exactly as in docker/compose.app.yaml. Unset, the
+      # reference derives from APP_VERSION — a tag, which the pin guard above refuses.
+      HEPHAESTUS_AGENT_IMAGE_REFERENCE: ${HEPHAESTUS_IMAGE_AGENT_PI:?verified release lock required}
       # thc healthcheck target: readiness (reports unhealthy while NATS/JetStream is unavailable).
       THC_PORT: "8080"
       THC_PATH: /actuator/health/readiness

--- a/scripts/check-env-roles.test.ts
+++ b/scripts/check-env-roles.test.ts
@@ -24,9 +24,15 @@ function failureAt(failures: readonly string[], index: number): string {
 	return failure;
 }
 
-/** Carries every path ROLE_SCOPES names, so a scope that goes stale fails loudly rather than here. */
+/**
+ * Carries every path ROLE_SCOPES and DEPLOYMENT_WIDE name, so a scope that goes stale fails loudly
+ * rather than here.
+ */
 const APPLICATION = `
 hephaestus:
+    agent:
+        image:
+            reference: ghcr.io/hephaestus-build/agent-pi:1.2.3
     webhook:
         secret: \${WEBHOOK_SECRET:}
         stream:
@@ -226,20 +232,22 @@ hephaestus:
 /** The lock digest, spelled as the shipped topology spells it. */
 const AGENT_DIGEST = `HEPHAESTUS_AGENT_IMAGE_REFERENCE: \${HEPHAESTUS_IMAGE_AGENT_PI:?verified release lock required}`;
 
-/** Two containers of the one image every role boots from, each given its own extra setting. */
-const applicationPair = (server: string, receiver: string): ComposeFile[] =>
-	compose(`  application-server:
+/** Two containers of the one image every role boots from, each given its own environment lines. */
+const applicationPair = (server: readonly string[], receiver: readonly string[]): ComposeFile[] => {
+	const lines = (env: readonly string[]): string => env.map((line) => `      ${line}`).join("\n");
+	return compose(`  application-server:
     image: "\${HEPHAESTUS_IMAGE_APPLICATION_SERVER:?verified release lock required}"
     environment:
       HEPHAESTUS_RUNTIME_WEBHOOK_ENABLED: "false"
-      ${server}
+${lines(server)}
   webhook-server:
     image: "\${HEPHAESTUS_IMAGE_APPLICATION_SERVER:?verified release lock required}"
     environment:
       HEPHAESTUS_RUNTIME_WEBHOOK_ENABLED: "true"
       HEPHAESTUS_WEBHOOK_STREAM_MAX_BYTES: \${HEPHAESTUS_WEBHOOK_STREAM_MAX_BYTES:-1073741824}
-      ${receiver}
+${lines(receiver)}
 `);
+};
 
 await test("application containers that spell an ungated setting differently fail", () => {
 	const { failures, applicationContainers: found } = analyse(
@@ -247,7 +255,7 @@ await test("application containers that spell an ungated setting differently fai
 		// The shape the release lock left behind: the digest on one container, a valueless passthrough
 		// on the other. Both resolve to nothing when the operator sets nothing, so only the spelling
 		// tells them apart — which is why the gate reads the value the file writes.
-		applicationPair(AGENT_DIGEST, "HEPHAESTUS_AGENT_IMAGE_REFERENCE:"),
+		applicationPair([AGENT_DIGEST], ["HEPHAESTUS_AGENT_IMAGE_REFERENCE:"]),
 	);
 
 	assert.deepEqual(found, ["compose.yaml:application-server", "compose.yaml:webhook-server"]);
@@ -256,8 +264,31 @@ await test("application containers that spell an ungated setting differently fai
 	assert.match(failureAt(failures, 0), /<nothing>/);
 });
 
+await test("an application container that omits a deployment-wide setting fails", () => {
+	// The half a comparison across only the containers that mention a key cannot see: the receiver
+	// makes no claim to disagree with, and reads application.yml's derived tag instead.
+	const { failures } = analyse(APPLICATION, applicationPair([AGENT_DIGEST], []));
+
+	assert.equal(failures.length, 1, failures.join("\n"));
+	assert.match(
+		failureAt(failures, 0),
+		/HEPHAESTUS_AGENT_IMAGE_REFERENCE binds hephaestus\.agent\.image\.reference/,
+	);
+	assert.match(
+		failureAt(failures, 0),
+		/run the application image without it:\n {4}compose\.yaml:webhook-server/,
+	);
+});
+
+await test("a deployment-wide setting no application container is given fails", () => {
+	const { failures } = analyse(APPLICATION, applicationPair([], []));
+
+	assert.equal(failures.length, 1, failures.join("\n"));
+	assert.match(failureAt(failures, 0), /no container running the application image is given it/);
+});
+
 await test("application containers agreeing on an ungated setting pass", () => {
-	const { failures } = analyse(APPLICATION, applicationPair(AGENT_DIGEST, AGENT_DIGEST));
+	const { failures } = analyse(APPLICATION, applicationPair([AGENT_DIGEST], [AGENT_DIGEST]));
 
 	assert.deepEqual(failures, []);
 });
@@ -266,10 +297,27 @@ await test("a setting named in PER_CONTAINER may differ", () => {
 	// THC_PATH is in the list: the receiver reports NATS through readiness and the others do not.
 	const { failures } = analyse(
 		APPLICATION,
-		applicationPair("THC_PATH: /actuator/health/liveness", "THC_PATH: /actuator/health/readiness"),
+		applicationPair(
+			[AGENT_DIGEST, "THC_PATH: /actuator/health/liveness"],
+			[AGENT_DIGEST, "THC_PATH: /actuator/health/readiness"],
+		),
 	);
 
 	assert.deepEqual(failures, []);
+});
+
+await test("a DEPLOYMENT_WIDE entry naming a path application.yml does not have is a failure", () => {
+	const withoutTheSetting = APPLICATION.replace(
+		"    agent:\n        image:\n            reference: ghcr.io/hephaestus-build/agent-pi:1.2.3\n",
+		"",
+	);
+
+	const { failures } = analyse(withoutTheSetting, applicationPair([AGENT_DIGEST], [AGENT_DIGEST]));
+
+	assert.ok(
+		failures.some((f) => /DEPLOYMENT_WIDE declares "hephaestus\.agent\.image\.reference"/.test(f)),
+		failures.join("\n"),
+	);
 });
 
 await test("a service running some other image is not compared against the application containers", () => {

--- a/scripts/check-env-roles.test.ts
+++ b/scripts/check-env-roles.test.ts
@@ -223,6 +223,73 @@ hephaestus:
 	assert.deepEqual([...disabled].toSorted(), ["server", "webhook"]);
 });
 
+/** The lock digest, spelled as the shipped topology spells it. */
+const AGENT_DIGEST = `HEPHAESTUS_AGENT_IMAGE_REFERENCE: \${HEPHAESTUS_IMAGE_AGENT_PI:?verified release lock required}`;
+
+/** Two containers of the one image every role boots from, each given its own extra setting. */
+const applicationPair = (server: string, receiver: string): ComposeFile[] =>
+	compose(`  application-server:
+    image: "\${HEPHAESTUS_IMAGE_APPLICATION_SERVER:?verified release lock required}"
+    environment:
+      HEPHAESTUS_RUNTIME_WEBHOOK_ENABLED: "false"
+      ${server}
+  webhook-server:
+    image: "\${HEPHAESTUS_IMAGE_APPLICATION_SERVER:?verified release lock required}"
+    environment:
+      HEPHAESTUS_RUNTIME_WEBHOOK_ENABLED: "true"
+      HEPHAESTUS_WEBHOOK_STREAM_MAX_BYTES: \${HEPHAESTUS_WEBHOOK_STREAM_MAX_BYTES:-1073741824}
+      ${receiver}
+`);
+
+await test("application containers that spell an ungated setting differently fail", () => {
+	const { failures, applicationContainers: found } = analyse(
+		APPLICATION,
+		// The shape the release lock left behind: the digest on one container, a valueless passthrough
+		// on the other. Both resolve to nothing when the operator sets nothing, so only the spelling
+		// tells them apart — which is why the gate reads the value the file writes.
+		applicationPair(AGENT_DIGEST, "HEPHAESTUS_AGENT_IMAGE_REFERENCE:"),
+	);
+
+	assert.deepEqual(found, ["compose.yaml:application-server", "compose.yaml:webhook-server"]);
+	assert.equal(failures.length, 1, failures.join("\n"));
+	assert.match(failureAt(failures, 0), /disagree on HEPHAESTUS_AGENT_IMAGE_REFERENCE/);
+	assert.match(failureAt(failures, 0), /<nothing>/);
+});
+
+await test("application containers agreeing on an ungated setting pass", () => {
+	const { failures } = analyse(APPLICATION, applicationPair(AGENT_DIGEST, AGENT_DIGEST));
+
+	assert.deepEqual(failures, []);
+});
+
+await test("a setting named in PER_CONTAINER may differ", () => {
+	// THC_PATH is in the list: the receiver reports NATS through readiness and the others do not.
+	const { failures } = analyse(
+		APPLICATION,
+		applicationPair("THC_PATH: /actuator/health/liveness", "THC_PATH: /actuator/health/readiness"),
+	);
+
+	assert.deepEqual(failures, []);
+});
+
+await test("a service running some other image is not compared against the application containers", () => {
+	const { failures, applicationContainers: found } = analyse(
+		APPLICATION,
+		compose(`  application-server:
+    image: "\${HEPHAESTUS_IMAGE_APPLICATION_SERVER:?verified release lock required}"
+    environment:
+      HEPHAESTUS_AGENT_IMAGE_REFERENCE: \${HEPHAESTUS_IMAGE_AGENT_PI:?verified release lock required}
+  webapp:
+    image: "\${HEPHAESTUS_IMAGE_WEBAPP:?verified release lock required}"
+    environment:
+      HEPHAESTUS_AGENT_IMAGE_REFERENCE: something-else
+${RECEIVER}`),
+	);
+
+	assert.deepEqual(failures, []);
+	assert.deepEqual(found, ["compose.yaml:application-server"]);
+});
+
 await test("a scope naming a path application.yml does not have is a failure", () => {
 	const { failures } = analyse("hephaestus:\n    webhook:\n        secret: x\n", compose(RECEIVER));
 
@@ -239,7 +306,7 @@ await test("the shipped topology delivers every role-scoped variable to a contai
 	);
 	// With the profile overlays, exactly as the CLI runs it. Omitting them makes this pass on a
 	// topology the real gate fails, which is the whole defect class the gate is here for.
-	const { failures } = analyse(
+	const { failures, applicationContainers } = analyse(
 		await readFile(
 			join(REPO_ROOT, "server/application/src/main/resources/application.yml"),
 			"utf8",
@@ -249,4 +316,12 @@ await test("the shipped topology delivers every role-scoped variable to a contai
 	);
 
 	assert.deepEqual(failures, []);
+	// Named rather than counted: the settings comparison only runs over containers the parse
+	// recognised as running the application image, so a renamed lock variable would otherwise retire
+	// that half of the gate by finding nothing to compare.
+	assert.deepEqual(applicationContainers, [
+		"docker/compose.app.yaml:application-server",
+		"docker/compose.app.yaml:application-worker",
+		"docker/compose.core.yaml:webhook-server",
+	]);
 });

--- a/scripts/check-env-roles.ts
+++ b/scripts/check-env-roles.ts
@@ -26,12 +26,17 @@
  *                  lock's agent image digest reached the app containers and not the webhook
  *                  receiver, which derived a tag from its own version instead and then refused to
  *                  boot on it, because the guards that read it are deliberately not role-gated.
+ *   omitted      — the same defect with the key left out rather than left blank. A container that
+ *                  never mentions a setting makes no claim to disagree with, so `DEPLOYMENT_WIDE`
+ *                  names the settings whose absence is itself the failure.
  *
- * `ROLE_SCOPES` is the only thing to extend. It is keyed on `application.yml` paths rather than on
- * whole property records because ownership is finer than a record: `hephaestus.webhook.secret` is
- * read on the server role (outbound registration) while `hephaestus.webhook.stream.*` is read on the
- * webhook role, out of the same `WebhookProperties`. A scope naming a path `application.yml` no
- * longer has fails too, so a rename cannot leave a dead entry behind that silently checks nothing.
+ * `ROLE_SCOPES` and `DEPLOYMENT_WIDE` are the two things to extend, and they are opposite claims
+ * about the same question — which containers read a setting. Both are keyed on `application.yml`
+ * paths rather than on whole property records because ownership is finer than a record:
+ * `hephaestus.webhook.secret` is read on the server role (outbound registration) while
+ * `hephaestus.webhook.stream.*` is read on the webhook role, out of the same `WebhookProperties`.
+ * An entry naming a path `application.yml` no longer has fails too, so a rename cannot leave a dead
+ * entry behind that silently checks nothing.
  *
  * Compose is read here rather than through `docker compose config`, which would be a stricter parse:
  * this gate runs in `pnpm run check` and the pre-push hook, where a Docker daemon is not a given, and
@@ -118,6 +123,42 @@ const PER_CONTAINER = new Map<string, string>([
 	["SPRING_LIQUIBASE_ENABLED", "one container owns the migration and the rest must not race it"],
 	["THC_PATH", "the receiver reports NATS through readiness; the others answer liveness"],
 ]);
+
+/**
+ * A setting every application container must be *given*, not merely agree about. These are the ones
+ * whose readers are gated on no role at all: the beans are constructed in every context, so the
+ * container that was skipped does not quietly run without the feature, it fails to boot.
+ *
+ * Declared rather than derived, and the reason is worth stating because it looks like a weakness.
+ * Nothing in Compose separates a setting the receiver must have from one it is right not to have:
+ * `GH_APP_PRIVATE_KEY` also reaches two of the three containers, and "deliver it to the third too"
+ * would be a private key shipped to a container with no use for it. Only the Java says which is
+ * which — whether the bean reading it carries a role gate — so the entry has to name that bean and
+ * be checkable by a reader against it.
+ *
+ * What is fail-closed, and needs nothing listed, is the other half: a setting more than one
+ * application container writes has to be written the same on all of them. Between the two, both
+ * shapes of the defect this exists for are covered — the container that was handed a different
+ * value, and the container that was handed none.
+ */
+interface DeploymentWideSetting {
+	readonly variable: string;
+	/** The `application.yml` path it binds. A path the file no longer has fails, as in `ROLE_SCOPES`. */
+	readonly path: string;
+	/** Named beans, so a reader can check the claim rather than take it. Quoted back in every failure. */
+	readonly why: string;
+}
+
+const DEPLOYMENT_WIDE: readonly DeploymentWideSetting[] = [
+	{
+		variable: "HEPHAESTUS_AGENT_IMAGE_REFERENCE",
+		path: "hephaestus.agent.image.reference",
+		why:
+			"AgentImageReferenceGuard and AgentImagePinGuard are plain @Components that ADR 0031 keeps " +
+			"ungated on purpose, so no pod can boot on an agent image the workers cannot run; a container " +
+			"left without the reference derives one from its own version, which is a tag, and refuses to start",
+	},
+];
 
 /** `application-<profile>.yml` turns roles off too, so a service's profiles decide as much as its env. */
 const PROFILE_YML = (profile: string): string =>
@@ -455,6 +496,34 @@ export function analyse(
 				"  No runtime role gates this setting, so every one of them reads it and they cannot both\n" +
 				"  be describing the same deployment.\n" +
 				`  Give them one value, or name ${variable} in PER_CONTAINER with the reason it differs.`,
+		);
+	}
+
+	// The disagreement above only sees containers that mention the key. A container that omits it
+	// makes no claim to disagree with, and reads the application default instead — which for the
+	// agent image is a tag derived from its own version, the exact thing the guards refuse. So an
+	// omission is a value here, not an absence.
+	for (const { variable, path, why } of DEPLOYMENT_WIDE) {
+		if (!paths.has(path)) {
+			failures.push(
+				`DEPLOYMENT_WIDE declares "${path}" (${variable}), which ${APPLICATION_YML} does not have.\n` +
+					"  Point it at wherever the setting moved, or drop the entry — as written it checks nothing.",
+			);
+			continue;
+		}
+		const missing = applicationContainers.filter(({ service }) => !service.env.has(variable));
+		if (missing.length === 0) continue;
+		const listed = missing.map(({ id }) => `    ${id}`).join("\n");
+		failures.push(
+			missing.length === applicationContainers.length
+				? `${variable} binds ${path}, and no container running the application image is given it.\n` +
+						`  ${why}.\n` +
+						"  Every one of them reads it, so the deployment has nowhere to get the value from."
+				: `${variable} binds ${path}, and these containers run the application image without it:\n${listed}\n` +
+						`  ${why}.\n` +
+						"  The setting is not gated on a runtime role, so leaving it off one container does not\n" +
+						"  scope it — that container falls back to the application default and reads a different\n" +
+						"  deployment than its siblings.",
 		);
 	}
 

--- a/scripts/check-env-roles.ts
+++ b/scripts/check-env-roles.ts
@@ -18,6 +18,15 @@
  *                  at all, so setting it in `.env` does nothing. A setting that is not meant to be
  *                  operator-tunable is written without a placeholder and is never in scope here.
  *
+ * The mirror image is a setting no role gates. Every container running the application image reads
+ * it, so the value one of them is given is a claim about the whole deployment, and two containers
+ * making different claims describe a stack that does not exist:
+ *
+ *   disagreed    — application containers spell one setting differently. That is how the release
+ *                  lock's agent image digest reached the app containers and not the webhook
+ *                  receiver, which derived a tag from its own version instead and then refused to
+ *                  boot on it, because the guards that read it are deliberately not role-gated.
+ *
  * `ROLE_SCOPES` is the only thing to extend. It is keyed on `application.yml` paths rather than on
  * whole property records because ownership is finer than a record: `hephaestus.webhook.secret` is
  * read on the server role (outbound registration) while `hephaestus.webhook.stream.*` is read on the
@@ -89,6 +98,27 @@ const ROLE_FLAGS: Record<Role, string> = {
 	webhook: "HEPHAESTUS_RUNTIME_WEBHOOK_ENABLED",
 };
 
+/**
+ * The lock variable naming the one image every role boots from. A service running it is an
+ * application container: whichever slice of the context its roles leave out, the ungated beans — and
+ * therefore every setting not listed in `ROLE_SCOPES` — are there and read on it.
+ */
+const APPLICATION_IMAGE = "HEPHAESTUS_IMAGE_APPLICATION_SERVER";
+
+/**
+ * Keys an application container is meant to spell differently from its siblings, because they are
+ * what makes it that slice of the deployment rather than another. Everything else describes the
+ * deployment, which is one thing: the roles differ, the stack they run in does not.
+ */
+const PER_CONTAINER = new Map<string, string>([
+	["SPRING_PROFILES_ACTIVE", "the profile list is how a container selects the slice it boots"],
+	[ROLE_FLAGS.server, "the role flags are the split itself"],
+	[ROLE_FLAGS.worker, "the role flags are the split itself"],
+	[ROLE_FLAGS.webhook, "the role flags are the split itself"],
+	["SPRING_LIQUIBASE_ENABLED", "one container owns the migration and the rest must not race it"],
+	["THC_PATH", "the receiver reports NATS through readiness; the others answer liveness"],
+]);
+
 /** `application-<profile>.yml` turns roles off too, so a service's profiles decide as much as its env. */
 const PROFILE_YML = (profile: string): string =>
 	`server/application/src/main/resources/application-${profile}.yml`;
@@ -135,8 +165,11 @@ const isStructural = (line: string): boolean =>
  * own answer, and the only one that is the same on every machine. `${VAR:-d}` and `${VAR-d}` fall
  * back to `d`; a bare `${VAR}` resolves to the empty string, exactly as Compose leaves it.
  */
+/** The value as the file writes it: trimmed, with the quotes YAML would have dropped anyway. */
+const unquote = (raw: string): string => raw.trim().replace(/^["']|["']$/g, "");
+
 export function composeDefault(raw: string): string {
-	const value = raw.trim().replace(/^["']|["']$/g, "");
+	const value = unquote(raw);
 	const placeholder = /^\$\{[A-Z0-9_]+(?<dash>:?-)?(?<fallback>[^}]*)\}$/.exec(value);
 	if (!placeholder) return value;
 	// The `-` is the only optional part: a placeholder without it offers no fallback at all, and
@@ -194,6 +227,14 @@ export interface ComposeService {
 	readonly name: string;
 	readonly env: Set<string>;
 	readonly flags: Map<string, string>;
+	/**
+	 * What the file writes for each key it spells itself, before interpolation. `flags` answers what
+	 * an operator who sets nothing gets, and two services can agree on that and still be handed
+	 * different values — `${VAR:?required}` and a valueless key both resolve to nothing here.
+	 */
+	readonly raw: Map<string, string>;
+	/** The `image:` line, uninterpolated, so a service can be recognised by the image it runs. */
+	image: string;
 }
 
 /**
@@ -226,7 +267,12 @@ export function readComposeServices(text: string): Map<string, ComposeService> {
 		}
 		if (top !== "services") continue;
 		if (path.length === 2) {
-			services.set(key, { name: key, env: new Set(), flags: new Map() });
+			services.set(key, { name: key, env: new Set(), flags: new Map(), raw: new Map(), image: "" });
+			continue;
+		}
+		if (path.length === 3 && key === "image" && serviceName !== undefined) {
+			const named = services.get(serviceName);
+			if (named) named.image = unquote(value);
 			continue;
 		}
 		if (path.length !== 4 || section !== "environment" || serviceName === undefined) continue;
@@ -241,6 +287,7 @@ export function readComposeServices(text: string): Map<string, ComposeService> {
 		}
 		service.env.add(key);
 		service.flags.set(key, composeDefault(value));
+		service.raw.set(key, unquote(value));
 	}
 	return services;
 }
@@ -305,6 +352,8 @@ interface DeliveredVariable {
 interface Analysis {
 	readonly failures: string[];
 	readonly delivered: ReadonlyMap<string, DeliveredVariable>;
+	/** Ids of the services running the application image, so a caller can check the set was found. */
+	readonly applicationContainers: readonly string[];
 }
 
 export function analyse(
@@ -333,6 +382,7 @@ export function analyse(
 	}
 
 	const delivered = new Map<string, DeliveredVariable>();
+	const applicationContainers: Delivery[] = [];
 	for (const [label, text] of compose) {
 		const services = readComposeServices(text);
 		if (services.size === 0) {
@@ -343,6 +393,7 @@ export function analyse(
 		}
 		for (const [name, service] of services) {
 			const id = `${label}:${name}`;
+			if (service.image.includes(APPLICATION_IMAGE)) applicationContainers.push({ id, service });
 			for (const variable of service.env) {
 				const scope = ownership.get(variable);
 				if (!scope) continue;
@@ -380,7 +431,34 @@ export function analyse(
 		);
 	}
 
-	return { failures, delivered };
+	// The other half of ROLE_SCOPES. A setting nothing gates on a role is read by every container
+	// running the application image, so the value one of them is handed is a claim about the whole
+	// deployment — and two containers making different claims describe a stack that does not exist.
+	// The release lock's agent digest reached the app containers and not the receiver that way; the
+	// receiver derived a tag from its own version instead and the pin guard refused to boot on it.
+	const spellings = new Map<string, Map<string, string[]>>();
+	for (const { id, service } of applicationContainers) {
+		for (const [variable, value] of service.raw) {
+			if (PER_CONTAINER.has(variable)) continue;
+			const byValue = spellings.get(variable) ?? new Map<string, string[]>();
+			spellings.set(variable, byValue);
+			byValue.set(value, [...(byValue.get(value) ?? []), id]);
+		}
+	}
+	for (const [variable, byValue] of spellings) {
+		if (byValue.size < 2) continue;
+		const written = [...byValue]
+			.map(([value, ids]) => `    ${value === "" ? "<nothing>" : value}\n      ${ids.join(", ")}`)
+			.join("\n");
+		failures.push(
+			`Containers running the application image disagree on ${variable}:\n${written}\n` +
+				"  No runtime role gates this setting, so every one of them reads it and they cannot both\n" +
+				"  be describing the same deployment.\n" +
+				`  Give them one value, or name ${variable} in PER_CONTAINER with the reason it differs.`,
+		);
+	}
+
+	return { failures, delivered, applicationContainers: applicationContainers.map((c) => c.id) };
 }
 
 if (process.argv[1] === import.meta.filename) {
@@ -389,7 +467,7 @@ if (process.argv[1] === import.meta.filename) {
 		compose.push([file, await readFile(join(REPO_ROOT, file), "utf8")]);
 	}
 	const profileRoles = await readProfileRoles();
-	const { failures, delivered } = analyse(
+	const { failures, delivered, applicationContainers } = analyse(
 		await readFile(join(REPO_ROOT, APPLICATION_YML), "utf8"),
 		compose,
 		profileRoles,
@@ -399,6 +477,7 @@ if (process.argv[1] === import.meta.filename) {
 		process.exit(1);
 	}
 	console.log(
-		`check-env-roles: ${delivered.size} role-scoped variable(s) reach a container that runs their role.`,
+		`check-env-roles: ${delivered.size} role-scoped variable(s) reach a container that runs their role, ` +
+			`and ${applicationContainers.length} application container(s) agree on every setting that is not role-scoped.`,
 	);
 }


### PR DESCRIPTION
## What changed and why

The blessed self-hosted install could not start `webhook-server`. It crash-looped on

```
Caused by: java.lang.IllegalStateException: hephaestus.agent.image.reference must be
digest-pinned (ending in @sha256:<64 lowercase hex>) when
hephaestus.agent.image.require-digest=true. Got: ghcr.io/hephaestus-build/agent-pi:0.75.0.
```

which failed `Host smoke (amd64)` and `(arm64)` in `Release` run 33711733128 and blocks anyone
installing v0.75.0.

**The bean is not ungated by mistake.** Both agent image guards are global on purpose (ADR 0031):
the server and the agent image are one runtime contract, so a reference the workers cannot run must
fail the deployment rather than only the pods that open sandboxes — a receiver that boots happily on
a pairing the rest of the stack rejects hides exactly the skew that ADR is about. What went missing
is the setting.

ADR 0034 moved the agent digest into the signed release lock, and #1565 switched
`application-server` and `application-worker` from the old valueless
`HEPHAESTUS_AGENT_IMAGE_REFERENCE` passthrough to
`${HEPHAESTUS_IMAGE_AGENT_PI:?verified release lock required}`. It left `webhook-server` in
`docker/compose.core.yaml` on the passthrough, under a comment still claiming that was "as in
docker/compose.app.yaml". Nothing in the install path sets that variable — the lock emits
`HEPHAESTUS_IMAGE_AGENT_PI` and `setup.sh` never writes it — so the receiver fell back to deriving
`agent-pi:${APP_VERSION}`, a tag, which the pin guard refuses. So this is the #1754 shape: the
install path owes the container a setting.

Three changes:

1. `webhook-server` reads the same lock digest as its siblings.
2. `docker/.env.example`'s commented `HEPHAESTUS_AGENT_IMAGE_REFERENCE` said it overrides the pin.
   That has not been true on any application container since #1565; it now says where the reference
   actually comes from.
3. `check-env-roles` grows the mirror image of the rule it already enforces, so the next one of
   these fails `pnpm run check` rather than a release smoke job.

**On the gate.** An architecture test asserting "no role instantiates beans outside its slice"
would not have caught this and cannot be written honestly here: it would demand that
`AgentImagePinGuard` be worker-gated, which contradicts ADR 0031. `RuntimeRoleBoundaryTest` already
pins every gate that does exist. The defect is a Compose delivery one, so the gate belongs where
`check-env-roles` already lives: role-scoped settings must reach a container that runs their role,
and — new here — a setting **no** role gates is read by every container running the application
image, so the value one of them is handed is a claim about the whole deployment and two of them
cannot make different claims. Comparing what the file *writes* rather than what it *resolves to* is
what makes this visible at all: `${VAR:?required}` and a valueless key both resolve to nothing.
`PER_CONTAINER` names the six settings meant to differ (the profile list, the three role flags,
`SPRING_LIQUIBASE_ENABLED`, `THC_PATH`), so anything else added to one container and not another
fails closed.

## How to test

Installed the released tree the way an operator does, on this machine, with the real v0.75.0
artifacts — the `agent-pi@sha256:2f5cf5d3…` digest below is the one the failing smoke log names.

```bash
cd docker/self-host && ./setup.sh
# fill APP_HOSTNAME / ACME_EMAIL / GH_OAUTH_* / HEPHAESTUS_AUTH_BOOTSTRAP_ADMINS, then a
# release-lock.env naming the v0.75.0 digests
docker compose --env-file .env --env-file release-lock.env up -d --wait
```

| Container | Roles | Before | After |
| --- | --- | --- | --- |
| `application-server` | `[server, worker]` | healthy | healthy |
| `webhook-server` | `[webhook]` | **crash-loop** | healthy |
| `application-worker` | `[worker]` | n/a — `reference-deployment-only`, excluded from this topology | healthy |

All three role slices boot; the roles are read back from each container's own
`Runtime roles enabled: […]` startup line. `application-worker` is not part of the blessed
single-host stack, so it needed the reference deployment's own DB password and trusted-proxy pin to
come up here — those are supplied by the reference topology, not a defect of this install.

The gate was checked in both directions: it fails on the pre-fix `compose.core.yaml` naming both
containers and both spellings, and passes on the fixed one. `pnpm run format` and `pnpm run check`
are green.

## Release impact

`.changeset/self-host-webhook-agent-image.md`, `patch`. No operator action: reinstall or upgrade as
usual.

## Notes for reviewers

Start at `docker/compose.core.yaml`; it is the whole fix. The rest is the gate and one stale
comment.

Worth a second opinion: whether `PER_CONTAINER` is the right list. It is derived from the current
topology — those six are every setting today's application containers legitimately disagree on —
so it is an observation, not a principle, and a reviewer who knows a seventh should say so.

I ran a Compose project named `hephaestus` on this host before switching to my own project name,
which recreated the containers of a stack that was already there. Volumes were untouched; if that
was yours, it is stopped, not deleted.

---

Model: Claude Fable 5 (`claude-fable-5`). Harness: Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed self-hosted webhook receiver crash loops caused by inconsistent agent image references.
  * All application containers now use the verified, digest-pinned agent image from the release lock.
  * Added validation to detect inconsistent shared settings across application containers.

* **Documentation**
  * Clarified that selecting a different agent image requires updating the release-lock configuration rather than an environment-variable override.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->