### PR TITLE
fix(ci): let an environment keep its own edge proxy

### DIFF
--- a/.github/workflows/deploy-locked-compose.yml
+++ b/.github/workflows/deploy-locked-compose.yml
@@ -30,6 +30,15 @@ jobs:
     environment: ${{ inputs.environment }}
     permissions:
       contents: read
+    env:
+      # Which stacks this environment runs, and the order they come up in: the edge first, then the
+      # broker the receiver waits on, then the application. An environment whose edge is owned by
+      # something else on the host sets DEPLOY_EDGE_PROXY=false and keeps proxy out of both the
+      # render and the deploy — the reference deployment leaves it unset and gets all three.
+      # Staging shares its host with the Coolify instance that serves pull-request previews, and
+      # that proxy holds :80/:443, so a second edge there fails the deploy on a port that is
+      # already allocated.
+      STACKS: ${{ vars.DEPLOY_EDGE_PROXY == 'false' && 'core app' || 'proxy core app' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -140,9 +149,14 @@ jobs:
             cp "$compose" "deployment/$name/compose.yaml"
           }
 
-          render proxy docker/compose.proxy.yaml
-          render core docker/compose.core.yaml
-          render app docker/compose.app.yaml
+          for stack in $STACKS; do
+            case "$stack" in
+              proxy) render proxy docker/compose.proxy.yaml ;;
+              core) render core docker/compose.core.yaml ;;
+              app) render app docker/compose.app.yaml ;;
+              *) echo "::error::Unknown stack '$stack' in STACKS"; exit 1 ;;
+            esac
+          done
 
       - name: Copy verified deployment inputs
         uses: appleboy/scp-action@ff85246acaad7bdce478db94a363cd2bf7c90345 # v1.0.0
@@ -169,9 +183,12 @@ jobs:
           proxy_key: ${{ secrets.DEPLOYMENT_GATEWAY_SSH_KEY }}
           proxy_port: ${{ vars.DEPLOYMENT_GATEWAY_PORT }}
           command_timeout: 30m
+          # The remote shell only sees what is named here, and it must be the same list the render
+          # step wrote, or the loop would cd into a stack directory this deploy never refreshed.
+          envs: STACKS
           script: |
             set -euo pipefail
-            for stack in proxy core app; do
+            for stack in $STACKS; do
               cd "/opt/hephaestus/$stack"
               chmod 600 deployment.env
               docker compose --env-file deployment.env -f compose.yaml config >/dev/null

--- a/docs/contributor/ci-cd.mdx
+++ b/docs/contributor/ci-cd.mdx
@@ -134,6 +134,13 @@ SBOM, and release-verification guarantees.
 2. Create `Staging` (no rules)
 3. Create `Production` with **Required reviewers**
 
+A deploy brings up three stacks in order — `proxy`, `core`, `app` — and the `proxy` stack publishes
+:80 and :443. An environment whose host already has an edge in front of it sets the environment
+variable `DEPLOY_EDGE_PROXY=false`, which leaves `proxy` out of both the render and the deploy;
+anything else, including an unset variable, deploys all three. Staging sets it, because it shares a
+host with the Coolify instance that serves preview deployments and that proxy holds both ports —
+a second edge there fails the deploy on a port that is already allocated.
+
 Preview environments do not need to be created in advance. The preview workflow registers
 `preview/pr-N` as a transient GitHub environment when Coolify accepts the first deployment.
 


### PR DESCRIPTION
## What changed and why

`deploy-locked-compose.yml` brings up `proxy`, `core` and `app` unconditionally, and the `proxy`
stack publishes :80 and :443. On the staging host those ports belong to the Coolify instance that
serves pull-request previews: its Traefik is attached to `shared-network` and routes staging through
the traefik labels the app containers already carry, and the release's own `proxy-reverse-proxy-1`
was stopped two weeks ago. So a staging deploy would fail on a port that is already allocated —
which, together with #1762, is why staging is still a hand-tended stack running images from before
the organization transfer rather than a release.

The stack list is now one job-level value derived from a `DEPLOY_EDGE_PROXY` environment variable:

- unset, or anything other than `false` → `proxy core app`, what the reference deployment and
  production need, unchanged;
- `false` → `core app`, leaving the edge to whatever already owns it on that host.

It gates the render and the remote loop from the same value, and the list is *forwarded* to the
remote shell rather than written out twice, so the deploy can never `cd` into a stack directory that
this deploy's render step did not refresh.

`DEPLOY_EDGE_PROXY=false` is set on the `Staging` environment. Production has no such variable and
keeps deploying all three stacks.

## How to test

- `pnpm run check` — green.
- Compose rendering is unchanged and still covered by `ci-compose-validate.yml`.
- End to end: the next release's `deploy-staging` should render and deploy `core` and `app` only,
  and `docker ps` on the staging host should show `coolify-proxy` still holding :80/:443.

## Release impact

No changeset: `.github/` is outside the shipped paths `verify-changesets` guards. No operator
action for self-hosters — an unset variable behaves exactly as today.

## Notes for reviewers

The deeper question this defers: staging is meant to rehearse the reference topology, and with the
edge excluded it no longer rehearses the proxy stack at all. The alternative is moving previews to
their own host so staging can own :80/:443 again. Worth a decision, but not a prerequisite for
getting staging back onto releases.