### PR TITLE
fix(docker): fsync every JetStream write on single-node installs

### DIFF
--- a/.changeset/durable-single-node-jetstream.md
+++ b/.changeset/durable-single-node-jetstream.md
@@ -1,0 +1,7 @@
+---
+"hephaestus": patch
+---
+
+The single-host Compose topology now persists each webhook and integration-sync event before the
+broker acknowledges it, closing the periodic-sync loss window during an unclean shutdown. This
+trades some ingest throughput and latency for stronger durability; no operator action is required.

--- a/.github/workflows/ci-compose-validate.yml
+++ b/.github/workflows/ci-compose-validate.yml
@@ -67,6 +67,10 @@ jobs:
           done
           # Some Compose releases accept `!override` without applying it.
           rendered=$(docker compose config)
+          nats_config=$(docker compose config --format json \
+            | jq -r '.configs["nats-server.conf"].content')
+          grep -Eq '^[[:space:]]*sync_interval:[[:space:]]*always[[:space:]]*$' <<< "$nats_config" || {
+            echo "::error::the single-node JetStream store must fsync every write"; exit 1; }
           for required in \
             'entrypoints.https.http.middlewares=security-headers@docker' \
             'request-body-limit@docker' \

--- a/docker/compose.core.yaml
+++ b/docker/compose.core.yaml
@@ -210,6 +210,9 @@ configs:
       jetstream {
         store_dir: "/data"
         max_mem: ${NATS_JS_MAX_MEM:-4G}
+        # Per-message fsync protects R1 acknowledgements at a throughput cost:
+        # https://jepsen.io/analyses/nats-2.12.1
+        sync_interval: always
         # In bytes, and shared with HEPHAESTUS_WEBHOOK_STREAM_STORAGE_BUDGET above so the two cannot
         # drift. A byte count is the one literal NATS and Spring read identically. Keep it under the
         # free space on this volume — docs/admin/webhook-ingestion-operations says what happens if not.

--- a/docs/admin/webhook-ingestion-operations.mdx
+++ b/docs/admin/webhook-ingestion-operations.mdx
@@ -14,6 +14,24 @@ receiver and the consumer is gone.
 This page is what to watch, what to set, and what to do when it goes wrong. Why it is built this way
 is [ADR 0008](https://github.com/ls1intum/Hephaestus/blob/main/docs/decisions/0008-webhook-runtime-role.md).
 
+## Durability and availability
+
+The supported Compose topology runs one NATS server and every webhook stream has one replica (R1).
+The bundled broker sets `sync_interval: always`, so it calls `fsync` for each message before
+acknowledging it. An acknowledged webhook or integration-sync event therefore survives host power
+loss or an unclean shutdown, provided the storage stack honours `fsync`. The
+[NATS durability documentation](https://docs.nats.io/nats-concepts/jetstream#syncing-data-to-disk)
+defines this guarantee; [Jepsen's NATS 2.12.1 analysis](https://jepsen.io/analyses/nats-2.12.1)
+demonstrates the acknowledged-write loss possible with periodic syncing.
+
+Waiting for durable storage costs write throughput and latency. R1 remains unavailable while its
+only server is down, and cannot survive loss or corruption of its only JetStream volume.
+
+A clustered profile with three servers and R3 streams can remain available after one server fails,
+as described by [NATS replicated storage](https://docs.nats.io/nats-concepts/jetstream/replication).
+That profile may use a longer sync interval after evaluating its failure model and latency budget;
+keep `always` to protect acknowledgements from a correlated, unclean shutdown of the whole cluster.
+
 ## What to alert on
 
 Metrics are Micrometer, exposed on the receiver's actuator endpoint, all tagged `stream` with one of


### PR DESCRIPTION
## What changed and why

The supported single-host topology previously acknowledged JetStream publishes before NATS had necessarily synced them to disk. A host power loss or OS crash could therefore lose webhook and integration-sync events that callers had already been told were durable.

This change sets `sync_interval: always` in the bundled JetStream configuration, making NATS sync each message before acknowledging it. The policy is intentionally unconditional for the R1 topology: it trades publish throughput and latency for crash durability rather than exposing a switch that can silently reopen the loss window.

The operator guide now distinguishes that durability guarantee from availability. R1 still stops ingesting while its only broker is unavailable and cannot survive loss of its only volume; an R3 cluster is the alternative when broker availability is required.

CI extracts the named NATS config from the fully rendered single-host Compose model and asserts that `sync_interval: always` is an active directive, not merely a comment.

Part of #1731. The qualified before/after throughput measurement remains part of the final 1.0 capacity baseline tracked in #1602; this PR does not claim results from an unqualified development host.

## How to test

- `pnpm run format`
- `pnpm run check`
- `pnpm run test:webapp` — 1,205 tests passed across the application and lint-rule suites
- `pnpm run test:server:unit` — 6,904 tests passed; all coverage checks met
- Rendered `docker/compose.core.yaml` with Compose, extracted `configs[\"nats-server.conf\"].content`, and verified an active `sync_interval: always` line
- Validated the rendered configuration with the release-pinned NATS 2.14.6 image using `nats-server -t`

## Release impact

Patch changeset: [`.changeset/durable-single-node-jetstream.md`](https://github.com/hephaestus-build/Hephaestus/blob/production-readiness-ego-death-v4/.changeset/durable-single-node-jetstream.md)

No operator action or new configuration is required. Upgrades recreate the NATS container so the bundled configuration takes effect. Operators should expect lower peak ingest throughput and higher publish latency in exchange for removing the periodic-sync durability window.

## Notes for reviewers

The most important review points are the JetStream block in `docker/compose.core.yaml` and the rendered-config assertion in `.github/workflows/ci-compose-validate.yml`.

The durability semantics and remaining R1 limitations are documented against [NATS's persistence guidance](https://docs.nats.io/nats-concepts/jetstream#syncing-data-to-disk) and [Jepsen's NATS 2.12.1 analysis](https://jepsen.io/analyses/nats-2.12.1). This does not add clustering, change stream retention, or replace backup and restore work.

Implemented with OpenAI Codex in the Jean harness.