### PR TITLE
fix(deps): keep Vercel AI SDK packages aligned

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -69,6 +69,13 @@
 			"dependencyDashboardApproval": true
 		},
 		{
+			"matchManagers": ["npm"],
+			"matchFileNames": ["webapp/package.json"],
+			"matchPackageNames": ["ai", "@ai-sdk/react"],
+			"groupName": "Vercel AI SDK",
+			"minimumGroupSize": 2
+		},
+		{
 			"matchDepNames": ["node"],
 			"groupName": "Node.js toolchain"
 		},

--- a/scripts/renovate-config.test.ts
+++ b/scripts/renovate-config.test.ts
@@ -61,6 +61,20 @@ void test("every pin of one toolchain version moves in a single pull request", (
 	}
 });
 
+void test("Vercel AI SDK packages move together", () => {
+	assert.ok(Array.isArray(config.packageRules));
+	const rules = config.packageRules.filter(isRecord);
+	const ruleIndex = rules.findLastIndex((rule) => rule.groupName === "Vercel AI SDK");
+	assert.ok(ruleIndex > rules.findLastIndex((rule) => rule.groupName === null));
+	const rule = rules[ruleIndex];
+	assert.ok(rule);
+	assert.deepEqual(rule.matchManagers, ["npm"]);
+	assert.deepEqual(rule.matchFileNames, ["webapp/package.json"]);
+	assert.deepEqual(rule.matchPackageNames, ["ai", "@ai-sdk/react"]);
+	assert.equal(rule.matchUpdateTypes, undefined);
+	assert.equal(rule.minimumGroupSize, 2);
+});
+
 void test("routine update groups preserve repository boundaries", () => {
 	assert.ok(Array.isArray(config.packageRules));
 	const rules = config.packageRules.filter(isRecord);


### PR DESCRIPTION
## What changed and why

Renovate could update `@ai-sdk/react` without the directly installed `ai` package, producing two incompatible versions of the shared `ChatInit` types and breaking [#1746](https://github.com/hephaestus-build/Hephaestus/pull/1746).

Group those two direct dependencies and require both updates to be available before Renovate opens a pull request. The rule remains narrow to the webapp manifest and preserves the existing review controls for high-risk updates.

## How to test

- `node --test scripts/renovate-config.test.ts`
- `pnpm run check`
- `renovate-config-validator renovate.json` using `renovate/renovate:44.52.1`

## Release impact

No changeset: this changes repository dependency automation, not shipped product behavior.

## Notes for reviewers

Renovate documents [`minimumGroupSize`](https://docs.renovatebot.com/configuration-options/#minimumgroupsize) for coupled updates that must wait for one another and [`matchPackageNames`](https://docs.renovatebot.com/configuration-options/#matchpackagenames) for exact package matching.

Implemented with OpenAI Codex.
