### PR TITLE
fix(ci): fail the Version PR gate when its release evidence preflight did not run

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -50,8 +50,12 @@ jobs:
       pmd-canary: ${{ steps.filter.outputs.pmd-canary }}
       version-bump: ${{ steps.version_bump.outputs.changed }}
       version: ${{ steps.version.outputs.version }}
+      version-branch: ${{ steps.version_branch.outputs.version-branch }}
       any-code: ${{ steps.filter.outputs.webapp == 'true' || steps.filter.outputs.application-server == 'true' || steps.filter.outputs.tooling == 'true' || steps.filter.outputs.agent-images == 'true' || steps.filter.outputs.postgres-image == 'true' }}
-      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+      # A Version PR head is validated once per head commit, never inherited from an earlier run that
+      # matched its tree: a skipped duplicate would skip the image builds the preflight below needs,
+      # and the gate refuses to pass on that branch without a preflight.
+      should_skip: ${{ steps.skip_check.outputs.should_skip == 'true' && steps.version_branch.outputs.version-branch != 'true' }}
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -69,6 +73,19 @@ jobs:
       - name: Read the release version
         id: version
         run: echo "version=$(jq -r .version package.json)" >> "$GITHUB_OUTPUT"
+
+      # Whether this run is looking at the Version PR's head, whichever event started it. The branch
+      # name is read from the config changesets derives it from rather than restated, so a
+      # base-branch rename cannot quietly turn the release evidence preflight off; ci-contract.test.ts
+      # runs this shell against `versionBranch()` and requires the two to agree.
+      - name: Detect the Version PR branch
+        id: version_branch
+        env:
+          HEAD_BRANCH: ${{ github.head_ref || github.ref_name }}
+        run: |
+          version_branch="changeset-release/$(jq -r .baseBranch .changeset/config.json)"
+          [ "$HEAD_BRANCH" = "$version_branch" ] && on_version_branch=true || on_version_branch=false
+          echo "version-branch=$on_version_branch" >> "$GITHUB_OUTPUT"
 
       - name: Detect version bump
         id: version_bump
@@ -436,10 +453,15 @@ jobs:
   # build, so ci-security-scan.yml already covers both of their platforms on the pull request that
   # changes them. release-management.mdx § Nothing may fail for the first time at a release carries
   # the check-by-check reasoning.
+  #
+  # On the Version PR's branch it runs whatever event started the run. That head is the commit whose
+  # merge cuts a release, and more than one run can report `CI Status Gate` for it — the run
+  # version-pr.yml dispatches, and an approved `pull_request` run — while the ruleset is satisfied by
+  # either. So the answer has to be in every one of them, not in the dispatched one alone.
   Release-preflight:
     name: "Release evidence preflight"
     needs: [detect-changes, Build, Docker]
-    if: ${{ github.event_name == 'workflow_dispatch' && inputs.release-preflight }}
+    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.release-preflight) || needs.detect-changes.outputs.version-branch == 'true' }}
     timeout-minutes: 45
     runs-on: ubuntu-latest
     permissions:
@@ -564,6 +586,7 @@ jobs:
           echo "Compose:        ${{ needs.Compose.result }}"
           echo "Docker:         ${{ needs.Docker.result }}"
           echo "Preflight:      ${{ needs.Release-preflight.result }}"
+          echo "Version branch: ${{ needs.detect-changes.outputs.version-branch == 'true' }}"
 
           if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]]; then
             echo "status=failure" >> $GITHUB_OUTPUT
@@ -572,6 +595,15 @@ jobs:
 
           if [[ "${{ contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
             echo "status=cancelled" >> $GITHUB_OUTPUT
+            exit 1
+          fi
+
+          # The Version PR's merge cuts a release, so its gate is only worth the name if the release
+          # evidence preflight actually ran here. A skipped job is a missing answer, not an
+          # affirmative one, and the checks above read it as neither failed nor cancelled.
+          if [[ "${{ needs.detect-changes.outputs.version-branch == 'true' && needs.Release-preflight.result != 'success' }}" == "true" ]]; then
+            echo "The Version PR requires a successful release evidence preflight; this run's was '${{ needs.Release-preflight.result }}'."
+            echo "status=failure" >> $GITHUB_OUTPUT
             exit 1
           fi
 
@@ -632,6 +664,11 @@ jobs:
           if [[ "${{ steps.evaluate.outputs.status }}" == "failure" ]]; then
             echo "### 💡 Troubleshooting Guide" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
+
+            if [[ "${{ needs.detect-changes.outputs.version-branch == 'true' && needs.Release-preflight.result != 'success' }}" == "true" ]]; then
+              echo "❌ **The release evidence preflight did not pass.** Merging this pull request cuts a release, so its gate requires the preflight to succeed in this run; it was \`${{ needs.Release-preflight.result }}\`." >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
+            fi
 
             if [[ "${{ needs.Quality.result }}" == "failure" ]]; then
               echo "<details><summary><b>❌ Quality Failed</b></summary>" >> $GITHUB_STEP_SUMMARY

--- a/docs/contributor/ci-cd.mdx
+++ b/docs/contributor/ci-cd.mdx
@@ -185,7 +185,7 @@ why the label is the authority, and which alternatives were priced and declined,
 
 | Workflow | Trigger | Purpose |
 | --- | --- | --- |
-| `cicd.yml` | PR, merge group, push to main, manual | Validates changes before merge and builds final-SHA images after merge; the `release-preflight` dispatch input adds the release evidence gate over the images the run built |
+| `cicd.yml` | PR, merge group, push to main, manual | Validates changes before merge and builds final-SHA images after merge; the release evidence gate runs over the images the run built on the Version PR's branch, and wherever the `release-preflight` dispatch input asks for it |
 | `review-policy.yml` | PR opened, reopened, synchronized, ready for review, edited | Approves a listed maintainer's pull request so the ruleset's required approval is met; does nothing for anyone else |
 | `pull-request.yml` | PR opened, edited, synchronized, reopened, ready for review | Validates the title with commitlint, applies labels, assigns the author |
 | `ci-quality-gates.yml` | Called by cicd.yml | Formatting, lint, type checks, webapp unit and story tests: everything verifiable from source |

--- a/docs/contributor/release-management.mdx
+++ b/docs/contributor/release-management.mdx
@@ -53,7 +53,11 @@ sequenceDiagram
    branch, `workflow_dispatch` being one of the two events that token may start. Every Version PR
    head commit gets one such run; `scripts/dispatch-version-pr-ci.ts` decides by asking whether the
    head already has one, so a missed dispatch heals on the next push and an unchanged head costs
-   nothing. The dispatched run also carries the **release evidence preflight** below.
+   nothing. Every CI/CD run on that branch also carries the **release evidence preflight** below,
+   whichever event started it, and `CI Status Gate` fails there unless the preflight succeeded in the
+   same run. More than one run can report that gate for a Version PR head — a dispatch and an
+   approved `pull_request` run both did for v0.75.1 — and the ruleset is satisfied by either, so a
+   green gate means the preflight passed only if no run can be green without it.
 3. **The merge is checked again.** The merge commit's push runs CI/CD in full — a push to `main`
    repeats the source-validation legs only when it carries a version bump, which is exactly this
    commit — and `release.yml` starts only when that run succeeds.
@@ -151,8 +155,8 @@ contract test rather than a release. The third structural entry is not condition
 verifier always demands a release version, and the preflight gives it the version the ref carries.
 
 The preflight is not free — it is a Syft and Trivy pass over every image on both architectures — so
-it runs only where its answer changes a decision: on the Version PR, and on any manual CI/CD dispatch
-that ticks `release-preflight`. It reuses the images that run already built, so what it judges is the
+it runs only where its answer changes a decision: on every CI/CD run on the Version PR's branch, and
+on any manual CI/CD dispatch that ticks `release-preflight`. It reuses the images that run already built, so what it judges is the
 artefact a release of that ref would promote, not a stand-in.
 
 The pinned upstream images are therefore judged twice on the Version PR, and deliberately: the

--- a/scripts/ci-contract.test.ts
+++ b/scripts/ci-contract.test.ts
@@ -1,11 +1,14 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
-import { glob, readFile } from "node:fs/promises";
+import { glob, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import { describe, test } from "node:test";
 
-import { type Document, isMap, isSeq, parseDocument, type YAMLMap } from "yaml";
+import { type Document, isMap, isScalar, isSeq, parseDocument, type YAMLMap } from "yaml";
 
+import { versionBranch } from "./dispatch-version-pr-ci.ts";
 import { planRelease, releaseOutputs } from "./plan-release.ts";
 import { planSubjects } from "./scan-main-images.ts";
 import { PLATFORMS, planUpstreamSubjects } from "./scan-upstream-images.ts";
@@ -80,6 +83,86 @@ function step(workflow: Document, jobPath: string[], action: string): YAMLMap {
 		}
 	}
 	throw new Error(`${jobPath.join(".")} has no ${action} step`);
+}
+
+/** The shell a named `run` step ships. */
+function runScript(workflow: Document, jobPath: string[], name: string): string {
+	const steps = workflow.getIn([...jobPath, "steps"]);
+	assert.ok(isSeq(steps), `${jobPath.join(".")} has no steps`);
+	for (const item of steps.items) {
+		if (!isMap(item) || item.get("name") !== name) continue;
+		const shell = item.get("run");
+		assert.ok(typeof shell === "string", `${name} is not a run step`);
+		return shell;
+	}
+	throw new Error(`${jobPath.join(".")} has no ${name} step`);
+}
+
+/**
+ * Runs a step's shell the way the runner does — `bash -e`, with `GITHUB_OUTPUT` pointing at a file
+ * of its own — and reports the exit status and the outputs it wrote. A gate whose verdict is bash
+ * is only pinned by running that bash.
+ */
+async function runStep(
+	shell: string,
+	environment: Record<string, string> = {},
+): Promise<{ readonly failed: boolean; readonly outputs: Record<string, string> }> {
+	const outputFile = path.join(await mkdtemp(path.join(tmpdir(), "ci-contract-")), "output");
+	await writeFile(outputFile, "");
+	const run = spawnSync("bash", ["--noprofile", "--norc", "-e", "-c", shell], {
+		encoding: "utf8",
+		env: { ...process.env, ...environment, GITHUB_OUTPUT: outputFile },
+	});
+	assert.equal(run.error, undefined);
+	const outputs = (await readFile(outputFile, "utf8"))
+		.split("\n")
+		.filter((line) => line.length > 0)
+		.map((line) => [line.slice(0, line.indexOf("=")), line.slice(line.indexOf("=") + 1)] as const);
+	return { failed: run.status !== 0, outputs: Object.fromEntries(outputs) };
+}
+
+/**
+ * Substitutes the workflow expressions a step's shell reads, as the runner substitutes them: by
+ * text, before bash sees any of it. An expression this cannot evaluate throws rather than rendering
+ * empty, so a new one has to be taught here instead of quietly leaving its case untested.
+ */
+function render(
+	shell: string,
+	results: Readonly<Record<string, string>>,
+	outputs: Readonly<Record<string, string>>,
+): string {
+	const value = (operand: string): string => {
+		const result = /^needs\.([\w-]+)\.result$/.exec(operand)?.[1];
+		if (result !== undefined) {
+			const conclusion = results[result];
+			assert.ok(conclusion !== undefined, `${operand} is not one of the job's needs`);
+			return conclusion;
+		}
+		const output = /^needs\.detect-changes\.outputs\.([\w-]+)$/.exec(operand)?.[1];
+		if (output !== undefined) {
+			const declared = outputs[output];
+			assert.ok(declared !== undefined, `${operand} is not a detect-changes output`);
+			return declared;
+		}
+		const contained = /^contains\(needs\.\*\.result, '(\w+)'\)$/.exec(operand)?.[1];
+		if (contained !== undefined) return String(Object.values(results).includes(contained));
+		throw new Error(`this test cannot evaluate \`${operand}\``);
+	};
+	return shell.replaceAll(/\$\{\{ (.+?) }}/g, (_, expression: string) => {
+		const terms = expression.split(" && ");
+		if (terms.length === 1 && !/ (?:==|!=) /.test(expression)) return value(expression);
+		// A conjunction of comparisons renders as the literal `true` or `false`, which is why the
+		// workflow reduces its conditions to one before a shell ever sees them.
+		return String(
+			terms.every((term) => {
+				const comparison = /^(.+) (==|!=) '(\w*)'$/.exec(term);
+				assert.ok(comparison, `this test cannot evaluate \`${term}\``);
+				const [, operand, operator, literal] = comparison;
+				const equal = value(operand ?? "") === literal;
+				return operator === "==" ? equal : !equal;
+			}),
+		);
+	});
 }
 
 void describe("CI contract", () => {
@@ -534,7 +617,7 @@ void describe("CI contract", () => {
 		assert.match(preflight, /max-age-hours: "24"/);
 		assert.match(
 			preflight,
-			/if: \$\{\{ github\.event_name == 'workflow_dispatch' && inputs\.release-preflight \}\}/,
+			/if: \$\{\{ \(github\.event_name == 'workflow_dispatch' && inputs\.release-preflight\) \|\| needs\.detect-changes\.outputs\.version-branch == 'true' \}\}/,
 		);
 		assert.match(cicd, /^ {6}release-preflight:$/m);
 		assert.match(job(cicd, "all-ci-passed"), /needs: \[[^\]]*Release-preflight\]/);
@@ -575,6 +658,72 @@ void describe("CI contract", () => {
 			job(await readFile(".github/workflows/cicd.yml", "utf8"), "all-ci-passed"),
 			/const sha = context\.payload\.pull_request\?\.head\?\.sha \|\| context\.sha;/,
 		);
+	});
+
+	void test("fails the CI gate on the Version PR when its release evidence preflight did not", async () => {
+		// #1745's guarantee is that a green Version PR gate means the release will clear its evidence
+		// gate. Two runs reported that gate for #1757's head — the dispatch, where the preflight
+		// succeeded, and a pull_request run, where it skipped — and the ruleset is satisfied by
+		// either, so the guarantee held only for as long as the dispatch was the sole reporter. Every
+		// run on that branch now runs the preflight, and the gate treats a preflight that is anything
+		// other than successful as the missing answer it is.
+		const workflow = parseDocument(await readFile(".github/workflows/cicd.yml", "utf8"));
+		const detection = ["jobs", "detect-changes"];
+
+		// One home for the branch name: the workflow reads it out of the same `.changeset/config.json`
+		// `versionBranch()` reads, so this runs the workflow's own shell and requires the two to agree
+		// rather than restating either. A base-branch rename moves both or fails here.
+		const detect = runScript(workflow, detection, "Detect the Version PR branch");
+		const branch = versionBranch(JSON.parse(await readFile(".changeset/config.json", "utf8")));
+		const detected = async (head: string): Promise<string | undefined> =>
+			(await runStep(detect, { HEAD_BRANCH: head })).outputs["version-branch"];
+		assert.equal(await detected(branch), "true");
+		for (const other of ["main", `${branch}-old`, "changeset-release/release-1.0", "renovate/vite"])
+			assert.equal(await detected(other), "false", `${other} is not the Version PR's branch`);
+
+		// The gate can only demand a preflight it lets run. On that branch the preflight runs for
+		// every event, and a duplicate-run skip must not take the image builds it needs away.
+		assert.match(
+			String(workflow.getIn(["jobs", "Release-preflight", "if"])),
+			/needs\.detect-changes\.outputs\.version-branch == 'true'/,
+		);
+		assert.match(
+			String(workflow.getIn([...detection, "outputs", "should_skip"])),
+			/steps\.version_branch\.outputs\.version-branch != 'true'/,
+		);
+
+		// The verdict itself, run rather than read. Its needs are the jobs it judges, so a new one is
+		// covered here the moment it is added.
+		const gate = ["jobs", "all-ci-passed"];
+		const needed = workflow.getIn([...gate, "needs"]);
+		assert.ok(isSeq(needed));
+		const green = Object.fromEntries(
+			needed.items.map((item) => {
+				const name = isScalar(item) ? item.value : item;
+				assert.ok(typeof name === "string");
+				return [name, "success"];
+			}),
+		);
+		const evaluate = runScript(workflow, gate, "Evaluate CI results");
+		const verdict = async (results: Record<string, string>, onVersionBranch: boolean) =>
+			runStep(
+				render(evaluate, { ...green, ...results }, { "version-branch": String(onVersionBranch) }),
+			);
+		const passes = { failed: false, outputs: { status: "success" } };
+
+		// An ordinary pull request legitimately skips the preflight, and blocking one would block
+		// every pull request in the repository.
+		assert.deepEqual(await verdict({ "Release-preflight": "skipped" }, false), passes);
+		// Nothing else changes meaning on that branch: a dispatched run has no `Changesets` job, and
+		// a path filter may skip any other leg, exactly as on `main`.
+		assert.deepEqual(await verdict({ Changesets: "skipped" }, true), passes);
+		// The Version PR, whichever run reports the gate: a preflight that did not succeed fails it.
+		for (const preflight of ["skipped", "failure", "cancelled"])
+			assert.equal(
+				(await verdict({ "Release-preflight": preflight }, true)).failed,
+				true,
+				`preflight ${preflight} must fail the gate`,
+			);
 	});
 
 	void test("rescans main's images weekly and reports drift to an issue, not a status", async () => {


### PR DESCRIPTION
## What changed and why

#1745 established that the Version PR — the commit whose merge cuts a release — runs real CI plus a
release evidence preflight, so that a green Version PR means the release will clear its evidence
gate. That was not enforced.

The preflight was gated on `github.event_name == 'workflow_dispatch' && inputs.release-preflight`, so
any other run on the Version PR's branch skipped it, and `CI Status Gate` — which needs it with
`if: always()` — fails only on `failure` or `cancelled`, so a **skipped** preflight passed. On
#1757's head `cdc780779` that produced two `CI Status Gate` check runs, both `success`: the
dispatched one whose preflight succeeded, and an approved `pull_request` one whose preflight was
skipped. The ruleset requires the context and either check run satisfies it, so the guarantee held
only for as long as the dispatch was the sole reporter.

CI/CD now knows whether a run is looking at the Version PR's head, and on that branch:

- the **release evidence preflight runs whatever event started the run**, so every run that can
  report the gate has its own answer;
- **`skip-duplicate-actions` cannot skip the run** — a skipped duplicate would skip the image builds
  the preflight needs and leave it skipped through the back door;
- **the gate fails unless the preflight succeeded in that same run.** A skipped job is a missing
  answer, not an affirmative one.

Because both runs now carry the preflight, the fix does not depend on which of two same-named check
runs GitHub picks for a required context.

### Why enforce rather than suppress the redundant run

Suppressing the `pull_request` run's gate was the alternative, and it fails open. A skipped check run
still satisfies a required status check — `Actionlint` and `Zizmor` are skipped on that same head
today and the ruleset is content — so a suppressed gate would not merely stop lying, it would keep
merging while saying nothing, and it would also let a *failed* dispatch run be papered over by the
skipped one. Enforcement fails closed, and it stops the guarantee depending on the dispatch happening
at all: if `version-pr.yml` never dispatches (it asks whether the head already has a run, and a
`pull_request` run awaiting approval is one), the branch is still validated with its preflight by
whatever run does report.

### One home for the branch name

`.changeset/config.json` stays the only home. The workflow composes the branch from its `baseBranch`
(`changeset-release/$(jq -r .baseBranch .changeset/config.json)`) exactly as
`scripts/dispatch-version-pr-ci.ts`'s `versionBranch()` composes it, and the contract test **runs the
workflow's own shell** and requires it to agree with `versionBranch()` on the committed config. A
base-branch rename moves both; a hard-coded copy that drifts fails the test (verified by mutation —
renaming `baseBranch` with the derivation in place still passes, with `changeset-release/main`
hard-coded it fails).

## How to test

`release.yml` and `cicd.yml` cannot be tested by running them, so the invariant is pinned by
`scripts/ci-contract.test.ts` → *"fails the CI gate on the Version PR when its release evidence
preflight did not"*, which parses `cicd.yml` and **executes the gate's own shell** under `bash -e`
with the workflow expressions substituted the way the runner substitutes them (an expression the test
cannot evaluate throws, so a new one cannot silently stop being covered). The judged jobs are derived
from the gate's `needs`, not listed.

- ordinary pull request, preflight `skipped` → gate passes;
- Version PR with preflight `success`, `Changesets` skipped → gate passes;
- Version PR with preflight `skipped`, `failure` or `cancelled` → gate fails.

Also asserted: the preflight's `if` covers the version branch (a gate may only demand a preflight it
lets run), `should_skip` cannot suppress it there, and the branch derivation agrees with
`versionBranch()` for the real branch and rejects `main`, `changeset-release/release-1.0` and
neighbours.

Verified by mutation: deleting the gate's guard fails the test with *"preflight skipped must fail the
gate"*. `pnpm run format` and `pnpm run check` both pass; the new step is clean under
`shellcheck --severity=warning`, which is what actionlint runs.

## Failure modes considered

| Case | `version-branch` | Preflight | Gate |
| --- | --- | --- | --- |
| Ordinary pull request (incl. forks, path-filtered skips) | `false` | skipped, as today | unchanged — the guard cannot fire |
| Version PR, dispatched run | `true` | runs, as today | fails unless it succeeded |
| Version PR, approved `pull_request` run | `true` | **now runs** | fails unless it succeeded |
| Version PR, duplicate of an earlier run | `true` | runs — `should_skip` is forced off there | fails unless it succeeded |
| Merge group | `false` (the ref is `gh-readonly-queue/...`) | skipped | unchanged |
| Push to `main`, manual dispatch elsewhere | `false` | only when `release-preflight` is ticked | unchanged |

- **Ordinary pull requests are untouched, deliberately.** The guard is `version-branch == 'true' &&
  preflight != 'success'`, and `version-branch` is a string comparison against a branch no ordinary
  PR is on. A content-based predicate ("this ref bumps the version") would also have covered the
  merge group, and I rejected it: it misfires on any branch whose `package.json` version differs from
  main's, and a bug in this guard blocks every pull request in the repository.
- **The Version PR can still merge.** This is the reason the preflight `if` and `should_skip` had to
  change with the gate: enforcing alone would have left the `pull_request` run permanently red, and
  a duplicate-run skip would have taken away the image builds the preflight needs.
- **`merge_group` is not covered, and that is a residual gap worth naming.** The Version PR merges
  through the queue (v0.75.0's did), and in a merge group the head ref is the queue's, so the
  preflight does not run and the guard does not fire — the same posture as today. What keeps the
  window narrow is that every push to `main` re-creates the Version PR head, which re-runs the
  preflight and ejects any stale queue entry, so the queued content is the content that was
  preflighted. Closing it properly needs a predicate that survives the queue ref, which is a
  different change from this one.
- **`release.yml` is untouched.** It consumes the push-to-`main` CI/CD run and runs the full evidence
  gate itself; nothing here changes what it verifies, only what must be proven before the merge.
- **Cost.** When a maintainer approves the Version PR's `pull_request` run, the preflight runs twice
  for that head (~13 min of runner time each, from #1757's dispatch run). That is the price of every
  reporter carrying its own answer; the runs are in different concurrency groups by design and do not
  cancel one another.

## Release impact

No changeset. `verify-changesets.yml` scopes `SHIPPED_PATHS` to `server`, `webapp` and `docker`
(minus tests and in-tree docs); this touches `.github/workflows/cicd.yml`, `scripts/` and `docs/`
only, so `Verify changesets` requires none and there is no operator action.

## Notes for reviewers

Start with the gate's *Evaluate CI results* step and the `Release-preflight` `if`, then the new
contract test — it runs those two rather than reading them. The three conditions are written as
single `${{ … }}` expressions that render to `true`/`false`, matching the file's existing idiom and
keeping raw `needs` outputs out of shell text.

#1757 is untouched: its preflight did run and pass, so it is safe to merge as it stands. This change
is for the release after it.

---

Model: Claude Fable 5 (`claude-fable-5`), harness: Claude Code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release evidence preflight now runs automatically for CI/CD runs on Version PR branches.
  * CI status checks now require successful release evidence preflight on those branches.
  * Manual release preflight dispatches remain supported.

* **Documentation**
  * Updated CI/CD and release-management guidance to describe the automatic preflight and status requirements.

* **Tests**
  * Added coverage verifying Version PR branch detection and enforcement of successful release evidence preflight.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->