### PR TITLE
fix(ci): give the Version PR the both-platform images its preflight needs

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -8,6 +8,12 @@ on:
         required: false
         type: string
         default: "false"
+      single_arch:
+        # No default: what a release is evidenced on is not a decision to make silently on a
+        # caller's behalf. cicd.yml derives it once, for every image build in the run.
+        description: "Whether to build linux/amd64 alone instead of the supported multi-architecture set"
+        required: true
+        type: string
       server_changed:
         description: "Whether anything that runs the packaged reactor changed"
         required: false
@@ -337,4 +343,4 @@ jobs:
       # renovate: datasource=docker depName=paketobuildpacks/ubuntu-noble-run-tiny
       run-image: "paketobuildpacks/ubuntu-noble-run-tiny@sha256:c32333227b6dfbc2a4a93b03ee6d3475cfe152468c7d396bf22f06099bb0ecc9"
       registry: "ghcr.io"
-      single-arch: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
+      single-arch: ${{ inputs.single_arch == 'true' }}

--- a/.github/workflows/ci-docker-build.yml
+++ b/.github/workflows/ci-docker-build.yml
@@ -15,6 +15,12 @@ on:
         required: false
         type: string
         default: "false"
+      single_arch:
+        # No default: what a release is evidenced on is not a decision to make silently on a
+        # caller's behalf. cicd.yml derives it once, for every image build in the run.
+        description: "Whether to build linux/amd64 alone instead of the supported multi-architecture set"
+        required: true
+        type: string
       webapp_changed:
         description: "Whether webapp files changed (or should build for other reasons)"
         required: false
@@ -61,7 +67,7 @@ jobs:
       build-args: |
         SOURCE_COMMIT=${{ github.sha }}
         COOLIFY_BRANCH=${{ github.head_ref || github.ref_name }}
-      single-arch: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
+      single-arch: ${{ inputs.single_arch == 'true' }}
       labels: |
         org.opencontainers.image.title=Hephaestus Webapp
         org.opencontainers.image.description=Web client for Hephaestus
@@ -86,7 +92,7 @@ jobs:
       # Cache-busts the OS-package upgrade layer; this build imports the `cache-main` registry cache.
       build-args: |
         SOURCE_COMMIT=${{ github.sha }}
-      single-arch: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
+      single-arch: ${{ inputs.single_arch == 'true' }}
       labels: |
         org.opencontainers.image.title=Hephaestus Agent - Pi
         org.opencontainers.image.description=Sandboxed Pi coding agent for AI-powered code review
@@ -113,7 +119,7 @@ jobs:
       # Cache-busts the OS-package upgrade layer; this build imports the `cache-main` registry cache.
       build-args: |
         SOURCE_COMMIT=${{ github.sha }}
-      single-arch: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
+      single-arch: ${{ inputs.single_arch == 'true' }}
       labels: |
         org.opencontainers.image.title=Hephaestus Postgres
         org.opencontainers.image.description=PostgreSQL + pg_partman for all environments (dev/preview/prod)

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -52,6 +52,14 @@ jobs:
       version: ${{ steps.version.outputs.version }}
       version-branch: ${{ steps.version_branch.outputs.version-branch }}
       any-code: ${{ steps.filter.outputs.webapp == 'true' || steps.filter.outputs.application-server == 'true' || steps.filter.outputs.tooling == 'true' || steps.filter.outputs.agent-images == 'true' || steps.filter.outputs.postgres-image == 'true' }}
+      # Which architectures the images this run builds are published on, decided once for every
+      # image. A pre-merge candidate is only ever run on amd64, so that is all a pull request or a
+      # merge group builds — except on the Version PR's branch, where the release evidence preflight
+      # below evidences each image on both published platforms. The vulnerability policy's match key
+      # includes the platform, so an arm64-only finding has to be found before the release rather
+      # than by it, and the preflight can only find it in a manifest that exists. That branch is a
+      # single pull request, and it is the one whose merge cuts the release.
+      single-arch: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && steps.version_branch.outputs.version-branch != 'true' }}
       # A Version PR head is validated once per head commit, never inherited from an earlier run that
       # matched its tree: a skipped duplicate would skip the image builds the preflight below needs,
       # and the gate refuses to pass on that branch without a preflight.
@@ -362,6 +370,7 @@ jobs:
       attestations: write
     with:
       should_skip: ${{ needs.detect-changes.outputs.should_skip }}
+      single_arch: ${{ needs.detect-changes.outputs.single-arch }}
       server_changed: ${{ (needs.detect-changes.outputs.application-server == 'true' || needs.detect-changes.outputs.e2e == 'true' || needs.detect-changes.outputs.postgres-image == 'true' || needs.detect-changes.outputs.build-config == 'true' || needs.detect-changes.outputs.application-server-image == 'true' || github.event_name != 'pull_request') && 'true' || 'false' }}
       contracts_changed: ${{ (github.event_name != 'push' || needs.detect-changes.outputs.version-bump == 'true') && (needs.detect-changes.outputs.application-server == 'true' || needs.detect-changes.outputs.postgres-image == 'true' || needs.detect-changes.outputs.build-config == 'true' || github.event_name != 'pull_request') && 'true' || 'false' }}
       e2e_changed: ${{ (github.event_name != 'push' || needs.detect-changes.outputs.version-bump == 'true') && (needs.detect-changes.outputs.e2e == 'true' || github.event_name != 'pull_request') && 'true' || 'false' }}
@@ -440,6 +449,7 @@ jobs:
       attestations: write
     with:
       should_skip: ${{ needs.detect-changes.outputs.should_skip }}
+      single_arch: ${{ needs.detect-changes.outputs.single-arch }}
       webapp_changed: ${{ (needs.detect-changes.outputs.webapp-image == 'true' || needs.detect-changes.outputs.docker-config == 'true' || github.event_name != 'pull_request') && 'true' || 'false' }}
       application_server_changed: ${{ (needs.detect-changes.outputs.application-server-image == 'true' || github.event_name != 'pull_request') && 'true' || 'false' }}
       agent_images_changed: ${{ (needs.detect-changes.outputs.agent-images == 'true' || needs.detect-changes.outputs.docker-config == 'true' || github.event_name != 'pull_request') && 'true' || 'false' }}

--- a/docs/contributor/ci-cd.mdx
+++ b/docs/contributor/ci-cd.mdx
@@ -36,7 +36,9 @@ flowchart TD
 Every push to `main` builds and attests multi-architecture images for that commit and maintains the
 Version PR; merging the Version PR cuts a release that promotes those images by digest —
 [Release management](./release-management.mdx). Pull requests and merge groups build `linux/amd64`
-only; a merge group has its own SHA, so its images are never the ones a release promotes.
+only; a merge group has its own SHA, so its images are never the ones a release promotes. The
+exception is the Version PR's branch, where every run builds both architectures, because the release
+evidence preflight that guards that branch evidences each image on both published platforms.
 
 ## Quality gates
 
@@ -272,7 +274,9 @@ nothing that ships, so they compile from source in `Test` and do not wait for pa
 
 - `Quality` legs and `Test` suites start from source; `Build` gates start when `App Server: Package`
   uploads its artifact.
-- Pull requests and merge groups build `linux/amd64`; pushes to `main` build both architectures.
+- Pull requests and merge groups build `linux/amd64`; pushes to `main`, and every run on the Version
+  PR's branch, build both architectures. `detect-changes` decides that once and hands it to every
+  image build in the run.
 - The `Quality` matrix uses `fail-fast: false`; the image matrix in `reusable-docker-build.yml` uses
   `fail-fast: true`.
 - Pull-request runs cancel superseded runs; `release.yml` never cancels.

--- a/docs/contributor/release-management.mdx
+++ b/docs/contributor/release-management.mdx
@@ -57,7 +57,10 @@ sequenceDiagram
    whichever event started it, and `CI Status Gate` fails there unless the preflight succeeded in the
    same run. More than one run can report that gate for a Version PR head — a dispatch and an
    approved `pull_request` run both did for v0.75.1 — and the ruleset is satisfied by either, so a
-   green gate means the preflight passed only if no run can be green without it.
+   green gate means the preflight passed only if no run can be green without it. Every run on that
+   branch therefore builds both architectures, unlike the `linux/amd64` candidate an ordinary pull
+   request builds: the preflight evidences each image on both published platforms, and it can only
+   do that for manifests that exist.
 3. **The merge is checked again.** The merge commit's push runs CI/CD in full — a push to `main`
    repeats the source-validation legs only when it carries a version bump, which is exactly this
    commit — and `release.yml` starts only when that run succeeds.
@@ -154,8 +157,9 @@ The two signature entries are the only mode-conditional behaviour in the verifie
 contract test rather than a release. The third structural entry is not conditional at all — the
 verifier always demands a release version, and the preflight gives it the version the ref carries.
 
-The preflight is not free — it is a Syft and Trivy pass over every image on both architectures — so
-it runs only where its answer changes a decision: on every CI/CD run on the Version PR's branch, and
+The preflight is not free — it is a Syft and Trivy pass over every image on both architectures, plus
+the `linux/arm64` half of the image builds it reads, which no other pre-merge run pays for — so it
+runs only where its answer changes a decision: on every CI/CD run on the Version PR's branch, and
 on any manual CI/CD dispatch that ticks `release-preflight`. It reuses the images that run already built, so what it judges is the
 artefact a release of that ref would promote, not a stand-in.
 

--- a/scripts/ci-contract.test.ts
+++ b/scripts/ci-contract.test.ts
@@ -385,7 +385,7 @@ void describe("CI contract", () => {
 		assert.match(job(source, "Compose"), /uses: \.\/\.github\/workflows\/ci-compose-validate\.yml/);
 	});
 
-	void test("builds pre-merge candidates on one architecture and final images on both", async () => {
+	void test("decides an image's architectures once, for every image the run builds", async () => {
 		const source = await readFile(".github/workflows/cicd.yml", "utf8");
 		const caller = job(source, "Docker");
 		for (const secret of ["SENTRY_AUTH_TOKEN", "SENTRY_ORG", "SENTRY_PROJECT"]) {
@@ -397,18 +397,24 @@ void describe("CI contract", () => {
 
 		const docker = await readFile(".github/workflows/ci-docker-build.yml", "utf8");
 		const build = await readFile(".github/workflows/ci-build.yml", "utf8");
+		// The architecture set is one decision, taken in cicd.yml and handed to every image build, so
+		// a run cannot evidence one image on both platforms and its sibling on one. The test below
+		// owns what that decision is; this owns that nothing decides it locally.
 		for (const image of [
 			job(docker, "webapp-build"),
 			job(docker, "agent-pi-build"),
 			job(docker, "postgres-build"),
 			job(build, "application-server-image"),
 		]) {
-			assert.match(
-				image,
-				/single-arch: \${{ github\.event_name == 'pull_request' \|\| github\.event_name == 'merge_group' }}/,
-			);
+			assert.match(image, /single-arch: \${{ inputs\.single_arch == 'true' }}/);
 			assert.doesNotMatch(image, /^\s+tags:/m);
 		}
+		for (const called of [docker, build])
+			// Required, and with no default: a caller that forgets it fails to start, rather than
+			// silently publishing one architecture where a release needs two.
+			assert.match(called, /^ {6}single_arch:\n(?: {8}.*\n)*? {8}required: true$/m);
+		for (const consumer of [job(source, "Build"), job(source, "Docker")])
+			assert.match(consumer, /single_arch: \${{ needs\.detect-changes\.outputs\.single-arch }}/);
 		const inherited = job(docker, "tag-unchanged-images");
 		assert.match(inherited, /HEAD_SHA/);
 		assert.match(inherited, /pr-\$PR_NUMBER/);
@@ -724,6 +730,37 @@ void describe("CI contract", () => {
 				true,
 				`preflight ${preflight} must fail the gate`,
 			);
+
+		// A demand the run cannot satisfy is not a gate, it is a wall. The preflight evidences every
+		// image on both published platforms — the vulnerability policy's match key includes the
+		// platform, so an arm64-only finding must not reach a release undiscovered (#1743) — and it
+		// can only do that for manifests that exist. So wherever the gate demands a preflight, the
+		// same run's image builds have to publish both. A pull request on that branch published
+		// `linux/amd64` alone and could not, which is what blocked v0.75.1.
+		const architectures = String(workflow.getIn([...detection, "outputs", "single-arch"]));
+		const shape =
+			/^\$\{\{ \(github\.event_name == '(\w+)' \|\| github\.event_name == '(\w+)'\) && steps\.version_branch\.outputs\.version-branch != 'true' }}$/.exec(
+				architectures,
+			);
+		assert.ok(shape, `this test cannot evaluate \`${architectures}\``);
+		const preMerge = shape.slice(1);
+		const bothPlatforms = (event: string, onVersionBranch: boolean): boolean =>
+			!preMerge.includes(event) || onVersionBranch;
+		const events = ["pull_request", "merge_group", "workflow_dispatch", "push"];
+		for (const onVersionBranch of [true, false]) {
+			const demanded = (await verdict({ "Release-preflight": "skipped" }, onVersionBranch)).failed;
+			for (const event of events)
+				assert.ok(
+					!demanded || bothPlatforms(event, onVersionBranch),
+					`a ${event} run that the gate demands a preflight from must publish both platforms`,
+				);
+		}
+		// And the cost stays where it was: everything else pre-merge is still one architecture, since
+		// a candidate image is only ever run on amd64 before it merges.
+		assert.deepEqual(
+			events.map((event) => bothPlatforms(event, false)),
+			[false, false, true, true],
+		);
 	});
 
 	void test("rescans main's images weekly and reports drift to an issue, not a status", async () => {


### PR DESCRIPTION
## What changed and why

#1766 closed a real hole — the Version PR's `CI Status Gate` could pass without the `Release evidence preflight` ever running — by running the preflight on the Version PR's branch for any event and refusing to pass the gate there without it. The demand was right; the branch could not satisfy it.

The preflight evidences every image on `linux/amd64` **and** `linux/arm64`, because the vulnerability policy's match key includes the platform and an arm64-only finding must not reach a release undiscovered (#1743). A `pull_request` run builds `linux/amd64` alone. So on head `a9e00e3f6` the two runs disagreed by construction:

| Run | Event | Preflight | Gate |
| --- | --- | --- | --- |
| 33742319493 | `workflow_dispatch` | success | success |
| 33742314454 | `pull_request` | `ghcr.io/…/webapp@sha256:1f0d6697… publishes no linux/arm64 manifest` | failure |

This builds both architectures on that branch, so the preflight has the manifests it verifies. `detect-changes` takes the decision once, as a `single-arch` output, and `ci-build.yml` and `ci-docker-build.yml` take it as a required input with no default: the architecture set is now one decision per run rather than four copies of an event test, no image can be published on a different set from its siblings, and a caller that forgets to pass it fails to start rather than quietly under-building.

Behaviour by case, unchanged except for one:

| Run | Preflight | Architectures |
| --- | --- | --- |
| Ordinary pull request | skipped; gate passes | `linux/amd64` — unchanged |
| Version branch, `pull_request` | runs; gate demands it | **both — this change** |
| Version branch, `workflow_dispatch` | runs; gate demands it | both — unchanged, this is why the dispatch already passed |
| `merge_group` | skipped; gate passes | `linux/amd64` — unchanged; a merge group has its own SHA and its ref is never the version branch |
| Push to `main` | skipped unless dispatched | both — unchanged |

### Alternatives rejected

- **Suppress the `pull_request` run's gate on that branch.** Rejected, and I re-verified the reason rather than taking it on trust: `Actionlint` and `Zizmor` are required contexts in the `Default` ruleset, and on head `907185b92` — merged as #1760 — the only check runs by those names are `skipped`, from that pull request's own run. A skipped check run satisfies a required context. Suppression therefore fails open: the last reporter for a head wins, so a skipped gate would paper over a failed dispatch run, which is the hole #1766 closed.
- **Let the preflight verify only the platforms that exist.** Rejected. The platform pair is not a property of the CI run, it is a property of what the release publishes, and `validateManifest` demands both in canonical order for every subject. Deriving it from the images a pre-merge run happens to have built would make the preflight agree with itself and disagree with the release — exactly the arm64 gap #1743 closed. There is no honest derivation that yields one platform here: the release ships two, so the evidence covers two, so the run has to build two.
- **Revert #1766.** Rejected. The enforcement is sound; only its precondition was missing.

### What it costs

An extra `ubuntu-24.04-arm` build plus the short `Create manifest` job, for each image the Version PR's own diff marks changed — in practice just `webapp`, since the Version PR touches `package.json` and `CHANGELOG.md`; `application-server`, `agent-pi` and `postgres` stay skipped and are aliased from `main`'s already multi-architecture images. Every push to `main` recreates that head, so this is roughly one extra arm64 webapp build per merge to `main`, on a warm `cache-main-linux-arm64` layer cache. The dispatch run on that branch already paid this. No other pull request pays anything.

## How to test

- `node --test scripts/ci-contract.test.ts`, and `pnpm run format && pnpm run check`, both green.
- `scripts/ci-contract.test.ts` now derives the invariant that broke rather than restating it: it runs the gate's shell to find the cases where a skipped preflight fails the gate, and asserts that the architecture expression publishes both platforms in every one of them. Mutating either half — the version-branch exemption in `cicd.yml`, or `required: true` on the new input — fails the suite; I checked both by mutation.
- The end state is verifiable on the Version PR once this lands: its next `pull_request` run should show `Docker / Webapp / Build linux/arm64 Docker Image` and `Create manifest`, and a green `Release evidence preflight`.

## Release impact

No changeset. `verify-changesets.yml` scopes `SHIPPED_PATHS` to `server`, `webapp` and `docker` (minus `**/*.md`, tests and stories); this changes `.github/workflows/**`, `scripts/*.test.ts` and `docs/contributor/**` only. #1766 shipped none for the same reason.

## Notes for reviewers

- Start at the `single-arch` output in `cicd.yml`; the rest is plumbing it to the four image builds.
- One case this does not change, and did not change before: a Version PR entering the merge queue produces a `merge_group` run whose ref is `gh-readonly-queue/…`, so it runs no preflight and its gate passes without one. That run's images carry their own SHA and are never promoted, and the guarantee rests on the pull-request head's runs — but it is worth a separate look, and it is not this fix.

Model: Claude Fable 5. Harness: Claude Code.
