### PR TITLE
fix(server): keep Heph off work that was deleted upstream

### DIFF
--- a/.changeset/heph-ignores-deleted-work.md
+++ b/.changeset/heph-ignores-deleted-work.md
@@ -1,0 +1,5 @@
+---
+"hephaestus": patch
+---
+
+Heph no longer uses issues or pull requests that were deleted upstream, and asking for a practice review of deleted work now says so instead of starting one. Leaderboard scores, profile counts and the practice feedback you already received are unchanged: they are a record of what happened, not of the work's current state.

--- a/docs/contributor/sync-lifecycle.md
+++ b/docs/contributor/sync-lifecycle.md
@@ -80,6 +80,11 @@ A tombstoned row is still queryable retained personal data, so a tombstone can n
 disconnect trigger. A hard delete destroys data the drift sweep expects to be able to resurrect, so
 erasure can never implement the drift path.
 
+There is no entity-level soft-delete filter: which reads honour a tombstone, and which keep returning
+the row because they record something that happened, is decided surface by surface in
+[ADR 0024](https://github.com/ls1intum/Hephaestus/blob/main/docs/decisions/0024-integration-sync-lifecycle-and-two-deletion-semantics.md)
+§ Update — 2026-09-03 (issue #1404): which reads honour a drift tombstone.
+
 ### Erasure is orphan-guarded
 
 SCM tables carry no `workspace_id`: `repository` and its cascade are instance-global and shared

--- a/docs/decisions/0024-integration-sync-lifecycle-and-two-deletion-semantics.md
+++ b/docs/decisions/0024-integration-sync-lifecycle-and-two-deletion-semantics.md
@@ -191,3 +191,52 @@ incomplete until a documented backup cycle exists; `sync_job` or `connection_act
 carrying mirrored third-party content, which would move it from "retained audit" to "must be erased";
 or SCM entities gain a `workspace_id`, which would retire the orphan guard in favour of scoped
 deletes.
+
+## Update — 2026-09-03 (issue #1404): which reads honour a drift tombstone
+
+Supersedes nothing above; it answers a question section (a) left open. (a) says a tombstone makes a
+row identifiable and reversible. It does not say who is allowed to keep reading it, and the answer
+had been decided query by query, which is how the same developer could be shown a merged-pull-request
+count and a list under it that disagreed.
+
+There is no entity-level `@SQLRestriction` and there will not be one: reconciliation, resurrection,
+retention and audit all read `deleted_at`, and a restriction that hid the column's own rows would
+break the self-healing (a) rests on. Filtering is therefore per query, the convention
+`SlackMessageRepository` and `OutlineDocumentRepository` already follow, and this section is the one
+home for who does it.
+
+**A tombstoned row is refused where Hephaestus would otherwise speak about work as if it were live.**
+
+| Surface | Honours the tombstone | Why |
+| --- | --- | --- |
+| Mentor context (`MentorContextQueryRepository`) | Yes | Heph describes the developer's current work; citing something they cannot open is a wrong claim about their work. |
+| Project-inventory evidence source (`WorkspaceInventoryContentSource`) | Yes | The "what else exists in this project" index staged into a review's evidence; listing work that is gone invites an observation about nothing. |
+| A review somebody asks for (`ManualReviewRequests`) | Yes | A review of deleted work is wrong by construction. Refused as `SignalStateReason.ARTIFACT_GONE` rather than 404'd by the ownership check: the workspace does monitor that artifact, so the asker gets the reason instead of an error status. |
+| A backfill or sweep campaign's scope (`ReviewBackfillScopeRepository`) | Yes | Predates this update — a campaign spends budget per artifact, so a tombstoned row never enters the scope rather than being refused per ask. |
+| Sync-admin counts and the sweep's own listings | Yes | Predates this update — the number is the operator's answer to "what is in the mirror". |
+
+**A tombstoned row stays visible where the record is of something that happened.**
+
+| Surface | Honours the tombstone | Why |
+| --- | --- | --- |
+| Activity events, XP, leaderboard (`activity`, `leaderboard`) | No | An event is a historical fact: the review happened, and the reviewer earned it. Deleting the work upstream does not un-review it, and rewriting scores retroactively is a worse lie than an orphaned row. |
+| Profile counts, contributed repositories, earliest-contribution dates (`profile`, `workspace`) | No | Same record, same reason; a profile that shrinks when somebody else deletes a branch is not a profile of the developer. |
+| Observations and delivered feedback (`practices`) | No | Feedback that was delivered was delivered — the ledger says so, and hiding it at read time would make the ledger and the read disagree with no recorded reason. Suppressing feedback about a vanished artifact is a *delivery* decision and belongs to `FeedbackSuppressionReason.ARTIFACT_GONE`, in the `agent` module that may depend on `integration.scm`. `practices` may depend on the integration contract and on nothing that implements it, so it never names the `issue` table. |
+| The gate loaders the pending-signal resubmitters read | No | They must tell "deleted upstream" apart from "temporarily swept": a resubmitter that cannot find the row records `SignalStateReason.ARTIFACT_GONE`, which is terminal, and the resurrection (a) promises would leave the occasion retired for good. So a review a person asks for on one artifact is refused with `SignalStateReason.ARTIFACT_GONE`; an automatically re-offered signal is not, and can still start a review of a tombstoned row. Retiring it needs a retryable reason meaning "temporarily swept", which the vocabulary does not have yet. |
+
+**Slack and Outline are out of scope of this update, deliberately.** `SlackMessage` and
+`OutlineDocument` carry their own `deletedAt` and their own repositories already filter it, so the
+mirror reads are consistent. What is undecided is whether an observation grounded in a deleted
+conversation thread or document should still be shown — the same question as the `practices` row
+above, and it gets the same answer for the same reason, through the delivery policy rather than a
+read filter.
+
+**Consequence.** The vocabulary for "the work is gone" stays split by stage and stays typed:
+`SignalStateReason.ARTIFACT_GONE` at the occasion stage, `FeedbackSuppressionReason.ARTIFACT_GONE` at
+delivery. A capture-stage refusal written as a free-text job failure is a bug, not a third option —
+`docs/contributor/practice-review-pipeline.mdx` § Where a review can stop.
+
+**Revisit trigger for this section.** A read surface changes side; an artifact kind other than
+`scm.pull_request` / `scm.issue` needs the same distinction; or a retryable signal-state reason for
+"temporarily swept" exists, at which point a re-offered pending signal can be held rather than
+allowed to review a tombstoned row.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -62,7 +62,7 @@ do, its home is the Admin Guide (`docs/admin/`) and the runbook links to it.
 | [0021](0021-observations-feedback-synthesis-seam.md) | Findings vs feedback — evidence and delivered feedback are separate records | Accepted (amended 2026-07-31 #1423, 2026-08-16 #1430) |
 | [0022](0022-observation-presence-assessment-and-schema-cleanup.md) | Observation = presence × assessment (drop `Practice.kind`); reaction anchors on feedback; ruthless column cleanup | Accepted |
 | [0023](0023-outline-documentation-integration.md) | Outline documentation integration — a content source, not a detection surface | Accepted |
-| [0024](0024-integration-sync-lifecycle-and-two-deletion-semantics.md) | Integration sync lifecycle — drift tombstones and mirror erasure are two different operations | Accepted |
+| [0024](0024-integration-sync-lifecycle-and-two-deletion-semantics.md) | Integration sync lifecycle — drift tombstones and mirror erasure are two different operations | Accepted (amended 2026-09-03 #1404 — which reads honour a drift tombstone) |
 | [0025](0025-agent-job-queue-on-postgresql.md) | Agent job queue moves off NATS onto PostgreSQL | Accepted |
 | [0026](0026-per-purpose-agent-bindings-and-llm-governance.md) | Per-purpose agent bindings and governed OpenAI-compatible LLM catalog | Accepted (amended 2026-07-26 — named-agent-config model deleted) |
 | [0027](0027-dialog-lifetime-and-where-a-write-outcome-lands.md) | Dialog lifetime, and where a write's outcome lands when the dialog is gone | Accepted |

--- a/docs/user/ai-mentor.mdx
+++ b/docs/user/ai-mentor.mdx
@@ -28,6 +28,8 @@ Depending on your workspace configuration, Heph can use:
 
 Heph uses this context to answer your question. It does not have an unrestricted checkout of every connected repository, and it may ask for a specific snippet when the available context is not enough.
 
+Heph does not use work that was deleted on GitHub or GitLab. Your leaderboard score, profile counts, and the practice feedback you already received are unaffected: they record what happened at the time.
+
 A practice review can also prepare a private coaching brief for Heph. The brief contains a situation,
 the capability to explore, an evidence summary, and something that can be observed in the conversation.
 It is not a queued reply and does not start a chat or send a notification. When you next talk to Heph,

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/activity/package-info.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/activity/package-info.java
@@ -6,6 +6,9 @@
  * SUM/GROUP BY against the event table — see {@link de.tum.cit.aet.hephaestus.leaderboard}
  * for the read side.
  *
+ * <p>Events are historical facts and remain when their upstream target is later deleted — ADR 0024
+ * § Update — 2026-09-03 (issue #1404): which reads honour a drift tombstone.
+ *
  * <p>Distinct bounded context from {@link de.tum.cit.aet.hephaestus.practices} (code-health
  * analysis), even though both consume {@code ScmDomainEvent}s.
  *

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/context/providers/mentor/MentorContextQueryRepository.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/context/providers/mentor/MentorContextQueryRepository.java
@@ -35,12 +35,14 @@ public interface MentorContextQueryRepository extends JpaRepository<User, Long> 
                 FROM PullRequest p1
                 JOIN RepositoryToMonitor rtm1 ON rtm1.nameWithOwner = p1.repository.nameWithOwner
                 WHERE p1.author.id = :userId
+                  AND p1.deletedAt IS NULL
                   AND rtm1.workspace.id = :workspaceId
                   AND p1.state = de.tum.cit.aet.hephaestus.integration.scm.domain.issue.Issue.State.OPEN), 0L),
             COALESCE((SELECT COUNT(p2)
                 FROM PullRequest p2
                 JOIN RepositoryToMonitor rtm2 ON rtm2.nameWithOwner = p2.repository.nameWithOwner
                 WHERE p2.author.id = :userId
+                  AND p2.deletedAt IS NULL
                   AND rtm2.workspace.id = :workspaceId
                   AND p2.isMerged = true
                   AND p2.mergedAt > :weekAgo
@@ -49,6 +51,7 @@ public interface MentorContextQueryRepository extends JpaRepository<User, Long> 
                 FROM PullRequest p3
                 JOIN RepositoryToMonitor rtm3 ON rtm3.nameWithOwner = p3.repository.nameWithOwner
                 WHERE p3.author.id = :userId
+                  AND p3.deletedAt IS NULL
                   AND rtm3.workspace.id = :workspaceId
                   AND p3.isMerged = true
                   AND p3.mergedAt > :twoWeeksAgo
@@ -58,12 +61,14 @@ public interface MentorContextQueryRepository extends JpaRepository<User, Long> 
                 JOIN RepositoryToMonitor rtmi ON rtmi.nameWithOwner = i.repository.nameWithOwner
                 WHERE TYPE(i) = Issue
                   AND i.author.id = :userId
+                  AND i.deletedAt IS NULL
                   AND rtmi.workspace.id = :workspaceId
                   AND i.state = de.tum.cit.aet.hephaestus.integration.scm.domain.issue.Issue.State.OPEN), 0L),
             COALESCE((SELECT COUNT(r1)
                 FROM PullRequestReview r1
                 JOIN RepositoryToMonitor rtmr1 ON rtmr1.nameWithOwner = r1.pullRequest.repository.nameWithOwner
                 WHERE r1.author.id = :userId
+                  AND r1.pullRequest.deletedAt IS NULL
                   AND rtmr1.workspace.id = :workspaceId
                   AND r1.submittedAt > :weekAgo
                   AND r1.submittedAt <= :now), 0L),
@@ -71,6 +76,7 @@ public interface MentorContextQueryRepository extends JpaRepository<User, Long> 
                 FROM PullRequestReview r2
                 JOIN RepositoryToMonitor rtmr2 ON rtmr2.nameWithOwner = r2.pullRequest.repository.nameWithOwner
                 WHERE r2.author.id = :userId
+                  AND r2.pullRequest.deletedAt IS NULL
                   AND rtmr2.workspace.id = :workspaceId
                   AND r2.submittedAt > :twoWeeksAgo
                   AND r2.submittedAt <= :weekAgo), 0L),
@@ -78,6 +84,7 @@ public interface MentorContextQueryRepository extends JpaRepository<User, Long> 
                 FROM PullRequestReview r3
                 JOIN RepositoryToMonitor rtmr3 ON rtmr3.nameWithOwner = r3.pullRequest.repository.nameWithOwner
                 WHERE r3.pullRequest.author.id = :userId
+                  AND r3.pullRequest.deletedAt IS NULL
                   AND rtmr3.workspace.id = :workspaceId
                   AND r3.submittedAt > :weekAgo
                   AND r3.submittedAt <= :now), 0L),
@@ -86,12 +93,14 @@ public interface MentorContextQueryRepository extends JpaRepository<User, Long> 
                 JOIN RepositoryToMonitor rtmpr ON rtmpr.nameWithOwner = prr.repository.nameWithOwner
                 JOIN prr.requestedReviewers reviewer
                 WHERE reviewer.id = :userId
+                  AND prr.deletedAt IS NULL
                   AND rtmpr.workspace.id = :workspaceId
                   AND prr.state = de.tum.cit.aet.hephaestus.integration.scm.domain.issue.Issue.State.OPEN), 0L),
             COALESCE((SELECT COUNT(t)
                 FROM PullRequestReviewThread t
                 JOIN RepositoryToMonitor rtmt ON rtmt.nameWithOwner = t.pullRequest.repository.nameWithOwner
                 WHERE t.pullRequest.author.id = :userId
+                  AND t.pullRequest.deletedAt IS NULL
                   AND rtmt.workspace.id = :workspaceId
                   AND t.pullRequest.state = de.tum.cit.aet.hephaestus.integration.scm.domain.issue.Issue.State.OPEN
                   AND t.state = de.tum.cit.aet.hephaestus.integration.scm.domain.pullrequestreviewthread.PullRequestReviewThread.State.UNRESOLVED), 0L)
@@ -123,6 +132,7 @@ public interface MentorContextQueryRepository extends JpaRepository<User, Long> 
         LEFT JOIN FETCH i.milestone
         WHERE TYPE(i) = Issue
           AND a.id = :userId
+          AND i.deletedAt IS NULL
           AND rtm.workspace.id = :workspaceId
           AND i.state = de.tum.cit.aet.hephaestus.integration.scm.domain.issue.Issue.State.OPEN
         ORDER BY i.createdAt DESC
@@ -138,6 +148,7 @@ public interface MentorContextQueryRepository extends JpaRepository<User, Long> 
         LEFT JOIN FETCH p.author
         LEFT JOIN FETCH p.repository
         WHERE reviewer.id = :userId
+          AND p.deletedAt IS NULL
           AND rtm.workspace.id = :workspaceId
           AND p.state = de.tum.cit.aet.hephaestus.integration.scm.domain.issue.Issue.State.OPEN
         ORDER BY p.createdAt DESC
@@ -199,6 +210,7 @@ public interface MentorContextQueryRepository extends JpaRepository<User, Long> 
         LEFT JOIN FETCH prr.author
         LEFT JOIN FETCH prr.pullRequest
         WHERE prr.pullRequest.author.id = :userId
+          AND prr.pullRequest.deletedAt IS NULL
           AND rtm.workspace.id = :workspaceId
           AND prr.submittedAt > :since
         ORDER BY prr.submittedAt DESC
@@ -220,6 +232,7 @@ public interface MentorContextQueryRepository extends JpaRepository<User, Long> 
         FROM PullRequest p
         JOIN RepositoryToMonitor rtm ON rtm.nameWithOwner = p.repository.nameWithOwner
         WHERE p.author.id = :userId
+          AND p.deletedAt IS NULL
           AND rtm.workspace.id = :workspaceId
         ORDER BY p.createdAt DESC
         """)
@@ -235,6 +248,7 @@ public interface MentorContextQueryRepository extends JpaRepository<User, Long> 
         FROM Issue i
         JOIN RepositoryToMonitor rtm ON rtm.nameWithOwner = i.repository.nameWithOwner
         WHERE i.author.id = :userId
+          AND i.deletedAt IS NULL
           AND rtm.workspace.id = :workspaceId
           AND TYPE(i) = Issue
         ORDER BY i.createdAt DESC

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/job/ManualReviewRequests.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/job/ManualReviewRequests.java
@@ -50,6 +50,13 @@ import org.springframework.transaction.support.TransactionTemplate;
  * <p>Checks run standing, then rate limits, then the ledger row, then the gate. Limiting before recording
  * keeps a declined ask from tightening the limit under retry (see {@link ManualReviewRateLimits}); the
  * gate runs last because only it needs a ledger row to settle against.
+ *
+ * <p>Work the mirror has tombstoned is refused here as {@link SignalStateReason#ARTIFACT_GONE}, not by the
+ * ownership check: the workspace does monitor that artifact, so ownership answers yes, and an asker who is
+ * looking straight at the work is better served by a reason they can read than by a 404. Only a review
+ * somebody asked for is stopped this way — a pending signal an automatic resubmitter re-offers reaches the
+ * gate on a tombstoned row, because every reason that would retire it is terminal and a tombstone is
+ * reversible. ADR 0024 § Update — 2026-09-03 (issue #1404): which reads honour a drift tombstone.
  */
 @Service
 public class ManualReviewRequests {
@@ -101,6 +108,9 @@ public class ManualReviewRequests {
                     requesters.size());
             return ManualReviewOutcome.forbidden();
         }
+        if (pullRequest.getDeletedAt() != null) {
+            return ManualReviewOutcome.refused(SignalStateReason.ARTIFACT_GONE);
+        }
         String headRefOid = pullRequest.getHeadRefOid();
         if (headRefOid == null || pullRequest.getHeadRefName() == null || pullRequest.getBaseRefName() == null) {
             // Reported as the artifact being gone, not a gate skip: the mirror hasn't caught up, the
@@ -134,6 +144,9 @@ public class ManualReviewRequests {
                     issue.getId(),
                     requesters.size());
             return ManualReviewOutcome.forbidden();
+        }
+        if (issue.getDeletedAt() != null) {
+            return ManualReviewOutcome.refused(SignalStateReason.ARTIFACT_GONE);
         }
         if (issue.getRepository() == null) {
             return ManualReviewOutcome.refused(SignalStateReason.ARTIFACT_GONE);

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/domain/issue/Issue.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/domain/issue/Issue.java
@@ -114,28 +114,9 @@ public class Issue extends BaseGitServiceEntity {
      * back to {@code null}, so an item that reappears upstream — or one a faulty sweep tombstoned
      * — is resurrected by the next ordinary sync with no operator intervention.
      *
-     * <p><strong>Read scope — deliberately narrow.</strong> This codebase uses no Hibernate
-     * soft-delete filter, and only the queries that exist to serve reconciliation honour the
-     * tombstone. Filtering is opt-in per query, so the exhaustive list of readers that see
-     * {@code deletedAt IS NULL} is:
-     *
-     * <ul>
-     *   <li>the per-repository sync counts the admin UI renders
-     *       ({@code IssueRepository.count{Issues,PullRequests}GroupedByRepositoryIds});
-     *   <li>the sweep's own local-number listing
-     *       ({@code IssueRepository.findLive{Issue,PullRequest}NumbersByRepositoryId});
-     *   <li>{@code IssueRepository.tombstone{Issues,PullRequests}ByRepositoryIdAndNumbers}, where it
-     *       preserves the first observation time.
-     * </ul>
-     *
-     * <p><strong>Everything else still shows upstream-deleted rows.</strong> The product read
-     * surfaces do not filter this column: {@code LeaderboardReviewQueryRepository},
-     * {@code ProfilePullRequestQueryRepository}, {@code WorkspaceContributionQueryRepository},
-     * {@code ActivityEventRepository}, {@code MentorContextQueryRepository}, and the review /
-     * review-comment / thread repositories all surface tombstoned issues and pull requests. The
-     * tombstone makes those rows <em>identifiable</em> and fixes the counts; it does not hide them.
-     * Teaching the remaining read paths to filter has a far wider blast radius (scoring, XP, profile
-     * history and mentor context would all shift) and is a separate change.
+     * <p>Which surfaces filter and which deliberately do not, and why there is no entity-level
+     * {@code @SQLRestriction}, is decided in ADR 0024 § Update — 2026-09-03 (issue #1404): which reads honour a
+     * drift tombstone.
      */
     @Column(name = "deleted_at")
     private Instant deletedAt;

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/domain/issue/IssueRepository.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/domain/issue/IssueRepository.java
@@ -177,14 +177,16 @@ public interface IssueRepository extends JpaRepository<Issue, Long> {
      * Repository-wide issue inventory (pure issues, PullRequest subclass rows excluded) ordered
      * newest-first by number, for the cross-artifact project-context telescope. The author is fetched
      * up front to avoid a per-row lazy load; labels/comments/bodies are intentionally NOT fetched — the
-     * inventory is a compact "what else exists in this project" index, not a full body.
+     * inventory is a compact "what else exists in this project" index, not a full body. Tombstones are
+     * excluded: something deleted upstream is no longer in the project.
      *
      * @param repositoryId the repository ID
      * @param pageable the cap (newest N) — caller supplies {@code PageRequest.of(0, cap)}
      * @return newest-first issues for the repository
      */
     @Query("SELECT i FROM Issue i LEFT JOIN FETCH i.author LEFT JOIN FETCH i.milestone "
-            + "WHERE TYPE(i) = Issue AND i.repository.id = :repositoryId ORDER BY i.number DESC")
+            + "WHERE TYPE(i) = Issue AND i.repository.id = :repositoryId AND i.deletedAt IS NULL "
+            + "ORDER BY i.number DESC")
     List<Issue> findIssueInventoryByRepositoryId(@Param("repositoryId") long repositoryId, Pageable pageable);
 
     /**

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/domain/pullrequest/PullRequestRepository.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/domain/pullrequest/PullRequestRepository.java
@@ -109,14 +109,15 @@ public interface PullRequestRepository extends JpaRepository<PullRequest, Long> 
      * Repository-wide pull-request inventory ordered newest-first by number, for the cross-artifact
      * project-context telescope. The author is fetched up front to avoid a per-row lazy load; review
      * threads/diffs/bodies are intentionally NOT fetched — the inventory is a compact "what else exists
-     * in this project" index, not a full body.
+     * in this project" index, not a full body. Tombstones are excluded: something deleted upstream is no
+     * longer in the project.
      *
      * @param repositoryId the repository ID
      * @param pageable the cap (newest N) — caller supplies {@code PageRequest.of(0, cap)}
      * @return newest-first pull requests for the repository
      */
     @Query("SELECT p FROM PullRequest p LEFT JOIN FETCH p.author LEFT JOIN FETCH p.milestone "
-            + "WHERE p.repository.id = :repositoryId ORDER BY p.number DESC")
+            + "WHERE p.repository.id = :repositoryId AND p.deletedAt IS NULL ORDER BY p.number DESC")
     List<PullRequest> findPullRequestInventoryByRepositoryId(
             @Param("repositoryId") long repositoryId, Pageable pageable);
 

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/job/UpstreamDeletedWorkReadScopeIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/job/UpstreamDeletedWorkReadScopeIntegrationTest.java
@@ -1,0 +1,304 @@
+package de.tum.cit.aet.hephaestus.agent.job;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import de.tum.cit.aet.hephaestus.agent.context.providers.mentor.MentorContextQueryRepository;
+import de.tum.cit.aet.hephaestus.integration.core.signal.SignalStateReason;
+import de.tum.cit.aet.hephaestus.integration.scm.domain.issue.Issue;
+import de.tum.cit.aet.hephaestus.integration.scm.domain.issue.IssueRepository;
+import de.tum.cit.aet.hephaestus.integration.scm.domain.pullrequest.PullRequest;
+import de.tum.cit.aet.hephaestus.integration.scm.domain.pullrequest.PullRequestRepository;
+import de.tum.cit.aet.hephaestus.integration.scm.domain.repository.Repository;
+import de.tum.cit.aet.hephaestus.integration.scm.domain.repository.RepositoryRepository;
+import de.tum.cit.aet.hephaestus.integration.scm.domain.user.User;
+import de.tum.cit.aet.hephaestus.workspace.AbstractWorkspaceIntegrationTest;
+import de.tum.cit.aet.hephaestus.workspace.AccountType;
+import de.tum.cit.aet.hephaestus.workspace.RepositoryToMonitor;
+import de.tum.cit.aet.hephaestus.workspace.RepositoryToMonitorRepository;
+import de.tum.cit.aet.hephaestus.workspace.Workspace;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
+
+/**
+ * The two halves of the tombstone decision, on one pull request and one issue that are tombstoned and
+ * then handed back by an ordinary upsert.
+ *
+ * <p>Heph must not describe work that no longer exists upstream, and a review somebody asks for must be
+ * refused on it by name — so the mentor's queries and the project inventory drop the tombstoned row, and
+ * the request path answers {@link SignalStateReason#ARTIFACT_GONE}. Everything the drift tombstone
+ * promises to be able to undo must still see it: the upsert that resurrects it, and the gate loader the
+ * pending-signal resubmitters read, which reports a missing row as {@code ARTIFACT_GONE} and retires the
+ * occasion for good.
+ *
+ * <p>Both kinds are exercised because {@code Issue} and {@code PullRequest} share one table and the
+ * issue side additionally has to hold its {@code TYPE(i) = Issue} discriminator.
+ *
+ * <p>Runs against a live Postgres because most of the behaviour is a {@code WHERE} clause; the unit
+ * tier mocks these repositories and would pass either way.
+ */
+class UpstreamDeletedWorkReadScopeIntegrationTest extends AbstractWorkspaceIntegrationTest {
+
+    private static final int PR_NUMBER = 42;
+    private static final int ISSUE_NUMBER = 43;
+    private static final PageRequest FIRST_PAGE = PageRequest.of(0, 20);
+
+    @Autowired
+    private RepositoryRepository repositoryRepository;
+
+    @Autowired
+    private RepositoryToMonitorRepository repositoryToMonitorRepository;
+
+    @Autowired
+    private PullRequestRepository pullRequestRepository;
+
+    @Autowired
+    private IssueRepository issueRepository;
+
+    @Autowired
+    private MentorContextQueryRepository mentorContextQueryRepository;
+
+    @Autowired
+    private ManualReviewRequests manualReviewRequests;
+
+    private Workspace workspace;
+    private User author;
+    private Repository repository;
+    private long pullRequestId;
+    private long issueId;
+
+    @BeforeEach
+    void seedMonitoredWork() {
+        User owner = persistUser("read-scope-owner");
+        workspace = createWorkspace("read-scope-ws", "Read Scope WS", "read-scope-org", AccountType.ORG, owner);
+        author = persistUser("read-scope-author");
+
+        repository = new Repository();
+        repository.setNativeId(9301L);
+        repository.setProvider(ensureGitHubProvider());
+        repository.setName("widgets");
+        repository.setNameWithOwner("read-scope-org/widgets");
+        repository.setHtmlUrl("https://github.com/read-scope-org/widgets");
+        repository.setDefaultBranch("main");
+        repository = repositoryRepository.save(repository);
+
+        RepositoryToMonitor monitor = new RepositoryToMonitor();
+        monitor.setWorkspace(workspace);
+        monitor.setNameWithOwner(repository.getNameWithOwner());
+        repositoryToMonitorRepository.save(monitor);
+
+        upsertPullRequest();
+        upsertIssue();
+        pullRequestId = pullRequestRepository
+                .findByRepositoryIdAndNumber(repository.getId(), PR_NUMBER)
+                .orElseThrow()
+                .getId();
+        issueId = issueRepository
+                .findByRepositoryIdAndNumber(repository.getId(), ISSUE_NUMBER)
+                .orElseThrow()
+                .getId();
+    }
+
+    @Test
+    void aTombstonedPullRequestLeavesTheMentorsContextAndComesBackWhenUpstreamHandsItOver() {
+        assertThat(mentorAuthoredPullRequestIds()).contains(pullRequestId);
+        assertThat(pullRequestInventoryIds()).contains(pullRequestId);
+
+        tombstonePullRequest();
+
+        assertThat(mentorAuthoredPullRequestIds())
+                .as("Heph would otherwise cite a pull request the developer cannot open")
+                .doesNotContain(pullRequestId);
+        assertThat(pullRequestInventoryIds()).doesNotContain(pullRequestId);
+
+        // Upstream hands the pull request back — a sweep that tombstoned on a truncated listing heals here.
+        upsertPullRequest();
+
+        assertThat(mentorAuthoredPullRequestIds()).contains(pullRequestId);
+        assertThat(pullRequestInventoryIds()).contains(pullRequestId);
+    }
+
+    @Test
+    void aTombstonedIssueLeavesTheProjectInventoryAndComesBackWhenUpstreamHandsItOver() {
+        assertThat(issueInventoryIds()).contains(issueId);
+
+        tombstoneIssue();
+
+        assertThat(issueInventoryIds()).doesNotContain(issueId);
+
+        upsertIssue();
+
+        assertThat(issueInventoryIds()).contains(issueId);
+    }
+
+    /**
+     * The refusal is the reason itself, answered to the person who asked, rather than a status code
+     * saying their button is broken: this workspace does monitor the pull request, so the question is
+     * not one of standing.
+     */
+    @Test
+    void askingForAReviewOfATombstonedPullRequestIsRefusedAsArtifactGone() {
+        tombstonePullRequest();
+
+        ManualReviewOutcome outcome =
+                manualReviewRequests.requestPullRequestReview(workspace, gateLoadedPullRequest(), List.of(author));
+
+        assertThat(outcome.status()).isEqualTo(ManualReviewOutcome.Status.REFUSED);
+        assertThat(outcome.reason()).isEqualTo(SignalStateReason.ARTIFACT_GONE);
+
+        upsertPullRequest();
+
+        assertThat(manualReviewRequests
+                        .requestPullRequestReview(workspace, gateLoadedPullRequest(), List.of(author))
+                        .reason())
+                .as("a resurrected pull request is back to whatever the gate makes of it")
+                .isNotEqualTo(SignalStateReason.ARTIFACT_GONE);
+    }
+
+    @Test
+    void askingForAReviewOfATombstonedIssueIsRefusedAsArtifactGone() {
+        tombstoneIssue();
+
+        ManualReviewOutcome outcome =
+                manualReviewRequests.requestIssueReview(workspace, gateLoadedIssue(), List.of(author));
+
+        assertThat(outcome.status()).isEqualTo(ManualReviewOutcome.Status.REFUSED);
+        assertThat(outcome.reason()).isEqualTo(SignalStateReason.ARTIFACT_GONE);
+    }
+
+    /**
+     * A pending signal re-offered while the row is tombstoned must not be retired: the resubmitters
+     * read this loader and record {@code SignalStateReason.ARTIFACT_GONE} — a terminal
+     * {@code LAPSED} — for anything it cannot find, and nothing would re-open the occasion once the
+     * next ordinary sync brought the pull request back.
+     */
+    @Test
+    void theGateLoaderAndTheUpsertLookupStillSeeATombstonedPullRequest() {
+        tombstonePullRequest();
+
+        assertThat(pullRequestRepository.findByIdWithAllForGate(pullRequestId))
+                .get()
+                .extracting(PullRequest::getId)
+                .isEqualTo(pullRequestId);
+        assertThat(pullRequestRepository.findByRepositoryIdAndNumber(repository.getId(), PR_NUMBER))
+                .get()
+                .extracting(PullRequest::getId)
+                .isEqualTo(pullRequestId);
+    }
+
+    private void tombstonePullRequest() {
+        assertThat(issueRepository.tombstonePullRequestsByRepositoryIdAndNumbers(
+                        repository.getId(), List.of(PR_NUMBER), Instant.now()))
+                .isEqualTo(1);
+    }
+
+    private void tombstoneIssue() {
+        assertThat(issueRepository.tombstoneIssuesByRepositoryIdAndNumbers(
+                        repository.getId(), List.of(ISSUE_NUMBER), Instant.now()))
+                .isEqualTo(1);
+    }
+
+    private List<Long> mentorAuthoredPullRequestIds() {
+        return mentorContextQueryRepository
+                .findRecentAuthoredPullRequests(workspace.getId(), author.getId(), FIRST_PAGE)
+                .stream()
+                .map(PullRequest::getId)
+                .toList();
+    }
+
+    private List<Long> pullRequestInventoryIds() {
+        return pullRequestRepository.findPullRequestInventoryByRepositoryId(repository.getId(), FIRST_PAGE).stream()
+                .map(PullRequest::getId)
+                .toList();
+    }
+
+    private List<Long> issueInventoryIds() {
+        return issueRepository.findIssueInventoryByRepositoryId(repository.getId(), FIRST_PAGE).stream()
+                .map(Issue::getId)
+                .toList();
+    }
+
+    /** The association graph a request needs: standing is judged on the author and the assignees. */
+    private PullRequest gateLoadedPullRequest() {
+        return pullRequestRepository.findByIdWithAllForGate(pullRequestId).orElseThrow();
+    }
+
+    private Issue gateLoadedIssue() {
+        return issueRepository.findByIdWithRepositoryAndAssignees(issueId).orElseThrow();
+    }
+
+    private void upsertPullRequest() {
+        Instant now = Instant.now();
+        pullRequestRepository.upsertCore(
+                9400L + PR_NUMBER,
+                providerId(),
+                PR_NUMBER,
+                "A change worth reviewing",
+                "Body",
+                "OPEN",
+                null,
+                "https://github.com/" + repository.getNameWithOwner() + "/pull/" + PR_NUMBER,
+                false,
+                null,
+                0,
+                now,
+                now,
+                now,
+                author.getId(),
+                repository.getId(),
+                null,
+                null,
+                false,
+                false,
+                1,
+                10,
+                5,
+                3,
+                null,
+                null,
+                null,
+                "feature/branch",
+                "main",
+                "headsha",
+                "basesha",
+                null,
+                null);
+    }
+
+    private void upsertIssue() {
+        Instant now = Instant.now();
+        issueRepository.upsertCore(
+                9500L + ISSUE_NUMBER,
+                providerId(),
+                ISSUE_NUMBER,
+                "Something worth discussing",
+                "Body",
+                "OPEN",
+                null,
+                "https://github.com/" + repository.getNameWithOwner() + "/issues/" + ISSUE_NUMBER,
+                false,
+                null,
+                0,
+                now,
+                now,
+                now,
+                author.getId(),
+                repository.getId(),
+                null,
+                null,
+                null,
+                null,
+                null,
+                null);
+    }
+
+    private Long providerId() {
+        Long providerId = repository.getProvider().getId();
+        assertNotNull(providerId);
+        return providerId;
+    }
+}

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/scm/domain/MirrorQueryPredicateGuardTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/scm/domain/MirrorQueryPredicateGuardTest.java
@@ -3,7 +3,9 @@ package de.tum.cit.aet.hephaestus.integration.scm.domain;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import de.tum.cit.aet.hephaestus.agent.context.providers.mentor.MentorContextQueryRepository;
+import de.tum.cit.aet.hephaestus.integration.scm.domain.issue.IssueRepository;
 import de.tum.cit.aet.hephaestus.integration.scm.domain.issuecomment.IssueCommentRepository;
+import de.tum.cit.aet.hephaestus.integration.scm.domain.pullrequest.PullRequestRepository;
 import de.tum.cit.aet.hephaestus.integration.scm.domain.pullrequestreview.PullRequestReviewRepository;
 import de.tum.cit.aet.hephaestus.integration.scm.domain.pullrequestreviewcomment.PullRequestReviewCommentRepository;
 import de.tum.cit.aet.hephaestus.testconfig.BaseUnitTest;
@@ -12,6 +14,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.junit.jupiter.api.DisplayName;
@@ -20,19 +23,104 @@ import org.junit.jupiter.api.Test;
 import org.springframework.data.jpa.repository.Query;
 
 /**
- * Guards the two ways a mirror query silently counts or returns rows it should not.
+ * Guards the ways a mirror query silently counts or returns rows it should not.
  *
- * <p><b>Why this asserts on the query text rather than on returned rows.</b> Both defects live
+ * <p><b>Why this asserts on the query text rather than on returned rows.</b> The defects live
  * entirely in JPQL semantics, and neither tier that could execute JPQL catches them cheaply: unit
  * tests mock the repository interface, so a mock returns whatever the test stubs regardless of what
  * the {@code @Query} says, and the integration tier needs a live Postgres. The predicates are
  * therefore verified where they are actually written. A missing predicate fails here, in the tier
- * every contributor runs first, instead of surfacing as a wrong number on an admin page.
+ * every contributor runs first, instead of surfacing as a wrong number in the product.
  */
 class MirrorQueryPredicateGuardTest extends BaseUnitTest {
 
     /** Matches a JPQL {@code FROM Issue <alias>} range declaration, including inside a subquery. */
     private static final Pattern ISSUE_RANGE = Pattern.compile("\\bFROM\\s+Issue\\s+(\\w+)\\b");
+
+    /**
+     * Matches any JPQL range declaration over a tombstonable artifact or one of its children.
+     * Longest-first alternation so {@code PullRequestReviewThread} is never read as
+     * {@code PullRequest}. {@code JOIN} declares a range as much as {@code FROM} does — this tree
+     * already writes entity joins with {@code ON} — while an association join ({@code JOIN p.author},
+     * {@code JOIN FETCH p.reviews}) never matches the entity-name alternation.
+     */
+    private static final Pattern ARTIFACT_RANGE = Pattern.compile("\\b(?:FROM|JOIN)\\s+(PullRequestReviewThread"
+            + "|PullRequestReviewComment|PullRequestReview|IssueComment|PullRequest|Issue)\\s+(\\w+)\\b");
+
+    /**
+     * The path from a range's alias to the {@code deleted_at} column that decides whether its rows are
+     * live. A review, review comment or thread carries no tombstone of its own — it goes away with the
+     * pull request it hangs off — so the parent's column is the only signal there is.
+     */
+    private static final Map<String, String> TOMBSTONE_PATH_BY_ENTITY = Map.of(
+            "PullRequestReviewThread", ".pullRequest.deletedAt IS NULL",
+            "PullRequestReviewComment", ".pullRequest.deletedAt IS NULL",
+            "PullRequestReview", ".pullRequest.deletedAt IS NULL",
+            "IssueComment", ".issue.deletedAt IS NULL",
+            "PullRequest", ".deletedAt IS NULL",
+            "Issue", ".deletedAt IS NULL");
+
+    /**
+     * Mentor queries the range scan cannot read — native SQL, and derived methods with no
+     * {@code @Query} at all. Each name here is a claim that the query reaches no issue or pull-request
+     * row; a mentor query that adds one has to be weighed and named here before the guard goes quiet.
+     */
+    private static final Set<String> MENTOR_QUERIES_THE_SCAN_CANNOT_READ = Set.of(
+            // chat_message joined to chat_thread; no SCM artifact in either.
+            "findFirstUserMessagePartsByThreadIds");
+
+    @Nested
+    @DisplayName("mentor context")
+    class MentorContext {
+
+        /**
+         * Heph answers about the developer's own work, so a pull request or issue deleted upstream must
+         * not reach it — the mentor would describe something the developer cannot open.
+         *
+         * <p>Scanned per range declaration rather than per method name: a whole-query substring passes a
+         * query that has two ranges and one predicate, and a method-name list goes quiet the moment a
+         * tenth query is added. Every range over an artifact or one of its children must carry its own
+         * predicate, so a new unguarded mentor query fails here without anyone remembering to extend a
+         * list.
+         */
+        @Test
+        void everyMentorArtifactRangeExcludesTombstones() {
+            assertEveryRangeHasLivePredicate(MentorContextQueryRepository.class, MENTOR_QUERIES_THE_SCAN_CANNOT_READ);
+        }
+    }
+
+    @Nested
+    @DisplayName("project inventory")
+    class ProjectInventory {
+
+        /**
+         * The project inventory is staged into a practice review's evidence, so it honours the tombstone
+         * for a neighbouring reason: an index of work that is gone invites an observation about nothing.
+         * Named rather than scanned per class: most queries on these two repositories must <em>not</em>
+         * filter — the gate loaders, the upsert lookups and the sweep's own listings all need to see a
+         * tombstoned row — so a whole-class scan would be mostly allow-list. Both kinds are checked
+         * together because {@code Issue} and {@code PullRequest} share a table, and one guarded side
+         * reads like coverage of the other.
+         */
+        @Test
+        void bothProjectInventoryQueriesExcludeTombstones() {
+            Map<String, String> offenders = new LinkedHashMap<>();
+
+            collectUnguardedRanges(
+                    "findIssueInventoryByRepositoryId",
+                    queryOf(IssueRepository.class, "findIssueInventoryByRepositoryId"),
+                    offenders);
+            collectUnguardedRanges(
+                    "findPullRequestInventoryByRepositoryId",
+                    queryOf(PullRequestRepository.class, "findPullRequestInventoryByRepositoryId"),
+                    offenders);
+
+            assertThat(offenders)
+                    .as("the project inventory must exclude tombstones, or a review is handed an index of work "
+                            + "that is no longer in the project. Offending method -> the predicate it is missing")
+                    .isEmpty();
+        }
+    }
 
     @Nested
     @DisplayName("single-table discriminator")
@@ -113,7 +201,7 @@ class MirrorQueryPredicateGuardTest extends BaseUnitTest {
                     new Guarded(PullRequestReviewCommentRepository.class, "c.pullRequest"));
 
             for (Guarded entry : guarded) {
-                String jpql = normalize(countQueryOf(entry.repository()));
+                String jpql = normalize(queryOf(entry.repository(), "countGroupedByRepositoryIds"));
 
                 assertThat(jpql)
                         .as(
@@ -131,7 +219,7 @@ class MirrorQueryPredicateGuardTest extends BaseUnitTest {
          */
         @Test
         void theExclusionStaysInsideTheExistingGroupedQuery() {
-            String jpql = normalize(countQueryOf(IssueCommentRepository.class));
+            String jpql = normalize(queryOf(IssueCommentRepository.class, "countGroupedByRepositoryIds"));
 
             assertThat(jpql).contains("GROUP BY");
             assertThat(countOccurrences(jpql, "SELECT"))
@@ -141,18 +229,68 @@ class MirrorQueryPredicateGuardTest extends BaseUnitTest {
         }
     }
 
-    private static String countQueryOf(Class<?> repository) {
+    private static String queryOf(Class<?> repository, String methodName) {
         for (Method method : repository.getDeclaredMethods()) {
-            if (!"countGroupedByRepositoryIds".equals(method.getName())) {
+            if (!methodName.equals(method.getName())) {
                 continue;
             }
             Query query = method.getAnnotation(Query.class);
             assertThat(query)
-                    .as("%s.countGroupedByRepositoryIds must carry an explicit @Query", repository.getSimpleName())
+                    .as("%s.%s must carry an explicit @Query", repository.getSimpleName(), methodName)
                     .isNotNull();
             return query.value();
         }
-        throw new AssertionError(repository.getSimpleName() + " declares no countGroupedByRepositoryIds");
+        throw new AssertionError(repository.getSimpleName() + " declares no " + methodName);
+    }
+
+    /**
+     * Fails for every artifact range whose alias carries no live predicate, and for every query the
+     * scan cannot read that the caller has not excused by name.
+     */
+    private static void assertEveryRangeHasLivePredicate(Class<?> repository, Set<String> unreadableButReviewed) {
+        Map<String, String> offenders = new LinkedHashMap<>();
+        List<String> unreadable = new ArrayList<>();
+
+        for (Method method : repository.getDeclaredMethods()) {
+            Query query = method.getAnnotation(Query.class);
+            if (query == null || query.nativeQuery()) {
+                if (!unreadableButReviewed.contains(method.getName())) {
+                    unreadable.add(method.getName());
+                }
+                continue;
+            }
+            collectUnguardedRanges(method.getName(), query.value(), offenders);
+        }
+
+        assertThat(offenders)
+                .as(
+                        "%s: every issue or pull-request range must exclude tombstones, or Heph describes work "
+                                + "the developer can no longer open. Offending method -> the predicate it is missing",
+                        repository.getSimpleName())
+                .isEmpty();
+        assertThat(unreadable)
+                .as(
+                        "%s: a derived or native query cannot be scanned for a tombstone predicate. Name it in the "
+                                + "reviewed set once it is known to reach no issue or pull-request row",
+                        repository.getSimpleName())
+                .isEmpty();
+    }
+
+    /** Records, per artifact range the JPQL declares, the live predicate its alias is missing. */
+    private static void collectUnguardedRanges(String methodName, String rawJpql, Map<String, String> offenders) {
+        String jpql = normalize(rawJpql);
+        Matcher matcher = ARTIFACT_RANGE.matcher(jpql);
+        while (matcher.find()) {
+            String alias = matcher.group(2);
+            String required = alias + TOMBSTONE_PATH_BY_ENTITY.get(matcher.group(1));
+            // Anchored on a word boundary rather than a bare substring: an alias that is a suffix of
+            // another alias in the same query would otherwise be excused by the other one's predicate.
+            if (!Pattern.compile("(?<![\\w.])" + Pattern.quote(required))
+                    .matcher(jpql)
+                    .find()) {
+                offenders.put(methodName + " (" + alias + ")", required);
+            }
+        }
     }
 
     private static List<String> issueAliases(String jpql) {


### PR DESCRIPTION
## What changed and why

Hephaestus could speak about work that no longer exists. A reconciliation sweep tombstones an issue
or pull request that vanished upstream, but the mentor's context queries kept returning those rows —
so Heph would cite a pull request the developer cannot open — the project-inventory evidence source
staged the same rows into a practice review's "what else exists in this project" index, and asking
for a practice review of deleted work started one, producing observations about nothing.

Mentor context and the project inventory now exclude tombstoned rows, and a review somebody asks for
— through the "Review this now" endpoint or the `/hephaestus review` comment — is refused with
`SignalStateReason.ARTIFACT_GONE`, the reason that already carries the sentence "The artifact was
deleted before a review could run." It is a 200 with a reason rather than a 404: this workspace does
monitor the artifact, so the ask is not broken, something nameable stopped it.

The gate loaders the pending-signal resubmitters read deliberately still see a tombstoned row,
because they report a missing artifact as `ARTIFACT_GONE`, which retires the occasion for good — and
a tombstone is reversible, so a row a faulty sweep marked is resurrected by the next ordinary sync.

Historical records keep upstream-deleted work on purpose. Activity events, XP, leaderboard scores,
profile counts, observations and delivered feedback are a record of what happened; deleting a branch
upstream does not un-review it. ADR 0024 gains the surface-by-surface decision, with the reason for
each side, and `Issue.deletedAt` points at it.

Part of #1404 — the per-artifact evidence sources and the developer's practice page still return
upstream-deleted work, and the practice page's fix belongs in the delivery policy rather than in a
read filter.

## How to test

- `vp run check:affected`
- `vp run test:server:unit`
- `cd server && MANAGEMENT_PORT=0 SERVER_PORT=0 ./mvnw -f application/pom.xml -Dtest=UpstreamDeletedWorkReadScopeIntegrationTest -Dsurefire.includedGroups=integration test --batch-mode`

The integration test persists one pull request and one issue in a monitored repository, tombstones
each through the sweep's own query, and asserts on those rows: gone from the mentor's authored-work
query and from the project inventory, refused as `ARTIFACT_GONE` when their author asks for a review,
still visible to the gate loader and to the upsert lookup — then hands them back through `upsertCore`
and asserts every read has them again, and that the refusal is no longer `ARTIFACT_GONE`.

`MirrorQueryPredicateGuardTest` fails when any mentor query declares a range — through `FROM` or an
entity `JOIN` — over an issue, a pull request, or one of their reviews, review comments, threads or
issue comments without the matching `deletedAt IS NULL`, including through the parent association. It
covers both halves of the project inventory by name, under its own display name because the inventory
is review evidence rather than mentor context. Queries the scan cannot read carry a named allow-list
entry, so a new native mentor query fails the guard until somebody weighs it.

## Release impact

Patch, `.changeset/heph-ignores-deleted-work.md`. No schema migration and no operator action.

## Notes for reviewers

Start at ADR 0024's update block for the surface-by-surface decision — it is the one home for which
read honours a tombstone and which deliberately does not — then `MentorContextQueryRepository`, the
two inventory queries, and the tombstone refusals in `ManualReviewRequests`.

Filtering stays per query rather than an entity-level `@SQLRestriction`: reconciliation, resurrection
and retention all read `deleted_at`, and it is the convention `SlackMessageRepository` and
`OutlineDocumentRepository` already follow.

Three gaps are deliberate and named in the ADR rather than fixed here. A pending signal an automatic
resubmitter re-offers can still start a review of a tombstoned row: retiring it needs a retryable
signal-state reason meaning "temporarily swept", which the vocabulary does not have. The per-artifact
evidence sources still load the row they are pointed at, so a sweep racing a capture is not handled —
only the project-inventory source filters, because it lists work rather than loading the work under
review. And observations and delivered feedback about deleted work stay visible, which is a
delivery-policy question (`FeedbackSuppressionReason.ARTIFACT_GONE`) rather than a read filter.

A backfill campaign's scope already excluded tombstoned rows before this PR; that surface is now
recorded in the ADR table too, so all three review-start paths are accounted for in one place.
