### PR TITLE
fix(ci): resolve release images through the build that produced them

### DIFF
--- a/.changeset/compose-comments-only.md
+++ b/.changeset/compose-comments-only.md
@@ -1,0 +1,7 @@
+---
+---
+
+No release note: the two shipped files this pull request touches carry comment changes only — the
+example environment file points at the production setup guide instead of naming a command it cannot
+support, and the broker service records why it names no database dependency. Neither changes what an
+operator runs or how the stack behaves.

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -2,15 +2,22 @@ name: Build
 
 on:
   workflow_call:
+    outputs:
+      application-server-digest:
+        description: "Digest of the application image built from this run's packaged JAR"
+        value: ${{ jobs.application-server-image.outputs.manifest-digest }}
     inputs:
       should_skip:
         description: "Whether to skip the workflow"
         required: false
         type: string
         default: "false"
+      # publish and single_arch have no default; reusable-docker-build.yml says why.
+      publish:
+        description: "Whether image jobs may write to the registry"
+        required: true
+        type: boolean
       single_arch:
-        # No default: what a release is evidenced on is not a decision to make silently on a
-        # caller's behalf. cicd.yml derives it once, for every image build in the run.
         description: "Whether to build linux/amd64 alone instead of the supported multi-architecture set"
         required: true
         type: string
@@ -343,4 +350,5 @@ jobs:
       # renovate: datasource=docker depName=paketobuildpacks/ubuntu-noble-run-tiny
       run-image: "paketobuildpacks/ubuntu-noble-run-tiny@sha256:c32333227b6dfbc2a4a93b03ee6d3475cfe152468c7d396bf22f06099bb0ecc9"
       registry: "ghcr.io"
+      publish: ${{ inputs.publish }}
       single-arch: ${{ inputs.single_arch == 'true' }}

--- a/.github/workflows/ci-docker-build.yml
+++ b/.github/workflows/ci-docker-build.yml
@@ -15,9 +15,12 @@ on:
         required: false
         type: string
         default: "false"
+      # publish and single_arch have no default; reusable-docker-build.yml says why.
+      publish:
+        description: "Whether image jobs may write to the registry"
+        required: true
+        type: boolean
       single_arch:
-        # No default: what a release is evidenced on is not a decision to make silently on a
-        # caller's behalf. cicd.yml derives it once, for every image build in the run.
         description: "Whether to build linux/amd64 alone instead of the supported multi-architecture set"
         required: true
         type: string
@@ -67,6 +70,7 @@ jobs:
       build-args: |
         SOURCE_COMMIT=${{ github.sha }}
         COOLIFY_BRANCH=${{ github.head_ref || github.ref_name }}
+      publish: ${{ inputs.publish }}
       single-arch: ${{ inputs.single_arch == 'true' }}
       labels: |
         org.opencontainers.image.title=Hephaestus Webapp
@@ -92,6 +96,7 @@ jobs:
       # Cache-busts the OS-package upgrade layer; this build imports the `cache-main` registry cache.
       build-args: |
         SOURCE_COMMIT=${{ github.sha }}
+      publish: ${{ inputs.publish }}
       single-arch: ${{ inputs.single_arch == 'true' }}
       labels: |
         org.opencontainers.image.title=Hephaestus Agent - Pi
@@ -117,6 +122,7 @@ jobs:
       # Cache-busts the OS-package upgrade layer; this build imports the `cache-main` registry cache.
       build-args: |
         SOURCE_COMMIT=${{ github.sha }}
+      publish: ${{ inputs.publish }}
       single-arch: ${{ inputs.single_arch == 'true' }}
       labels: |
         org.opencontainers.image.title=Hephaestus Postgres
@@ -129,7 +135,7 @@ jobs:
   tag-unchanged-images:
     name: "Tag unchanged images"
     if: >-
-      inputs.should_skip != 'true' && github.event_name == 'pull_request' &&
+      inputs.should_skip != 'true' && inputs.publish && github.event_name == 'pull_request' &&
       (inputs.webapp_changed != 'true' || inputs.application_server_changed != 'true' ||
        inputs.agent_images_changed != 'true' ||
        inputs.postgres_image_changed != 'true')
@@ -163,8 +169,6 @@ jobs:
           REPOSITORY: ${{ github.repository }}
           REPOSITORY_OWNER: ${{ github.repository_owner }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          RUN_ID: ${{ github.run_id }}
-          RUN_ATTEMPT: ${{ github.run_attempt }}
         run: |
           set -euo pipefail
 
@@ -196,7 +200,6 @@ jobs:
             docker buildx imagetools create \
               --tag "$image:$HEAD_SHA" \
               --tag "$image:pr-$PR_NUMBER" \
-              --tag "$image:run-$RUN_ID-$RUN_ATTEMPT" \
               "$verified"
           }
 

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -39,6 +39,7 @@ jobs:
       e2e: ${{ steps.filter.outputs.e2e }}
       agent-images: ${{ steps.filter.outputs.agent-images }}
       postgres-image: ${{ steps.filter.outputs.postgres-image }}
+      supported-host-smoke: ${{ steps.filter.outputs.supported-host-smoke }}
       docs: ${{ steps.filter.outputs.docs }}
       ci-config: ${{ steps.filter.outputs.ci-config }}
       quality-config: ${{ steps.filter.outputs.quality-config }}
@@ -52,26 +53,14 @@ jobs:
       version: ${{ steps.version.outputs.version }}
       version-branch: ${{ steps.version_branch.outputs.version-branch }}
       any-code: ${{ steps.filter.outputs.webapp == 'true' || steps.filter.outputs.application-server == 'true' || steps.filter.outputs.tooling == 'true' || steps.filter.outputs.agent-images == 'true' || steps.filter.outputs.postgres-image == 'true' }}
-      # Which architectures the images this run builds are published on, decided once for every
-      # image. A pre-merge candidate is only ever run on amd64, so that is all a pull request or a
-      # merge group builds — except on the Version PR's branch, where the release evidence preflight
-      # below evidences each image on both published platforms. The vulnerability policy's match key
-      # includes the platform, so an arm64-only finding has to be found before the release rather
-      # than by it, and the preflight can only find it in a manifest that exists. That branch is a
-      # single pull request, and it is the one whose merge cuts the release.
+      # The vulnerability policy's match key includes the platform, so an arm64-only finding has to
+      # be found before the release rather than by it, and only a manifest that exists can carry it.
       single-arch: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && steps.version_branch.outputs.version-branch != 'true' }}
-      # Whether this run publishes every release image itself, rather than building what its diff
-      # touched and aliasing the rest from `main`. Aliasing is right for a preview and wrong on the
-      # Version PR's branch, for two reasons that both hold every time: the alias falls back to the
-      # candidate the merged pull request built, which is `linux/amd64` alone, and it falls back
-      # because `main`'s own push run — started by the same push that wrote this head — has not
-      # published anything yet when the alias runs. Neither is a race the preflight can win by
-      # waiting, so that branch builds the whole set under any event, which is what the dispatch run
-      # on it already did.
+      # Aliasing an unchanged image falls back to main's own push run, which has published nothing
+      # yet when the Version PR head is written, so that branch builds the whole set itself.
       all-images: ${{ github.event_name != 'pull_request' || steps.version_branch.outputs.version-branch == 'true' }}
-      # A Version PR head is validated once per head commit, never inherited from an earlier run that
-      # matched its tree: a skipped duplicate would skip the image builds the preflight below needs,
-      # and the gate refuses to pass on that branch without a preflight.
+      # A skipped duplicate would skip the image builds the release evidence preflight needs, and
+      # the gate refuses to pass the Version PR without one.
       should_skip: ${{ steps.skip_check.outputs.should_skip == 'true' && steps.version_branch.outputs.version-branch != 'true' }}
     timeout-minutes: 5
     steps:
@@ -220,6 +209,16 @@ jobs:
               - 'docker/agents/**'
             postgres-image:
               - 'docker/postgres/**'
+            # What a fresh installation binds at boot. `ci-contract.test.ts` fails if a source that
+            # declares or scans `@ConfigurationProperties` is not selected here, so the Java globs
+            # are the whole binding tree rather than the part someone remembered.
+            supported-host-smoke:
+              - 'docker/**'
+              - 'server/application/src/main/resources/application*.yml'
+              - 'server/application/src/main/java/**/*Properties.java'
+              - 'server/application/src/main/java/**/Application.java'
+              - '.github/workflows/cicd.yml'
+              - '.github/workflows/ci-build.yml'
             docs:
               - 'docs/**'
             ci-config:
@@ -384,12 +383,13 @@ jobs:
       attestations: write
     with:
       should_skip: ${{ needs.detect-changes.outputs.should_skip }}
+      publish: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
       single_arch: ${{ needs.detect-changes.outputs.single-arch }}
-      server_changed: ${{ (needs.detect-changes.outputs.application-server == 'true' || needs.detect-changes.outputs.e2e == 'true' || needs.detect-changes.outputs.postgres-image == 'true' || needs.detect-changes.outputs.build-config == 'true' || needs.detect-changes.outputs.application-server-image == 'true' || needs.detect-changes.outputs.all-images == 'true') && 'true' || 'false' }}
+      server_changed: ${{ (needs.detect-changes.outputs.application-server == 'true' || needs.detect-changes.outputs.e2e == 'true' || needs.detect-changes.outputs.postgres-image == 'true' || needs.detect-changes.outputs.build-config == 'true' || needs.detect-changes.outputs.application-server-image == 'true' || needs.detect-changes.outputs.supported-host-smoke == 'true' || needs.detect-changes.outputs.all-images == 'true') && 'true' || 'false' }}
       contracts_changed: ${{ (github.event_name != 'push' || needs.detect-changes.outputs.version-bump == 'true') && (needs.detect-changes.outputs.application-server == 'true' || needs.detect-changes.outputs.postgres-image == 'true' || needs.detect-changes.outputs.build-config == 'true' || github.event_name != 'pull_request') && 'true' || 'false' }}
       e2e_changed: ${{ (github.event_name != 'push' || needs.detect-changes.outputs.version-bump == 'true') && (needs.detect-changes.outputs.e2e == 'true' || github.event_name != 'pull_request') && 'true' || 'false' }}
       postgres_image_changed: ${{ (needs.detect-changes.outputs.postgres-image == 'true' || github.event_name != 'pull_request') && 'true' || 'false' }}
-      server_image_changed: ${{ (needs.detect-changes.outputs.application-server-image == 'true' || needs.detect-changes.outputs.all-images == 'true') && 'true' || 'false' }}
+      server_image_changed: ${{ (needs.detect-changes.outputs.application-server-image == 'true' || needs.detect-changes.outputs.supported-host-smoke == 'true' || needs.detect-changes.outputs.all-images == 'true') && 'true' || 'false' }}
 
   Security:
     uses: ./.github/workflows/ci-security-scan.yml
@@ -463,11 +463,81 @@ jobs:
       attestations: write
     with:
       should_skip: ${{ needs.detect-changes.outputs.should_skip }}
+      publish: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
       single_arch: ${{ needs.detect-changes.outputs.single-arch }}
       webapp_changed: ${{ (needs.detect-changes.outputs.webapp-image == 'true' || needs.detect-changes.outputs.docker-config == 'true' || needs.detect-changes.outputs.all-images == 'true') && 'true' || 'false' }}
-      application_server_changed: ${{ (needs.detect-changes.outputs.application-server-image == 'true' || needs.detect-changes.outputs.all-images == 'true') && 'true' || 'false' }}
+      application_server_changed: ${{ (needs.detect-changes.outputs.application-server-image == 'true' || needs.detect-changes.outputs.supported-host-smoke == 'true' || needs.detect-changes.outputs.all-images == 'true') && 'true' || 'false' }}
       agent_images_changed: ${{ (needs.detect-changes.outputs.agent-images == 'true' || needs.detect-changes.outputs.docker-config == 'true' || needs.detect-changes.outputs.all-images == 'true') && 'true' || 'false' }}
       postgres_image_changed: ${{ (needs.detect-changes.outputs.postgres-image == 'true' || needs.detect-changes.outputs.docker-config == 'true' || needs.detect-changes.outputs.all-images == 'true') && 'true' || 'false' }}
+
+  Supported-host-smoke:
+    name: "Supported-host boot smoke"
+    # `Docker` publishes no output this job reads, but it is what puts `postgres:<head sha>` in the
+    # registry — by building it, or by aliasing the base image when the diff left it alone.
+    needs: [detect-changes, Build, Docker]
+    # A fork pull request builds its images without publishing them, so there is nothing to pull
+    # and no boot to check; the release path exercises a fork's install path once it is on `main`.
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      needs.detect-changes.outputs.should_skip != 'true' &&
+      needs.detect-changes.outputs.supported-host-smoke == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: ./.github/actions/setup-toolchain
+        with:
+          install: "none"
+
+      - name: Log in to GitHub Container Registry
+        uses: ./.github/actions/ghcr-login
+        with:
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Boot the operator installation path
+        working-directory: docker/self-host
+        env:
+          APPLICATION_DIGEST: ${{ needs.Build.outputs.application-server-digest }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          cleanup() {
+            status=$?
+            if [ "$status" -ne 0 ]; then
+              docker compose --env-file .env --env-file smoke-lock.env logs --no-color || true
+            fi
+            docker compose --env-file .env --env-file smoke-lock.env down -v --remove-orphans || true
+            exit "$status"
+          }
+          trap cleanup EXIT
+
+          [[ "$APPLICATION_DIGEST" =~ ^sha256:[a-f0-9]{64}$ ]] || {
+            echo "::error::Build returned an invalid application image digest"; exit 1; }
+          node ../../scripts/prepare-host-smoke-env.ts
+          placeholder="example.invalid/unused@sha256:$(printf '0%.0s' {1..64})"
+          {
+            printf 'IMAGE_TAG=%s\n' "$HEAD_SHA"
+            printf 'HEPHAESTUS_IMAGE_APPLICATION_SERVER=ghcr.io/hephaestus-build/application-server@%s\n' "$APPLICATION_DIGEST"
+            printf 'HEPHAESTUS_IMAGE_POSTGRES=ghcr.io/hephaestus-build/postgres:%s\n' "$HEAD_SHA"
+            for name in WEBAPP AGENT_PI NGINX TRAEFIK; do
+              printf 'HEPHAESTUS_IMAGE_%s=%s\n' "$name" "$placeholder"
+            done
+            jq -r '.upstream[] | select(.name == "alpine" or .name == "nats") |
+              "HEPHAESTUS_IMAGE_\(.name | ascii_upcase)=\(.repository)@\(.digest)"' \
+              ../../security/release-images.json
+          } > smoke-lock.env
+
+          docker compose --env-file .env --env-file smoke-lock.env config --quiet
+          docker compose --env-file .env --env-file smoke-lock.env up -d --wait \
+            --wait-timeout 600 postgres nats-server application-server
 
   # Everything the release evidence gate checks, against the images this run just built, except the
   # signatures and attestations that do not exist until a release creates them. A release was the
@@ -519,14 +589,16 @@ jobs:
           # being prepared; on any other ref it is the version already published, and either way it
           # resolves the namespace and identity the evidence gate demands.
           RELEASE: v${{ needs.detect-changes.outputs.version }}
-          SOURCE_TAG: run-${{ github.run_id }}-${{ github.run_attempt }}
+          # The commit whose images this run built, which is also the tag reusable-docker-build.yml
+          # published them under, so the evidence describes the artefacts of the run that made it.
+          COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
           TRIVY_USERNAME: ${{ github.actor }}
           TRIVY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          node scripts/resolve-release-images.ts "$SOURCE_TAG" release-images.tsv
+          node scripts/resolve-release-images.ts "$COMMIT" release-images.tsv
           node scripts/generate-release-evidence.ts evidence \
-            --release "$RELEASE" --commit "$GITHUB_SHA" --digests release-images.tsv
+            --release "$RELEASE" --commit "$COMMIT" --digests release-images.tsv
           node scripts/verify-release-evidence.ts evidence --write-validation
           # Again without --write-validation, which re-derives the validation documents and fails if
           # they changed: the release runs the verifier twice for the same reason.
@@ -549,7 +621,7 @@ jobs:
     permissions:
       actions: read
       statuses: write
-    needs: [detect-changes, workflow-lint, zizmor, Quality, Build, Security, Test, Changesets, Compose, Docker, Release-preflight]
+    needs: [detect-changes, workflow-lint, zizmor, Quality, Build, Security, Test, Changesets, Compose, Docker, Supported-host-smoke, Release-preflight]
     if: always()
     steps:
       - name: Generate workflow timeline
@@ -609,6 +681,7 @@ jobs:
           echo "Changesets:     ${{ needs.Changesets.result }}"
           echo "Compose:        ${{ needs.Compose.result }}"
           echo "Docker:         ${{ needs.Docker.result }}"
+          echo "Host smoke:     ${{ needs.Supported-host-smoke.result }}"
           echo "Preflight:      ${{ needs.Release-preflight.result }}"
           echo "Version branch: ${{ needs.detect-changes.outputs.version-branch == 'true' }}"
 
@@ -672,6 +745,7 @@ jobs:
           echo "| Compose | $(result_to_emoji '${{ needs.Compose.result }}') |" >> $GITHUB_STEP_SUMMARY
           echo "| Security | $(result_to_emoji '${{ needs.Security.result }}') |" >> $GITHUB_STEP_SUMMARY
           echo "| Docker | $(result_to_emoji '${{ needs.Docker.result }}') |" >> $GITHUB_STEP_SUMMARY
+          echo "| Supported-host boot smoke | $(result_to_emoji '${{ needs.Supported-host-smoke.result }}') |" >> $GITHUB_STEP_SUMMARY
           echo "| Release evidence preflight | $(result_to_emoji '${{ needs.Release-preflight.result }}') |" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 

--- a/.github/workflows/deploy-locked-compose.yml
+++ b/.github/workflows/deploy-locked-compose.yml
@@ -31,14 +31,15 @@ jobs:
     permissions:
       contents: read
     env:
-      # Which stacks this environment runs, and the order they come up in: the edge first, then the
-      # broker the receiver waits on, then the application. An environment whose edge is owned by
-      # something else on the host sets DEPLOY_EDGE_PROXY=false and keeps proxy out of both the
-      # render and the deploy — the reference deployment leaves it unset and gets all three.
+      # Which stacks this environment runs, and the order they come up in: the application server
+      # migrates the database before the new webhook runtime in core may use it, and the edge comes
+      # last so it never routes to a stack that is still starting. An environment whose edge is
+      # owned by something else on the host sets DEPLOY_EDGE_PROXY=false and keeps proxy out of both
+      # the render and the deploy — the reference deployment leaves it unset and gets all three.
       # Staging shares its host with the Coolify instance that serves pull-request previews, and
       # that proxy holds :80/:443, so a second edge there fails the deploy on a port that is
       # already allocated.
-      STACKS: ${{ vars.DEPLOY_EDGE_PROXY == 'false' && 'core app' || 'proxy core app' }}
+      STACKS: ${{ vars.DEPLOY_EDGE_PROXY == 'false' && 'app core' || 'app core proxy' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -188,15 +189,25 @@ jobs:
           envs: STACKS
           script: |
             set -euo pipefail
+
+            # The broker is recreated before the stacks so a running application server never loses
+            # its JetStream connection mid-deploy; ordering inside a stack is its own compose file's
+            # depends_on.
+            case " $STACKS " in *" core "*)
+              cd /opt/hephaestus/core
+              chmod 600 deployment.env
+              docker compose --env-file deployment.env -f compose.yaml config >/dev/null
+              docker compose --env-file deployment.env -f compose.yaml pull nats-server
+              docker compose --env-file deployment.env -f compose.yaml up -d --wait \
+                --wait-timeout 600 --force-recreate nats-server
+              ;;
+            esac
+
             for stack in $STACKS; do
               cd "/opt/hephaestus/$stack"
               chmod 600 deployment.env
               docker compose --env-file deployment.env -f compose.yaml config >/dev/null
               docker compose --env-file deployment.env -f compose.yaml pull
-              if [ "$stack" = core ]; then
-                docker compose --env-file deployment.env -f compose.yaml up -d \
-                  --force-recreate nats-server
-              fi
               docker compose --env-file deployment.env -f compose.yaml up -d --remove-orphans \
                 --wait --wait-timeout 600
             done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,7 +114,7 @@ jobs:
       - name: Capture release image digests
         id: retag
         env:
-          SOURCE_TAG: run-${{ github.event.workflow_run.id }}-${{ github.event.workflow_run.run_attempt }}
+          SOURCE_TAG: ${{ github.event.workflow_run.head_sha }}
         run: node scripts/resolve-release-images.ts "$SOURCE_TAG" release-images.tsv
 
       - name: Verify Node-only agent-pi sandbox
@@ -366,17 +366,12 @@ jobs:
           [ "$(printf '%s\n' 2.24.4 "$compose_version" | sort -V | head -n1)" = 2.24.4 ] || {
             echo "::error::Docker Compose 2.24.4 or newer is required"; exit 1; }
 
-          ./setup.sh
-          sed -i \
-            -e 's/^APP_HOSTNAME=$/APP_HOSTNAME=hephaestus-smoke.invalid/' \
-            -e 's/^ACME_EMAIL=$/ACME_EMAIL=release-smoke@example.invalid/' \
-            -e 's/^GH_OAUTH_CLIENT_ID=$/GH_OAUTH_CLIENT_ID=release-smoke/' \
-            -e 's/^GH_OAUTH_CLIENT_SECRET=$/GH_OAUTH_CLIENT_SECRET=release-smoke-secret/' \
-            -e 's/^HEPHAESTUS_AUTH_BOOTSTRAP_ADMINS=$/HEPHAESTUS_AUTH_BOOTSTRAP_ADMINS=github:1/' \
-            .env
+          node ../../scripts/prepare-host-smoke-env.ts
           node ../../scripts/prepare-release-lock.ts "$TAG_NAME"
           docker compose --env-file .env --env-file release-lock.env config --quiet
           docker compose --env-file .env --env-file release-lock.env up -d --wait --wait-timeout 600
+          # Traefik routes by the hostname the installer answered with: SMOKE_HOSTNAME in
+          # scripts/prepare-host-smoke-env.ts, which release-deployment-policy.test.ts holds to this.
           curl --fail --insecure --silent --show-error --max-time 10 --noproxy '*' \
             --resolve hephaestus-smoke.invalid:443:127.0.0.1 \
             https://hephaestus-smoke.invalid/ >/dev/null
@@ -484,28 +479,7 @@ jobs:
             --certificate-identity '${{ github.server_url }}/${{ github.repository }}/.github/workflows/release.yml@refs/heads/main' \
             --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' "$asset" >/dev/null
 
-      - name: Promote verified image digests
-        env:
-          VERSION: ${{ needs.release.outputs.version }}
-          SERIES: ${{ needs.release.outputs.major }}.${{ needs.release.outputs.minor }}
-        run: |
-          set -euo pipefail
-          jq -er '[.subjects[] | select(.provenance == "first-party") | [.repository, .indexDigest]] | unique[] | @tsv' evidence/manifest.json |
-          while IFS=$'\t' read -r ref digest; do
-            docker buildx imagetools create -t "$ref:$VERSION" "$ref@$digest"
-            promoted=$(docker buildx imagetools inspect "$ref:$VERSION" --format '{{json .Manifest}}' | jq -r .digest)
-            [ "$promoted" = "$digest" ] || { echo "::error::Promotion changed $ref:$VERSION digest"; exit 1; }
-          done
-          jq -er '[.subjects[] | select(.provenance == "first-party") | [.repository, .indexDigest]] | unique[] | @tsv' evidence/manifest.json |
-          while IFS=$'\t' read -r ref digest; do
-            docker buildx imagetools create -t "$ref:$SERIES" -t "$ref:latest" "$ref@$digest"
-            for tag in "$SERIES" latest; do
-              promoted=$(docker buildx imagetools inspect "$ref:$tag" --format '{{json .Manifest}}' | jq -r .digest)
-              [ "$promoted" = "$digest" ] || { echo "::error::Promotion changed $ref:$tag digest"; exit 1; }
-            done
-          done
-
-      - name: Publish release
+      - name: Publish immutable release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG_NAME: ${{ needs.release.outputs.tag_name }}
@@ -514,7 +488,33 @@ jobs:
           gh release upload "$TAG_NAME" host-smoke/*.json --clobber --repo "${{ github.repository }}"
           gh release edit "$TAG_NAME" --repo "${{ github.repository }}" --draft=false
           [ "$(gh release view "$TAG_NAME" --repo "${{ github.repository }}" --json isImmutable --jq .isImmutable)" = true ] || {
-            echo "::error::Repository immutable releases must be enabled before publishing"; exit 1; }
+            echo "::error::The published release is not immutable; refusing to promote image aliases"; exit 1; }
+
+      - name: Promote verified image digests
+        env:
+          VERSION: ${{ needs.release.outputs.version }}
+          SERIES: ${{ needs.release.outputs.major }}.${{ needs.release.outputs.minor }}
+        run: |
+          set -euo pipefail
+          jq -er '[.subjects[] | select(.provenance == "first-party") | [.repository, .indexDigest]] | unique[] | @tsv' \
+            evidence/manifest.json > "$RUNNER_TEMP/promotions.tsv"
+
+          # Resolve every immutable source before changing aliases. OCI registries update one tag
+          # at a time, so retries and final verification recover any interrupted promotion.
+          while IFS=$'\t' read -r ref digest; do
+            source=$(docker buildx imagetools inspect "$ref@$digest" --format '{{json .Manifest}}' | jq -r .digest)
+            [ "$source" = "$digest" ] || { echo "::error::Cannot resolve promotion source $ref@$digest"; exit 1; }
+          done < "$RUNNER_TEMP/promotions.tsv"
+          while IFS=$'\t' read -r ref digest; do
+            docker buildx imagetools create \
+              -t "$ref:$VERSION" -t "$ref:$SERIES" -t "$ref:latest" "$ref@$digest"
+          done < "$RUNNER_TEMP/promotions.tsv"
+          while IFS=$'\t' read -r ref digest; do
+            for tag in "$VERSION" "$SERIES" latest; do
+              promoted=$(docker buildx imagetools inspect "$ref:$tag" --format '{{json .Manifest}}' | jq -r .digest)
+              [ "$promoted" = "$digest" ] || { echo "::error::Promotion changed $ref:$tag digest"; exit 1; }
+            done
+          done < "$RUNNER_TEMP/promotions.tsv"
 
   # Staging pulls: this asks for the promotion and waits for it, so production is still only offered
   # a release staging is actually running. Nothing here reaches the host, and no deploy credential

--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -55,6 +55,12 @@ on:
         type: string
         required: false
         description: "Build arguments"
+      publish:
+        # No default: whether a build may write to the registry is not a decision to make silently
+        # on a caller's behalf. cicd.yml derives it once, for every image build in the run.
+        type: boolean
+        required: true
+        description: "Publish, attest, sign, and scan the image; false builds it locally without registry writes"
       single-arch:
         type: boolean
         required: false
@@ -68,13 +74,16 @@ on:
 permissions: {}
 
 env:
+  # Every tag is guarded on the event that started the run, so a consumer can derive from its own
+  # event which tag exists. The commit tag is the one every consumer resolves through: `github.sha`
+  # is the commit a push, dispatch or merge group built, and a pull request uses its head commit
+  # because `github.sha` there is a merge commit no other run can name.
   STANDARD_IMAGE_TAGS: |
     ${{ github.event_name == 'push' && github.ref_name || '' }}
-    ${{ github.event_name == 'push' && github.sha || '' }}
     ${{ github.event_name == 'push' && format('ci-{0}', github.run_number) || '' }}
+    ${{ github.event_name != 'pull_request' && github.sha || '' }}
     ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}
     ${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.number) || '' }}
-    run-${{ github.run_id }}-${{ github.run_attempt }}
 
 jobs:
   build:
@@ -102,6 +111,7 @@ jobs:
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       - name: Log in to Container Registry
+        if: inputs.publish
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ inputs.registry }}
@@ -166,8 +176,11 @@ jobs:
             sentry_project=${{ github.event_name == 'push' && matrix.platform == 'linux/amd64' && secrets.SENTRY_PROJECT || '' }}
           labels: ${{ steps.meta.outputs.labels }}
           tags: ${{ inputs.single-arch && steps.meta.outputs.tags || '' }}
-          push: ${{ inputs.single-arch }}
-          outputs: ${{ !inputs.single-arch && format('type=image,"name={0}/{1}",push-by-digest=true,name-canonical=true,push=true', inputs.registry, inputs.image-name) || '' }}
+          push: ${{ inputs.publish }}
+          # A local build is only tagged on the single-architecture path, and loading an untagged
+          # image into the daemon leaves something nothing can name.
+          load: ${{ !inputs.publish && inputs.single-arch }}
+          outputs: ${{ inputs.publish && !inputs.single-arch && format('type=image,"name={0}/{1}",push-by-digest=true,name-canonical=true,push=true', inputs.registry, inputs.image-name) || '' }}
           cache-from: |
             type=registry,ref=${{ inputs.registry }}/${{ inputs.image-name }}:cache-main-${{ steps.prep.outputs.platform_pair }}
           cache-to: ${{ github.ref == 'refs/heads/main' && format('type=registry,ref={0}/{1}:cache-main-{2},mode=max', inputs.registry, inputs.image-name, steps.prep.outputs.platform_pair) || '' }}
@@ -186,9 +199,9 @@ jobs:
           name: ${{ inputs.application-artifact }}
           path: ${{ runner.temp }}/application
 
-      # --publish exports straight to the registry; --trust-builder lets one creator container run
-      # every lifecycle phase, which is safe because the builder is pinned by digest.
-      - name: Build and push (Buildpacks + CDS)
+      # --trust-builder lets one creator container run every lifecycle phase; that is only safe
+      # because the builder is pinned by digest.
+      - name: Build with Buildpacks and CDS
         id: build-buildpacks
         if: inputs.use-buildpacks
         env:
@@ -198,6 +211,7 @@ jobs:
           MATRIX_PLATFORM: ${{ matrix.platform }}
           PLATFORM_PAIR: ${{ steps.prep.outputs.platform_pair }}
           PROJECT_DESCRIPTOR: ${{ inputs.project-descriptor }}
+          PUBLISH: ${{ inputs.publish }}
           RUN_IMAGE: ${{ inputs.run-image }}
         run: |
           set -euo pipefail
@@ -205,6 +219,14 @@ jobs:
           mapfile -t jars < <(find "$APPLICATION_DIRECTORY" -name 'hephaestus-application-*.jar')
           (( ${#jars[@]} == 1 ))
           PER_ARCH_TAG="$INPUT_REGISTRY/$INPUT_IMAGE_NAME:ci-$GITHUB_RUN_ID-$PLATFORM_PAIR"
+          if [ "$PUBLISH" != true ]; then
+            # A local build has no registry to read a manifest back from, and nothing downstream of
+            # a fork build consumes the digest, so the daemon's image ID is what it can report.
+            pack build "$PER_ARCH_TAG" --path "${jars[0]}" --descriptor "$PROJECT_DESCRIPTOR" \
+              --run-image "$RUN_IMAGE" --platform "$MATRIX_PLATFORM" --trust-builder
+            echo "digest=$(docker image inspect --format '{{.Id}}' "$PER_ARCH_TAG")" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           pack build "$PER_ARCH_TAG" --path "${jars[0]}" --descriptor "$PROJECT_DESCRIPTOR" \
             --run-image "$RUN_IMAGE" --platform "$MATRIX_PLATFORM" --publish --trust-builder
           # Buildpacks may wrap one platform in an index; capture its manifest, not the wrapper.
@@ -241,7 +263,7 @@ jobs:
           fi
 
       - name: Apply tags to buildpack image
-        if: inputs.single-arch && inputs.use-buildpacks
+        if: inputs.publish && inputs.single-arch && inputs.use-buildpacks
         env:
           SOURCE_IMAGE: ${{ inputs.registry }}/${{ inputs.image-name }}@${{ steps.build-buildpacks.outputs.digest }}
         run: |
@@ -254,7 +276,7 @@ jobs:
 
       - name: Capture single-architecture digest
         id: single-digest
-        if: inputs.single-arch
+        if: inputs.publish && inputs.single-arch
         env:
           IMAGE_TAG_REF: ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
         run: |
@@ -267,7 +289,7 @@ jobs:
           echo "manifest-digest=$DIGEST" >> "$GITHUB_OUTPUT"
 
       - name: Generate build provenance attestation
-        if: inputs.single-arch
+        if: inputs.publish && inputs.single-arch
         uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
           subject-name: ${{ inputs.registry }}/${{ inputs.image-name }}
@@ -275,11 +297,11 @@ jobs:
           push-to-registry: true
 
       - name: Install Cosign
-        if: inputs.single-arch
+        if: inputs.publish && inputs.single-arch
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Sign and verify image
-        if: inputs.single-arch
+        if: inputs.publish && inputs.single-arch
         env:
           IMAGE_REF: ${{ inputs.registry }}/${{ inputs.image-name }}@${{ steps.single-digest.outputs.manifest-digest }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -293,7 +315,7 @@ jobs:
           gh attestation verify "oci://$IMAGE_REF" --owner "${{ github.repository_owner }}"
 
       - name: Upload digest
-        if: ${{ !inputs.single-arch }}
+        if: ${{ inputs.publish && !inputs.single-arch }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: digests-${{ steps.prep.outputs.image_name }}-${{ steps.prep.outputs.platform_pair }}
@@ -306,7 +328,7 @@ jobs:
     timeout-minutes: 30
     runs-on: ubuntu-latest
     needs: build
-    if: ${{ !inputs.single-arch }}
+    if: ${{ inputs.publish && !inputs.single-arch }}
     permissions:
       packages: write
       id-token: write
@@ -441,7 +463,7 @@ jobs:
     # `merge` is skipped for single-architecture builds, which would skip this job too
     # without a status-check function to suppress the implicit success() over every need.
     if: >-
-      ${{ !cancelled() && needs.build.result == 'success' &&
+      ${{ inputs.publish && !cancelled() && needs.build.result == 'success' &&
       needs.merge.result != 'failure' && needs.merge.result != 'cancelled' }}
     timeout-minutes: 20
     runs-on: ubuntu-24.04
@@ -473,7 +495,7 @@ jobs:
       - name: Resolve the linux/amd64 subject
         id: subject
         env:
-          IMAGE_REF: ${{ inputs.registry }}/${{ inputs.image-name }}:run-${{ github.run_id }}-${{ github.run_attempt }}
+          IMAGE_REF: ${{ inputs.registry }}/${{ inputs.image-name }}@${{ inputs.single-arch && needs.build.outputs.manifest-digest || needs.merge.outputs.manifest-digest }}
           INPUT_IMAGE_NAME: ${{ inputs.image-name }}
         run: |
           set -euo pipefail

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -4,8 +4,9 @@
 #
 # Copy this file to .env and fill in the values for your production deployment.
 #
-# Usage:
-#   docker compose -f compose.proxy.yaml -f compose.core.yaml -f compose.app.yaml up -d
+# The reference deployment runs proxy, core, and app as independent Compose projects. Follow the
+# production setup guide for the required startup order and per-project commands:
+# https://docs.hephaestus.build/admin/production-setup
 #
 # =============================================================================
 

--- a/docker/compose.core.yaml
+++ b/docker/compose.core.yaml
@@ -98,14 +98,12 @@ services:
       # thc healthcheck target: readiness (reports unhealthy while NATS/JetStream is unavailable).
       THC_PORT: "8080"
       THC_PATH: /actuator/health/readiness
-    # nats-server only. `postgres` is a service of docker/compose.app.yaml, and the reference
-    # deployment runs proxy, core and app as three separate Compose projects under
-    # /opt/hephaestus/<stack>; depends_on is project-scoped, so naming it here orders nothing and
-    # makes this file refuse to render on its own. The receiver reaches the database across
-    # shared-network by the alias compose.app.yaml gives it, `restart: unless-stopped` carries it
-    # over a database that is not up yet, and its readiness group (application.yml) names no `db`
-    # contributor, so ingestion health stays honest either way. The single-host install merges all
-    # three files into one project and does declare it — docker/self-host/compose.single-host.yaml.
+    # nats-server only: `postgres` belongs to compose.app.yaml, and depends_on is project-scoped, so
+    # naming it here orders nothing and makes this file refuse to render. Cross-project ordering is
+    # the deployment workflow's; docker/self-host/compose.single-host.yaml merges all three projects
+    # into one and does declare it. Losing the ordering is safe here: `restart: unless-stopped`
+    # carries the receiver over a database that is not up yet, and its readiness group names no `db`
+    # contributor, so ingestion health stays honest while it waits.
     depends_on:
       nats-server:
         condition: service_healthy

--- a/docs/admin/production-setup.mdx
+++ b/docs/admin/production-setup.mdx
@@ -353,11 +353,30 @@ obligation. Only what is different about the multi-file stack is listed here.
    it.
 3. **Bootstrap secrets:** Load those variables into your secret manager or the `.env` files consumed
    by Docker/Kubernetes.
-4. **Deploy services:** Use `docker/compose.proxy.yaml`, `docker/compose.core.yaml` and
-   `docker/compose.app.yaml`, or your Kubernetes manifests.
-5. **Run database migrations:** The application server runs Liquibase migrations on startup; monitor
-   logs to confirm success.
-6. **Verify:**
+4. **Deploy services:** Each file is its own Compose project, so each needs its own `-p` and its own
+   `up`, and every one of them resolves its images from the verified release lock — `docker/.env`
+   defines no `HEPHAESTUS_IMAGE_*` variable, so a project started without the lock refuses to start.
+   Prepare it as [Install § 1](./install#1-get-the-files) does, writing it beside the reference
+   stack, then start the projects in this order, waiting for each to report healthy:
+
+   ```bash
+   VERSION=<the release you are deploying>   # without the leading "v"
+   node scripts/prepare-release-lock.ts "v$VERSION" docker/release-lock.env
+   cd docker
+   dc() { docker compose --env-file .env --env-file release-lock.env "$@"; }
+   dc -p hephaestus-core -f compose.core.yaml up -d --wait nats-server
+   dc -p hephaestus-app -f compose.app.yaml up -d --wait
+   dc -p hephaestus-core -f compose.core.yaml up -d --wait
+   dc -p hephaestus-proxy -f compose.proxy.yaml up -d --wait
+   ```
+
+   `depends_on` does not cross a project boundary, so the order between projects is yours to keep.
+   The broker comes up first, so a redeploy never drops the JetStream connection of an application
+   server that is already running. The application stack owns PostgreSQL and runs the Liquibase
+   migrations during its own startup — watch `application-server`'s logs to confirm they complete.
+   The core stack's webhook runtime reads what those migrations wrote, and the proxy goes last so it
+   never routes to a stack that is still starting. Kubernetes manifests need the same ordering.
+5. **Verify:**
    - The bootstrap admin can sign in and reach instance-admin navigation, and can reach workspace
      admin endpoints for workspaces they are a member of (auto-elevated to workspace ADMIN there).
    - A test webhook from GitHub or GitLab reaches the ingest pipeline.

--- a/docs/contributor/ci-cd.mdx
+++ b/docs/contributor/ci-cd.mdx
@@ -63,6 +63,7 @@ published.
 | Changesets → Verify changesets | policy tests, verified-revert detection, release-note presence, `MIGRATION.md` freeze | `vp run gate:changesets` |
 | Compose → Render compose stacks | the self-hosted, preview and reference stacks render | `vp run gate:preview-stack` |
 | Docker → Webapp, Agent: Pi, Postgres (pg_partman), Tag unchanged images | Dockerfile images; aliases for unchanged ones | — |
+| Supported-host boot smoke | `docker/self-host/setup.sh`, then PostgreSQL, NATS and the application server from this run's own images, waiting for the application to report healthy | — |
 | Actionlint, Zizmor | workflow lint with ShellCheck warnings; Zizmor at medium confidence | — |
 
 The four quality legs are one matrix job, one entry per leg of the task graph. Each runs
@@ -278,6 +279,7 @@ action directly rather than checking out the repository only to reach a wrapper.
 | Every quality leg | `vite.config.ts`, `.vite-hooks/**`, `.java-version`, `cicd.yml`, `ci-quality-gates.yml` and the setup actions: the task graph, the hooks and the JDK decide every leg's verdict, so a change to one runs all of them |
 | Build artifact gates | contracts: the App Server paths or `docker/postgres/**`; E2E: webapp source and the server main sources; image: `server/application/src/main/**`, the poms, `server/application/project.toml`, `server/generated-clients/**` |
 | Docker images | `webapp-image`: the webapp build inputs and non-test source; `agent-images`: `docker/agents/**`; `postgres-image`: `docker/postgres/**` |
+| Supported-host boot smoke | `docker/**`, `application*.yml`, and the sources Spring binds configuration from — `**/*Properties.java` and `Application.java`. `ci-contract.test.ts` fails if a source carrying `@ConfigurationProperties` or `@ConfigurationPropertiesScan` is not selected |
 | CI config | one filter per leg naming its own workflow files and actions; any `.github/workflows/**` or `.github/actions/**` change runs Actionlint and Zizmor |
 
 `docker/agents/**` is in both the tooling and the agent-image filters: `test:agents` and
@@ -295,6 +297,27 @@ path (`App Server image`) does not use this cache.
 Image builds authenticate to `ghcr.io` with the workflow's `GITHUB_TOKEN`; base images are pulled from
 Docker Hub anonymously, which
 [GitHub-hosted runners may do without a rate limit](https://docs.github.com/en/actions/reference/limits).
+A job that reads a first-party image back — the scan, the preflight, the boot smoke — logs in as
+well, because `packages: read` alone buys nothing.
+
+A pull request from a fork gets a read-only `GITHUB_TOKEN`, so `cicd.yml` passes `publish: false`
+to both image workflows. That build compiles the image and stops: no login, no push, no signature,
+no attestation, no policy scan and no alias moves. Forks therefore get no preview and no boot smoke;
+the release path exercises their code once it is on `main`.
+
+## Image identity
+
+Every consumer resolves an image through the commit the run built it from, and
+`reusable-docker-build.yml` publishes exactly that tag for the event the run started under:
+`github.sha` for a push, dispatch or merge group, and the pull request's head SHA for a pull request,
+where `github.sha` is a merge commit no image carries. Within a run, the vulnerability scan skips
+tags entirely and reads the digest its own build or merge job emitted as an output, so re-running the
+scan alone scans the artefact that build produced.
+
+`ci-contract.test.ts` asserts the whole contract: every tag a consumer resolves is one the build
+publishes for that consumer's event, and no job resolves an image by the run that happened to build
+it. A run-scoped tag names the attempt rather than the artefact, and GitHub's *re-run failed jobs*
+gives the retried job a new attempt number.
 
 ## Build once
 

--- a/docs/contributor/release-management.mdx
+++ b/docs/contributor/release-management.mdx
@@ -108,6 +108,13 @@ waits for stack readiness, and exercises HTTPS ingress. Either cell can block pu
 Each cell's status record is attached to the immutable GitHub release. This qualification covers a
 clean boot; the seeded-upgrade gate separately proves the supported migration path.
 
+A pull request that can change what a fresh installation binds gets the same boot before merge:
+`Supported-host boot smoke` in `cicd.yml` runs `docker/self-host/setup.sh` and starts PostgreSQL,
+NATS and the application server from the images that run built, on `amd64` only and without the
+edge. Both jobs fill the installer's blank settings through `scripts/prepare-host-smoke-env.ts`, so
+the pre-merge boot and the release boot answer the operator's questions identically. The paths that
+select it are in [CI/CD § Path filters](./ci-cd.mdx#path-filters).
+
 ## Supply-chain evidence
 
 No release exists until every image in `security/release-images.json` passes the evidence gate, and
@@ -151,6 +158,7 @@ which performs every check except signature verification.
 | SBOM attestation matches the durable evidence | **Yes, structurally.** `cosign attest` creates the attestation during the release; there is nothing to verify before it exists |
 | Image index signature and build provenance carry the release's identity | **Yes, structurally.** The Fulcio certificate identity is the release workflow's, on `refs/heads/main`, and no earlier run can produce one |
 | The manifest names a release version | **Yes, structurally.** Only `plan-release.ts` decides the tag; the preflight substitutes the version the ref carries |
+| The bundle describes the images this run built | No — the preflight and `release.yml` both resolve subjects through the commit tag the image build publishes, and `ci-contract.test.ts` requires the build to publish it for every event either can run under. See [CI/CD § Image identity](./ci-cd.mdx#image-identity) |
 
 The two signature entries are the only mode-conditional behaviour in the verifier, and
 `ci-contract.test.ts` asserts exactly that: a check gated on anything other than

--- a/scripts/ci-contract.test.ts
+++ b/scripts/ci-contract.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
-import { glob, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { chmod, glob, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { describe, test } from "node:test";
@@ -140,17 +140,19 @@ function step(workflow: Document, jobPath: string[], action: string): YAMLMap {
 	throw new Error(`${jobPath.join(".")} has no ${action} step`);
 }
 
-/** The shell a named `run` step ships. */
-function runScript(workflow: Document, jobPath: string[], name: string): string {
+/** A job's step by its `name`. */
+function namedStep(workflow: Document, jobPath: string[], name: string): YAMLMap {
 	const steps = workflow.getIn([...jobPath, "steps"]);
 	assert.ok(isSeq(steps), `${jobPath.join(".")} has no steps`);
-	for (const item of steps.items) {
-		if (!isMap(item) || item.get("name") !== name) continue;
-		const shell = item.get("run");
-		assert.ok(typeof shell === "string", `${name} is not a run step`);
-		return shell;
-	}
+	for (const item of steps.items) if (isMap(item) && item.get("name") === name) return item;
 	throw new Error(`${jobPath.join(".")} has no ${name} step`);
+}
+
+/** The shell a named `run` step ships. */
+function runScript(workflow: Document, jobPath: string[], name: string): string {
+	const shell = namedStep(workflow, jobPath, name).get("run");
+	assert.ok(typeof shell === "string", `${name} is not a run step`);
+	return shell;
 }
 
 /**
@@ -350,10 +352,15 @@ void describe("CI contract", () => {
 		assert.match(job(orchestrator, "Build"), /needs: \[detect-changes\]/);
 
 		const reusable = await readFile(".github/workflows/reusable-docker-build.yml", "utf8");
-		const packBuild = reusable.replace(/\\\n\s*/g, " ").match(/^\s+pack build .*$/m)?.[0];
-		assert.ok(packBuild, "the buildpacks path must call pack build");
-		for (const flag of ["--path", "--descriptor", "--run-image", "--publish"])
-			assert.ok(packBuild.includes(flag), `pack build must pass ${flag}`);
+		const packBuilds = [...reusable.replace(/\\\n\s*/g, " ").matchAll(/^\s+pack build .*$/gm)].map(
+			(match) => match[0],
+		);
+		assert.ok(packBuilds.length > 0, "the buildpacks path must call pack build");
+		for (const packBuild of packBuilds)
+			for (const flag of ["--path", "--descriptor", "--run-image"])
+				assert.ok(packBuild.includes(flag), `pack build must pass ${flag}`);
+		// One invocation exports to the registry; the fork path builds the same image locally.
+		assert.equal(packBuilds.filter((call) => call.includes("--publish")).length, 1);
 		for (const [file, source] of await workflowSources()) {
 			assert.doesNotMatch(
 				source,
@@ -468,19 +475,8 @@ void describe("CI contract", () => {
 		const inherited = job(docker, "tag-unchanged-images");
 		assert.match(inherited, /HEAD_SHA/);
 		assert.match(inherited, /pr-\$PR_NUMBER/);
-		assert.match(inherited, /run-\$RUN_ID-\$RUN_ATTEMPT/);
 
 		const reusable = await readFile(".github/workflows/reusable-docker-build.yml", "utf8");
-		for (const tag of [
-			/github\.event_name == 'push' && github\.ref_name/,
-			/github\.event_name == 'push' && github\.sha/,
-			/github\.event_name == 'push' && format\('ci-\{0\}', github\.run_number\)/,
-			/github\.event_name == 'pull_request' && github\.event\.pull_request\.head\.sha/,
-			/github\.event_name == 'pull_request' && format\('pr-\{0\}', github\.event\.number\)/,
-			/run-\${{ github\.run_id }}-\${{ github\.run_attempt }}/,
-		]) {
-			assert.match(reusable, tag);
-		}
 		for (const secret of ["SENTRY_AUTH_TOKEN", "SENTRY_ORG", "SENTRY_PROJECT"]) {
 			assert.match(reusable, new RegExp(`github\\.event_name == 'push'.*secrets\\.${secret}`));
 		}
@@ -488,6 +484,242 @@ void describe("CI contract", () => {
 			reusable,
 			/inputs\.single-arch.*linux\/amd64.*ubuntu-24\.04.*linux\/arm64.*ubuntu-24\.04-arm/,
 		);
+	});
+
+	void test("builds fork pull-request images without registry writes", async () => {
+		const orchestrator = parseDocument(await readFile(".github/workflows/cicd.yml", "utf8"));
+		// One decision, taken where the run can see whose repository the head branch is on. A fork's
+		// GITHUB_TOKEN is read-only, so a publishing build there fails on its first write.
+		for (const caller of ["Build", "Docker"])
+			assert.match(
+				String(orchestrator.getIn(["jobs", caller, "with", "publish"])),
+				/^\$\{\{ github\.event_name != 'pull_request' \|\| github\.event\.pull_request\.head\.repo\.full_name == github\.repository }}$/,
+			);
+
+		const reusable = parseDocument(
+			await readFile(".github/workflows/reusable-docker-build.yml", "utf8"),
+		);
+		const declaration = reusable.getIn(["on", "workflow_call", "inputs", "publish"]);
+		assert.ok(isMap(declaration));
+		assert.equal(declaration.get("type"), "boolean");
+		// No default: a caller that forgets it fails to start, rather than silently writing to the
+		// registry on behalf of a run that may not be allowed to.
+		assert.equal(declaration.get("required"), true);
+		assert.equal(declaration.get("default"), undefined);
+
+		const build = ["jobs", "build"];
+		for (const name of [
+			"Log in to Container Registry",
+			"Apply tags to buildpack image",
+			"Capture single-architecture digest",
+			"Generate build provenance attestation",
+			"Install Cosign",
+			"Sign and verify image",
+			"Upload digest",
+		])
+			assert.match(
+				String(namedStep(reusable, build, name).get("if")),
+				/inputs\.publish/,
+				`${name} writes to the registry and must be gated on publish`,
+			);
+		const buildx = namedStep(reusable, build, "Build and push (Dockerfile)");
+		const inputs = buildx.get("with");
+		assert.ok(isMap(inputs));
+		assert.match(String(inputs.get("push")), /^\$\{\{ inputs\.publish }}$/);
+		// An untagged local image is one nothing can name, so a fork only loads what it also tags.
+		assert.match(String(inputs.get("load")), /^\$\{\{ !inputs\.publish && inputs\.single-arch }}$/);
+		assert.match(String(inputs.get("outputs")), /inputs\.publish &&/);
+		for (const gated of ["merge", "scan"])
+			assert.match(String(reusable.getIn(["jobs", gated, "if"])), /inputs\.publish/);
+
+		const docker = parseDocument(await readFile(".github/workflows/ci-docker-build.yml", "utf8"));
+		assert.match(String(docker.getIn(["jobs", "tag-unchanged-images", "if"])), /inputs\.publish/);
+	});
+
+	void test("a fork's buildpack build produces an image without contacting the registry", async () => {
+		const reusable = parseDocument(
+			await readFile(".github/workflows/reusable-docker-build.yml", "utf8"),
+		);
+		const shell = runScript(reusable, ["jobs", "build"], "Build with Buildpacks and CDS");
+		const directory = await mkdtemp(path.join(tmpdir(), "buildpacks-"));
+		await writeFile(path.join(directory, "hephaestus-application-1.0.0.jar"), "");
+		const calls = path.join(directory, "calls");
+		for (const tool of ["pack", "docker"]) {
+			const stub = path.join(directory, tool);
+			await writeFile(
+				stub,
+				`#!/bin/sh\necho "${tool} $*" >> "${calls}"\n[ "$1" = image ] && echo sha256:stub\nexit 0\n`,
+			);
+			await chmod(stub, 0o755);
+		}
+		const environment = {
+			APPLICATION_DIRECTORY: directory,
+			GITHUB_RUN_ID: "1",
+			INPUT_IMAGE_NAME: "hephaestus-build/application-server",
+			INPUT_REGISTRY: "ghcr.io",
+			MATRIX_PLATFORM: "linux/amd64",
+			PATH: `${directory}${path.delimiter}${process.env["PATH"] ?? ""}`,
+			PLATFORM_PAIR: "linux-amd64",
+			PROJECT_DESCRIPTOR: "project.toml",
+			RUN_IMAGE: "paketobuildpacks/run",
+		};
+
+		const local = await runStep(shell, { ...environment, PUBLISH: "false" });
+		assert.equal(local.failed, false);
+		// The digest is the daemon's image ID: a local build has no registry to read a manifest back
+		// from, and the step must still tell its caller what it produced.
+		assert.match(local.outputs["digest"] ?? "", /^sha256:/);
+		const invoked = await readFile(calls, "utf8");
+		assert.doesNotMatch(invoked, /--publish/);
+		assert.match(invoked, /^pack build .*--trust-builder/m);
+	});
+
+	void test("every job that boots the supported installation authenticates to the registry", async () => {
+		// `packages: read` is inert without a login, and the boot's first pull is where that shows.
+		// Only a boot the runner performs itself needs one: a deploy hands its script to a host that
+		// authenticates on its own.
+		for (const [file, source] of await workflowSources()) {
+			const jobs = parseDocument(source).get("jobs");
+			if (!isMap(jobs)) continue;
+			for (const entry of jobs.items) {
+				const steps = isMap(entry.value) ? entry.value.get("steps") : undefined;
+				if (!isSeq(steps)) continue;
+				const boots = steps.items.some(
+					(item) =>
+						isMap(item) &&
+						typeof item.get("run") === "string" &&
+						/docker compose .*--env-file[\s\S]*?\bup -d\b/.test(String(item.get("run"))),
+				);
+				const name = isScalar(entry.key) ? String(entry.key.value) : "";
+				if (!boots) continue;
+				assert.match(
+					job(source, name),
+					/uses: \.\/\.github\/actions\/ghcr-login/,
+					`${file} ${name} boots first-party images and must log in to the registry`,
+				);
+			}
+		}
+	});
+
+	void test("a pull request boots the supported installation from the images its own run built", async () => {
+		const build = parseDocument(await readFile(".github/workflows/ci-build.yml", "utf8"));
+		assert.match(
+			String(build.getIn(["on", "workflow_call", "outputs", "application-server-digest", "value"])),
+			/^\$\{\{ jobs\.application-server-image\.outputs\.manifest-digest }}$/,
+		);
+
+		const source = await readFile(".github/workflows/cicd.yml", "utf8");
+		const orchestrator = parseDocument(source);
+		const condition = String(orchestrator.getIn(["jobs", "Supported-host-smoke", "if"]));
+		// A fork publishes no images, so there is nothing for this job to pull.
+		assert.match(condition, /github\.event_name == 'pull_request'/);
+		assert.match(condition, /head\.repo\.full_name == github\.repository/);
+		assert.match(condition, /needs\.detect-changes\.outputs\.supported-host-smoke == 'true'/);
+
+		const smoke = job(source, "Supported-host-smoke");
+		assert.match(
+			smoke,
+			/APPLICATION_DIGEST: \${{ needs\.Build\.outputs\.application-server-digest }}/,
+		);
+		// The reduced topology an operator's first boot has to get through: no edge, no webapp. The
+		// service list runs onto a continuation line, so the command is rejoined before it is read.
+		const boot = /up -d --wait --wait-timeout \d+ ([^\n]+)/.exec(smoke.replace(/\s*\\\n\s+/g, " "));
+		assert.ok(boot, "the boot smoke must start the installation and wait for it to be ready");
+		assert.deepEqual(String(boot[1]).trim().split(/\s+/).toSorted(), [
+			"application-server",
+			"nats-server",
+			"postgres",
+		]);
+		// The installer an operator runs, filled in by the one script both smoke jobs call.
+		assert.match(smoke, /scripts\/prepare-host-smoke-env\.ts/);
+		assert.match(
+			job(await readFile(".github/workflows/release.yml", "utf8"), "supported-host-smoke"),
+			/scripts\/prepare-host-smoke-env\.ts/,
+		);
+		// The paths that trigger the smoke also have to rebuild the images it boots.
+		for (const flag of ["server_image_changed", "application_server_changed"])
+			assert.match(source, new RegExp(`${flag}:.*supported-host-smoke`));
+		assert.match(job(source, "all-ci-passed"), /needs: \[[^\]]*Supported-host-smoke[^\]]*\]/);
+	});
+
+	void test("the supported-host boot smoke runs on every source it can be broken by", async () => {
+		const filter = pathFilter(
+			await readFile(".github/workflows/cicd.yml", "utf8"),
+			"supported-host-smoke",
+		);
+		const patterns = [...filter.matchAll(/^ +- '(.+)'$/gm)].map((match) => String(match[1]));
+		const selected = new Set((await Promise.all(patterns.map(posixGlob))).flat());
+		// Spring binds a class the moment it carries the annotation, wherever it lives, so the filter
+		// has to select the whole binding tree rather than the part someone remembered.
+		for (const file of await posixGlob("server/application/src/main/java/**/*.java")) {
+			if (!/^@ConfigurationProperties(?:Scan)?\b/m.test(await readFile(file, "utf8"))) continue;
+			assert.ok(
+				selected.has(file),
+				`${file} binds configuration at boot, so a change to it must run the supported-host boot smoke`,
+			);
+		}
+	});
+
+	void test("every image a consumer resolves is one the build published for that event", async () => {
+		const reusable = parseDocument(
+			await readFile(".github/workflows/reusable-docker-build.yml", "utf8"),
+		);
+		const declared = reusable.getIn(["env", "STANDARD_IMAGE_TAGS"]);
+		assert.equal(typeof declared, "string");
+		// `${{ github.event_name <op> '<event>' && <expression> || '' }}`: every tag the build
+		// publishes is guarded on the event that started the run, so a consumer can derive from its
+		// own event which tags exist. A tag published under every event names the attempt rather than
+		// the artefact, and a re-run of a failed job would resolve nothing.
+		const guard = /^\$\{\{ github\.event_name (==|!=) '(\w+)' && (.+?) \|\| '' }}$/;
+		const lines = String(declared)
+			.split("\n")
+			.filter((line) => line.length > 0);
+		const publishedOn = (event: string): string[] =>
+			lines.flatMap((line) => {
+				const parsed = guard.exec(line);
+				assert.ok(parsed, `image tag "${line}" is published under every event`);
+				return (parsed[1] === "==") === (parsed[2] === event) ? [String(parsed[3])] : [];
+			});
+
+		const source = await readFile(".github/workflows/cicd.yml", "utf8");
+		const triggers = /^on:\n([\s\S]*?)^\S/m.exec(source)?.[1] ?? "";
+		const events = [...triggers.matchAll(/^ {2}(\w+):/gm)].map((match) => String(match[1]));
+		assert.ok(events.includes("workflow_dispatch") && events.includes("merge_group"));
+		for (const event of events) {
+			// A pull request resolves its own head: `github.sha` there is a merge commit no image
+			// carries. Every other event resolves the commit it ran on.
+			const resolved =
+				event === "pull_request" ? "github.event.pull_request.head.sha" : "github.sha";
+			assert.ok(
+				publishedOn(event).includes(resolved),
+				`a ${event} run resolves images by ${resolved}, which the image build does not publish`,
+			);
+		}
+
+		// The consumers, and the commit each resolves through. The scan resolves a digest its own
+		// producer job emitted, so it needs no tag at all.
+		const preflight = job(source, "Release-preflight");
+		assert.match(
+			preflight,
+			/COMMIT: \${{ github\.event\.pull_request\.head\.sha \|\| github\.sha }}/,
+		);
+		assert.match(preflight, /resolve-release-images\.ts "\$COMMIT"/);
+		assert.match(preflight, /--commit "\$COMMIT"/);
+		const smoke = job(source, "Supported-host-smoke");
+		assert.match(smoke, /HEAD_SHA: \${{ github\.event\.pull_request\.head\.sha }}/);
+		// `workflow_run.head_sha` is the producing push run's own `github.sha`.
+		const release = await readFile(".github/workflows/release.yml", "utf8");
+		assert.match(
+			job(release, "tag-images"),
+			/SOURCE_TAG: \${{ github\.event\.workflow_run\.head_sha }}/,
+		);
+
+		for (const [file, workflow] of await workflowSources())
+			assert.doesNotMatch(
+				workflow,
+				/:run-\$/,
+				`${file} must not resolve an image by the run that happened to build it`,
+			);
 	});
 
 	void test("enforces the release vulnerability policy where images are built", async () => {
@@ -504,7 +736,10 @@ void describe("CI contract", () => {
 			scan,
 			/node scripts\/check-release-vulnerabilities\.ts[\s\S]*security\/vulnerability-policy\.json/,
 		);
-		assert.match(scan, /run-\${{ github\.run_id }}-\${{ github\.run_attempt }}/);
+		assert.match(scan, /needs\.build\.outputs\.manifest-digest/);
+		assert.match(scan, /needs\.merge\.outputs\.manifest-digest/);
+		assert.match(scan, /IMAGE_REF:.*@\${{/);
+		assert.doesNotMatch(scan, /github\.(?:run_id|run_attempt)/);
 		assert.match(scan, /linux\/amd64/);
 		assert.doesNotMatch(scan, /linux\/arm64/);
 		// A gate that cannot say what it rejected is not finished.
@@ -1005,14 +1240,8 @@ void describe("CI contract", () => {
 	void test("runs release evidence verification through tested TypeScript", async () => {
 		const release = await readFile(".github/workflows/release.yml", "utf8");
 		const rescan = await readFile(".github/workflows/rescan-release-images.yml", "utf8");
-		assert.match(
-			release,
-			/SOURCE_TAG: run-\${{ github\.event\.workflow_run\.id }}-\${{ github\.event\.workflow_run\.run_attempt }}/,
-		);
+		assert.match(release, /SOURCE_TAG: \${{ github\.event\.workflow_run\.head_sha }}/);
 		assert.match(release, /node scripts\/resolve-release-images\.ts "\$SOURCE_TAG"/);
-		// The run tag names this build; a branch or commit tag names whatever it points at now, and
-		// resolving either belongs in the tested resolver rather than in a shell loop the preflight
-		// would have to grow its own copy of.
 		assert.doesNotMatch(job(release, "tag-images"), /imagetools/);
 		assert.match(rescan, /node scripts\/verify-release-evidence\.ts release-evidence/);
 		assert.doesNotMatch(rescan, /node scripts\/check-release-sbom\.ts/);
@@ -1033,6 +1262,13 @@ void describe("CI contract", () => {
 		assert.ok(gated >= 0, "tag-images must run the evidence verifier");
 		assert.ok(created > gated, "the draft must be created after the evidence gate");
 		assert.ok(uploaded > created, "release assets need a draft to upload to");
+		const publication = job(source, "publish-release");
+		const published = publication.indexOf('gh release edit "$TAG_NAME"');
+		const immutable = publication.indexOf("--json isImmutable");
+		const promoted = publication.indexOf("docker buildx imagetools create");
+		assert.ok(published >= 0 && immutable > published, "publication must verify immutable state");
+		assert.ok(promoted > immutable, "image aliases must only move after immutable publication");
+
 		// A re-run resumes the draft, so uploads must replace assets instead of failing on names.
 		for (const upload of source.matchAll(/gh release upload[\s\S]*?\n\n/g)) {
 			assert.match(upload[0], /--clobber/);

--- a/scripts/prepare-host-smoke-env.test.ts
+++ b/scripts/prepare-host-smoke-env.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { test } from "node:test";
+
+import { answerBlankSettings } from "./prepare-host-smoke-env.ts";
+
+// `setup.sh` copies `.env.example` and fills in the secrets it generates; every setting the smoke
+// has to answer is still blank in it, so the shipped example is the honest input for this.
+const example = await readFile(
+	join(import.meta.dirname, "..", "docker", "self-host", ".env.example"),
+	"utf8",
+);
+
+await test("answers the settings a boot refuses to start without, and touches nothing else", () => {
+	const answered = answerBlankSettings(example);
+	const before = example.split("\n");
+	const after = answered.split("\n");
+	assert.equal(after.length, before.length);
+
+	const changed = new Map<string, string>();
+	for (const [index, line] of before.entries()) {
+		if (after[index] === line) continue;
+		const key = /^(\w+)=$/.exec(line)?.[1];
+		assert.ok(key, `only a blank setting may be answered, but line ${index + 1} was "${line}"`);
+		assert.match(String(after[index]), new RegExp(`^${key}=.+$`));
+		changed.set(key, String(after[index]).slice(key.length + 1));
+	}
+
+	// Without these five the installation stops at boot: no hostname, no certificate contact, no
+	// login provider, and nobody who can reach instance administration.
+	assert.deepEqual([...changed.keys()].toSorted(), [
+		"ACME_EMAIL",
+		"APP_HOSTNAME",
+		"GH_OAUTH_CLIENT_ID",
+		"GH_OAUTH_CLIENT_SECRET",
+		"HEPHAESTUS_AUTH_BOOTSTRAP_ADMINS",
+	]);
+	// Placeholders, not credentials: a smoke boot authenticates against no provider, and every
+	// hostname it names has to stay unresolvable.
+	assert.match(String(changed.get("APP_HOSTNAME")), /\.invalid$/);
+	assert.match(String(changed.get("ACME_EMAIL")), /@[\w.-]+\.invalid$/);
+	assert.match(String(changed.get("HEPHAESTUS_AUTH_BOOTSTRAP_ADMINS")), /^github:\d+$/);
+});
+
+await test("refuses a setting the installer did not leave blank", () => {
+	const supplied = example.replace(/^APP_HOSTNAME=$/m, "APP_HOSTNAME=hephaestus.example");
+	assert.throws(() => answerBlankSettings(supplied), /APP_HOSTNAME/);
+});

--- a/scripts/prepare-host-smoke-env.ts
+++ b/scripts/prepare-host-smoke-env.ts
@@ -1,0 +1,48 @@
+/**
+ * Prepares `docker/self-host/.env` for an unattended boot of the supported installation: it runs
+ * the installer an operator runs, then answers the settings `setup.sh` deliberately leaves blank.
+ *
+ * None of the answers is a credential — nothing in a smoke boot authenticates against a provider —
+ * but every one has to be non-empty, because a blank required setting is exactly what the boot is
+ * checking the installation refuses to start on.
+ */
+import { readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { run } from "./lib/process.ts";
+
+const SELF_HOST = join(import.meta.dirname, "..", "docker", "self-host");
+
+/**
+ * Traefik routes a boot by `Host(APP_HOSTNAME)`, so the release smoke's ingress check reaches the
+ * installation only under the name answered here; `release.yml` resolves this name to the loopback.
+ */
+export const SMOKE_HOSTNAME = "hephaestus-smoke.invalid";
+
+const ANSWERS: Readonly<Record<string, string>> = {
+	APP_HOSTNAME: SMOKE_HOSTNAME,
+	ACME_EMAIL: "smoke@example.invalid",
+	GH_OAUTH_CLIENT_ID: "smoke",
+	GH_OAUTH_CLIENT_SECRET: "smoke-secret",
+	HEPHAESTUS_AUTH_BOOTSTRAP_ADMINS: "github:1",
+};
+
+/**
+ * A key `setup.sh` left blank is answered; a key it did not leave blank is a rename in
+ * `.env.example` that this file has not followed, and the boot would otherwise start on a setting
+ * the operator is required to supply.
+ */
+export function answerBlankSettings(environment: string): string {
+	return Object.entries(ANSWERS).reduce((text, [key, value]) => {
+		const blank = new RegExp(`^${key}=$`, "m");
+		if (!blank.test(text))
+			throw new Error(`${key} is not a blank setting of docker/self-host/.env`);
+		return text.replace(blank, () => `${key}=${value}`);
+	}, environment);
+}
+
+if (import.meta.main) {
+	await run("./setup.sh", [], { cwd: SELF_HOST });
+	const file = join(SELF_HOST, ".env");
+	await writeFile(file, answerBlankSettings(await readFile(file, "utf8")));
+}

--- a/scripts/release-deployment-policy.test.ts
+++ b/scripts/release-deployment-policy.test.ts
@@ -3,6 +3,7 @@ import { readFileSync } from "node:fs";
 import { test } from "node:test";
 
 import { releaseSignerIdentity, releaseSignerRepository } from "./lib/release-signer.ts";
+import { SMOKE_HOSTNAME } from "./prepare-host-smoke-env.ts";
 
 const release = readFileSync(".github/workflows/release.yml", "utf8");
 const deployment = readFileSync(".github/workflows/deploy-locked-compose.yml", "utf8");
@@ -19,6 +20,38 @@ await test("deployment uses Compose metadata, waits for readiness, and preserves
 	assert.match(deployment, /config --variables --format json/);
 	assert.match(deployment, /--wait --wait-timeout 600/);
 	assert.doesNotMatch(deployment, /docker image prune/);
+});
+
+await test("a deployment starts the broker before the stacks that talk to it", () => {
+	const configured = /^\s+STACKS: (.+)$/m.exec(deployment)?.[1];
+	assert.ok(configured, "the deploy job must declare the stacks and their order in STACKS");
+	// Every stack list the expression can yield: one per environment shape it selects between.
+	const orders = [...configured.matchAll(/&& '([a-z ]+)' \|\| '([a-z ]+)'/g)].flatMap((match) => [
+		String(match[1]).split(" "),
+		String(match[2]).split(" "),
+	]);
+	assert.ok(orders.length > 0);
+	for (const stacks of orders) {
+		// The application server runs the Liquibase migration the webhook runtime in core reads.
+		assert.ok(
+			stacks.indexOf("app") < stacks.indexOf("core"),
+			`${stacks.join(" ")} starts the webhook runtime before the migration that feeds it`,
+		);
+		// The edge comes last, so it never routes to a stack that is still starting.
+		if (stacks.includes("proxy")) assert.equal(stacks.at(-1), "proxy");
+	}
+
+	const script = deployment.slice(deployment.indexOf("envs: STACKS"));
+	// The broker is recreated before any stack, and only where this environment runs core, so an
+	// environment that leaves core out never deploys a broker it did not render.
+	const broker = script.search(/\*" core "\*\)/);
+	const stacks = script.indexOf("for stack in $STACKS");
+	assert.ok(
+		broker >= 0,
+		"the broker must be guarded on core being one of this deployment's stacks",
+	);
+	assert.ok(stacks > broker, "the broker must be recreated before any stack starts");
+	assert.match(script.slice(broker, stacks), /--force-recreate nats-server/);
 });
 
 const upgrade = readFileSync(".github/workflows/release-upgrade.yml", "utf8");
@@ -112,4 +145,17 @@ await test("release publication requires native smoke tests for every supported 
 	assert.match(smokeGate, /prepare-release-lock\.ts/);
 	assert.match(smokeGate, /contents: write/);
 	assert.match(release, /gh release upload "\$TAG_NAME" host-smoke\/\*\.json/);
+});
+
+await test("the release smoke reaches the installation by the name the installer answers with", () => {
+	// Traefik routes on the hostname the installer answered with, so a rename in the script has to
+	// reach this curl or the ingress check fails for the first time at a release.
+	assert.ok(
+		release.includes(`--resolve ${SMOKE_HOSTNAME}:443:127.0.0.1`),
+		`release.yml must resolve ${SMOKE_HOSTNAME} to the loopback`,
+	);
+	assert.ok(
+		release.includes(`https://${SMOKE_HOSTNAME}/`),
+		`release.yml must request the installation at ${SMOKE_HOSTNAME}`,
+	);
 });

--- a/scripts/resolve-release-images.ts
+++ b/scripts/resolve-release-images.ts
@@ -1,10 +1,8 @@
 /**
  * Resolves the first-party release images a CI/CD run published to their index digests.
  *
- * `reusable-docker-build.yml` tags every run's images `run-<run id>-<attempt>`. That is the only tag
- * that names *this* build rather than whatever a branch tag happens to point at now, so it is what
- * both the release and the pre-merge evidence preflight resolve their subjects through — one
- * resolver, so the two can never disagree about which artefact the evidence describes.
+ * Both release paths resolve through the commit tag the image build publishes, so a re-run of a
+ * failed job resolves the artefact its own run produced.
  *
  * The image set itself is not redefined here: `planSubjects` derives it from
  * `security/release-images.json`, the same file the release evidence gate validates the finished


### PR DESCRIPTION
## What changed and why

A CI run could not reliably resolve the images it had just built. The image build tagged them
`run-<id>-<attempt>`, so re-running only the failed jobs changed the key and the scan resolved a tag
nothing had pushed (#1750); the release-evidence preflight then moved to a commit tag the build did
not publish on `workflow_dispatch` or `merge_group`, which is the one path a release depends on. And
the only job that installs Hephaestus the way an operator does still ran after the tag was cut.

- Every consumer resolves the artefact its own run produced. `reusable-docker-build.yml` publishes a
  commit tag for every event a consumer can run under, the vulnerability scan reads the digest its
  producer job emitted rather than any tag, and the run-scoped tag nothing consumed is gone from both
  producers. `release.yml` and the preflight go through the same commit and the same resolver.
- A contract test holds the two halves together: every tag a consumer resolves must be one the build
  publishes for that consumer's event, every tag must be event-guarded, and no job may resolve an
  image by the run that happened to build it.
- The release path fails closed around it. A release is published and verified immutable before any
  image alias moves; promotion resolves every source first, writes all three aliases in one call and
  re-verifies, so a partial per-tag registry write is recoverable rather than final.
- A locked deploy recreates the broker before it starts any stack, so an application server that is
  already running never loses its JetStream connection mid-deploy, and it keeps the per-environment
  stack list that decides whether this host runs its own edge. Ordering inside a stack stays that
  stack's own `depends_on`. The reference deployment's per-project startup order is now a command
  block an operator can run.
- A same-repository pull request that touches the install or configuration-binding paths boots
  PostgreSQL, NATS and the application server from its own images, through the operator's own
  installer. A fork pull request builds its images without a registry login, publication, signature,
  attestation, scan or alias change.

Fixes #1750.
Fixes #1758.

## How to test

- `vp run format`
- `vp run check`
- `vp run test:agents`
- `node --test scripts/ci-contract.test.ts scripts/release-deployment-policy.test.ts scripts/prepare-host-smoke-env.test.ts`
- In CI: **Supported-host boot smoke** reaches healthy, and re-running only a failed scan job scans
  the image its own build pushed.

## Release impact

No changeset: this changes CI workflows, repository automation and documentation; the two shipped
files it touches carry comments only. No operator action is required. The reference deployment's startup order is now a runnable command
block in [Production setup](https://docs.hephaestus.build/admin/production-setup) rather than a
`docker/.env.example` comment that named a single-command form the compose files do not support.

## Notes for reviewers

Start with `STANDARD_IMAGE_TAGS` in `.github/workflows/reusable-docker-build.yml` and the test *"every
image a consumer resolves is one the build published for that event"* in `scripts/ci-contract.test.ts`
— together they are the whole image-identity contract, and
`docs/contributor/ci-cd.mdx` § Image identity is its one home. Then `Supported-host-smoke` in
`cicd.yml` and the `STACKS` resolution in `deploy-locked-compose.yml`. Both smoke jobs answer the
installer through `scripts/prepare-host-smoke-env.ts`; its `SMOKE_HOSTNAME` is the name the release
smoke's ingress check resolves, and `scripts/release-deployment-policy.test.ts` fails if the script
and the workflow ever disagree about it.

Threading producer digests into the preflight instead of a tag was considered and rejected: on a run
where `all-images` is false, some release subjects are aliased by `tag-unchanged-images` rather than
built, so no producer job emits a digest for them. The commit tag is the only key that covers the
whole set, and the contract test is what keeps producer and consumer honest about it.

One platform limitation remains: GitHub's immutable-release settings endpoint requires Administration
read, which `GITHUB_TOKEN` cannot receive. Rather than introduce a higher-value credential, the
workflow publishes the already-verified draft, immediately checks the release's `isImmutable` state
with `contents: write`, and refuses all image-alias promotion if it is mutable. A repository
misconfiguration can therefore expose a mutable release, but cannot move the supported image
channels.
