### PR TITLE
fix(docker): let the core stack render on its own again

### DIFF
--- a/.changeset/reference-core-stack-renders.md
+++ b/.changeset/reference-core-stack-renders.md
@@ -1,0 +1,12 @@
+---
+"hephaestus": patch
+---
+
+The reference multi-host stack now deploys instead of stopping with `service "webhook-server"
+depends on undefined service "postgres": invalid compose project`. That deployment brings the proxy,
+core and app stacks up as three separate Compose projects, and the core stack had been asking Compose
+to start the webhook receiver after a database that belongs to the app stack — an order Compose
+cannot honour across projects, and one that made the core stack refuse to render at all. The receiver
+reaches the database over the shared network as it always did, and retries until it answers. The
+single-host install is unaffected: it runs everything as one project and still starts the receiver
+after the database. Nothing to set on either — deploy or upgrade as usual.

--- a/.github/workflows/ci-compose-validate.yml
+++ b/.github/workflows/ci-compose-validate.yml
@@ -108,8 +108,14 @@ jobs:
         working-directory: docker
         run: |
           set -euo pipefail
-          # Values mirror what the deploy workflow supplies; only proves the files
-          # still render, not that they are correct for production.
-          docker compose \
-            -f compose.proxy.yaml -f compose.core.yaml -f compose.app.yaml \
-            --env-file self-host/.env --env-file self-host/release-lock.env config --quiet
+          # One stack at a time, because that is how the reference deployment runs them:
+          # deploy-locked-compose.yml renders each file on its own and brings it up as its own
+          # Compose project under /opt/hephaestus/<stack>. Rendering the three merged instead made
+          # every cross-project reference look satisfiable, and hid a `depends_on` no stack could
+          # honour until a release had already been published. The merged combination is still
+          # covered — the single-host stack above includes all three. Values mirror what the deploy
+          # workflow supplies; this only proves each file renders, not that it is right for production.
+          for stack in proxy core app; do
+            docker compose -f "compose.${stack}.yaml" \
+              --env-file self-host/.env --env-file self-host/release-lock.env config --quiet
+          done

--- a/docker/compose.core.yaml
+++ b/docker/compose.core.yaml
@@ -98,10 +98,16 @@ services:
       # thc healthcheck target: readiness (reports unhealthy while NATS/JetStream is unavailable).
       THC_PORT: "8080"
       THC_PATH: /actuator/health/readiness
+    # nats-server only. `postgres` is a service of docker/compose.app.yaml, and the reference
+    # deployment runs proxy, core and app as three separate Compose projects under
+    # /opt/hephaestus/<stack>; depends_on is project-scoped, so naming it here orders nothing and
+    # makes this file refuse to render on its own. The receiver reaches the database across
+    # shared-network by the alias compose.app.yaml gives it, `restart: unless-stopped` carries it
+    # over a database that is not up yet, and its readiness group (application.yml) names no `db`
+    # contributor, so ingestion health stays honest either way. The single-host install merges all
+    # three files into one project and does declare it — docker/self-host/compose.single-host.yaml.
     depends_on:
       nats-server:
-        condition: service_healthy
-      postgres:
         condition: service_healthy
     restart: unless-stopped
     # Spring drains HTTP (timeout-per-shutdown-phase 20s) THEN WebhookGracefulShutdown drains


### PR DESCRIPTION
## What changed and why

The v0.75.0 staging deploy failed at *Validate and render release topology* with

```
service "webhook-server" depends on undefined service "postgres": invalid compose project
```

The reference deployment does not run one merged Compose project. `deploy-locked-compose.yml`
renders `docker/compose.{proxy,core,app}.yaml` one at a time, copies each to
`/opt/hephaestus/<stack>/`, and brings each up as its own project with `--remove-orphans` — which
only makes sense if they are three projects. So the render step is right to validate each file
alone; the topology was wrong.

`postgres` is a service of `compose.app.yaml`. `depends_on` is project-scoped, so the entry
`compose.core.yaml` carried for it ordered nothing and only made the file unrenderable.
`docker/self-host/compose.single-host.yaml` has said so since #1565, in the comment above the very
same dependency it declares for the merged single-host project:

> Both live in this one project, so ordering can be expressed here — the reference deploys them as
> separate projects and cannot.

#1661 added the contradicting line to `compose.core.yaml`; nothing has deployed the core stack
through the new workflow since, so it stayed latent until this release. `application-server` needs
`nats-server` across the same boundary and correctly declares no dependency on it, which is the
pattern this restores.

Removing it does not create a race. The receiver reaches the database over `shared-network` by the
alias `compose.app.yaml` gives `postgres`, an alias that exists precisely for consumers outside that
project; `restart: unless-stopped` carries it over a database that is not up yet; and its readiness
group (`application.yml`) is `readinessState,integrationConsumer,webhook,practiceReview,catalogProvenanceBackfillStartup`
— no `db` contributor, so ingestion health still reports honestly. The single-host install keeps the
ordering it always had, from the overlay.

`ci-compose-validate.yml` missed this because its *Render the reference deployment* step rendered
the three files merged, which resolves every cross-project reference and models a topology nothing
deploys. It now renders each stack the way the deploy does.

## How to test

```sh
cd docker/self-host && ./setup.sh          # then fill APP_HOSTNAME / ACME_EMAIL and release-lock.env
                                           # exactly as ci-compose-validate.yml does
cd .. && for s in proxy core app; do
  docker compose -f "compose.$s.yaml" \
    --env-file self-host/.env --env-file self-host/release-lock.env config --quiet
done
```

- Before this change, `core` fails with the error above; `proxy` and `app` pass. Rendering the three
  merged passes, which is why CI was green.
- After it, all three pass, and `docker compose config` on `docker/self-host/compose.yaml` still
  shows `webhook-server` depending on `postgres` and `application-server`.
- `pnpm run format` and `pnpm run check` both pass.

## Release impact

`.changeset/reference-core-stack-renders.md`, `patch`. No operator action: the single-host install is
unaffected, and the reference stack needs nothing set.

## Notes for reviewers

One thing this deliberately does **not** change, so it is a decision rather than an oversight: the
deploy brings the stacks up in the order `proxy`, `core`, `app`, so on a host with no `postgres`
running yet the receiver would restart-loop and `up -d --wait` on `core` would spend its 600s.
Staging and production both run `postgres` continuously under `restart: unless-stopped`, so this
does not affect them, and the dependency being removed never guarded against it either — it was
never enforceable across projects. Worth its own change if we ever bootstrap a fresh reference host.

---

Model: Claude Opus 5. Harness: Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed reference deployments failing during Compose validation because of an invalid cross-stack database dependency.
  * The webhook receiver now connects to the database over the shared network and retries until it is available.
  * Single-host installations remain unchanged and require no configuration updates.

* **Documentation**
  * Added a patch release note for the deployment fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->