### PR TITLE
fix(scripts): bound every captured subprocess so the Version PR keeps running

### DIFF
--- a/scripts/check-affected.ts
+++ b/scripts/check-affected.ts
@@ -1,5 +1,7 @@
 import { spawnSync } from "node:child_process";
 
+import { CAPTURE_LIMIT_BYTES } from "./lib/process.ts";
+
 export type Scope = "agents" | "docs" | "full" | "server" | "webapp";
 export type Command = readonly [string, ...string[]];
 
@@ -69,6 +71,7 @@ function git(cwd: string, ...args: string[]): string[] {
 	const result = spawnSync("git", args, {
 		cwd,
 		encoding: "utf8",
+		maxBuffer: CAPTURE_LIMIT_BYTES,
 		env: environmentWithoutGitRepository(),
 	});
 	if (result.status !== 0)

--- a/scripts/check-artifact-source-contract-immutability.ts
+++ b/scripts/check-artifact-source-contract-immutability.ts
@@ -1,5 +1,7 @@
 import { execFileSync } from "node:child_process";
 
+import { CAPTURE_LIMIT_BYTES } from "./lib/process.ts";
+
 // Git hooks export GIT_DIR and GIT_INDEX_FILE, which would silently redirect every command below at
 // whichever repository invoked the hook. This check is about the working tree it was pointed at, so
 // it resolves that itself.
@@ -20,7 +22,13 @@ const baseRef =
 	(process.env.GITHUB_BASE_REF ? `origin/${process.env.GITHUB_BASE_REF}` : "origin/main");
 
 const git = (...args: string[]): string =>
-	execFileSync("git", args, { cwd: repoRoot, encoding: "utf8", env });
+	execFileSync("git", args, {
+		cwd: repoRoot,
+		encoding: "utf8",
+		env,
+		// A diff over the contract tree has no useful size limit.
+		maxBuffer: CAPTURE_LIMIT_BYTES,
+	});
 
 const base = git("merge-base", "HEAD", baseRef).trim();
 

--- a/scripts/check-package-manager.ts
+++ b/scripts/check-package-manager.ts
@@ -4,6 +4,8 @@ import { isDeepStrictEqual } from "node:util";
 
 import packageArgument from "npm-package-arg";
 
+import { CAPTURE_LIMIT_BYTES } from "./lib/process.ts";
+
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null;
 }
@@ -152,7 +154,12 @@ if (
 const retired = ["b", "un"].join("");
 const isHistorical = (file: string): boolean =>
 	file === "CHANGELOG.md" || file === "MIGRATION.md" || file.startsWith("docs/decisions/");
-const tracked = execFileSync("git", ["ls-files", "-z"], { encoding: "utf8" })
+// The tracked-file list grows with the repository, so it needs the shared ceiling rather than
+// Node's 1 MiB default — this runs in `pnpm run check` on every machine.
+const tracked = execFileSync("git", ["ls-files", "-z"], {
+	encoding: "utf8",
+	maxBuffer: CAPTURE_LIMIT_BYTES,
+})
 	.split("\0")
 	.filter(Boolean);
 const forbiddenWord = new RegExp(`\\b${retired}\\b`, "i");

--- a/scripts/check-preview-stack.ts
+++ b/scripts/check-preview-stack.ts
@@ -12,6 +12,8 @@ import { readFileSync } from "node:fs";
 import { readComposeServices } from "./check-env-roles.ts";
 import { isRecord } from "./lib/json.ts";
 
+import { CAPTURE_LIMIT_BYTES } from "./lib/process.ts";
+
 const COMPOSE_FILE = "docker/preview/compose.app.yaml";
 const REFERENCE_FILE = "docker/compose.app.yaml";
 /** Images this repository builds, addressed by commit rather than digest. */
@@ -244,7 +246,7 @@ export function renderStack(): unknown {
 		// against. Rendering without it resolves them under docker/preview/ and checks a stack that
 		// would never be deployed.
 		["compose", "-f", COMPOSE_FILE, "--project-directory", ".", "config", "--format", "json"],
-		{ encoding: "utf8", env: { ...ambient, ...RENDER_ENV } },
+		{ encoding: "utf8", env: { ...ambient, ...RENDER_ENV }, maxBuffer: CAPTURE_LIMIT_BYTES },
 	);
 	if (result.status !== 0) {
 		const unavailable =

--- a/scripts/ci-contract.test.ts
+++ b/scripts/ci-contract.test.ts
@@ -486,6 +486,25 @@ void describe("CI contract", () => {
 			);
 	});
 
+	void test("bounds every captured subprocess above Node's 1 MiB default", async () => {
+		// Node caps a captured subprocess at 1 MiB and throws past it. That default has broken the
+		// release pipeline three times: a cosign attestation carrying an SBOM, a `gh api` release
+		// listing, and a `gh api` workflow-run listing that stopped the Version PR being maintained
+		// at all. The ceiling has one home, and a capture that does not use it is the fourth.
+		const offenders: string[] = [];
+		for await (const file of glob("scripts/**/*.ts")) {
+			if (file.endsWith(".test.ts")) continue;
+			const source = await readFile(file, "utf8");
+			// `stdio: inherit`/`ignore` streams to the parent and buffers nothing; only a capture,
+			// which is what `encoding` marks, can overflow.
+			const captures =
+				source.match(/exec(?:File)?Sync\(|execFileAsync\(|spawnSync\(/g)?.length ?? 0;
+			if (captures === 0 || !source.includes("encoding")) continue;
+			if (!/maxBuffer/.test(source)) offenders.push(file);
+		}
+		assert.deepEqual(offenders, [], "these capture a subprocess without bounding its buffer");
+	});
+
 	void test("scans both released platforms before the release, not just linux/amd64", async () => {
 		// The policy match key is `image | platform | vulnerability | package | installedVersion`, so
 		// a single-platform pre-release scan leaves an arm64-only finding — or an arm64 exception

--- a/scripts/coolify-preview.ts
+++ b/scripts/coolify-preview.ts
@@ -5,6 +5,8 @@ import { appendFileSync } from "node:fs";
 import { requiredEnv as required, requiredPositiveInteger } from "./lib/env.ts";
 import { isRecord } from "./lib/json.ts";
 
+import { CAPTURE_LIMIT_BYTES } from "./lib/process.ts";
+
 type WebhookAction = "closed" | "opened";
 type FinalState = "error" | "failure" | "success";
 
@@ -521,6 +523,7 @@ const systemCommandRunner: CommandRunner = {
 	run: (command, arguments_, options) => {
 		const result = spawnSync(command, [...arguments_], {
 			encoding: "utf8",
+			maxBuffer: CAPTURE_LIMIT_BYTES,
 			input: options?.input,
 			stdio: ["pipe", "pipe", "pipe"],
 		});

--- a/scripts/dispatch-version-pr-ci.ts
+++ b/scripts/dispatch-version-pr-ci.ts
@@ -83,6 +83,11 @@ if (import.meta.main) {
 				await gh([
 					"api",
 					`repos/${repository}/actions/workflows/${CI_WORKFLOW}/runs?branch=${encodeURIComponent(branch)}&per_page=100`,
+					// Only the head SHA decides whether a run already exists. The unprojected listing
+					// carries the full repository object per run and passed a megabyte at 135 runs,
+					// which is a payload that grows with the branch's history for no gain.
+					"--jq",
+					"{workflow_runs: [.workflow_runs[] | {head_sha}]}",
 				]),
 			),
 		);

--- a/scripts/lib/process.ts
+++ b/scripts/lib/process.ts
@@ -3,6 +3,15 @@ import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
 
+/**
+ * Node caps a captured subprocess at 1 MiB and throws `ERR_CHILD_PROCESS_STDIO_MAXBUFFER` past it.
+ * Nothing captured here has a useful size limit — a `gh api` listing, a git diff, an SBOM — and the
+ * default has broken the release pipeline three separate times. The ceiling is stated once, here,
+ * rather than rediscovered per call site. It stays finite on purpose: an unbounded capture of a
+ * runaway process is its own failure.
+ */
+export const CAPTURE_LIMIT_BYTES = 256 * 1024 * 1024;
+
 export interface RunOptions {
 	cwd?: string;
 	env?: Record<string, string | undefined>;
@@ -56,6 +65,7 @@ export async function output(
 		env: { ...process.env, ...options.env },
 		signal: options.signal,
 		encoding: "utf8",
+		maxBuffer: CAPTURE_LIMIT_BYTES,
 	});
 	return stdout;
 }

--- a/scripts/release-upgrade-test.ts
+++ b/scripts/release-upgrade-test.ts
@@ -3,6 +3,8 @@ import { randomUUID } from "node:crypto";
 import process from "node:process";
 import { setTimeout as sleep } from "node:timers/promises";
 
+import { CAPTURE_LIMIT_BYTES } from "./lib/process.ts";
+
 const [previousImage, candidateImage, postgresImage] = process.argv.slice(2);
 
 if (!previousImage || !candidateImage || !postgresImage) {
@@ -17,7 +19,7 @@ const postgres = `${runId}-postgres`;
 let application = `${runId}-previous`;
 
 function docker(...args: string[]): string {
-	const result = spawnSync("docker", args, { encoding: "utf8" });
+	const result = spawnSync("docker", args, { encoding: "utf8", maxBuffer: CAPTURE_LIMIT_BYTES });
 	if (result.status !== 0) {
 		throw new Error(`docker ${args.join(" ")} failed:\n${result.stdout}${result.stderr}`);
 	}

--- a/scripts/resolve-release-upgrade-images.ts
+++ b/scripts/resolve-release-upgrade-images.ts
@@ -4,6 +4,8 @@ import process from "node:process";
 
 import { currentReleaseIdentity, releaseIdentityFor } from "./lib/release-identities.ts";
 
+import { CAPTURE_LIMIT_BYTES } from "./lib/process.ts";
+
 // The candidate is built by this repository's CI, so it lives in the current
 // namespace. The previous release keeps the namespace it was published under —
 // GHCR packages do not transfer between organizations (issue #1599) — so its
@@ -13,7 +15,7 @@ const applicationRepository = `${currentNamespace}/application-server`;
 const postgresRepository = `${currentNamespace}/postgres`;
 
 function command(executable: string, args: string[]): string {
-	const result = spawnSync(executable, args, { encoding: "utf8" });
+	const result = spawnSync(executable, args, { encoding: "utf8", maxBuffer: CAPTURE_LIMIT_BYTES });
 	if (result.status !== 0)
 		throw new Error(`${executable} ${args.join(" ")} failed:\n${result.stdout}${result.stderr}`);
 	return result.stdout.trim();


### PR DESCRIPTION
## Problem — `main` is red

`Version PR` has been failing on every push to `main`:

```
RangeError [ERR_CHILD_PROCESS_STDIO_MAXBUFFER]: stdout maxBuffer length exceeded
  cmd: 'gh api repos/.../actions/workflows/cicd.yml/runs?branch=changeset-release%2Fmain&per_page=100'
```

That workflow maintains the changesets Version PR. While it fails the Version PR is not updated, so **no release can be cut**.

`scripts/dispatch-version-pr-ci.ts` captured the unprojected listing — 135 runs, each carrying the full repository object — through `output()`, which set no `maxBuffer` and therefore inherited Node's 1 MiB default.

## Fix

**Stop asking for it.** `parseRuns` reads only `head_sha`, so the query is now projected server-side with `--jq '{workflow_runs: [.workflow_runs[] | {head_sha}]}'`. Measured against the live API: **1 MB → 5.6 KB**, and it no longer grows with the branch's history. The response shape is preserved, so `parseRuns` and its tests are unchanged.

**Then stop it recurring.** This default has now broken the release pipeline three separate times:

| | Capture |
|---|---|
| #1748 | `cosign verify-attestation` — the DSSE envelope carries the whole SPDX SBOM |
| #1744 | `gh api` release listing — worked around by projecting to four fields |
| this | `gh api` workflow-run listing — took `main` red |

So the ceiling is stated once in `scripts/lib/process.ts` and exported; every remaining capture in `scripts/**` uses it. A contract test finds any capture that does not — it caught five more while I was writing it (`check-affected`, `check-preview-stack`, `coolify-preview`, `release-upgrade-test`, `resolve-release-upgrade-images`), all now bounded. `check-package-manager.ts` reading `git ls-files -z` over the whole tree was the most exposed: it grows with the repository and runs in `pnpm run check` on every machine.

The bound stays finite deliberately — an unbounded capture of a runaway process is its own failure.

Closes #1749.

## Verification

- The projection run against the live API: correct shape, 5620 bytes.
- `node --test scripts/ci-contract.test.ts` → **28/28**, including the new guard; it fails with a named list when a capture is unbounded.
- `node --test scripts/dispatch-version-pr-ci.test.ts` → 5/5.
- `pnpm run format` then `pnpm run check` both pass.

No changeset: `verify-changesets` scopes `SHIPPED_PATHS` to `server`, `webapp`, `docker`; this touches `scripts/` only.