### PR TITLE
fix(deps): unblock Renovate's dependency update pull requests

### DIFF
--- a/.changeset/agent-image-release-age.md
+++ b/.changeset/agent-image-release-age.md
@@ -1,0 +1,7 @@
+---
+"hephaestus": patch
+---
+
+Dependencies in the agent image that runs practice reviews could be less than three days old,
+escaping the release-age floor every other Hephaestus dependency is held to. The image now applies
+that floor and verifies it while it builds.

--- a/docker/agents/pi/Dockerfile
+++ b/docker/agents/pi/Dockerfile
@@ -5,8 +5,8 @@ FROM ghcr.io/pnpm/pnpm:12.0.0@sha256:bce5ae25ef95edd79e696d7fa8489b80561ef660100
 ARG NODE_VERSION
 WORKDIR /opt/pi-sdk
 RUN pnpm runtime set node ${NODE_VERSION} -g
-COPY pi/package.json pi/pnpm-lock.yaml ./
-RUN pnpm install --prod --frozen-lockfile --ignore-scripts --ignore-workspace
+COPY pi/package.json pi/pnpm-lock.yaml pi/pnpm-workspace.yaml ./
+RUN pnpm install --prod --frozen-lockfile --ignore-scripts
 
 FROM node:${NODE_VERSION}-slim@sha256:a9f5f7c91a432850b2a8a7797adf5eadb6c733ceed61167806cee7ea7fbc29df
 ARG NODE_VERSION

--- a/docker/agents/pi/package.json
+++ b/docker/agents/pi/package.json
@@ -4,5 +4,8 @@
   "version": "0.0.0",
   "dependencies": {
     "@earendil-works/pi-coding-agent": "0.84.3"
+  },
+  "engines": {
+    "pnpm": "12.0.0"
   }
 }

--- a/docker/agents/pi/pnpm-lock.yaml
+++ b/docker/agents/pi/pnpm-lock.yaml
@@ -277,8 +277,8 @@ packages:
     resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
     engines: {node: '>=14.0.0'}
 
-  '@smithy/node-http-handler@4.12.0':
-    resolution: {integrity: sha512-0mq1pHadfyXCYCqm2cNpbjNIT+fbaUpNxewZb/YNr2L0IrEVMOb8gM/Fl4K6XvHCW3uSNDFwPl/+iKm0bx9jYg==}
+  '@smithy/node-http-handler@4.11.3':
+    resolution: {integrity: sha512-2jY1tSpERfPfWqyBV2pH+iGFaghVsIJszJNsT7hxtQYhVJpWDyc0LqOWI+nXOxOAHaEfZ4PXXtp1wW1TGpHhkA==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/node-http-handler@4.7.3':
@@ -636,7 +636,7 @@ snapshots:
       '@aws-sdk/types': 3.974.5
       '@smithy/core': 3.33.3
       '@smithy/fetch-http-handler': 5.7.2
-      '@smithy/node-http-handler': 4.12.0
+      '@smithy/node-http-handler': 4.11.3
       '@smithy/types': 4.17.2
       tslib: 2.8.1
 
@@ -737,7 +737,7 @@ snapshots:
       '@aws-sdk/types': 3.974.5
       '@smithy/core': 3.33.3
       '@smithy/fetch-http-handler': 5.7.2
-      '@smithy/node-http-handler': 4.12.0
+      '@smithy/node-http-handler': 4.11.3
       '@smithy/types': 4.17.2
       tslib: 2.8.1
 
@@ -965,7 +965,7 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@smithy/node-http-handler@4.12.0':
+  '@smithy/node-http-handler@4.11.3':
     dependencies:
       '@smithy/core': 3.33.3
       '@smithy/types': 4.17.2

--- a/docker/agents/pi/pnpm-workspace.yaml
+++ b/docker/agents/pi/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+# pnpm resolves against the nearest `pnpm-workspace.yaml` at or above the install directory. This
+# file puts that here rather than at the repository root, so no root setting reaches this image.
+minimumReleaseAge: 4320

--- a/docs/contributor/ci-cd.mdx
+++ b/docs/contributor/ci-cd.mdx
@@ -103,7 +103,10 @@ Renovate opens pull requests before 07:00 Europe/Berlin on weekdays after a thre
 majors wait seven days and a Dependency Dashboard approval, and vulnerability alerts skip both.
 Lockfile maintenance runs on Mondays. Enabled managers: npm, Maven, the Maven wrapper, Dockerfiles,
 Compose files, GitHub Actions, and the regex managers in `renovate.json`, which
-`scripts/renovate-config.test.ts` covers.
+`scripts/renovate-config.test.ts` covers. The Node, pnpm and Pi SDK pins are grouped, so a version
+stated in several managed files moves in one pull request; the toolchain checks reject a version that
+reads differently in any of them. Renovate provisions the Node it runs lockfile updates with from
+`engines`, so `engines.node` restates `devEngines.runtime` exactly rather than the supported line.
 
 [Vulnerability remediation](./vulnerability-remediation.mdx) owns the blocking and exception policy.
 [Release management](./release-management.mdx#supply-chain-evidence) owns artifact signing, provenance,

--- a/package.json
+++ b/package.json
@@ -156,7 +156,7 @@
 		}
 	},
 	"engines": {
-		"node": ">=24.19.0 <25"
+		"node": "24.19.0"
 	},
 	"packageManager": "pnpm@12.0.0"
 }

--- a/renovate.json
+++ b/renovate.json
@@ -30,71 +30,28 @@
 			"enabled": false
 		},
 		{
-			"matchManagers": ["maven"],
-			"matchDepTypes": ["compile", "runtime", "provided", "optional", "parent", "parent-root"],
+			"matchManagers": ["github-actions"],
 			"matchUpdateTypes": ["minor", "patch", "digest", "pin", "pinDigest"],
-			"labels": ["dependencies", "java"]
-		},
-		{
-			"matchManagers": ["maven"],
-			"matchDepTypes": ["build", "test"],
-			"matchUpdateTypes": ["minor", "patch", "digest", "pin", "pinDigest"],
-			"labels": ["dependencies", "java"]
-		},
-		{
-			"matchFileNames": ["webapp/package.json"],
-			"matchDepTypes": ["dependencies"],
-			"matchUpdateTypes": ["minor", "patch"],
-			"labels": ["dependencies", "webapp"]
-		},
-		{
-			"matchFileNames": ["webapp/package.json"],
-			"matchDepTypes": ["devDependencies"],
-			"matchUpdateTypes": ["minor", "patch"],
-			"labels": ["dependencies", "webapp"]
-		},
-		{
-			"matchFileNames": ["docs/package.json"],
-			"matchDepTypes": ["dependencies"],
-			"matchUpdateTypes": ["minor", "patch"],
-			"labels": ["dependencies", "docs"]
-		},
-		{
-			"matchFileNames": ["docs/package.json"],
-			"matchDepTypes": ["devDependencies"],
-			"matchUpdateTypes": ["minor", "patch"],
-			"labels": ["dependencies", "docs"]
+			"groupName": "GitHub Actions"
 		},
 		{
 			"matchUpdateTypes": ["major"],
 			"minimumReleaseAge": "7 days",
-			"labels": ["dependencies", "breaking"],
-			"dependencyDashboardApproval": true
-		},
-		{
-			"matchPackageNames": [
-				"typescript",
-				"react",
-				"react-dom",
-				"/^@tanstack/",
-				"/^org\\.springframework/"
-			],
-			"matchUpdateTypes": ["minor"]
-		},
-		{
-			"matchManagers": ["github-actions"],
-			"matchUpdateTypes": ["minor", "patch", "digest", "pin", "pinDigest"],
-			"groupName": "GitHub Actions",
-			"labels": ["dependencies", "ci"]
-		},
-		{
-			"matchManagers": ["dockerfile", "docker-compose"],
-			"labels": ["dependencies", "infrastructure"]
-		},
-		{
-			"matchUpdateTypes": ["major"],
+			"addLabels": ["breaking"],
 			"groupName": null,
 			"dependencyDashboardApproval": true
+		},
+		{
+			"matchDepNames": ["node"],
+			"groupName": "Node.js toolchain"
+		},
+		{
+			"matchDepNames": ["pnpm", "ghcr.io/pnpm/pnpm"],
+			"groupName": "pnpm toolchain"
+		},
+		{
+			"matchDepNames": ["@earendil-works/pi-coding-agent"],
+			"groupName": "Pi SDK"
 		}
 	],
 	"customManagers": [
@@ -164,6 +121,37 @@
 			"depNameTemplate": "OpenAPITools/openapi-generator",
 			"extractVersionTemplate": "^v(?<version>.*)$",
 			"versioningTemplate": "semver"
+		},
+		{
+			"description": "Track the Node.js pin in devEngines",
+			"customType": "regex",
+			"managerFilePatterns": ["/^package\\.json$/"],
+			"matchStrings": [
+				"\"runtime\":\\s*\\{\\s*\"name\":\\s*\"node\",\\s*\"version\":\\s*\"(?<currentValue>[^\"]+)\""
+			],
+			"depNameTemplate": "node",
+			"datasourceTemplate": "node-version",
+			"versioningTemplate": "node"
+		},
+		{
+			"description": "Track the pnpm pin in devEngines",
+			"customType": "regex",
+			"managerFilePatterns": ["/^package\\.json$/"],
+			"matchStrings": [
+				"\"packageManager\":\\s*\\{\\s*\"name\":\\s*\"pnpm\",\\s*\"version\":\\s*\"(?<currentValue>[^\"]+)\""
+			],
+			"depNameTemplate": "pnpm",
+			"datasourceTemplate": "npm",
+			"versioningTemplate": "npm"
+		},
+		{
+			"description": "Track the Pi SDK pin in the live agent tests",
+			"customType": "regex",
+			"managerFilePatterns": ["/^server/application/src/test/java/.*\\.java$/"],
+			"matchStrings": ["private static final String PI_SDK_VERSION = \"(?<currentValue>[^\"]+)\";"],
+			"depNameTemplate": "@earendil-works/pi-coding-agent",
+			"datasourceTemplate": "npm",
+			"versioningTemplate": "npm"
 		},
 		{
 			"description": "Track release image tags and digests",

--- a/scripts/check-package-manager.ts
+++ b/scripts/check-package-manager.ts
@@ -3,31 +3,26 @@ import { existsSync, readFileSync } from "node:fs";
 import { isDeepStrictEqual } from "node:util";
 
 import packageArgument from "npm-package-arg";
+import { parse } from "yaml";
 
+import { asRecord, asString, isRecord, parseJson } from "./lib/json.ts";
 import { CAPTURE_LIMIT_BYTES } from "./lib/process.ts";
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-	return typeof value === "object" && value !== null;
-}
-
-const manifest: unknown = JSON.parse(readFileSync("package.json", "utf8"));
-if (!isRecord(manifest)) throw new Error("package.json must be an object");
+const manifest = asRecord(parseJson(readFileSync("package.json", "utf8")), "package.json");
 const { devEngines, engines, packageManager } = manifest;
 const match =
 	typeof packageManager === "string" ? /^pnpm@(\d+\.\d+\.\d+)$/.exec(packageManager) : null;
 if (!match) throw new Error("package.json#packageManager must pin an exact pnpm version");
-const version = match[1];
-if (!isRecord(engines) || engines.node !== ">=24.19.0 <25")
-	throw new Error("package.json#engines.node must require the supported Node 24 line");
+const version = asString(match[1], "package.json#packageManager");
 const runtime = isRecord(devEngines) ? devEngines.runtime : undefined;
 const manager = isRecord(devEngines) ? devEngines.packageManager : undefined;
-if (
-	!isRecord(runtime) ||
-	runtime.name !== "node" ||
-	runtime.version !== "24.19.0" ||
-	runtime.onFail !== "error"
-)
-	throw new Error("package.json#devEngines.runtime must pin Node 24.19.0");
+if (!isRecord(runtime) || runtime.name !== "node" || runtime.onFail !== "error")
+	throw new Error("package.json#devEngines.runtime must pin Node and fail on drift");
+const runtimeVersion = asString(runtime.version, "package.json#devEngines.runtime.version");
+if (!/^\d+\.\d+\.\d+$/.test(runtimeVersion))
+	throw new Error("package.json#devEngines.runtime must pin an exact Node version");
+if (!isRecord(engines) || engines.node !== runtimeVersion)
+	throw new Error(`package.json#engines.node must pin Node ${runtimeVersion}`);
 if (
 	!isRecord(manager) ||
 	manager.name !== "pnpm" ||
@@ -39,7 +34,12 @@ const runningVersion = execFileSync("pnpm", ["--version"], { encoding: "utf8" })
 if (runningVersion !== version)
 	throw new Error(`Expected pnpm ${version}, found ${runningVersion}`);
 
-for (const file of ["package.json", "docs/package.json", "webapp/package.json"]) {
+for (const file of [
+	"package.json",
+	"docs/package.json",
+	"webapp/package.json",
+	"docker/agents/pi/package.json",
+]) {
 	const workspaceManifest: unknown = JSON.parse(readFileSync(file, "utf8"));
 	if (!isRecord(workspaceManifest)) throw new Error(`${file} must be an object`);
 	const scripts = workspaceManifest.scripts;
@@ -91,7 +91,22 @@ expectConfig("publicHoistPattern", [
 	"@types/react-dom",
 	"@types/hast",
 ]);
-expectConfig("minimumReleaseAge", 4320);
+const releaseAge = 4320;
+expectConfig("minimumReleaseAge", releaseAge);
+// The agent image is its own pnpm project: nothing the root pins reaches it unless it is restated.
+const imageWorkspace = asRecord(
+	parse(readFileSync("docker/agents/pi/pnpm-workspace.yaml", "utf8")),
+	"docker/agents/pi/pnpm-workspace.yaml",
+);
+if (imageWorkspace.minimumReleaseAge !== releaseAge)
+	throw new Error(`docker/agents/pi/pnpm-workspace.yaml must set minimumReleaseAge ${releaseAge}`);
+const imageManifest = asRecord(
+	parseJson(readFileSync("docker/agents/pi/package.json", "utf8")),
+	"docker/agents/pi/package.json",
+);
+const imageEngines = imageManifest.engines;
+if (!isRecord(imageEngines) || imageEngines.pnpm !== version)
+	throw new Error(`docker/agents/pi/package.json must pin pnpm ${version} through engines`);
 expectConfig("allowBuilds", {
 	"@nestjs/core": false,
 	protobufjs: false,
@@ -136,18 +151,44 @@ if (/^\s*(?:version|runtime):/m.test(setup)) {
 }
 
 const dockerfile = readFileSync("webapp/Dockerfile", "utf8");
-if (!dockerfile.includes(`ghcr.io/pnpm/pnpm:${version}@sha256:`)) {
-	throw new Error(`webapp/Dockerfile must use the digest-pinned pnpm ${version} image`);
+const agentDockerfile = readFileSync("docker/agents/pi/Dockerfile", "utf8");
+// One tag over two digests is two different pnpm builds wearing a single version number.
+const pnpmImage = new RegExp(
+	`ghcr\\.io/pnpm/pnpm:${version.replaceAll(".", "\\.")}@(sha256:[a-f0-9]{64})`,
+);
+const pnpmDigests = new Set(
+	(
+		[
+			["webapp/Dockerfile", dockerfile],
+			["docker/agents/pi/Dockerfile", agentDockerfile],
+		] as const
+	).map(([file, content]) => {
+		const digest = pnpmImage.exec(content)?.[1];
+		if (!digest) throw new Error(`${file} must use the digest-pinned pnpm ${version} image`);
+		return digest;
+	}),
+);
+if (pnpmDigests.size !== 1) throw new Error("both Dockerfiles must pin one pnpm base digest");
+// Those settings only bind if the image copies them and lets pnpm read them.
+if (
+	!/^COPY pi\/package\.json pi\/pnpm-lock\.yaml pi\/pnpm-workspace\.yaml \.\/$/m.test(
+		agentDockerfile,
+	) ||
+	!/^RUN pnpm install --prod --frozen-lockfile --ignore-scripts$/m.test(agentDockerfile)
+) {
+	throw new Error(
+		"docker/agents/pi/Dockerfile must install from its own workspace settings, without lifecycle scripts",
+	);
 }
 if (
-	!new RegExp(`^ARG NODE_VERSION=${runtime.version.replaceAll(".", "\\.")}$`, "m").test(
+	!new RegExp(`^ARG NODE_VERSION=${runtimeVersion.replaceAll(".", "\\.")}$`, "m").test(
 		dockerfile,
 	) ||
 	!new RegExp(["^RUN pnpm runtime set node \\$", "\\{NODE_VERSION\\} -g$"].join(""), "m").test(
 		dockerfile,
 	)
 ) {
-	throw new Error(`webapp/Dockerfile must install Node ${runtime.version} through pnpm`);
+	throw new Error(`webapp/Dockerfile must install Node ${runtimeVersion} through pnpm`);
 }
 
 // Construct the token so this source file also satisfies the repository-wide ban.
@@ -181,5 +222,5 @@ for (const file of tracked) {
 	}
 }
 console.log(
-	`pnpm ${version}, Node ${runtime.version}, and the no-legacy-runtime policy are consistent`,
+	`pnpm ${version}, Node ${runtimeVersion}, and the no-legacy-runtime policy are consistent`,
 );

--- a/scripts/renovate-config.test.ts
+++ b/scripts/renovate-config.test.ts
@@ -30,6 +30,27 @@ void test("Renovate creates bounded update PRs without a manual dispatch queue",
 	);
 });
 
+void test("every pin of one toolchain version moves in a single pull request", () => {
+	// Renovate merges every matching packageRule in order, so the last one to set a key wins.
+	assert.ok(Array.isArray(config.packageRules));
+	const rules = config.packageRules.filter(isRecord);
+	const ungrouped = rules.findLastIndex((rule) => rule.groupName === null);
+	assert.ok(ungrouped >= 0, "a rule must ungroup majors for the toolchain rules to reinstate it");
+	for (const [depName, groupName] of [
+		["node", "Node.js toolchain"],
+		["pnpm", "pnpm toolchain"],
+		["ghcr.io/pnpm/pnpm", "pnpm toolchain"],
+		["@earendil-works/pi-coding-agent", "Pi SDK"],
+	]) {
+		const index = rules.findLastIndex(
+			(rule) => Array.isArray(rule.matchDepNames) && rule.matchDepNames.includes(depName),
+		);
+		assert.equal(rules[index]?.groupName, groupName, `${depName} must be grouped as ${groupName}`);
+		assert.equal(rules[index]?.matchUpdateTypes, undefined, `${depName} groups every update type`);
+		assert.ok(index > ungrouped, `${depName} must be grouped after majors are ungrouped`);
+	}
+});
+
 void test("vulnerability remediation bypasses normal update latency", () => {
 	assert.equal(config.osvVulnerabilityAlerts, true);
 	assert.equal(config.dependencyDashboardOSVVulnerabilitySummary, "unresolved");
@@ -58,6 +79,16 @@ void test("every custom manager extracts a dependency from its real source", asy
 			["server/application/project.toml"],
 		],
 		["Track the OpenAPI Generator CLI distribution", ["openapitools.json"]],
+		["Track the Node.js pin in devEngines", ["package.json"]],
+		["Track the pnpm pin in devEngines", ["package.json"]],
+		[
+			"Track the Pi SDK pin in the live agent tests",
+			[
+				"server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/mentor/live/MentorLiveLlmTest.java",
+				"server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/mentor/live/MentorSandboxStressTest.java",
+				"server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/practice/live/PracticeRunnerLiveLlmTest.java",
+			],
+		],
 		["Track release image tags and digests", ["security/release-images.json"]],
 	]);
 	assert.ok(Array.isArray(config.customManagers));


### PR DESCRIPTION
## What changed and why

Every dependency update Renovate opens is unmergeable, and has been since the pnpm migration.
All five open bot pull requests sit at `BLOCKED`, and `git log --author=renovate -- pnpm-lock.yaml`
returns nothing: **Renovate has never once updated our lockfile.**

The chain is short. Renovate cannot read `devEngines`, so it picks the Node.js it runs lockfile
updates with from `engines.node`. That field said `>=24.19.0 <25`, which resolves to the newest
24.x release — but `devEngines.runtime` pins `24.19.0` with `onFail: "error"`, so pnpm refuses to
run:

```
Error: ERR_PNPM_BAD_RUNTIME_VERSION
  × This project requires Node.js 24.19.0. Your current Node.js is v24.20.0
```

Renovate then pushes a `package.json` bump next to a stale `pnpm-lock.yaml`, every job that runs
`pnpm install --frozen-lockfile` fails, and the required `CI Status Gate` goes red.

`engines.node` now states the same exact version `devEngines` does. The range was never true anyway —
`onFail: "error"` means this project does not run on 24.20.0, so the manifest was claiming support it
does not have.

**Three pins also had to move together and could not.** `check:package-manager` and
`check:agent-runtime-pins` reject a Node, pnpm or Pi SDK version that reads differently in any file
that states it — but Renovate opens one pull request per dependency, so each arrived red by
construction. The Pi SDK version lives in six files and Renovate managed three of them; the three
Java live tests had no manager at all, so *every* Pi bump was guaranteed to fail. These are now
grouped, and the two `devEngines` pins and the Java pins have custom managers.

**Fixing the last one turned up something worse.** `docker/agents/pi/` keeps its own lockfile, but
pnpm resolves against the nearest ancestor `pnpm-workspace.yaml` — and there was none, so installs
there silently operated on the repository root. The Dockerfile hid that with `--ignore-workspace`,
which also discarded the root's `minimumReleaseAge: 4320`. The agent image that runs practice reviews
was the one image not held to the three-day release-age floor, and the committed lockfile had already
drifted through the gap:

```
Error: ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION
  × @smithy/node-http-handler@4.12.0 was published at 2026-08-31T17:47:43.278Z,
    within the minimumReleaseAge cutoff
```

That package was published about 1.6 days before the lockfile was committed. The directory now
declares itself a pnpm project and carries the floor, the lockfile is regenerated under it (one
transitive entry moves back), the image copies the settings, and `--ignore-workspace` is gone.

## How to test

```bash
pnpm run check                    # gate:package-manager and gate:agent-runtime-pins both run here
node --test scripts/renovate-config.test.ts
```

Prove the supply-chain hole was real, on `main`:

```bash
git switch main
printf 'minimumReleaseAge: 4320\n' > docker/agents/pi/pnpm-workspace.yaml
cd docker/agents/pi && pnpm install --lockfile-only    # ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION
```

Prove the image now enforces it:

```bash
cd docker/agents && docker build --no-cache -f pi/Dockerfile --target dependencies .
# ✓ Lockfile passes supply-chain policies (131 entries in 738ms)
```

Prove the guards are not decoration — each of these must fail `pnpm run check:package-manager`
or the config test:

- re-add `--ignore-workspace` to `docker/agents/pi/Dockerfile`, or drop a file from its `COPY` line
- set the nested `minimumReleaseAge` to `0`
- give a toolchain rule a `matchUpdateTypes`, delete `groupName: null` from the major rule, or move
  the toolchain rules above it
- relax `engines.node` back to a range

## Release impact

`.changeset/agent-image-release-age.md` (`patch`). No operator action: the agent image applies the
release-age floor it should always have applied, and the only closure change is one transitive
package moving to the newest release old enough to qualify.

The rest of the change is repository tooling and has no user-facing effect.

## Notes for reviewers

**Start with `scripts/check-package-manager.ts`** — it is where the invariants are, and the rest
follows from them.

**On scope.** This is one cause with two faces: Renovate reads the wrong `package.json` for a given
lockfile. I considered splitting the agent-image fix into its own pull request and decided against
it, because the pnpm-workspace file is what makes that lockfile updatable at all — landing the halves
separately would leave #1747 failing on the second error and read as a regression. The release-age
finding was a consequence of that fix, not a separate errand, so it is the one part with a changeset.

**What I checked but did not change:**

- The nested workspace file does not inherit the root's `overrides`, `patchedDependencies` or
  `publicHoistPattern`. I checked all 131 packages in the closure against every one: zero overlap.
  `allowBuilds` is moot because the install passes `--ignore-scripts`, which the new guard now pins.
- `MentorLiveLlmTest`, `MentorSandboxStressTest` and `PracticeRunnerLiveLlmTest` install the same SDK
  into `target/pi-sdk` with no lockfile and no floor. Pre-existing, different risk profile, not this
  change's job — but worth knowing it is not covered.
- `docker/agents/pi/.dockerignore` is dead config: the build context is `docker/agents`, so Docker
  never reads it. Pre-existing; left alone to keep this diff honest.

**One new failure mode.** The agent image build now resolves registry metadata to check publish
dates. This is monotone-safe — lockfile entries only get older, so a lockfile that passes today
passes forever — but a registry outage can now fail a build that previously succeeded.

**After merge**, the five open bot pull requests need a rebase (tick the rebase box, or use the
dashboard in #709). Renovate reads its config from `main` but reads `engines` from the branch, so
each branch has to pick up this commit first. #1747 will be recreated as a grouped *Pi SDK* pull
request covering all six files rather than three.

I added no `constraints.node` to `renovate.json`: [Renovate's own docs](https://docs.renovatebot.com/language-constraints-and-upgrading/)
call hand-written constraints undesirable because Renovate will not update them, and fixing the
manifest fixes the detection at its source.

---

Written by Claude Opus 5 in Claude Code, reviewed against the repository's own gates.
