### PR TITLE
fix(ci): collapse superseded automatic approval reviews

### DIFF
--- a/docs/contributor/ci-cd.mdx
+++ b/docs/contributor/ci-cd.mdx
@@ -74,7 +74,8 @@ accepting a same-named external status.
 Review is a native ruleset requirement with stale approvals dismissed on every push. Authors listed
 in `REVIEW_POLICY_MAINTAINERS` receive an automated approval; every other author needs a human with
 write access. Repository administrators own that allow-list. Remove the automation when independent
-maintainer review is available.
+maintainer review is available. The workflow minimizes superseded automatic reviews after approving
+the current commit, so only its current automatic approval remains expanded.
 
 The approval workflow runs on `pull_request_target` with `pull-requests: write`, so it checks out only
 `scripts/` from the default branch, reads the author login and nothing else, and executes no

--- a/scripts/review-policy.test.ts
+++ b/scripts/review-policy.test.ts
@@ -23,6 +23,7 @@ const OTHER = "fedcba9876543210fedcba9876543210fedcba98";
 
 /** A review this module submitted: it carries the marker. */
 const ours = (over: Partial<Review> & Pick<Review, "id">): Review => ({
+	node_id: `review-${over.id}`,
 	state: "APPROVED",
 	commit_id: HEAD,
 	body: approvalBody("Maintainer"),
@@ -32,6 +33,7 @@ const ours = (over: Partial<Review> & Pick<Review, "id">): Review => ({
 
 /** A review somebody else submitted: no marker. */
 const theirs = (over: Partial<Review> & Pick<Review, "id">): Review => ({
+	node_id: `review-${over.id}`,
 	state: "APPROVED",
 	commit_id: HEAD,
 	body: "Looks good.",
@@ -64,10 +66,12 @@ interface GitHubOptions {
 	readonly reviews?: readonly Review[];
 	readonly failPullWith?: Error;
 	readonly failReviewWith?: Error;
+	readonly failMinimizeWith?: Error;
 }
 
 const makeGitHub = (options: GitHubOptions = {}) => {
 	const submitted: CreateReviewRequest[] = [];
+	const minimized: string[] = [];
 	const reviews = [...(options.reviews ?? [])];
 	const getPull = () =>
 		options.failPullWith
@@ -75,6 +79,11 @@ const makeGitHub = (options: GitHubOptions = {}) => {
 			: Promise.resolve({ data: options.resolvedPull ?? pull });
 
 	const github: GitHubApi = {
+		graphql: (_query, variables) => {
+			if (options.failMinimizeWith) return Promise.reject(options.failMinimizeWith);
+			minimized.push(variables.subjectId);
+			return Promise.resolve({});
+		},
 		paginate: () => Promise.resolve(reviews),
 		rest: {
 			pulls: {
@@ -88,7 +97,7 @@ const makeGitHub = (options: GitHubOptions = {}) => {
 			},
 		},
 	};
-	return { submitted, github };
+	return { minimized, submitted, github };
 };
 
 /** The single review a run under test is expected to have submitted. */
@@ -250,6 +259,16 @@ void describe("review policy", () => {
 			assert.deepEqual(core.failures, []);
 		});
 
+		void it("minimizes earlier automatic approvals after submitting their replacement", async () => {
+			const { minimized, github, submitted } = makeGitHub({
+				reviews: [ours({ id: 1, commit_id: OTHER }), ours({ id: 2, commit_id: OTHER })],
+			});
+			await enforce({ github, context, core: makeCore() });
+
+			assert.equal(submitted.length, 1);
+			assert.deepEqual(minimized, ["review-1", "review-2"]);
+		});
+
 		void it("submits nothing for an author who is not on the allow-list", async () => {
 			const { submitted, github } = makeGitHub({
 				resolvedPull: { ...pull, user: { login: "Contributor" } },
@@ -261,11 +280,28 @@ void describe("review policy", () => {
 			assert.deepEqual(core.failures, []);
 		});
 
-		void it("submits nothing when its own approval already stands", async () => {
-			const { submitted, github } = makeGitHub({ reviews: [ours({ id: 1 })] });
+		void it("keeps the standing approval visible and minimizes its predecessors", async () => {
+			const { minimized, submitted, github } = makeGitHub({
+				reviews: [ours({ id: 1, commit_id: OTHER }), ours({ id: 2 })],
+			});
 			await enforce({ github, context, core: makeCore() });
 
 			assert.deepEqual(submitted, []);
+			assert.deepEqual(minimized, ["review-1"]);
+		});
+
+		void it("keeps a new approval when an old review cannot be minimized", async () => {
+			const { submitted, github } = makeGitHub({
+				reviews: [ours({ id: 1, commit_id: OTHER })],
+				failMinimizeWith: new Error("minimization rejected"),
+			});
+			const core = makeCore();
+			await enforce({ github, context, core });
+
+			assert.equal(submitted.length, 1);
+			assert.equal(core.warnings.length, 1);
+			assert.match(String(core.warnings[0]), /minimization rejected/);
+			assert.deepEqual(core.failures, []);
 		});
 
 		void it("approves a stacked pull request, so it survives being retargeted onto main", async () => {

--- a/scripts/review-policy.ts
+++ b/scripts/review-policy.ts
@@ -28,6 +28,7 @@ type ApiMethod<T> = (params: Record<string, unknown>) => Promise<{ data: T }>;
 
 export interface Review {
 	readonly id: number;
+	readonly node_id: string;
 	readonly state: string;
 	readonly commit_id: string;
 	readonly body?: string | null;
@@ -51,6 +52,7 @@ export interface CreateReviewRequest {
 }
 
 export interface GitHubApi {
+	readonly graphql: (query: string, variables: { subjectId: string }) => Promise<unknown>;
 	readonly paginate: (
 		endpoint: ApiMethod<Review[]>,
 		params: Record<string, unknown>,
@@ -123,14 +125,39 @@ export const parseMaintainers = (raw: string | undefined): Set<string> =>
  * race in the safe direction: an approval recorded against an earlier commit does not count here
  * either way, so a re-approval is submitted whether or not GitHub has finished dismissing it yet.
  */
-export const approvalStands = (reviews: readonly Review[], headSha: string): boolean => {
-	const ours = reviews
+const ourReviews = (reviews: readonly Review[]): Review[] =>
+	reviews
 		.filter((entry) => (entry.body ?? "").includes(APPROVAL_MARKER))
-		.filter((entry) => DECISIVE_STATES.has(entry.state))
 		.toSorted((left, right) => left.id - right.id);
+
+export const approvalStands = (reviews: readonly Review[], headSha: string): boolean => {
+	const ours = ourReviews(reviews).filter((entry) => DECISIVE_STATES.has(entry.state));
 
 	const latest = ours.at(-1);
 	return latest !== undefined && latest.state === "APPROVED" && latest.commit_id === headSha;
+};
+
+const minimizeReview = `mutation MinimizeReview($subjectId: ID!) {
+	minimizeComment(input: { subjectId: $subjectId, classifier: OUTDATED }) {
+		minimizedComment {
+			isMinimized
+		}
+	}
+}`;
+
+const minimizeSupersededApprovals = async (
+	github: GitHubApi,
+	reviews: readonly Review[],
+	core: ActionsCore,
+): Promise<void> => {
+	for (const review of reviews) {
+		try {
+			await github.graphql(minimizeReview, { subjectId: review.node_id });
+		} catch (error) {
+			const reason = error instanceof Error ? error.message : String(error);
+			core.warning(`Could not minimize superseded automatic approval ${review.id}: ${reason}`);
+		}
+	}
 };
 
 export type DecisionKind = "approve" | "standing" | "skip";
@@ -228,7 +255,11 @@ export const enforce = async ({ github, context, core }: EnforceInput): Promise<
 			reviews,
 		});
 		core.info(decision.reason);
-		if (decision.kind !== "approve") return;
+		if (decision.kind === "skip") return;
+		if (decision.kind === "standing") {
+			await minimizeSupersededApprovals(github, ourReviews(reviews).slice(0, -1), core);
+			return;
+		}
 
 		// `commit_id` pins the approval to the commit the decision was made against. If a push landed
 		// between the read and this call, the approval attaches to the commit that was evaluated and
@@ -241,6 +272,7 @@ export const enforce = async ({ github, context, core }: EnforceInput): Promise<
 			event: "APPROVE",
 			body: approvalBody(pull.user.login),
 		});
+		await minimizeSupersededApprovals(github, ourReviews(reviews), core);
 		core.info(`Approved ${shortSha(pull.head.sha)} on pull request #${pull.number}.`);
 	} catch (error) {
 		const reason = error instanceof Error ? error.message : String(error);


### PR DESCRIPTION
## What changed and why

Automatic approvals keep maintainer pull requests moving through the native review requirement, but every push previously left another dismissed bot review expanded in the timeline. [#1765](https://github.com/hephaestus-build/Hephaestus/pull/1765) made the resulting noise especially visible.

The approval flow remains unchanged. After submitting the approval for the current commit, the workflow now uses GitHub's native comment minimization to collapse its superseded reviews as `OUTDATED`. Re-running the workflow is idempotent: it keeps the current approval expanded and minimizes any older automatic reviews. Cleanup failures are reported as warnings and never discard or block the current approval.

The existing superseded reviews on #1765 have also been minimized, leaving only its current automatic approval expanded.

## How to test

```bash
pnpm run format
pnpm run check
```

The complete local quality gate passes. The focused policy tests cover replacement approvals, idempotent reruns, and cleanup failures. On GitHub, push another commit to an allow-listed maintainer pull request and confirm that the new approval remains expanded while the previous one is marked outdated and collapsed.

## Release impact

Contributor workflow only. No shipped application, deployment configuration, or operator upgrade path changes, so no changeset is required.

## Notes for reviewers

Start with `minimizeSupersededApprovals` in `scripts/review-policy.ts`. The approval is created before cleanup, so a minimization failure cannot interrupt the review requirement the workflow exists to satisfy.

Implemented with OpenAI Codex (GPT-5.4).
