### PR TITLE
fix(ci): build the Version PR's whole image set, not three aliases of it

### DIFF
--- a/.github/workflows/ci-docker-build.yml
+++ b/.github/workflows/ci-docker-build.yml
@@ -102,9 +102,7 @@ jobs:
 
   postgres-build:
     name: "Postgres (pg_partman)"
-    if: >-
-      inputs.should_skip != 'true' &&
-      (inputs.postgres_image_changed == 'true' || github.event_name != 'pull_request')
+    if: inputs.should_skip != 'true' && inputs.postgres_image_changed == 'true'
     uses: ./.github/workflows/reusable-docker-build.yml
     permissions:
       contents: read

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -60,6 +60,15 @@ jobs:
       # than by it, and the preflight can only find it in a manifest that exists. That branch is a
       # single pull request, and it is the one whose merge cuts the release.
       single-arch: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && steps.version_branch.outputs.version-branch != 'true' }}
+      # Whether this run publishes every release image itself, rather than building what its diff
+      # touched and aliasing the rest from `main`. Aliasing is right for a preview and wrong on the
+      # Version PR's branch, for two reasons that both hold every time: the alias falls back to the
+      # candidate the merged pull request built, which is `linux/amd64` alone, and it falls back
+      # because `main`'s own push run — started by the same push that wrote this head — has not
+      # published anything yet when the alias runs. Neither is a race the preflight can win by
+      # waiting, so that branch builds the whole set under any event, which is what the dispatch run
+      # on it already did.
+      all-images: ${{ github.event_name != 'pull_request' || steps.version_branch.outputs.version-branch == 'true' }}
       # A Version PR head is validated once per head commit, never inherited from an earlier run that
       # matched its tree: a skipped duplicate would skip the image builds the preflight below needs,
       # and the gate refuses to pass on that branch without a preflight.
@@ -371,11 +380,11 @@ jobs:
     with:
       should_skip: ${{ needs.detect-changes.outputs.should_skip }}
       single_arch: ${{ needs.detect-changes.outputs.single-arch }}
-      server_changed: ${{ (needs.detect-changes.outputs.application-server == 'true' || needs.detect-changes.outputs.e2e == 'true' || needs.detect-changes.outputs.postgres-image == 'true' || needs.detect-changes.outputs.build-config == 'true' || needs.detect-changes.outputs.application-server-image == 'true' || github.event_name != 'pull_request') && 'true' || 'false' }}
+      server_changed: ${{ (needs.detect-changes.outputs.application-server == 'true' || needs.detect-changes.outputs.e2e == 'true' || needs.detect-changes.outputs.postgres-image == 'true' || needs.detect-changes.outputs.build-config == 'true' || needs.detect-changes.outputs.application-server-image == 'true' || needs.detect-changes.outputs.all-images == 'true') && 'true' || 'false' }}
       contracts_changed: ${{ (github.event_name != 'push' || needs.detect-changes.outputs.version-bump == 'true') && (needs.detect-changes.outputs.application-server == 'true' || needs.detect-changes.outputs.postgres-image == 'true' || needs.detect-changes.outputs.build-config == 'true' || github.event_name != 'pull_request') && 'true' || 'false' }}
       e2e_changed: ${{ (github.event_name != 'push' || needs.detect-changes.outputs.version-bump == 'true') && (needs.detect-changes.outputs.e2e == 'true' || github.event_name != 'pull_request') && 'true' || 'false' }}
       postgres_image_changed: ${{ (needs.detect-changes.outputs.postgres-image == 'true' || github.event_name != 'pull_request') && 'true' || 'false' }}
-      server_image_changed: ${{ (needs.detect-changes.outputs.application-server-image == 'true' || github.event_name != 'pull_request') && 'true' || 'false' }}
+      server_image_changed: ${{ (needs.detect-changes.outputs.application-server-image == 'true' || needs.detect-changes.outputs.all-images == 'true') && 'true' || 'false' }}
 
   Security:
     uses: ./.github/workflows/ci-security-scan.yml
@@ -450,10 +459,10 @@ jobs:
     with:
       should_skip: ${{ needs.detect-changes.outputs.should_skip }}
       single_arch: ${{ needs.detect-changes.outputs.single-arch }}
-      webapp_changed: ${{ (needs.detect-changes.outputs.webapp-image == 'true' || needs.detect-changes.outputs.docker-config == 'true' || github.event_name != 'pull_request') && 'true' || 'false' }}
-      application_server_changed: ${{ (needs.detect-changes.outputs.application-server-image == 'true' || github.event_name != 'pull_request') && 'true' || 'false' }}
-      agent_images_changed: ${{ (needs.detect-changes.outputs.agent-images == 'true' || needs.detect-changes.outputs.docker-config == 'true' || github.event_name != 'pull_request') && 'true' || 'false' }}
-      postgres_image_changed: ${{ (needs.detect-changes.outputs.postgres-image == 'true' || needs.detect-changes.outputs.docker-config == 'true' || github.event_name != 'pull_request') && 'true' || 'false' }}
+      webapp_changed: ${{ (needs.detect-changes.outputs.webapp-image == 'true' || needs.detect-changes.outputs.docker-config == 'true' || needs.detect-changes.outputs.all-images == 'true') && 'true' || 'false' }}
+      application_server_changed: ${{ (needs.detect-changes.outputs.application-server-image == 'true' || needs.detect-changes.outputs.all-images == 'true') && 'true' || 'false' }}
+      agent_images_changed: ${{ (needs.detect-changes.outputs.agent-images == 'true' || needs.detect-changes.outputs.docker-config == 'true' || needs.detect-changes.outputs.all-images == 'true') && 'true' || 'false' }}
+      postgres_image_changed: ${{ (needs.detect-changes.outputs.postgres-image == 'true' || needs.detect-changes.outputs.docker-config == 'true' || needs.detect-changes.outputs.all-images == 'true') && 'true' || 'false' }}
 
   # Everything the release evidence gate checks, against the images this run just built, except the
   # signatures and attestations that do not exist until a release creates them. A release was the

--- a/docs/contributor/ci-cd.mdx
+++ b/docs/contributor/ci-cd.mdx
@@ -37,8 +37,10 @@ Every push to `main` builds and attests multi-architecture images for that commi
 Version PR; merging the Version PR cuts a release that promotes those images by digest —
 [Release management](./release-management.mdx). Pull requests and merge groups build `linux/amd64`
 only; a merge group has its own SHA, so its images are never the ones a release promotes. The
-exception is the Version PR's branch, where every run builds both architectures, because the release
-evidence preflight that guards that branch evidences each image on both published platforms.
+exception is the Version PR's branch, where every run builds every release image on both
+architectures, whichever event started it, because the release evidence preflight that guards that
+branch evidences each image on both published platforms and can only evidence what the run
+published.
 
 ## Quality gates
 
@@ -136,6 +138,9 @@ Preview environments do not need to be created in advance. The preview workflow 
 Add the `preview` label to a same-repository pull request. Every push redeploys, and a preview does
 not wait for tests. `Docker` rebuilds the images whose inputs changed and its `Tag unchanged images`
 job aliases the base commit's verified digests for the rest, so every image exists at the head SHA.
+An alias serves a preview and never release evidence: when the base commit's image is still
+publishing it falls back to the candidate the merged pull request built, which carries `linux/amd64`
+alone. That is why the Version PR's branch builds every image itself instead.
 
 A sticky comment carries the URL, and GitHub records each accepted update as the transient
 environment `preview/pr-N`, so the pull request's **View deployment** link opens it too.
@@ -275,8 +280,9 @@ nothing that ships, so they compile from source in `Test` and do not wait for pa
 - `Quality` legs and `Test` suites start from source; `Build` gates start when `App Server: Package`
   uploads its artifact.
 - Pull requests and merge groups build `linux/amd64`; pushes to `main`, and every run on the Version
-  PR's branch, build both architectures. `detect-changes` decides that once and hands it to every
-  image build in the run.
+  PR's branch, build both architectures. A pull request also builds only the images its diff touched
+  and aliases the rest, while the Version PR's branch builds all of them. `detect-changes` decides
+  both once, as `single-arch` and `all-images`, and hands them to every image build in the run.
 - The `Quality` matrix uses `fail-fast: false`; the image matrix in `reusable-docker-build.yml` uses
   `fail-fast: true`.
 - Pull-request runs cancel superseded runs; `release.yml` never cancels.

--- a/docs/contributor/release-management.mdx
+++ b/docs/contributor/release-management.mdx
@@ -58,9 +58,10 @@ sequenceDiagram
    same run. More than one run can report that gate for a Version PR head — a dispatch and an
    approved `pull_request` run both did for v0.75.1 — and the ruleset is satisfied by either, so a
    green gate means the preflight passed only if no run can be green without it. Every run on that
-   branch therefore builds both architectures, unlike the `linux/amd64` candidate an ordinary pull
-   request builds: the preflight evidences each image on both published platforms, and it can only
-   do that for manifests that exist.
+   branch therefore publishes the whole release image set on both architectures, where an ordinary
+   pull request builds the `linux/amd64` candidates its diff touched and aliases the rest from
+   `main`: the preflight evidences each image on both published platforms, and it can only evidence
+   what the run it belongs to published.
 3. **The merge is checked again.** The merge commit's push runs CI/CD in full — a push to `main`
    repeats the source-validation legs only when it carries a version bump, which is exactly this
    commit — and `release.yml` starts only when that run succeeds.
@@ -158,7 +159,8 @@ contract test rather than a release. The third structural entry is not condition
 verifier always demands a release version, and the preflight gives it the version the ref carries.
 
 The preflight is not free — it is a Syft and Trivy pass over every image on both architectures, plus
-the `linux/arm64` half of the image builds it reads, which no other pre-merge run pays for — so it
+the image builds it reads, which on the Version PR's branch means the whole set on both
+architectures where an ordinary pull request would build one image on one — so it
 runs only where its answer changes a decision: on every CI/CD run on the Version PR's branch, and
 on any manual CI/CD dispatch that ticks `release-preflight`. It reuses the images that run already built, so what it judges is the
 artefact a release of that ref would promote, not a stand-in.

--- a/docs/contributor/release-management.mdx
+++ b/docs/contributor/release-management.mdx
@@ -160,7 +160,8 @@ verifier always demands a release version, and the preflight gives it the versio
 
 The preflight is not free — it is a Syft and Trivy pass over every image on both architectures, plus
 the image builds it reads, which on the Version PR's branch means the whole set on both
-architectures where an ordinary pull request would build one image on one — so it
+architectures where an ordinary pull request would build only the images its diff touches, on
+`linux/amd64` — so it
 runs only where its answer changes a decision: on every CI/CD run on the Version PR's branch, and
 on any manual CI/CD dispatch that ticks `release-preflight`. It reuses the images that run already built, so what it judges is the
 artefact a release of that ref would promote, not a stand-in.

--- a/scripts/ci-contract.test.ts
+++ b/scripts/ci-contract.test.ts
@@ -761,6 +761,70 @@ void describe("CI contract", () => {
 			events.map((event) => bothPlatforms(event, false)),
 			[false, false, true, true],
 		);
+
+		// Nor can the gate demand evidence for images the run never published. Off that branch a pull
+		// request builds what its diff touched and aliases the rest from `main`, which is right for a
+		// preview and cannot serve the preflight: the alias falls back to the candidate the merged
+		// pull request built — `linux/amd64` and an `unknown/unknown` attestation manifest, no arm64 —
+		// and it falls back every time, because `main`'s push run was started by the same push that
+		// wrote this head and has published nothing yet when the alias runs. So the version branch
+		// publishes every release image itself, under every event, exactly as its dispatch run did.
+		const complete = String(workflow.getIn([...detection, "outputs", "all-images"]));
+		const completeShape =
+			/^\$\{\{ github\.event_name != '(\w+)' \|\| steps\.version_branch\.outputs\.version-branch == 'true' }}$/.exec(
+				complete,
+			);
+		assert.ok(completeShape, `this test cannot evaluate \`${complete}\``);
+		const buildsEveryImage = (event: string, onVersionBranch: boolean): boolean =>
+			event !== completeShape[1] || onVersionBranch;
+		for (const event of events)
+			assert.ok(
+				buildsEveryImage(event, true),
+				`a ${event} run on the Version PR's branch must publish every release image itself`,
+			);
+		assert.deepEqual(
+			events.map((event) => buildsEveryImage(event, false)),
+			[false, true, true, true],
+		);
+
+		// One home for that decision too: an input that selects an image reads it, and no input
+		// re-tests the event on its own. `server_changed` is in the list because the buildpacks image
+		// is built from the JAR `App Server: Package` uploads.
+		const imageInputs = {
+			Build: ["server_changed", "server_image_changed"],
+			Docker: [
+				"webapp_changed",
+				"application_server_changed",
+				"agent_images_changed",
+				"postgres_image_changed",
+			],
+		};
+		for (const [caller, inputs] of Object.entries(imageInputs))
+			for (const name of inputs) {
+				const value = String(workflow.getIn(["jobs", caller, "with", name]));
+				assert.match(
+					value,
+					/needs\.detect-changes\.outputs\.all-images == 'true'/,
+					`${caller}.${name} must read the one decision`,
+				);
+				assert.doesNotMatch(
+					value,
+					/github\.event_name/,
+					`${caller}.${name} must not test the event itself`,
+				);
+			}
+		// And the alias cannot run behind their backs: it is reachable only while some image is
+		// unchanged, so a run that builds the whole set evidences nothing another run published.
+		const images = parseDocument(await readFile(".github/workflows/ci-docker-build.yml", "utf8"));
+		const alias = String(images.getIn(["jobs", "tag-unchanged-images", "if"]));
+		for (const name of imageInputs.Docker)
+			assert.match(alias, new RegExp(`inputs\\.${name} != 'true'`));
+		for (const image of ["webapp-build", "agent-pi-build", "postgres-build"])
+			assert.doesNotMatch(
+				String(images.getIn(["jobs", image, "if"])),
+				/github\.event_name/,
+				`${image} must not re-test the event its caller already decided on`,
+			);
 	});
 
 	void test("rescans main's images weekly and reports drift to an issue, not a status", async () => {


### PR DESCRIPTION
## What changed and why

#1767 made the Version PR's `pull_request` run build both architectures, and it does — but only for the images that run *builds*. It builds one. The preflight needs four.

### What the digest turned out to be

`ghcr.io/hephaestus-build/application-server@sha256:70a33487…` is **a manifest list with exactly one child**, `sha256:230607198f…`, `linux/amd64`. It is neither `main`'s index nor a child of it. It is the index that #1767's own pull-request build published for head `62183f0ee` — `imagetools inspect --format '{{.Manifest.Digest}}'` on `application-server:62183f0eee…` returns `70a33487…` exactly. The alias step did not synthesise or truncate anything: its log shows it copying one child and re-pushing the same digest, and for `agent-pi` it copied two — `linux/amd64` plus an `unknown/unknown` attestation manifest, still no arm64.

So the alias was faithful; its **source** was wrong, and it was wrong for two independent reasons, both of which hold on every run:

1. `application-server:<base sha>` **did not exist yet.** `main`'s CI/CD for `924009cb3` started at 10:50:44 and published webapp at 11:02:10, agent-pi at 11:05:57 and application-server at 11:07:03. The version branch's `pull_request` run reached `Tag unchanged images` at **11:00:23**. Both runs are started by the same push, and the alias job is fast while the image builds are not, so the alias is *always* early. `agent-pi:<base sha>` resolves to `25d3d516…` today; the alias used `070b84ce…`, its fallback, for the same reason.
2. The fallback — the head SHA of the pull request merged into the base commit — is by construction an **ordinary pull request's candidate**, and ordinary pull requests build `linux/amd64` alone. There is no version of this fallback that carries arm64.

So the alias serves a preview (amd64, at the head SHA, verified) and can never serve release evidence.

### The fix

The Version PR's branch builds every release image itself, under any event — which is exactly what the dispatched run on that branch already did, and why only that run passed. `detect-changes` decides it once as an `all-images` output; `Build` and `Docker` read it in place of the `github.event_name != 'pull_request'` test each of their image inputs used to repeat. `Tag unchanged images` becomes unreachable there (it requires some image to be unchanged), so nothing on that branch is evidenced from an image another run published. The `postgres` image build's own `|| github.event_name != 'pull_request'` clause is gone: it was a second home for the decision its caller now owns.

The two runs on that branch are now identical by construction, which is the property #1766 needs — "the answer has to be in every one of them" is cheapest to guarantee when every run does the same thing.

### Alternatives weighed

- **Make the alias publish the full multi-arch index on the version branch** — i.e. require the base commit's index and wait for it. Rejected on the timings above: this is not a race the run can win, it is the normal ordering. Every version-PR run would idle ~7–13 minutes waiting on a run started at the same instant, the release would block whenever that wait timed out, and the evidence would still describe the *base* commit's build rather than this head's. It also keeps the two runs behaviourally different, which is the shape of the bug.
- **Narrow the preflight to the platforms that exist** — not considered; it re-opens the #1743 arm64 gap.
- **Something better**: I looked for a way to avoid the duplicate work between the dispatch and the `pull_request` run rather than the duplicate *builds* — aliasing from the dispatch run's images, or letting one run suppress the other. Both need one run to trust another run's images or another run's gate, and a skipped required check satisfies the ruleset, so suppression fails open. Making the runs identical is the honest version. The genuinely better fix is for that head to have **one** run rather than two; that is a change to `version-pr.yml` and its dispatch, not to this file, and it is not this PR.

### What it costs

Measured on the base commit's own push run, warm caches: agent-pi 55s + 44s + 56s manifest, postgres 31s + 33s + 57s, application-server 2m43s + 2m26s + 48s. So **≈ 10.5 extra runner-minutes per Version PR head**, i.e. per push to `main`, minus the ~30s alias job it replaces. Wall clock grows by roughly the application-server image's ~4 minutes, which lands inside the window the preflight already waits on `Build` for. No other pull request changes at all.

## How to test

- `pnpm run format` then `pnpm run check`, both green.
- Behaviour by case, all derived in `ci-contract.test.ts` rather than described:

| Run | Preflight | Images built | Architectures |
| --- | --- | --- | --- |
| Ordinary pull request | skipped, gate passes | diff-selected, rest aliased | amd64 |
| Version branch, `pull_request` | demanded | **all four — this change** | both |
| Version branch, `workflow_dispatch` | demanded | all four | both |
| `merge_group` | skipped, gate passes | all four | amd64 |
| Push to `main` | skipped | all four | both |

## Release impact

No changeset. `verify-changesets.yml` scopes `SHIPPED_PATHS` to `server`, `webapp`, `docker`; this touches `.github/workflows/**`, `scripts/*.test.ts` and `docs/contributor/**`.

## Notes for reviewers

- `scripts/ci-contract.test.ts` now pins the asymmetry: it evaluates the `all-images` expression over every (event, branch) pair, requires every image-selecting input to read that one decision and to contain no event test of its own, and requires `Tag unchanged images` to be gated on some image being unchanged. Each of the three assertions fails the suite under mutation; I checked all three.
- **`merge_group` interaction, as asked:** none. `all-images` is `github.event_name != 'pull_request' || version-branch`, so a merge group evaluates it exactly as the old expressions did — it builds all four images, single-architecture, and runs no preflight. The gap you flagged (a merge-queue run's gate passes without a preflight, because its ref is `gh-readonly-queue/…` and never the version branch) is neither widened nor narrowed here. Still a separate change.

Model: Claude Fable 5. Harness: Claude Code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI/CD**
  * Version PR builds now publish the complete release image set across both supported architectures.
  * Pull requests continue to build only images affected by their changes, using aliases for the remainder.
  * Unchanged images are no longer force-built in applicable non-pull-request workflows.

* **Documentation**
  * Updated CI/CD and release-management guidance to describe image publishing, preview aliases, release evidence, and build costs.

* **Tests**
  * Expanded CI contract checks to validate full-image decisions and image aliasing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->