### PR TITLE
fix(db): let a practice be written again

### DIFF
--- a/.changeset/practices-can-be-written-again.md
+++ b/.changeset/practices-can-be-written-again.md
@@ -2,4 +2,4 @@
 "hephaestus": patch
 ---
 
-Fixes adopting a practice from the catalog, creating one, and editing one failing with "an unexpected error occurred". Every write to a practice was rejected as it was saved, so a workspace could not take on the practices it wanted to review, and a workspace that had never recorded a catalog installation no longer received one at start-up. Practices already in a workspace kept working and nothing was lost — the writes were refused rather than half-applied.
+Workspaces can again adopt, create, and edit practices. Existing practices keep working, and failed writes did not lose or partially save data.

--- a/.changeset/practices-can-be-written-again.md
+++ b/.changeset/practices-can-be-written-again.md
@@ -1,0 +1,5 @@
+---
+"hephaestus": patch
+---
+
+Fixes adopting a practice from the catalog, creating one, and editing one failing with "an unexpected error occurred". Every write to a practice was rejected as it was saved, so a workspace could not take on the practices it wanted to review, and a workspace that had never recorded a catalog installation no longer received one at start-up. Practices already in a workspace kept working and nothing was lost — the writes were refused rather than half-applied.

--- a/scripts/release-upgrade-test.ts
+++ b/scripts/release-upgrade-test.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "node:crypto";
 import process from "node:process";
 import { setTimeout as sleep } from "node:timers/promises";
 
+import { asArray, asRecord, asString } from "./lib/json.ts";
 import { CAPTURE_LIMIT_BYTES } from "./lib/process.ts";
 
 const [previousImage, candidateImage, postgresImage] = process.argv.slice(2);
@@ -14,6 +15,9 @@ if (!previousImage || !candidateImage || !postgresImage) {
 }
 
 const WORKSPACE_SLUG = "upgrade-fixture";
+const ADOPTION_WORKSPACE_SLUG = "upgrade-adoption-fixture";
+const HTTP_TIMEOUT_MS = 30_000;
+const READINESS_TIMEOUT_MS = 2_000;
 
 const runId = `upgrade-${randomUUID().slice(0, 8)}`;
 const network = runId;
@@ -26,6 +30,10 @@ function docker(...args: string[]): string {
 		throw new Error(`docker ${args.join(" ")} failed:\n${result.stdout}${result.stderr}`);
 	}
 	return result.stdout.trim();
+}
+
+function fetchWithTimeout(input: string, init?: RequestInit): Promise<Response> {
+	return fetch(input, { ...init, signal: AbortSignal.timeout(HTTP_TIMEOUT_MS) });
 }
 
 function startApplication(name: string, image: string): number {
@@ -75,7 +83,9 @@ async function waitUntilReady(name: string, port: number): Promise<void> {
 		const state = docker("inspect", "--format", "{{.State.Status}}", name);
 		if (state !== "running") throw new Error(`${name} stopped during startup`);
 		try {
-			const response = await fetch(`http://127.0.0.1:${port}/actuator/health/readiness`);
+			const response = await fetch(`http://127.0.0.1:${port}/actuator/health/readiness`, {
+				signal: AbortSignal.timeout(READINESS_TIMEOUT_MS),
+			});
 			if (response.ok) return;
 		} catch {
 			// The endpoint is unavailable while the container starts.
@@ -86,7 +96,7 @@ async function waitUntilReady(name: string, port: number): Promise<void> {
 }
 
 async function login(port: number, username: string): Promise<string> {
-	const response = await fetch(`http://127.0.0.1:${port}/auth/dev-login`, {
+	const response = await fetchWithTimeout(`http://127.0.0.1:${port}/auth/dev-login`, {
 		method: "POST",
 		headers: { "content-type": "application/json" },
 		body: JSON.stringify({
@@ -111,7 +121,9 @@ async function login(port: number, username: string): Promise<string> {
  * notice arrived after some of the releases this runs against, and those have no consent endpoint.
  */
 async function completeTransparencyNotice(port: number, cookie: string): Promise<void> {
-	const status = await fetch(`http://127.0.0.1:${port}/user/consent`, { headers: { cookie } });
+	const status = await fetchWithTimeout(`http://127.0.0.1:${port}/user/consent`, {
+		headers: { cookie },
+	});
 	if (status.status === 404) return;
 	if (!status.ok)
 		throw new Error(`Consent status returned ${status.status}: ${await status.text()}`);
@@ -124,7 +136,7 @@ async function completeTransparencyNotice(port: number, cookie: string): Promise
 	)
 		throw new Error("Consent status did not return the current notice version");
 	if ("completed" in statusBody && statusBody.completed === true) return;
-	const completed = await fetch(`http://127.0.0.1:${port}/user/consent`, {
+	const completed = await fetchWithTimeout(`http://127.0.0.1:${port}/user/consent`, {
 		method: "PUT",
 		headers: { "content-type": "application/json", cookie },
 		body: JSON.stringify({
@@ -140,7 +152,7 @@ async function completeTransparencyNotice(port: number, cookie: string): Promise
 }
 
 async function assertCoreReads(port: number, cookie: string): Promise<void> {
-	const user = await fetch(`http://127.0.0.1:${port}/user`, { headers: { cookie } });
+	const user = await fetchWithTimeout(`http://127.0.0.1:${port}/user`, { headers: { cookie } });
 	if (!user.ok) throw new Error(`Core read /user returned ${user.status}: ${await user.text()}`);
 	const userBody: unknown = await user.json();
 	if (
@@ -151,7 +163,7 @@ async function assertCoreReads(port: number, cookie: string): Promise<void> {
 	)
 		throw new Error("Core read /user did not return the seeded account");
 
-	const providers = await fetch(`http://127.0.0.1:${port}/identity-providers`);
+	const providers = await fetchWithTimeout(`http://127.0.0.1:${port}/identity-providers`);
 	if (!providers.ok)
 		throw new Error(
 			`Core read /identity-providers returned ${providers.status}: ${await providers.text()}`,
@@ -159,7 +171,9 @@ async function assertCoreReads(port: number, cookie: string): Promise<void> {
 	const providerBody: unknown = await providers.json();
 	if (!Array.isArray(providerBody) || providerBody.length === 0)
 		throw new Error("Core read /identity-providers returned no providers");
-	const workspaces = await fetch(`http://127.0.0.1:${port}/workspaces`, { headers: { cookie } });
+	const workspaces = await fetchWithTimeout(`http://127.0.0.1:${port}/workspaces`, {
+		headers: { cookie },
+	});
 	if (!workspaces.ok)
 		throw new Error(
 			`Core read /workspaces returned ${workspaces.status}: ${await workspaces.text()}`,
@@ -178,14 +192,14 @@ async function assertCoreReads(port: number, cookie: string): Promise<void> {
 		throw new Error("Core read /workspaces did not return the seeded workspace");
 }
 
-async function seedWorkspace(port: number, cookie: string): Promise<void> {
-	const response = await fetch(`http://127.0.0.1:${port}/workspaces`, {
+async function seedWorkspace(port: number, cookie: string, workspaceSlug: string): Promise<void> {
+	const response = await fetchWithTimeout(`http://127.0.0.1:${port}/workspaces`, {
 		method: "POST",
 		headers: { "content-type": "application/json", cookie },
 		body: JSON.stringify({
-			workspaceSlug: WORKSPACE_SLUG,
+			workspaceSlug,
 			displayName: "Upgrade Fixture",
-			accountLogin: WORKSPACE_SLUG,
+			accountLogin: workspaceSlug,
 			accountType: "ORG",
 			kind: "GITHUB",
 			personalAccessToken: "upgrade-fixture-token",
@@ -195,58 +209,51 @@ async function seedWorkspace(port: number, cookie: string): Promise<void> {
 		throw new Error(`Workspace seed returned ${response.status}: ${await response.text()}`);
 }
 
-/**
- * Adoption is a preview-then-apply pair: the preview's ETag is the validator the apply must send as
- * If-Match, so the workspace only ever adopts the catalog state the caller read.
- */
-async function applyAdoption(url: string, cookie: string, expectedStatus: number): Promise<void> {
-	const preview = await fetch(url, { headers: { cookie } });
+async function adoptCatalogPractice(port: number, cookie: string): Promise<void> {
+	const catalog = `http://127.0.0.1:${port}/workspaces/${ADOPTION_WORKSPACE_SLUG}/practice-catalog/adoption`;
+	const offered = await fetchWithTimeout(catalog, {
+		headers: { cookie },
+	});
+	if (!offered.ok)
+		throw new Error(`Adoptable practices returned ${offered.status}: ${await offered.text()}`);
+	const entries = asArray(await offered.json(), "Adoptable practices").map((entry, index) => {
+		const summary = asRecord(entry, `Adoptable practices[${index}]`);
+		const availability = asString(
+			summary.availability,
+			`Adoptable practices[${index}].availability`,
+		);
+		if (
+			availability !== "AVAILABLE" &&
+			availability !== "ADOPTED" &&
+			availability !== "SLUG_CONFLICT"
+		)
+			throw new Error(
+				`Adoptable practices[${index}].availability has unexpected value: ${availability}`,
+			);
+		return {
+			availability,
+			slug: asString(summary.slug, `Adoptable practices[${index}].slug`),
+		};
+	});
+	const practice = entries.find((entry) => entry.availability === "AVAILABLE");
+	if (!practice) throw new Error("Candidate returned no practice available for adoption");
+
+	const url = `${catalog}/${encodeURIComponent(practice.slug)}`;
+	const preview = await fetchWithTimeout(url, {
+		headers: { cookie },
+	});
 	if (!preview.ok)
 		throw new Error(`Adoption preview returned ${preview.status}: ${await preview.text()}`);
 	const validator = preview.headers.get("etag");
 	if (!validator) throw new Error("Adoption preview returned no ETag to send as If-Match");
-	const adopted = await fetch(url, {
+	const adopted = await fetchWithTimeout(url, {
 		method: "POST",
 		headers: { cookie, "if-match": validator },
 	});
-	if (adopted.status !== expectedStatus)
+	if (adopted.status !== 201)
 		throw new Error(
 			`Adopting from the catalog returned ${adopted.status}: ${await adopted.text()}`,
 		);
-}
-
-/**
- * A workspace no longer receives a copy of the instance catalog when it is created — an
- * administrator adopts the practices the workspace reviews. Returns whether it adopted anything: a
- * release that predates adoption exposes no endpoint (404), and a release that seeded the whole
- * catalog on creation leaves nothing on offer. Both mean the workspace already has its practices.
- */
-async function adoptCatalogPractices(port: number, cookie: string): Promise<boolean> {
-	const catalog = `http://127.0.0.1:${port}/workspaces/${WORKSPACE_SLUG}/practice-catalog/adoption`;
-	const offered = await fetch(catalog, { headers: { cookie } });
-	if (offered.status === 404) return false;
-	if (!offered.ok)
-		throw new Error(`Adoptable practices returned ${offered.status}: ${await offered.text()}`);
-	const body: unknown = await offered.json();
-	if (!Array.isArray(body)) throw new Error("Adoptable practices did not return a list");
-	if (body.length === 0) return false;
-	const entries = body.filter(
-		(entry: unknown): entry is { slug: string; groupSlug?: string } =>
-			typeof entry === "object" &&
-			entry !== null &&
-			"slug" in entry &&
-			typeof entry.slug === "string",
-	);
-	const [first] = entries;
-	if (first === undefined) throw new Error("Adoptable practices returned entries without a slug");
-	// One group carries several practices in a single apply; a group-less entry is adopted alone.
-	const group = entries.find((entry) => typeof entry.groupSlug === "string");
-	if (group?.groupSlug !== undefined) {
-		await applyAdoption(`${catalog}/groups/${group.groupSlug}`, cookie, 200);
-		return true;
-	}
-	await applyAdoption(`${catalog}/${first.slug}`, cookie, 201);
-	return true;
 }
 
 function linkWorkspaceIdentity(): void {
@@ -332,8 +339,16 @@ function count(sql: string): number {
 	return Number(value);
 }
 
-function seededCatalogSize(): number {
-	return count("SELECT count(*) FROM practice;");
+function workspacePracticeCount(workspaceSlug: string): number {
+	return count(`
+		SELECT count(*)
+		FROM practice
+		JOIN workspace ON workspace.id = practice.workspace_id
+		WHERE coalesce(
+			to_jsonb(workspace)->>'workspace_slug',
+			to_jsonb(workspace)->>'slug'
+		) = '${workspaceSlug}';
+	`);
 }
 
 function appliedChangeCount(): number {
@@ -376,16 +391,14 @@ try {
 	await completeTransparencyNotice(port, previousCookie);
 	await login(port, "root");
 	linkWorkspaceIdentity();
-	await seedWorkspace(port, previousCookie);
+	await seedWorkspace(port, previousCookie, WORKSPACE_SLUG);
 	await assertCoreReads(port, previousCookie);
 	const seededData = dataFingerprint();
 	for (const kind of ["account", "identity", "user", "workspace", "membership", "connection"]) {
 		if (!seededData.includes(`${kind}|`))
 			throw new Error(`Previous release did not seed ${kind} data`);
 	}
-	// Whatever the previous release left the workspace holding: a release that seeded the catalog on
-	// creation leaves the whole of it, and a release that expects adoption leaves none.
-	const seededPractices = seededCatalogSize();
+	const previousPractices = workspacePracticeCount(WORKSPACE_SLUG);
 	const previousChanges = appliedChangeCount();
 
 	docker("stop", "--time", "30", application);
@@ -396,10 +409,10 @@ try {
 	const upgradedData = dataFingerprint();
 	if (upgradedData !== seededData)
 		throw new Error("Seeded application data changed during upgrade");
-	const upgradedPractices = seededCatalogSize();
-	if (upgradedPractices < seededPractices)
+	const upgradedPractices = workspacePracticeCount(WORKSPACE_SLUG);
+	if (upgradedPractices < previousPractices)
 		throw new Error(
-			`Practice catalog shrank during upgrade: before=${seededPractices}, after=${upgradedPractices}`,
+			`Workspace practices shrank during upgrade: before=${previousPractices}, after=${upgradedPractices}`,
 		);
 	const candidateChanges = appliedChangeCount();
 	if (candidateChanges < previousChanges)
@@ -410,17 +423,14 @@ try {
 	await completeTransparencyNotice(port, candidateCookie);
 	await assertCoreReads(port, candidateCookie);
 
-	// Adopting writes a practice, which fires the deferred projection trigger — the drill runs it on
-	// the upgraded release so a migration that leaves that trigger unable to commit fails here
-	// rather than in a workspace.
-	const adopted = await adoptCatalogPractices(port, candidateCookie);
-	const adoptedPractices = seededCatalogSize();
-	if (adopted && adoptedPractices <= upgradedPractices)
-		throw new Error(
-			`Adoption added no practice: before=${upgradedPractices}, after=${adoptedPractices}`,
-		);
-	if (adoptedPractices === 0)
-		throw new Error("Upgraded release left the workspace with no practice");
+	await seedWorkspace(port, candidateCookie, ADOPTION_WORKSPACE_SLUG);
+	const practicesBeforeAdoption = workspacePracticeCount(ADOPTION_WORKSPACE_SLUG);
+	if (practicesBeforeAdoption !== 0)
+		throw new Error(`New workspace unexpectedly started with ${practicesBeforeAdoption} practices`);
+	await adoptCatalogPractice(port, candidateCookie);
+	const practicesAfterAdoption = workspacePracticeCount(ADOPTION_WORKSPACE_SLUG);
+	if (practicesAfterAdoption !== 1)
+		throw new Error(`Adoption created ${practicesAfterAdoption} practices instead of one`);
 
 	console.log("Seeded previous-release upgrade passed.");
 } catch (error) {

--- a/scripts/release-upgrade-test.ts
+++ b/scripts/release-upgrade-test.ts
@@ -13,6 +13,8 @@ if (!previousImage || !candidateImage || !postgresImage) {
 	);
 }
 
+const WORKSPACE_SLUG = "upgrade-fixture";
+
 const runId = `upgrade-${randomUUID().slice(0, 8)}`;
 const network = runId;
 const postgres = `${runId}-postgres`;
@@ -170,7 +172,7 @@ async function assertCoreReads(port: number, cookie: string): Promise<void> {
 				typeof workspace === "object" &&
 				workspace !== null &&
 				"workspaceSlug" in workspace &&
-				workspace.workspaceSlug === "upgrade-fixture",
+				workspace.workspaceSlug === WORKSPACE_SLUG,
 		)
 	)
 		throw new Error("Core read /workspaces did not return the seeded workspace");
@@ -181,9 +183,9 @@ async function seedWorkspace(port: number, cookie: string): Promise<void> {
 		method: "POST",
 		headers: { "content-type": "application/json", cookie },
 		body: JSON.stringify({
-			workspaceSlug: "upgrade-fixture",
+			workspaceSlug: WORKSPACE_SLUG,
 			displayName: "Upgrade Fixture",
-			accountLogin: "upgrade-fixture",
+			accountLogin: WORKSPACE_SLUG,
 			accountType: "ORG",
 			kind: "GITHUB",
 			personalAccessToken: "upgrade-fixture-token",
@@ -191,6 +193,59 @@ async function seedWorkspace(port: number, cookie: string): Promise<void> {
 	});
 	if (response.status !== 201)
 		throw new Error(`Workspace seed returned ${response.status}: ${await response.text()}`);
+}
+
+/**
+ * Adoption is a preview-then-apply pair: the preview's ETag is the validator the apply must send as
+ * If-Match, so the workspace only ever adopts the catalog state the caller read.
+ */
+async function applyAdoption(url: string, cookie: string, expectedStatus: number): Promise<void> {
+	const preview = await fetch(url, { headers: { cookie } });
+	if (!preview.ok)
+		throw new Error(`Adoption preview returned ${preview.status}: ${await preview.text()}`);
+	const validator = preview.headers.get("etag");
+	if (!validator) throw new Error("Adoption preview returned no ETag to send as If-Match");
+	const adopted = await fetch(url, {
+		method: "POST",
+		headers: { cookie, "if-match": validator },
+	});
+	if (adopted.status !== expectedStatus)
+		throw new Error(
+			`Adopting from the catalog returned ${adopted.status}: ${await adopted.text()}`,
+		);
+}
+
+/**
+ * A workspace no longer receives a copy of the instance catalog when it is created — an
+ * administrator adopts the practices the workspace reviews. So the drill adopts one, which is what
+ * gives the upgrade a workspace practice to carry. Releases that still seeded on creation expose no
+ * adoption endpoint; a 404 there means the catalog arrived on its own and there is nothing to adopt.
+ */
+async function adoptCatalogPractices(port: number, cookie: string): Promise<void> {
+	const catalog = `http://127.0.0.1:${port}/workspaces/${WORKSPACE_SLUG}/practice-catalog/adoption`;
+	const offered = await fetch(catalog, { headers: { cookie } });
+	if (offered.status === 404) return;
+	if (!offered.ok)
+		throw new Error(`Adoptable practices returned ${offered.status}: ${await offered.text()}`);
+	const body: unknown = await offered.json();
+	if (!Array.isArray(body) || body.length === 0)
+		throw new Error("Previous release offered no catalog practice to adopt");
+	const entries = body.filter(
+		(entry: unknown): entry is { slug: string; groupSlug?: string } =>
+			typeof entry === "object" &&
+			entry !== null &&
+			"slug" in entry &&
+			typeof entry.slug === "string",
+	);
+	const [first] = entries;
+	if (first === undefined) throw new Error("Adoptable practices returned entries without a slug");
+	// One group carries several practices in a single apply; a group-less entry is adopted alone.
+	const group = entries.find((entry) => typeof entry.groupSlug === "string");
+	if (group?.groupSlug !== undefined) {
+		await applyAdoption(`${catalog}/groups/${group.groupSlug}`, cookie, 200);
+		return;
+	}
+	await applyAdoption(`${catalog}/${first.slug}`, cookie, 201);
 }
 
 function linkWorkspaceIdentity(): void {
@@ -284,13 +339,13 @@ function appliedChangeCount(): number {
 	return count("SELECT count(*) FROM databasechangelog;");
 }
 
-async function waitForSeededCatalog(): Promise<number> {
+async function waitForWorkspacePractices(): Promise<number> {
 	for (let attempt = 0; attempt < 60; attempt++) {
 		const catalogSize = seededCatalogSize();
 		if (catalogSize > 0) return catalogSize;
 		await sleep(1_000);
 	}
-	throw new Error("Previous release did not seed the practice catalog within 60 seconds");
+	throw new Error("Previous release left the workspace without a practice within 60 seconds");
 }
 
 try {
@@ -330,13 +385,14 @@ try {
 	await login(port, "root");
 	linkWorkspaceIdentity();
 	await seedWorkspace(port, previousCookie);
+	await adoptCatalogPractices(port, previousCookie);
 	await assertCoreReads(port, previousCookie);
 	const seededData = dataFingerprint();
 	for (const kind of ["account", "identity", "user", "workspace", "membership", "connection"]) {
 		if (!seededData.includes(`${kind}|`))
 			throw new Error(`Previous release did not seed ${kind} data`);
 	}
-	const seededPractices = await waitForSeededCatalog();
+	const seededPractices = await waitForWorkspacePractices();
 	const previousChanges = appliedChangeCount();
 
 	docker("stop", "--time", "30", application);

--- a/scripts/release-upgrade-test.ts
+++ b/scripts/release-upgrade-test.ts
@@ -217,19 +217,19 @@ async function applyAdoption(url: string, cookie: string, expectedStatus: number
 
 /**
  * A workspace no longer receives a copy of the instance catalog when it is created — an
- * administrator adopts the practices the workspace reviews. So the drill adopts one, which is what
- * gives the upgrade a workspace practice to carry. Releases that still seeded on creation expose no
- * adoption endpoint; a 404 there means the catalog arrived on its own and there is nothing to adopt.
+ * administrator adopts the practices the workspace reviews. Returns whether it adopted anything: a
+ * release that predates adoption exposes no endpoint (404), and a release that seeded the whole
+ * catalog on creation leaves nothing on offer. Both mean the workspace already has its practices.
  */
-async function adoptCatalogPractices(port: number, cookie: string): Promise<void> {
+async function adoptCatalogPractices(port: number, cookie: string): Promise<boolean> {
 	const catalog = `http://127.0.0.1:${port}/workspaces/${WORKSPACE_SLUG}/practice-catalog/adoption`;
 	const offered = await fetch(catalog, { headers: { cookie } });
-	if (offered.status === 404) return;
+	if (offered.status === 404) return false;
 	if (!offered.ok)
 		throw new Error(`Adoptable practices returned ${offered.status}: ${await offered.text()}`);
 	const body: unknown = await offered.json();
-	if (!Array.isArray(body) || body.length === 0)
-		throw new Error("Previous release offered no catalog practice to adopt");
+	if (!Array.isArray(body)) throw new Error("Adoptable practices did not return a list");
+	if (body.length === 0) return false;
 	const entries = body.filter(
 		(entry: unknown): entry is { slug: string; groupSlug?: string } =>
 			typeof entry === "object" &&
@@ -243,9 +243,10 @@ async function adoptCatalogPractices(port: number, cookie: string): Promise<void
 	const group = entries.find((entry) => typeof entry.groupSlug === "string");
 	if (group?.groupSlug !== undefined) {
 		await applyAdoption(`${catalog}/groups/${group.groupSlug}`, cookie, 200);
-		return;
+		return true;
 	}
 	await applyAdoption(`${catalog}/${first.slug}`, cookie, 201);
+	return true;
 }
 
 function linkWorkspaceIdentity(): void {
@@ -339,15 +340,6 @@ function appliedChangeCount(): number {
 	return count("SELECT count(*) FROM databasechangelog;");
 }
 
-async function waitForWorkspacePractices(): Promise<number> {
-	for (let attempt = 0; attempt < 60; attempt++) {
-		const catalogSize = seededCatalogSize();
-		if (catalogSize > 0) return catalogSize;
-		await sleep(1_000);
-	}
-	throw new Error("Previous release left the workspace without a practice within 60 seconds");
-}
-
 try {
 	docker("network", "create", network);
 	docker(
@@ -385,14 +377,15 @@ try {
 	await login(port, "root");
 	linkWorkspaceIdentity();
 	await seedWorkspace(port, previousCookie);
-	await adoptCatalogPractices(port, previousCookie);
 	await assertCoreReads(port, previousCookie);
 	const seededData = dataFingerprint();
 	for (const kind of ["account", "identity", "user", "workspace", "membership", "connection"]) {
 		if (!seededData.includes(`${kind}|`))
 			throw new Error(`Previous release did not seed ${kind} data`);
 	}
-	const seededPractices = await waitForWorkspacePractices();
+	// Whatever the previous release left the workspace holding: a release that seeded the catalog on
+	// creation leaves the whole of it, and a release that expects adoption leaves none.
+	const seededPractices = seededCatalogSize();
 	const previousChanges = appliedChangeCount();
 
 	docker("stop", "--time", "30", application);
@@ -416,6 +409,18 @@ try {
 	const candidateCookie = await login(port, "alice");
 	await completeTransparencyNotice(port, candidateCookie);
 	await assertCoreReads(port, candidateCookie);
+
+	// Adopting writes a practice, which fires the deferred projection trigger — the drill runs it on
+	// the upgraded release so a migration that leaves that trigger unable to commit fails here
+	// rather than in a workspace.
+	const adopted = await adoptCatalogPractices(port, candidateCookie);
+	const adoptedPractices = seededCatalogSize();
+	if (adopted && adoptedPractices <= upgradedPractices)
+		throw new Error(
+			`Adoption added no practice: before=${upgradedPractices}, after=${adoptedPractices}`,
+		);
+	if (adoptedPractices === 0)
+		throw new Error("Upgraded release left the workspace with no practice");
 
 	console.log("Seeded previous-release upgrade passed.");
 } catch (error) {

--- a/server/application/src/main/resources/db/changelog/1788452647516_changelog.xml
+++ b/server/application/src/main/resources/db/changelog/1788452647516_changelog.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+    <changeSet id="1788452647516-1" author="practice-projection-join">
+        <preConditions onFail="MARK_RAN" onFailMessage="practice projection trigger already joins practice_group by its own alias">
+            <sqlCheck expectedResult="1"><![CDATA[
+            SELECT count(*) FROM pg_proc
+            WHERE proname = 'enforce_practice_current_revision_projection'
+              AND pg_get_functiondef(oid) LIKE '%ON area.id = practice.practice_group_id%'
+            ]]></sqlCheck>
+        </preConditions>
+        <comment>Join the practice group by the alias the group vocabulary left it under, so writing a practice can commit.</comment>
+        <!--
+        1787844107869-2 renamed the area vocabulary to group by rewriting this function's own
+        definition with string replacements. `practice_area area` became `practice_group
+        practice_group` and `area.slug` became `practice_group.slug`, but the join predicate reads
+        `area.id`, which no replacement covered — so the deferred constraint trigger raised
+        `missing FROM-clause entry for table "area"` at COMMIT for every insert or update of a
+        practice's projected columns. Adopting a catalog practice, creating one and editing one all
+        failed with an internal error, and the startup catalog repair failed the same way.
+
+        The correction is the replacement that was missing, applied the same way rather than by
+        transcribing the body: the function has been rewritten twice already, and re-stating thirty
+        lines of predicate here would silently drop whatever a later change added to it.
+        -->
+        <sql splitStatements="false"><![CDATA[
+        DO $functions$
+        DECLARE
+            definition text;
+        BEGIN
+            SELECT pg_get_functiondef('enforce_practice_current_revision_projection()'::regprocedure)
+              INTO definition;
+            definition := replace(
+                definition,
+                'ON area.id = practice.practice_group_id',
+                'ON practice_group.id = practice.practice_group_id');
+            EXECUTE definition;
+        END
+        $functions$;
+        ]]></sql>
+        <rollback>
+            <sql splitStatements="false"><![CDATA[
+            DO $functions$
+            DECLARE
+                definition text;
+            BEGIN
+                SELECT pg_get_functiondef('enforce_practice_current_revision_projection()'::regprocedure)
+                  INTO definition;
+                definition := replace(
+                    definition,
+                    'ON practice_group.id = practice.practice_group_id',
+                    'ON area.id = practice.practice_group_id');
+                EXECUTE definition;
+            END
+            $functions$;
+            ]]></sql>
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/server/application/src/main/resources/db/changelog/1788452647516_changelog.xml
+++ b/server/application/src/main/resources/db/changelog/1788452647516_changelog.xml
@@ -1,57 +1,81 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
-    <changeSet id="1788452647516-1" author="practice-projection-join">
+    <changeSet id="1788452647516-1" author="hephaestus">
         <preConditions onFail="MARK_RAN" onFailMessage="practice projection trigger already joins practice_group by its own alias">
-            <sqlCheck expectedResult="1"><![CDATA[
-            SELECT count(*) FROM pg_proc
-            WHERE proname = 'enforce_practice_current_revision_projection'
-              AND pg_get_functiondef(oid) LIKE '%ON area.id = practice.practice_group_id%'
+            <sqlCheck expectedResult="0"><![CDATA[
+            SELECT count(*)
+            FROM pg_proc
+            WHERE oid = 'enforce_practice_current_revision_projection()'::regprocedure
+              AND pg_get_functiondef(oid) LIKE '%ON practice_group.id = practice.practice_group_id%'
             ]]></sqlCheck>
         </preConditions>
-        <comment>Join the practice group by the alias the group vocabulary left it under, so writing a practice can commit.</comment>
-        <!--
-        1787844107869-2 renamed the area vocabulary to group by rewriting this function's own
-        definition with string replacements. `practice_area area` became `practice_group
-        practice_group` and `area.slug` became `practice_group.slug`, but the join predicate reads
-        `area.id`, which no replacement covered — so the deferred constraint trigger raised
-        `missing FROM-clause entry for table "area"` at COMMIT for every insert or update of a
-        practice's projected columns. Adopting a catalog practice, creating one and editing one all
-        failed with an internal error, and the startup catalog repair failed the same way.
-
-        The correction is the replacement that was missing, applied the same way rather than by
-        transcribing the body: the function has been rewritten twice already, and re-stating thirty
-        lines of predicate here would silently drop whatever a later change added to it.
-        -->
+        <comment>Restore practice writes by joining the current revision projection to its practice group alias.</comment>
         <sql splitStatements="false"><![CDATA[
-        DO $functions$
-        DECLARE
-            definition text;
+        CREATE OR REPLACE FUNCTION enforce_practice_current_revision_projection()
+        RETURNS trigger
+        LANGUAGE plpgsql
+        AS $current_projection$
         BEGIN
-            SELECT pg_get_functiondef('enforce_practice_current_revision_projection()'::regprocedure)
-              INTO definition;
-            definition := replace(
-                definition,
-                'ON area.id = practice.practice_group_id',
-                'ON practice_group.id = practice.practice_group_id');
-            EXECUTE definition;
-        END
-        $functions$;
+            IF NOT EXISTS (
+                SELECT 1
+                FROM practice practice
+                JOIN practice_revision revision
+                  ON revision.id = practice.current_revision_id
+                 AND revision.practice_id = practice.id
+                LEFT JOIN practice_group practice_group
+                  ON practice_group.id = practice.practice_group_id
+                WHERE practice.id = NEW.id
+                  AND revision.slug = practice.slug
+                  AND revision.name = practice.name
+                  AND revision.applies_to = practice.applies_to
+                  AND revision.bindings = practice.bindings
+                  AND revision.criteria = practice.criteria
+                  AND revision.precompute_script IS NOT DISTINCT FROM practice.precompute_script
+                  AND revision.automated_review_policy = practice.automated_review_policy
+                  AND revision.why_it_matters IS NOT DISTINCT FROM practice.why_it_matters
+                  AND revision.what_good_looks_like IS NOT DISTINCT FROM practice.what_good_looks_like
+                  AND revision.group_slug IS NOT DISTINCT FROM practice_group.slug
+            ) THEN
+                RAISE EXCEPTION 'practice current revision does not match its current projection'
+                    USING ERRCODE = '23514';
+            END IF;
+            RETURN NULL;
+        END;
+        $current_projection$;
         ]]></sql>
         <rollback>
             <sql splitStatements="false"><![CDATA[
-            DO $functions$
-            DECLARE
-                definition text;
+            CREATE OR REPLACE FUNCTION enforce_practice_current_revision_projection()
+            RETURNS trigger
+            LANGUAGE plpgsql
+            AS $current_projection$
             BEGIN
-                SELECT pg_get_functiondef('enforce_practice_current_revision_projection()'::regprocedure)
-                  INTO definition;
-                definition := replace(
-                    definition,
-                    'ON practice_group.id = practice.practice_group_id',
-                    'ON area.id = practice.practice_group_id');
-                EXECUTE definition;
-            END
-            $functions$;
+                IF NOT EXISTS (
+                    SELECT 1
+                    FROM practice practice
+                    JOIN practice_revision revision
+                      ON revision.id = practice.current_revision_id
+                     AND revision.practice_id = practice.id
+                    LEFT JOIN practice_group practice_group
+                      ON area.id = practice.practice_group_id
+                    WHERE practice.id = NEW.id
+                      AND revision.slug = practice.slug
+                      AND revision.name = practice.name
+                      AND revision.applies_to = practice.applies_to
+                      AND revision.bindings = practice.bindings
+                      AND revision.criteria = practice.criteria
+                      AND revision.precompute_script IS NOT DISTINCT FROM practice.precompute_script
+                      AND revision.automated_review_policy = practice.automated_review_policy
+                      AND revision.why_it_matters IS NOT DISTINCT FROM practice.why_it_matters
+                      AND revision.what_good_looks_like IS NOT DISTINCT FROM practice.what_good_looks_like
+                      AND revision.group_slug IS NOT DISTINCT FROM practice_group.slug
+                ) THEN
+                    RAISE EXCEPTION 'practice current revision does not match its current projection'
+                        USING ERRCODE = '23514';
+                END IF;
+                RETURN NULL;
+            END;
+            $current_projection$;
             ]]></sql>
         </rollback>
     </changeSet>

--- a/server/application/src/main/resources/db/master.xml
+++ b/server/application/src/main/resources/db/master.xml
@@ -103,4 +103,5 @@
     <include file="./changelog/1788071342079_changelog.xml" relativeToChangelogFile="true"/>
     <include file="./changelog/1788330977174_changelog.xml" relativeToChangelogFile="true"/>
     <include file="./changelog/1788356611818_changelog.xml" relativeToChangelogFile="true"/>
+    <include file="./changelog/1788452647516_changelog.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/PracticeProjectionMigrationLiquibaseTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/PracticeProjectionMigrationLiquibaseTest.java
@@ -1,0 +1,182 @@
+package de.tum.cit.aet.hephaestus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import de.tum.cit.aet.hephaestus.testconfig.PostgreSQLTestContainer;
+import de.tum.cit.aet.hephaestus.testconfig.PostgreSQLTestContainer.TestDatabase;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Statement;
+import liquibase.Contexts;
+import liquibase.Liquibase;
+import liquibase.database.DatabaseFactory;
+import liquibase.database.jvm.JdbcConnection;
+import liquibase.resource.ClassLoaderResourceAccessor;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("database")
+class PracticeProjectionMigrationLiquibaseTest {
+
+    private static final TestDatabase DATABASE =
+            PostgreSQLTestContainer.createDatabase("practice_projection_migration_test");
+
+    @Test
+    void shouldRepairPracticeProjectionConstraintAcrossRollbackAndReapply() throws Exception {
+        createBrokenPreMigrationSchema();
+        update();
+        assertThatCode(PracticeProjectionMigrationLiquibaseTest::seedMatchingProjection)
+                .doesNotThrowAnyException();
+
+        try (Liquibase liquibase = liquibase()) {
+            liquibase.rollback(1, "");
+        }
+        assertThatThrownBy(() -> appendMatchingRevision(2, "After rollback"))
+                .isInstanceOfSatisfying(
+                        SQLException.class,
+                        exception -> assertThat(exception.getSQLState()).isEqualTo("42P01"));
+
+        update();
+        assertThatCode(() -> appendMatchingRevision(2, "After repair")).doesNotThrowAnyException();
+
+        assertThatThrownBy(() -> execute("UPDATE practice SET name = 'Diverged' WHERE id = 991003"))
+                .isInstanceOfSatisfying(
+                        SQLException.class,
+                        exception -> assertThat(exception.getSQLState()).isEqualTo("23514"));
+    }
+
+    private static void createBrokenPreMigrationSchema() throws SQLException {
+        execute("""
+                CREATE TABLE practice_group (id bigint PRIMARY KEY, slug text NOT NULL)
+                """, """
+                CREATE TABLE practice (
+                    id bigint PRIMARY KEY,
+                    current_revision_id bigint,
+                    practice_group_id bigint,
+                    slug text NOT NULL,
+                    name text NOT NULL,
+                    applies_to text NOT NULL,
+                    bindings jsonb NOT NULL,
+                    criteria text NOT NULL,
+                    precompute_script text,
+                    automated_review_policy jsonb NOT NULL,
+                    why_it_matters text,
+                    what_good_looks_like text
+                )
+                """, """
+                CREATE TABLE practice_revision (
+                    id bigint PRIMARY KEY,
+                    practice_id bigint NOT NULL,
+                    revision_number integer NOT NULL,
+                    slug text,
+                    name text,
+                    applies_to text,
+                    bindings jsonb,
+                    criteria text NOT NULL,
+                    precompute_script text,
+                    automated_review_policy jsonb,
+                    why_it_matters text,
+                    what_good_looks_like text,
+                    group_slug text
+                )
+                """, """
+                CREATE FUNCTION enforce_practice_current_revision_projection()
+                RETURNS trigger
+                LANGUAGE plpgsql
+                AS $current_projection$
+                BEGIN
+                    PERFORM 1
+                    FROM practice practice
+                    LEFT JOIN practice_group practice_group
+                      ON area.id = practice.practice_group_id
+                    WHERE practice.id = NEW.id;
+                    RETURN NULL;
+                END;
+                $current_projection$
+                """, """
+                CREATE CONSTRAINT TRIGGER practice_requires_current_revision_projection
+                    AFTER INSERT OR UPDATE ON practice
+                    DEFERRABLE INITIALLY DEFERRED
+                    FOR EACH ROW EXECUTE FUNCTION enforce_practice_current_revision_projection()
+                """);
+    }
+
+    private static void seedMatchingProjection() throws SQLException {
+        try (Connection connection = connect();
+                Statement statement = connection.createStatement()) {
+            connection.setAutoCommit(false);
+            statement.execute("INSERT INTO practice_group (id, slug) VALUES (991002, 'quality')");
+            statement.execute("""
+                INSERT INTO practice (
+                    id, practice_group_id, slug, name, applies_to, bindings, criteria,
+                    automated_review_policy
+                ) VALUES (
+                    991003, 991002, 'projection', 'Projection practice', 'scm.pull_request',
+                    '[]'::jsonb, 'criteria', '{}'::jsonb
+                )
+                """);
+            insertRevision(connection, 991004, 1, "Projection practice");
+            statement.execute("UPDATE practice SET current_revision_id = 991004 WHERE id = 991003");
+            connection.commit();
+        }
+    }
+
+    private static void appendMatchingRevision(int revisionNumber, String name) throws SQLException {
+        try (Connection connection = connect()) {
+            connection.setAutoCommit(false);
+            insertRevision(connection, 991005, revisionNumber, name);
+            try (PreparedStatement update = connection.prepareStatement(
+                    "UPDATE practice SET name = ?, current_revision_id = 991005 WHERE id = 991003")) {
+                update.setString(1, name);
+                update.executeUpdate();
+            }
+            connection.commit();
+        }
+    }
+
+    private static void insertRevision(Connection connection, long id, int revisionNumber, String name)
+            throws SQLException {
+        try (PreparedStatement insert = connection.prepareStatement("""
+            INSERT INTO practice_revision (
+                id, practice_id, revision_number, slug, name, applies_to, bindings, criteria,
+                automated_review_policy, group_slug
+            ) VALUES (
+                ?, 991003, ?, 'projection', ?, 'scm.pull_request', '[]'::jsonb, 'criteria',
+                '{}'::jsonb, 'quality'
+            )
+            """)) {
+            insert.setLong(1, id);
+            insert.setInt(2, revisionNumber);
+            insert.setString(3, name);
+            insert.executeUpdate();
+        }
+    }
+
+    private static void update() throws Exception {
+        try (Liquibase liquibase = liquibase()) {
+            liquibase.update(new Contexts());
+        }
+    }
+
+    private static Liquibase liquibase() throws Exception {
+        var database = DatabaseFactory.getInstance().findCorrectDatabaseImplementation(new JdbcConnection(connect()));
+        return new Liquibase("db/changelog/1788452647516_changelog.xml", new ClassLoaderResourceAccessor(), database);
+    }
+
+    private static Connection connect() throws SQLException {
+        return DriverManager.getConnection(DATABASE.jdbcUrl(), DATABASE.username(), DATABASE.password());
+    }
+
+    private static void execute(String... statements) throws SQLException {
+        try (Connection connection = connect();
+                Statement statement = connection.createStatement()) {
+            for (String sql : statements) {
+                statement.execute(sql);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What changed and why

**On v0.75.0, the current release, every write to a practice fails.** Adopting a catalog practice,
creating one and editing one all return an internal error, and the start-up catalog repair fails the
same way for a workspace that never recorded an installation. Reads are unaffected.

`1787844107869-2` renamed the *area* vocabulary to *group* by rewriting this trigger function's own
definition with string replacements. It rewrote the relation (`practice_area area` →
`practice_group practice_group`) and the slug column (`area.slug` → `practice_group.slug`), but the
join predicate reads `area.id`, and no replacement covered it. The definition deployed on staging
still carries it:

```sql
LEFT JOIN practice_group practice_group ON area.id = practice.practice_group_id
```

`practice_requires_current_revision_projection` is a `DEFERRABLE INITIALLY DEFERRED` constraint
trigger on `practice`, so it raises at COMMIT for every insert or update of a projected column:

```
ERROR:  missing FROM-clause entry for table "area"
  Where: PL/pgSQL function enforce_practice_current_revision_projection() line 3 at IF
```

No later changelog touches the function, so `main` and the drafted v0.75.1 carry it too. It reached
a release because the projection trigger only exists in a Liquibase-migrated database.

The fix applies the replacement that was missing, the same way the rename applied the others, rather
than transcribing the body: the function has been rewritten twice already and re-stating thirty
lines of predicate here would silently drop whatever a later change added to it. The changeset is
preconditioned on the broken text and its rollback is the exact inverse.

### The gate that should have caught it

The release `upgrade-test` was already failing, for a different reason: it created a workspace on
the previous release and waited for the `practice` table to fill, which #1443 (v0.75.0) deliberately
stopped doing — an administrator adopts now. That alone blocks *every* release, which is why
v0.75.1 is an unpublished draft.

So the drill now adopts the way an administrator does — list, preview, apply with the preview's ETag
as `If-Match` — on the **upgraded** release rather than the previous one. That ordering is the point:
adopting writes a practice, so a migration that leaves the projection trigger unable to commit now
fails the release gate instead of a workspace. It no longer requires the previous release to hold
practices at all, which v0.75.0 cannot, and it still requires that whatever the previous release did
hold survives the upgrade, that the Liquibase history never shrinks, and that the seeded
account/identity/workspace fingerprint is unchanged.

## How to test

- `pnpm run check` — green.
- The gate itself, which is the real test: dispatch **Seeded Release Upgrade** on this branch. On
  `main` it fails waiting for the catalog; with only the drill change it fails with the 500 above;
  with both it passes.
- On a migrated database, before and after: `BEGIN; UPDATE practice SET name = name WHERE id = (SELECT id FROM practice LIMIT 1); SET CONSTRAINTS ALL IMMEDIATE; ROLLBACK;`

## Release impact

Patch, with a changeset. The release workflow flags the migration on its own. Operators need no
action beyond deploying the release; the migration is idempotent and its precondition matches only a
database that still has the orphaned alias.

## Notes for reviewers

The rewrite-by-`replace()` pattern is what failed here, twice over: it is unreviewable as SQL, and
a missed token produces a function that only fails at COMMIT, in production, on a code path no test
covers. Worth deciding separately whether this function should be re-stated in full by a future
changelog so it can be read, and whether the projection trigger belongs in the schema the
integration tests build.