### PR TITLE
fix(server): skip undecryptable credentials during key rotation

### DIFF
--- a/.changeset/healthy-credential-rotation.md
+++ b/.changeset/healthy-credential-rotation.md
@@ -1,0 +1,5 @@
+---
+"hephaestus": patch
+---
+
+Credential key rotation now quarantines and reports undecryptable integration credentials while continuing to rotate healthy connections. The rotation guide explains how operators identify, recover, or replace affected credentials.

--- a/docs/admin/credential-key-rotation.mdx
+++ b/docs/admin/credential-key-rotation.mdx
@@ -36,12 +36,62 @@ Stop if the result contains an unexpected version.
    configuration if any credential cannot be decrypted.
 4. Set `HEPHAESTUS_SECURITY_CREDENTIAL_ROTATION_ENABLED=true` on the server runtime only. Disable it
    if application errors, database latency, replication lag, or WAL growth leave their normal range.
-5. Poll the starting-state query. Rotation is complete only when every row reports the active version.
+5. Poll this verification query, replacing `<active version>` with the configured active version:
+
+   ```sql
+   SELECT
+       count(*) FILTER (
+           WHERE credentials_rotation_failed_at IS NULL
+             AND credentials_key_version IS DISTINCT FROM <active version>
+       ) AS pending,
+       count(*) FILTER (WHERE credentials_rotation_failed_at IS NOT NULL) AS undecryptable
+   FROM connection
+   WHERE credentials_encrypted IS NOT NULL;
+   ```
+
+   Rotation is complete when `pending` is zero. Do not remove the prior key while `undecryptable` is
+   nonzero unless every affected integration credential has been replaced.
 6. Disable rotation and repeat the provider checks. Deploy every runtime without the prior key and
    version.
 
 ## Failure recovery
 
 Before rotation starts, restore the previous configuration. After any row is re-encrypted, retain both
-keys and roll forward. If a batch repeatedly fails, disable rotation and preserve the ciphertext; do
-not replace an unreadable credential automatically.
+keys and roll forward. The rotation job quarantines a row it cannot decrypt, continues with later rows,
+logs the connection, workspace and integration kind, and increments
+`integration_credential_rotation_failures_total` for alerting. List quarantined rows without
+selecting their ciphertext:
+
+```sql
+SELECT id, workspace_id, kind, credentials_key_version, credentials_rotation_failed_at
+FROM connection
+WHERE credentials_rotation_failed_at IS NOT NULL
+  AND credentials_encrypted IS NOT NULL
+ORDER BY credentials_rotation_failed_at, id;
+```
+
+A key version that has no key configured at all stops rotation instead of quarantining anything: the
+job fails the batch with an error naming that version, marks no row, and resumes on its own once you
+configure the key. While this is happening `pending` stops falling and `undecryptable` stays flat;
+find the affected rows with
+`SELECT id, workspace_id, kind FROM connection WHERE credentials_key_version = <version>`.
+
+Key material that is configured but wrong cannot be told apart from a corrupt ciphertext, so it
+quarantines every row it is used on — a wrong prior key quarantines each row that batch reaches.
+Those rows appear in the listing above, and the update below clears them once the key is corrected.
+
+First determine whether the prior key or version was configured incorrectly. After restoring the key
+that can decrypt the affected rows, disable rotation and clear only their quarantine marker:
+
+```sql
+UPDATE connection
+SET credentials_rotation_failed_at = NULL
+WHERE id IN (<verified connection ids>);
+```
+
+Re-enable rotation only after the update is applied.
+
+If the ciphertext is corrupt or its key is permanently unavailable, reconnect the affected integration
+through workspace administration. Saving replacement credentials clears the marker. Confirm the
+provider request succeeds and rerun the verification query before removing the prior key. Never clear
+the marker repeatedly without correcting the credential: that recreates a retry loop and alert noise.

--- a/docs/contributor/erd/schema.mmd
+++ b/docs/contributor/erd/schema.mmd
@@ -231,6 +231,7 @@ erDiagram
         TIMESTAMPTZ updated_at "NOT NULL"
         BIGINT version "NOT NULL"
         INTEGER credentials_key_version
+        TIMESTAMPTZ credentials_rotation_failed_at
     }
 
     ConnectionActivity {

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/security/MissingCredentialKeyException.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/security/MissingCredentialKeyException.java
@@ -1,0 +1,13 @@
+package de.tum.cit.aet.hephaestus.core.security;
+
+/**
+ * Exception thrown when the key a stored credential was encrypted under is not configured on this
+ * instance. Separated from a decryption failure because it is a property of the configuration, not
+ * of the row: correcting the configuration makes the same ciphertext readable again.
+ */
+public class MissingCredentialKeyException extends EncryptionException {
+
+    public MissingCredentialKeyException(String message) {
+        super(message);
+    }
+}

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/core/connection/Connection.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/core/connection/Connection.java
@@ -94,6 +94,10 @@ public class Connection {
     @Nullable
     private Integer credentialsKeyVersion;
 
+    @Column(name = "credentials_rotation_failed_at")
+    @Nullable
+    private Instant credentialsRotationFailedAt;
+
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)
     private @Nullable Instant createdAt;
@@ -191,6 +195,11 @@ public class Connection {
         return credentialsKeyVersion;
     }
 
+    @Nullable
+    public Instant getCredentialsRotationFailedAt() {
+        return credentialsRotationFailedAt;
+    }
+
     public Instant getCreatedAt() {
         return Objects.requireNonNull(createdAt, "Connection has not been persisted");
     }
@@ -219,12 +228,8 @@ public class Connection {
         this.config = config;
     }
 
-    public void setCredentialsEncrypted(byte @Nullable [] credentialsEncrypted) {
+    void setCredentialsEncrypted(byte @Nullable [] credentialsEncrypted) {
         this.credentialsEncrypted = credentialsEncrypted;
-    }
-
-    public void setCredentialsAlg(@Nullable String credentialsAlg) {
-        this.credentialsAlg = credentialsAlg;
     }
 
     /** Encrypts or clears this connection's credentials. */
@@ -233,11 +238,17 @@ public class Connection {
             this.credentialsEncrypted = null;
             this.credentialsAlg = null;
             this.credentialsKeyVersion = null;
+            this.credentialsRotationFailedAt = null;
             return;
         }
         this.credentialsEncrypted = converter.encrypt(bundle, encryptionContext());
         this.credentialsAlg = CredentialBundleConverter.ALGORITHM_TAG;
         this.credentialsKeyVersion = converter.activeKeyVersion();
+        this.credentialsRotationFailedAt = null;
+    }
+
+    void markCredentialRotationFailed(Instant failedAt) {
+        this.credentialsRotationFailedAt = failedAt;
     }
 
     /** Returns the decrypted credentials, if configured. */

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/core/connection/ConnectionRepository.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/core/connection/ConnectionRepository.java
@@ -19,12 +19,14 @@ public interface ConnectionRepository extends JpaRepository<Connection, Long> {
                     SELECT id FROM connection
                     WHERE credentials_encrypted IS NOT NULL
                       AND credentials_key_version IS DISTINCT FROM :activeVersion
+                      AND credentials_rotation_failed_at IS NULL
                     ORDER BY id
                     LIMIT :batchSize
                     FOR UPDATE SKIP LOCKED
                     """, nativeQuery = true)
     List<Long> lockCredentialRotationBatch(
             @Param("activeVersion") int activeVersion, @Param("batchSize") int batchSize);
+
     /**
      * Serializes connection lifecycle changes with sync-job creation. Both paths acquire this row lock
      * before checking their respective state, closing the check-then-act window in which a job could

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/core/connection/ConnectionService.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/core/connection/ConnectionService.java
@@ -530,8 +530,7 @@ public class ConnectionService {
         connection.setStateReason(req.detail());
         if (req.next() == IntegrationState.UNINSTALLED) {
             if (connection.getCredentialsEncrypted() != null) {
-                connection.setCredentialsEncrypted(null);
-                connection.setCredentialsAlg(null);
+                connection.setCredentials(null, credentialConverter);
                 log.info("Purged credentials on UNINSTALLED transition for connection={}", connection.getId());
             }
             if (connection.getConfig() instanceof ConnectionConfig.GitLabConfig gitLabConfig) {

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/core/connection/CredentialBundleConverter.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/core/connection/CredentialBundleConverter.java
@@ -1,6 +1,7 @@
 package de.tum.cit.aet.hephaestus.integration.core.connection;
 
 import de.tum.cit.aet.hephaestus.core.security.EncryptionException;
+import de.tum.cit.aet.hephaestus.core.security.MissingCredentialKeyException;
 import de.tum.cit.aet.hephaestus.core.security.SecurityProperties;
 import de.tum.cit.aet.hephaestus.integration.core.spi.ApiCredentialProvider.CredentialBundle;
 import java.nio.charset.StandardCharsets;
@@ -192,7 +193,8 @@ public class CredentialBundleConverter {
     private SecretKey requireKey(int version) {
         SecretKey key = keys.get(version);
         if (key == null) {
-            throw new EncryptionException("No encryption key configured for credential key version " + version);
+            throw new MissingCredentialKeyException(
+                    "No encryption key configured for credential key version " + version);
         }
         return key;
     }
@@ -211,7 +213,7 @@ public class CredentialBundleConverter {
 
     private void requireEnabled(String operation) {
         if (!enabled) {
-            throw new EncryptionException(
+            throw new MissingCredentialKeyException(
                     "Credential encryption is disabled; cannot " + operation + " without a configured key");
         }
     }

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/core/connection/CredentialRotationService.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/core/connection/CredentialRotationService.java
@@ -1,10 +1,21 @@
 package de.tum.cit.aet.hephaestus.integration.core.connection;
 
+import static de.tum.cit.aet.hephaestus.core.TransactionCallbacks.afterCommit;
+
 import de.tum.cit.aet.hephaestus.core.WorkspaceAgnostic;
 import de.tum.cit.aet.hephaestus.core.runtime.ConditionalOnServerRole;
+import de.tum.cit.aet.hephaestus.core.security.EncryptionException;
+import de.tum.cit.aet.hephaestus.core.security.MissingCredentialKeyException;
 import de.tum.cit.aet.hephaestus.core.security.SecurityProperties;
+import de.tum.cit.aet.hephaestus.integration.core.metrics.IntegrationCoreMetrics;
 import de.tum.cit.aet.hephaestus.integration.core.spi.ApiCredentialProvider.CredentialBundle;
+import de.tum.cit.aet.hephaestus.integration.core.spi.IntegrationKind;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.time.Clock;
+import java.util.ArrayList;
 import java.util.List;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -22,14 +33,22 @@ public class CredentialRotationService {
     private final ConnectionRepository connectionRepository;
     private final CredentialBundleConverter converter;
     private final SecurityProperties properties;
+    private final Clock clock;
+    private final Counter failureCounter;
 
     public CredentialRotationService(
             ConnectionRepository connectionRepository,
             CredentialBundleConverter converter,
-            SecurityProperties properties) {
+            SecurityProperties properties,
+            Clock clock,
+            MeterRegistry meterRegistry) {
         this.connectionRepository = connectionRepository;
         this.converter = converter;
         this.properties = properties;
+        this.clock = clock;
+        this.failureCounter = Counter.builder(IntegrationCoreMetrics.CREDENTIAL_ROTATION_FAILURES)
+                .description("Credentials newly quarantined because key rotation could not decrypt them")
+                .register(meterRegistry);
     }
 
     @Scheduled(fixedDelayString = "${hephaestus.security.credential-rotation-delay:PT1S}")
@@ -41,14 +60,52 @@ public class CredentialRotationService {
         if (ids.isEmpty()) {
             return;
         }
+        List<Quarantined> quarantined = new ArrayList<>();
         for (Connection connection : connectionRepository.findAllById(ids)) {
-            CredentialBundle credentials = connection.credentials(converter).orElseThrow();
+            CredentialBundle credentials;
+            // The decrypt call is inside the try and the re-encrypt below is not: a failure to
+            // re-encrypt is an instance fault and must roll the batch back.
+            try {
+                credentials = connection.credentials(converter).orElseThrow();
+            } catch (MissingCredentialKeyException unconfiguredKey) {
+                // A key version this instance holds no key for is an instance fault as well; rolling
+                // back leaves its rows unmarked for a later tick, once the key is configured.
+                throw unconfiguredKey;
+            } catch (EncryptionException undecryptable) {
+                connection.markCredentialRotationFailed(clock.instant());
+                quarantined.add(new Quarantined(
+                        connection.getId(),
+                        connection.getWorkspace().getId(),
+                        connection.getKind(),
+                        undecryptable.getMessage()));
+                continue;
+            }
             connection.setCredentials(credentials, converter);
         }
-        log.info(
-                "Credential key rotation progress: rotated={}, activeKeyVersion={}, lastConnectionId={}",
-                ids.size(),
-                converter.activeKeyVersion(),
-                ids.getLast());
+        afterCommit(() -> report(ids.size() - quarantined.size(), quarantined));
     }
+
+    private void report(int rotated, List<Quarantined> quarantined) {
+        for (Quarantined row : quarantined) {
+            failureCounter.increment();
+            log.error(
+                    "Credential key rotation quarantined undecryptable row: connectionId={}, workspaceId={}, kind={}, reason={}",
+                    row.connectionId(),
+                    row.workspaceId(),
+                    row.kind(),
+                    row.reason());
+        }
+        log.info(
+                "Credential key rotation progress: rotated={}, quarantined={}, activeKeyVersion={}",
+                rotated,
+                quarantined.size(),
+                converter.activeKeyVersion());
+    }
+
+    /** Carries only values, because the log line runs after the transaction closed its entities. */
+    private record Quarantined(
+            Long connectionId,
+            Long workspaceId,
+            IntegrationKind kind,
+            @Nullable String reason) {}
 }

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/core/metrics/IntegrationCoreMetrics.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/core/metrics/IntegrationCoreMetrics.java
@@ -2,6 +2,7 @@ package de.tum.cit.aet.hephaestus.integration.core.metrics;
 
 public final class IntegrationCoreMetrics {
 
+    public static final String CREDENTIAL_ROTATION_FAILURES = "integration.credential.rotation.failures";
     public static final String INTEGRATION_SYNC_PUSH_MESSAGES = "integration.sync.push.messages";
     public static final String INTEGRATION_SYNC_SSE_SUBSCRIBERS = "integration.sync.sse.subscribers";
     public static final String OAUTH_STATE_NONCE_PRUNED = "oauth.state.nonce.pruned";

--- a/server/application/src/main/resources/db/changelog/1788445799918_changelog.xml
+++ b/server/application/src/main/resources/db/changelog/1788445799918_changelog.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+    <changeSet id="1788445799918-1" author="hephaestus">
+        <preConditions onFail="MARK_RAN">
+            <not><columnExists tableName="connection" columnName="credentials_rotation_failed_at"/></not>
+        </preConditions>
+        <comment>Mark a credential the rotation job cannot decrypt so later batches skip it.</comment>
+        <addColumn tableName="connection">
+            <column name="credentials_rotation_failed_at" type="TIMESTAMP(6) WITH TIME ZONE"/>
+        </addColumn>
+        <rollback>
+            <dropColumn tableName="connection" columnName="credentials_rotation_failed_at"/>
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/server/application/src/main/resources/db/master.xml
+++ b/server/application/src/main/resources/db/master.xml
@@ -104,4 +104,5 @@
     <include file="./changelog/1788330977174_changelog.xml" relativeToChangelogFile="true"/>
     <include file="./changelog/1788356611818_changelog.xml" relativeToChangelogFile="true"/>
     <include file="./changelog/1788452647516_changelog.xml" relativeToChangelogFile="true"/>
+    <include file="./changelog/1788445799918_changelog.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/core/connection/ConnectionServiceTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/core/connection/ConnectionServiceTest.java
@@ -19,6 +19,7 @@ import de.tum.cit.aet.hephaestus.integration.core.sync.SyncJobService;
 import de.tum.cit.aet.hephaestus.testconfig.BaseUnitTest;
 import de.tum.cit.aet.hephaestus.workspace.Workspace;
 import java.lang.reflect.Field;
+import java.time.Instant;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -222,6 +223,7 @@ class ConnectionServiceTest extends BaseUnitTest {
     void transition_toUninstalled_purgesCredentials() {
         Connection connection = connectionInState(IntegrationState.ACTIVE);
         connection.setCredentials(new BearerToken("ghp-secret", null), credentialConverter);
+        connection.markCredentialRotationFailed(Instant.parse("2026-09-03T12:00:00Z"));
         assertThat(connection.getCredentialsEncrypted()).isNotNull();
         assertThat(connection.getCredentialsAlg()).isEqualTo(CredentialBundleConverter.ALGORITHM_TAG);
 
@@ -233,6 +235,8 @@ class ConnectionServiceTest extends BaseUnitTest {
         assertThat(result.getState()).isEqualTo(IntegrationState.UNINSTALLED);
         assertThat(result.getCredentialsEncrypted()).isNull();
         assertThat(result.getCredentialsAlg()).isNull();
+        assertThat(result.getCredentialsKeyVersion()).isNull();
+        assertThat(result.getCredentialsRotationFailedAt()).isNull();
         // The transition that purged credentials is still audited.
         ArgumentCaptor<ConnectionAudit> audit = ArgumentCaptor.forClass(ConnectionAudit.class);
         verify(auditRepository).save(audit.capture());

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/core/connection/ConnectionTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/core/connection/ConnectionTest.java
@@ -1,0 +1,42 @@
+package de.tum.cit.aet.hephaestus.integration.core.connection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import de.tum.cit.aet.hephaestus.integration.core.spi.ApiCredentialProvider.BearerToken;
+import de.tum.cit.aet.hephaestus.integration.core.spi.IntegrationKind;
+import de.tum.cit.aet.hephaestus.testconfig.BaseUnitTest;
+import de.tum.cit.aet.hephaestus.workspace.Workspace;
+import java.time.Instant;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class ConnectionTest extends BaseUnitTest {
+
+    private static final String OLD_KEY = "0123456789abcdef0123456789abcdef";
+    private static final String NEW_KEY = "ABCDEFabcdef0123ABCDEFabcdef0123";
+    private static final BearerToken TOKEN = new BearerToken("glpat-rotate-me", null);
+
+    @Test
+    void shouldClearQuarantineWhenCredentialsAreReplaced() {
+        CredentialBundleConverter oldConverter = new CredentialBundleConverter(OLD_KEY, "dev");
+        CredentialBundleConverter rotatingConverter = new CredentialBundleConverter(NEW_KEY, 2, OLD_KEY, 1, "dev");
+        Connection connection = connection();
+        connection.setCredentials(TOKEN, oldConverter);
+        connection.markCredentialRotationFailed(Instant.parse("2026-09-03T12:00:00Z"));
+
+        connection.setCredentials(TOKEN, rotatingConverter);
+
+        assertThat(connection.getCredentialsRotationFailedAt()).isNull();
+        assertThat(connection.getCredentialsKeyVersion()).isEqualTo(2);
+    }
+
+    private static Connection connection() {
+        Workspace workspace = new Workspace();
+        workspace.setId(7L);
+        return new Connection(
+                workspace,
+                IntegrationKind.GITHUB,
+                "100",
+                new ConnectionConfig.GitHubAppConfig(100L, null, null, Set.of()));
+    }
+}

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/core/connection/CredentialBundleConverterTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/core/connection/CredentialBundleConverterTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import de.tum.cit.aet.hephaestus.core.security.EncryptionException;
+import de.tum.cit.aet.hephaestus.core.security.MissingCredentialKeyException;
 import de.tum.cit.aet.hephaestus.integration.core.spi.ApiCredentialProvider.BearerToken;
 import de.tum.cit.aet.hephaestus.integration.core.spi.ApiCredentialProvider.CredentialBundle;
 import de.tum.cit.aet.hephaestus.integration.core.spi.ApiCredentialProvider.InstallationCredential;
@@ -236,7 +237,7 @@ class CredentialBundleConverterTest extends BaseUnitTest {
             CredentialBundleConverter c = enabled();
             byte[] blob = c.encrypt(new BearerToken("secret", null), CTX_A);
             assertThatThrownBy(() -> c.decrypt(blob, CTX_A, 99))
-                    .isInstanceOf(EncryptionException.class)
+                    .isInstanceOf(MissingCredentialKeyException.class)
                     .hasMessageContaining("No encryption key configured");
         }
     }

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/core/connection/CredentialRotationServiceIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/core/connection/CredentialRotationServiceIntegrationTest.java
@@ -1,0 +1,89 @@
+package de.tum.cit.aet.hephaestus.integration.core.connection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import de.tum.cit.aet.hephaestus.core.security.SecurityProperties;
+import de.tum.cit.aet.hephaestus.integration.core.spi.ApiCredentialProvider.BearerToken;
+import de.tum.cit.aet.hephaestus.integration.core.spi.IntegrationKind;
+import de.tum.cit.aet.hephaestus.integration.scm.domain.user.User;
+import de.tum.cit.aet.hephaestus.workspace.AbstractWorkspaceIntegrationTest;
+import de.tum.cit.aet.hephaestus.workspace.AccountType;
+import de.tum.cit.aet.hephaestus.workspace.Workspace;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.support.TransactionTemplate;
+
+class CredentialRotationServiceIntegrationTest extends AbstractWorkspaceIntegrationTest {
+
+    private static final String OLD_KEY = "0123456789abcdef0123456789abcdef";
+    private static final String NEW_KEY = "ABCDEFabcdef0123ABCDEFabcdef0123";
+    private static final BearerToken TOKEN = new BearerToken("glpat-rotate-me", null);
+    private static final Instant QUARANTINED_AT = Instant.parse("2026-09-03T12:00:00Z");
+
+    @Autowired
+    private ConnectionRepository connectionRepository;
+
+    @Autowired
+    private TransactionTemplate transactionTemplate;
+
+    @Test
+    void shouldCommitHealthyRowsAndExcludeCorruptRowsFromLaterBatches() {
+        User owner = persistUser("rotation-owner-" + System.nanoTime());
+        Workspace workspace = createWorkspace(
+                "rotation-ws-" + System.nanoTime(), "Rotation Test", "rotation-org", AccountType.ORG, owner);
+        CredentialBundleConverter oldConverter = new CredentialBundleConverter(OLD_KEY, "test");
+        CredentialBundleConverter rotatingConverter = new CredentialBundleConverter(NEW_KEY, 2, OLD_KEY, 1, "test");
+
+        Connection corrupt = connectionRepository.save(connection(workspace, "corrupt"));
+        corrupt.setCredentials(TOKEN, oldConverter);
+        byte[] corrupted =
+                Objects.requireNonNull(corrupt.getCredentialsEncrypted()).clone();
+        corrupted[corrupted.length - 1] ^= 1;
+        corrupt.setCredentialsEncrypted(corrupted);
+        corrupt = connectionRepository.save(corrupt);
+        Connection healthy = connectionRepository.save(connection(workspace, "healthy"));
+        healthy.setCredentials(TOKEN, oldConverter);
+        healthy = connectionRepository.saveAndFlush(healthy);
+
+        SecurityProperties properties = new SecurityProperties(null, NEW_KEY, 2, OLD_KEY, 1, true, 25);
+        CredentialRotationService service = new CredentialRotationService(
+                connectionRepository,
+                rotatingConverter,
+                properties,
+                Clock.fixed(QUARANTINED_AT, ZoneOffset.UTC),
+                new SimpleMeterRegistry());
+
+        transactionTemplate.executeWithoutResult(__ -> service.rotateBatch());
+
+        Connection persistedCorrupt =
+                connectionRepository.findById(corrupt.getId()).orElseThrow();
+        Connection persistedHealthy =
+                connectionRepository.findById(healthy.getId()).orElseThrow();
+        assertThat(persistedCorrupt.getCredentialsEncrypted()).isEqualTo(corrupted);
+        assertThat(persistedCorrupt.getCredentialsKeyVersion()).isEqualTo(1);
+        assertThat(persistedCorrupt.getCredentialsRotationFailedAt()).isEqualTo(QUARANTINED_AT);
+        assertThat(persistedHealthy.getCredentialsKeyVersion()).isEqualTo(2);
+
+        Connection pending = connectionRepository.save(connection(workspace, "pending"));
+        pending.setCredentials(TOKEN, oldConverter);
+        pending = connectionRepository.saveAndFlush(pending);
+        List<Long> remaining = Objects.requireNonNull(
+                transactionTemplate.execute(__ -> connectionRepository.lockCredentialRotationBatch(2, 25)));
+        assertThat(remaining).contains(pending.getId()).doesNotContain(corrupt.getId());
+    }
+
+    private static Connection connection(Workspace workspace, String instanceKey) {
+        return new Connection(
+                workspace,
+                IntegrationKind.GITHUB,
+                instanceKey,
+                new ConnectionConfig.GitHubAppConfig(100L, null, null, Set.of()));
+    }
+}

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/core/connection/CredentialRotationServiceTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/core/connection/CredentialRotationServiceTest.java
@@ -2,18 +2,28 @@ package de.tum.cit.aet.hephaestus.integration.core.connection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import de.tum.cit.aet.hephaestus.core.security.EncryptionException;
+import de.tum.cit.aet.hephaestus.core.security.MissingCredentialKeyException;
 import de.tum.cit.aet.hephaestus.core.security.SecurityProperties;
+import de.tum.cit.aet.hephaestus.integration.core.metrics.IntegrationCoreMetrics;
 import de.tum.cit.aet.hephaestus.integration.core.spi.ApiCredentialProvider.BearerToken;
 import de.tum.cit.aet.hephaestus.integration.core.spi.IntegrationKind;
 import de.tum.cit.aet.hephaestus.testconfig.BaseUnitTest;
 import de.tum.cit.aet.hephaestus.workspace.Workspace;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.lang.reflect.Field;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
@@ -23,18 +33,13 @@ import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-/**
- * Batch contract for {@link CredentialRotationService#rotateBatch()}: a locked batch is
- * re-encrypted under the active key and stamped with the active version, legacy rows with a
- * {@code NULL} key version decrypt through the prior key, an empty batch is a no-op, and a row
- * whose version matches no configured key fails closed instead of being rewritten.
- */
 @Tag("unit")
 class CredentialRotationServiceTest extends BaseUnitTest {
 
     private static final String OLD_KEY = "0123456789abcdef0123456789abcdef";
     private static final String NEW_KEY = "ABCDEFabcdef0123ABCDEFabcdef0123";
     private static final BearerToken TOKEN = new BearerToken("glpat-rotate-me", null);
+    private static final Instant NOW = Instant.parse("2026-09-03T12:00:00Z");
 
     @Mock
     private ConnectionRepository connectionRepository;
@@ -43,6 +48,7 @@ class CredentialRotationServiceTest extends BaseUnitTest {
     private CredentialBundleConverter rotatingConverter;
     private CredentialRotationService service;
     private Workspace workspace;
+    private SimpleMeterRegistry meterRegistry;
 
     @BeforeEach
     void setUp() {
@@ -50,7 +56,9 @@ class CredentialRotationServiceTest extends BaseUnitTest {
         oldConverter = new CredentialBundleConverter(OLD_KEY, "dev");
         rotatingConverter = new CredentialBundleConverter(NEW_KEY, 2, OLD_KEY, 1, "dev");
         SecurityProperties properties = new SecurityProperties(null, NEW_KEY, 2, OLD_KEY, 1, true, 25);
-        service = new CredentialRotationService(connectionRepository, rotatingConverter, properties);
+        meterRegistry = new SimpleMeterRegistry();
+        service = new CredentialRotationService(
+                connectionRepository, rotatingConverter, properties, Clock.fixed(NOW, ZoneOffset.UTC), meterRegistry);
         workspace = new Workspace();
         workspace.setId(7L);
     }
@@ -97,19 +105,90 @@ class CredentialRotationServiceTest extends BaseUnitTest {
     }
 
     @Test
-    void shouldFailClosedWhenARowsKeyVersionMatchesNoConfiguredKey() {
+    void shouldQuarantineAnUndecryptableRowAndContinueTheBatch() {
         Connection orphaned = connection(57L);
         orphaned.setCredentials(TOKEN, oldConverter);
-        setKeyVersion(orphaned, 99);
-        byte[] blobBefore = orphaned.getCredentialsEncrypted();
-        when(connectionRepository.lockCredentialRotationBatch(2, 25)).thenReturn(List.of(57L));
-        when(connectionRepository.findAllById(List.of(57L))).thenReturn(List.of(orphaned));
+        byte[] corrupted =
+                Objects.requireNonNull(orphaned.getCredentialsEncrypted()).clone();
+        corrupted[corrupted.length - 1] ^= 1;
+        orphaned.setCredentialsEncrypted(corrupted);
+        Connection stale = connection(58L);
+        stale.setCredentials(TOKEN, oldConverter);
+        when(connectionRepository.lockCredentialRotationBatch(2, 25)).thenReturn(List.of(57L, 58L));
+        when(connectionRepository.findAllById(List.of(57L, 58L))).thenReturn(List.of(orphaned, stale));
 
-        assertThatThrownBy(() -> service.rotateBatch())
-                .isInstanceOf(EncryptionException.class)
-                .hasMessageContaining("No encryption key configured");
-        assertThat(orphaned.getCredentialsEncrypted()).isEqualTo(blobBefore);
+        service.rotateBatch();
+
+        assertThat(orphaned.getCredentialsEncrypted()).isEqualTo(corrupted);
+        assertThat(orphaned.getCredentialsKeyVersion()).isEqualTo(1);
+        assertThat(orphaned.getCredentialsRotationFailedAt()).isEqualTo(NOW);
+        assertThat(stale.getCredentialsKeyVersion()).isEqualTo(2);
+        assertThat(meterRegistry
+                        .counter(IntegrationCoreMetrics.CREDENTIAL_ROTATION_FAILURES)
+                        .count())
+                .isEqualTo(1);
+    }
+
+    @Test
+    void shouldQuarantineTheOnlyRowInTheBatchWhenItCannotBeDecrypted() {
+        Connection orphaned = connection(61L);
+        orphaned.setCredentials(TOKEN, oldConverter);
+        byte[] corrupted =
+                Objects.requireNonNull(orphaned.getCredentialsEncrypted()).clone();
+        corrupted[corrupted.length - 1] ^= 1;
+        orphaned.setCredentialsEncrypted(corrupted);
+        when(connectionRepository.lockCredentialRotationBatch(2, 25)).thenReturn(List.of(61L));
+        when(connectionRepository.findAllById(List.of(61L))).thenReturn(List.of(orphaned));
+
+        service.rotateBatch();
+
+        assertThat(orphaned.getCredentialsRotationFailedAt()).isEqualTo(NOW);
+        assertThat(meterRegistry
+                        .counter(IntegrationCoreMetrics.CREDENTIAL_ROTATION_FAILURES)
+                        .count())
+                .isEqualTo(1);
+    }
+
+    @Test
+    void shouldAbortTheBatchWhenARowsKeyVersionHasNoConfiguredKey() {
+        Connection orphaned = connection(59L);
+        orphaned.setCredentials(TOKEN, oldConverter);
+        setKeyVersion(orphaned, 99);
+        byte[] blob = orphaned.getCredentialsEncrypted();
+        when(connectionRepository.lockCredentialRotationBatch(2, 25)).thenReturn(List.of(59L));
+        when(connectionRepository.findAllById(List.of(59L))).thenReturn(List.of(orphaned));
+
+        assertThatThrownBy(service::rotateBatch).isInstanceOf(MissingCredentialKeyException.class);
+
+        assertThat(orphaned.getCredentialsRotationFailedAt()).isNull();
+        assertThat(orphaned.getCredentialsEncrypted()).isEqualTo(blob);
         assertThat(orphaned.getCredentialsKeyVersion()).isEqualTo(99);
+        assertThat(meterRegistry
+                        .counter(IntegrationCoreMetrics.CREDENTIAL_ROTATION_FAILURES)
+                        .count())
+                .isZero();
+    }
+
+    @Test
+    void shouldAbortInsteadOfQuarantiningWhenReEncryptionFails() {
+        Connection stale = connection(60L);
+        stale.setCredentials(TOKEN, oldConverter);
+        CredentialBundleConverter failingConverter = spy(rotatingConverter);
+        doThrow(new EncryptionException("Credential encryption failed"))
+                .when(failingConverter)
+                .encrypt(any(), any());
+        SecurityProperties properties = new SecurityProperties(null, NEW_KEY, 2, OLD_KEY, 1, true, 25);
+        service = new CredentialRotationService(
+                connectionRepository, failingConverter, properties, Clock.fixed(NOW, ZoneOffset.UTC), meterRegistry);
+        when(connectionRepository.lockCredentialRotationBatch(2, 25)).thenReturn(List.of(60L));
+        when(connectionRepository.findAllById(List.of(60L))).thenReturn(List.of(stale));
+
+        assertThatThrownBy(service::rotateBatch).isInstanceOf(EncryptionException.class);
+        assertThat(stale.getCredentialsRotationFailedAt()).isNull();
+        assertThat(meterRegistry
+                        .counter(IntegrationCoreMetrics.CREDENTIAL_ROTATION_FAILURES)
+                        .count())
+                .isZero();
     }
 
     private Connection connection(long id) {


### PR DESCRIPTION
## What changed and why

A single integration credential that could not be decrypted caused every scheduled rotation batch to
select and fail on the same row, so healthy credentials never reached the active key version.

The job now gives that failure a durable state. A row whose ciphertext will not decrypt is marked
with a timestamp, excluded from later batches by the same query that locks them, and reported through
a counter and an error log that carries no ciphertext. Rotation continues with the rest of
the batch. A key version this instance holds no key for is not a property of the row, so the
converter raises a distinct exception for it and the job lets that roll the batch back untouched;
rotation picks the rows up again once the key is configured.

Purging credentials on an UNINSTALLED transition now goes through the one method that owns the
credential fields, so the key version and the quarantine marker are cleared with the ciphertext
rather than left behind. Saving replacement credentials clears the marker the same way. The operator
guide gained a completion query, a listing query, and recovery paths for a corrected key and for a
credential that is gone for good.

Fixes #1648
Part of #543 and #1369

## How to test

- `vp run format` and `vp run check:affected`
- `MANAGEMENT_PORT=0 SERVER_PORT=0 ./server/mvnw -f server/application/pom.xml -Dtest='CredentialRotationServiceTest,ConnectionServiceTest,CredentialBundleConverterTest,ConnectionTest' test --batch-mode`
- `vp run test:server:integration` for `CredentialRotationServiceIntegrationTest`

`CredentialRotationServiceIntegrationTest` corrupts one ciphertext against real PostgreSQL, proves
the healthy row rotates to the active key version, proves the corrupt row keeps its ciphertext and
prior key version and carries the marker, and proves that a row still pending rotation is locked by
the next batch while the quarantined row is not.

## Release impact

[Patch changeset](https://github.com/hephaestus-build/Hephaestus/blob/production-readiness-ego-death-audit-v4-total/.changeset/healthy-credential-rotation.md).
The additive migration is applied automatically and needs no operator action. Operators rotating a
key should alert on `integration_credential_rotation_failures_total` and follow the updated
credential rotation guide when it increases.

## Notes for reviewers

The distinction the job draws is between a **missing key** and a **wrong key**. If no key is
configured for a row's key version, that is a fact about the instance, not the row: the converter
throws `MissingCredentialKeyException`, the job rethrows it, the batch rolls back with nothing
marked, and the next tick rotates those rows once the operator configures the key. If key material
*is* configured but is the wrong material, the decryption failure is indistinguishable from a corrupt
ciphertext, so the row is quarantined — and a wrong prior key quarantines every row it touches. That
is deliberate: quarantine is visible in the counter, in the log and in the runbook's listing query,
and one `UPDATE` clears it after the key is corrected, whereas a stalled job would be silent in all
three. The job never infers a fault from how a batch happens to be composed.

Clearing a marker after the operator corrects the key is deliberately a runbook `UPDATE` rather than
a product control. It is a rare, instance-wide operator action on a state no workspace member can see
or cause, and #1648 scoped the recovery path to the runbook; a "retry this credential" button would
be a new admin surface for a state that should not recur.

The partial index backing the batch query, `ix_connection_credential_rotation`, was deliberately not
extended with the new `credentials_rotation_failed_at IS NULL` predicate. Quarantined rows stay
index-resident and are filtered on recheck, which is invisible at the handful of rows this feature
expects. Extending it costs a second change set and is better as its own PR.

Start with `CredentialRotationService.rotateBatch` and then
`CredentialRotationServiceIntegrationTest`.
