### PR TITLE
chore(deps): group low-risk Renovate updates

### DIFF
--- a/docs/contributor/ci-cd.mdx
+++ b/docs/contributor/ci-cd.mdx
@@ -101,14 +101,17 @@ changesets rather than adding one. [Release management](./release-management.mdx
 | OpenSSF Scorecard | `main` pushes, branch-protection changes, and weekly; never on pull requests | reports | code scanning and a run artifact |
 | Renovate | configured schedule and vulnerability alerts | pull requests require normal review and CI | dependency dashboard |
 
-Renovate opens pull requests before 07:00 Europe/Berlin on weekdays after a three-day release age;
-majors wait seven days and a Dependency Dashboard approval, and vulnerability alerts skip both.
-Lockfile maintenance runs on Mondays. Enabled managers: npm, Maven, the Maven wrapper, Dockerfiles,
-Compose files, GitHub Actions, and the regex managers in `renovate.json`, which
-`scripts/renovate-config.test.ts` covers. The Node, pnpm and Pi SDK pins are grouped, so a version
-stated in several managed files moves in one pull request; the toolchain checks reject a version that
-reads differently in any of them. Renovate provisions the Node it runs lockfile updates with from
-`engines`, so `engines.node` restates `devEngines.runtime` exactly rather than the supported line.
+Renovate groups routine updates only when they share a review and verification boundary. Production
+dependencies remain separate unless Renovate identifies a package family that must move together.
+Major updates and minor updates to pre-1.0 dependencies remain ungrouped, wait seven days, and require
+Dependency Dashboard approval. Vulnerability alerts remain ungrouped and bypass those gates.
+
+Lockfile maintenance runs on Mondays. `renovate.json` owns the managed ecosystems and extraction
+rules; `scripts/renovate-config.test.ts` exercises each custom manager against its source. The Node,
+pnpm and Pi SDK pins are grouped, so a version stated in several managed files moves in one pull
+request; the toolchain checks reject a version that reads differently in any of them. Renovate
+provisions the Node it runs lockfile updates with from `engines`, so `engines.node` restates
+`devEngines.runtime` exactly rather than the supported line.
 
 [Vulnerability remediation](./vulnerability-remediation.mdx) owns the blocking and exception policy.
 [Release management](./release-management.mdx#supply-chain-evidence) owns artifact signing, provenance,

--- a/renovate.json
+++ b/renovate.json
@@ -35,7 +35,34 @@
 			"groupName": "GitHub Actions"
 		},
 		{
+			"matchManagers": ["npm"],
+			"matchFileNames": ["package.json"],
+			"matchUpdateTypes": ["minor", "patch", "digest", "pin", "pinDigest"],
+			"groupName": "repository tooling dependencies"
+		},
+		{
+			"matchManagers": ["npm"],
+			"matchFileNames": ["webapp/package.json"],
+			"matchDepTypes": ["devDependencies"],
+			"matchUpdateTypes": ["minor", "patch", "digest", "pin", "pinDigest"],
+			"groupName": "webapp development dependencies"
+		},
+		{
+			"matchManagers": ["maven"],
+			"matchDepTypes": ["build", "test"],
+			"matchUpdateTypes": ["minor", "patch", "digest", "pin", "pinDigest"],
+			"groupName": "server build dependencies"
+		},
+		{
 			"matchUpdateTypes": ["major"],
+			"minimumReleaseAge": "7 days",
+			"addLabels": ["breaking"],
+			"groupName": null,
+			"dependencyDashboardApproval": true
+		},
+		{
+			"matchCurrentVersion": "/^0\\./",
+			"matchUpdateTypes": ["minor"],
 			"minimumReleaseAge": "7 days",
 			"addLabels": ["breaking"],
 			"groupName": null,

--- a/scripts/renovate-config.test.ts
+++ b/scripts/renovate-config.test.ts
@@ -18,24 +18,34 @@ void test("Renovate creates bounded update PRs without a manual dispatch queue",
 	assert.equal(config.prHourlyLimit, 2);
 	assert.equal(config.prConcurrentLimit, 5);
 	assert.equal(config.branchConcurrentLimit, 10);
-	assert.ok(
-		Array.isArray(config.packageRules) &&
-			config.packageRules.some(
-				(rule) =>
-					isRecord(rule) &&
-					rule.dependencyDashboardApproval === true &&
-					Array.isArray(rule.matchUpdateTypes) &&
-					rule.matchUpdateTypes.includes("major"),
-			),
-	);
+	assert.ok(Array.isArray(config.packageRules));
+	const rules = config.packageRules.filter(isRecord);
+	for (const [updateType, currentVersion] of [
+		["major", undefined],
+		["minor", "/^0\\./"],
+	]) {
+		const rule = rules.find(
+			(candidate) =>
+				candidate.matchCurrentVersion === currentVersion &&
+				Array.isArray(candidate.matchUpdateTypes) &&
+				candidate.matchUpdateTypes.includes(updateType),
+		);
+		assert.ok(rule);
+		assert.equal(rule.minimumReleaseAge, "7 days");
+		assert.equal(rule.dependencyDashboardApproval, true);
+		assert.equal(rule.groupName, null);
+		assert.ok(Array.isArray(rule.addLabels) && rule.addLabels.includes("breaking"));
+	}
 });
 
 void test("every pin of one toolchain version moves in a single pull request", () => {
-	// Renovate merges every matching packageRule in order, so the last one to set a key wins.
 	assert.ok(Array.isArray(config.packageRules));
 	const rules = config.packageRules.filter(isRecord);
-	const ungrouped = rules.findLastIndex((rule) => rule.groupName === null);
-	assert.ok(ungrouped >= 0, "a rule must ungroup majors for the toolchain rules to reinstate it");
+	const lastUngroupedRule = rules.findLastIndex((rule) => rule.groupName === null);
+	assert.ok(
+		lastUngroupedRule >= 0,
+		"high-risk updates must be ungrouped before toolchain groups reinstate them",
+	);
 	for (const [depName, groupName] of [
 		["node", "Node.js toolchain"],
 		["pnpm", "pnpm toolchain"],
@@ -47,7 +57,29 @@ void test("every pin of one toolchain version moves in a single pull request", (
 		);
 		assert.equal(rules[index]?.groupName, groupName, `${depName} must be grouped as ${groupName}`);
 		assert.equal(rules[index]?.matchUpdateTypes, undefined, `${depName} groups every update type`);
-		assert.ok(index > ungrouped, `${depName} must be grouped after majors are ungrouped`);
+		assert.ok(index > lastUngroupedRule, `${depName} must follow the high-risk update rules`);
+	}
+});
+
+void test("routine update groups preserve repository boundaries", () => {
+	assert.ok(Array.isArray(config.packageRules));
+	const rules = config.packageRules.filter(isRecord);
+	const groups = [
+		["repository tooling dependencies", "npm", "package.json", undefined],
+		["webapp development dependencies", "npm", "webapp/package.json", ["devDependencies"]],
+		["server build dependencies", "maven", undefined, ["build", "test"]],
+	] as const;
+	for (const [groupName, manager, fileName, depTypes] of groups) {
+		const rule = rules.find((candidate) => candidate.groupName === groupName);
+		assert.ok(rule);
+		assert.deepEqual(rule.matchManagers, [manager]);
+		assert.deepEqual(rule.matchFileNames, fileName === undefined ? undefined : [fileName]);
+		assert.deepEqual(rule.matchDepTypes, depTypes);
+		assert.ok(Array.isArray(rule.matchUpdateTypes));
+		assert.deepEqual(
+			new Set(rule.matchUpdateTypes),
+			new Set(["minor", "patch", "digest", "pin", "pinDigest"]),
+		);
 	}
 });
 


### PR DESCRIPTION
## What changed and why

Renovate can now open viable dependency pull requests, but treating every routine update as a separate change creates avoidable review and CI traffic. This groups non-major repository tooling, webapp development dependencies, server build dependencies, and GitHub Actions while leaving unrelated production dependencies independent.

The policy deliberately relies on Renovate's built-in package-family grouping instead of replacing it with broad runtime groups. A local full dry run preserves the native Docusaurus monorepo group, for example. Major updates and minor updates to pre-1.0 dependencies remain isolated, wait seven days, require Dependency Dashboard approval, and receive the `breaking` label. Vulnerability remediation continues to bypass those normal delays.

The configuration tests now cover the complete high-risk update contract, repository boundaries, synchronized toolchain pins, and every custom manager. Contributor documentation records the durable policy and leaves exact group membership in `renovate.json`.

This follows [Renovate's guidance](https://docs.renovatebot.com/noise-reduction/#be-smart-about-grouping-dependencies): group updates that share a review boundary, but do not create a repository-wide batch in which one failure blocks unrelated upgrades. It builds on the lockfile and toolchain fixes from #1763.

## How to test

```bash
pnpm run format
pnpm run check

docker run --rm \
  -v \"$PWD/renovate.json:/usr/src/app/renovate.json:ro\" \
  renovate/renovate:44.52.1 \
  renovate-config-validator /usr/src/app/renovate.json

docker run --rm \
  -e LOG_LEVEL=debug \
  -e RENOVATE_CONFIG='{\"platform\":\"local\",\"dryRun\":\"full\",\"repositoryCache\":\"disabled\"}' \
  -v \"$PWD:/usr/src/app/repo:ro\" \
  -w /usr/src/app/repo \
  renovate/renovate:44.52.1 renovate
```

`pnpm run check` passed before commit and again in the pre-push hook. The official Renovate image validated the configuration and its full dry run extracted 457 dependencies from 69 managed files. It produced the intended tooling groups and the native `renovate/docusaurus-monorepo` group, with no broad webapp, documentation, or server runtime group.

## Release impact

No changeset: this changes repository dependency-maintenance policy and contributor documentation, not shipped application behavior. Operators and users do not need to take action.

## Notes for reviewers

Start with `renovate.json`. The important boundary is intentional: development and build tooling may be grouped, while production libraries remain separate unless Renovate identifies a coordinated package family. `scripts/renovate-config.test.ts` protects that boundary and the stricter treatment of pre-1.0 minor updates.

The hosted Renovate app will apply the new branch layout only after this reaches `main`; existing bot pull requests are therefore not expected to regroup on this branch.

Prepared with OpenAI Codex; the model identifier was not exposed to this session. Verified with the repository's `land-pr` workflow and local quality gate.