### PR TITLE
feat(ci): let a host pull the release it should run

### DIFF
--- a/.changeset/hosts-can-update-themselves.md
+++ b/.changeset/hosts-can-update-themselves.md
@@ -1,0 +1,7 @@
+---
+"hephaestus": minor
+---
+
+Hosts can now keep themselves on a release instead of being deployed to. A host polls a channel naming the release it should run, verifies the release signature and the channel's own signature itself, and applies the digest-pinned stacks — so no deployment credential, and no way in to the machine, has to exist anywhere else. A failed upgrade stops and alerts rather than rolling back, because schema changes only ever move forward.
+
+**Operators:** this is opt-in and nothing changes until you install the units in `docker/self-host/systemd/`. Set up the staleness alert described in the guide before relying on it: a host that stops updating is quiet, and that alert is what makes it loud.

--- a/.changeset/hosts-can-update-themselves.md
+++ b/.changeset/hosts-can-update-themselves.md
@@ -4,4 +4,4 @@
 
 Hosts can now keep themselves on a release instead of being deployed to. A host polls a channel naming the release it should run, verifies the release signature and the channel's own signature itself, and applies the digest-pinned stacks — so no deployment credential, and no way in to the machine, has to exist anywhere else. A failed upgrade stops and alerts rather than rolling back, because schema changes only ever move forward.
 
-**Operators:** this is opt-in and nothing changes until you install the units in `docker/self-host/systemd/`. Set up the staleness alert described in the guide before relying on it: a host that stops updating is quiet, and that alert is what makes it loud.
+Nothing changes until you install the units in `docker/self-host/systemd/`. If you do, set up the staleness alert the guide describes before relying on it: a host that stops updating is quiet, and that alert is what makes it loud.

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -2,7 +2,9 @@
 #
 # The hosts pin this workflow's identity, and a GitHub environment gates it, so a signature carrying
 # that identity is proof its reviewers approved. That holds only while this workflow stays
-# non-reusable: a `workflow_call` trigger would let any caller mint the same identity.
+# non-reusable: a `workflow_call` trigger would let any caller mint the same identity. The release
+# reaches staging by dispatching this workflow, not by triggering on its completion, so no run here
+# inherits a context it did not ask for.
 name: Promote
 
 on:
@@ -25,23 +27,17 @@ on:
         description: Hold the environment where it is and ignore this release
         type: boolean
         default: false
-  # A published release moves staging on its own; production is only ever moved by hand above.
-  workflow_run:
-    workflows: [Release]
-    types: [completed]
-
 permissions: {}
 
 concurrency:
-  group: promote-${{ inputs.environment || 'Staging' }}
+  group: promote-${{ inputs.environment }}
   cancel-in-progress: false
 
 jobs:
   promote:
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    environment: ${{ inputs.environment || 'Staging' }}
+    environment: ${{ inputs.environment }}
     permissions:
       contents: write
       id-token: write
@@ -60,8 +56,7 @@ jobs:
           REQUESTED: ${{ inputs.release }}
         run: |
           set -euo pipefail
-          # A dispatch names the release; the automatic staging promotion takes the newest one.
-          release="${REQUESTED:-$(gh release view --repo "$GITHUB_REPOSITORY" --json tagName --jq .tagName)}"
+          release="$REQUESTED"
           [[ "$release" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
             echo "::error::Promote an immutable vX.Y.Z release, not '$release'"; exit 1; }
           # A draft is a half-published release; refusing it here keeps it off a host.
@@ -72,7 +67,7 @@ jobs:
 
       - name: Write and sign the channel
         env:
-          CHANNEL: ${{ inputs.environment && format('{0}', inputs.environment) || 'Staging' }}
+          CHANNEL: ${{ inputs.environment }}
           RELEASE: ${{ steps.release.outputs.release }}
           ALLOW_ROLLBACK: ${{ inputs.allow-rollback || false }}
           FREEZE: ${{ inputs.freeze || false }}

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -1,10 +1,8 @@
 # Moves an environment to a release by writing its channel on `deploy-state`, which the hosts poll.
 #
-# This file is the production control. Cosign cannot check the certificate's environment claim, so
-# the hosts pin the *identity of this workflow* instead — and because a GitHub environment gates the
-# job below, a signature carrying this identity is proof the environment's reviewers approved. That
-# only holds while this workflow stays non-reusable: a `workflow_call` trigger would let any caller
-# mint the same identity, so it must never gain one.
+# The hosts pin this workflow's identity, and a GitHub environment gates it, so a signature carrying
+# that identity is proof its reviewers approved. That holds only while this workflow stays
+# non-reusable: a `workflow_call` trigger would let any caller mint the same identity.
 name: Promote
 
 on:
@@ -62,12 +60,11 @@ jobs:
           REQUESTED: ${{ inputs.release }}
         run: |
           set -euo pipefail
-          # A dispatch names the release; the automatic staging promotion takes whatever the release
-          # that just finished published, which is the newest non-draft release.
+          # A dispatch names the release; the automatic staging promotion takes the newest one.
           release="${REQUESTED:-$(gh release view --repo "$GITHUB_REPOSITORY" --json tagName --jq .tagName)}"
           [[ "$release" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
             echo "::error::Promote an immutable vX.Y.Z release, not '$release'"; exit 1; }
-          # Refusing a draft here is what keeps a half-finished release from reaching a host.
+          # A draft is a half-published release; refusing it here keeps it off a host.
           [ "$(gh release view "$release" --repo "$GITHUB_REPOSITORY" --json isDraft --jq .isDraft)" = false ] || {
             echo "::error::$release is still a draft"; exit 1; }
           echo "release=$release" >> "$GITHUB_OUTPUT"
@@ -101,8 +98,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add channels
-          # A promotion that changes nothing must not create an empty commit: the hosts read the
-          # commit graph to tell forwards from backwards, and a no-op commit would read as forwards.
+          # An empty commit would read as a move forward to hosts that compare ancestry.
           git diff --cached --quiet && { echo "Channel already at $RELEASE"; exit 0; }
           git commit -m "chore(deploy): ${CHANNEL_FILE} -> ${RELEASE}"
           git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}" HEAD:deploy-state
@@ -114,9 +110,8 @@ jobs:
           HOSTNAME: ${{ vars.APP_HOSTNAME }}
         run: |
           set -euo pipefail
-          # The hosts pull, so nothing here can push them; the deploy is only observed. The webapp
-          # publishes the version it is running in its runtime config, which is what makes this
-          # observable at all without granting the runner any access to the host.
+          # Nothing here can push the hosts, so the deploy is observed: the webapp publishes the
+          # version it runs, which makes convergence visible without any access to the host.
           deadline=$(( SECONDS + 900 ))
           while [ "$SECONDS" -lt "$deadline" ]; do
             config=$(curl -fsS --max-time 20 "https://${HOSTNAME}/" |

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -1,0 +1,132 @@
+# Moves an environment to a release by writing its channel on `deploy-state`, which the hosts poll.
+#
+# This file is the production control. Cosign cannot check the certificate's environment claim, so
+# the hosts pin the *identity of this workflow* instead — and because a GitHub environment gates the
+# job below, a signature carrying this identity is proof the environment's reviewers approved. That
+# only holds while this workflow stays non-reusable: a `workflow_call` trigger would let any caller
+# mint the same identity, so it must never gain one.
+name: Promote
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Environment to move
+        type: choice
+        options: [Staging, Production]
+        required: true
+      release:
+        description: Release to run, as vX.Y.Z
+        type: string
+        required: true
+      allow-rollback:
+        description: Permit moving this environment backwards
+        type: boolean
+        default: false
+      freeze:
+        description: Hold the environment where it is and ignore this release
+        type: boolean
+        default: false
+  # A published release moves staging on its own; production is only ever moved by hand above.
+  workflow_run:
+    workflows: [Release]
+    types: [completed]
+
+permissions: {}
+
+concurrency:
+  group: promote-${{ inputs.environment || 'Staging' }}
+  cancel-in-progress: false
+
+jobs:
+  promote:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment: ${{ inputs.environment || 'Staging' }}
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: deploy-state
+          persist-credentials: false
+
+      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Resolve the release to promote
+        id: release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REQUESTED: ${{ inputs.release }}
+        run: |
+          set -euo pipefail
+          # A dispatch names the release; the automatic staging promotion takes whatever the release
+          # that just finished published, which is the newest non-draft release.
+          release="${REQUESTED:-$(gh release view --repo "$GITHUB_REPOSITORY" --json tagName --jq .tagName)}"
+          [[ "$release" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+            echo "::error::Promote an immutable vX.Y.Z release, not '$release'"; exit 1; }
+          # Refusing a draft here is what keeps a half-finished release from reaching a host.
+          [ "$(gh release view "$release" --repo "$GITHUB_REPOSITORY" --json isDraft --jq .isDraft)" = false ] || {
+            echo "::error::$release is still a draft"; exit 1; }
+          echo "release=$release" >> "$GITHUB_OUTPUT"
+          echo "version=${release#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Write and sign the channel
+        env:
+          CHANNEL: ${{ inputs.environment && format('{0}', inputs.environment) || 'Staging' }}
+          RELEASE: ${{ steps.release.outputs.release }}
+          ALLOW_ROLLBACK: ${{ inputs.allow-rollback || false }}
+          FREEZE: ${{ inputs.freeze || false }}
+        run: |
+          set -euo pipefail
+          channel=$(echo "$CHANNEL" | tr '[:upper:]' '[:lower:]')
+          mkdir -p channels
+          jq -n --arg release "$RELEASE" --argjson allowRollback "$ALLOW_ROLLBACK" \
+            --argjson freeze "$FREEZE" \
+            '{release: $release, allowRollback: $allowRollback, freeze: $freeze}' \
+            > "channels/${channel}.json"
+          cosign sign-blob --yes \
+            --bundle "channels/${channel}.json.sigstore.json" \
+            "channels/${channel}.json"
+          echo "CHANNEL_FILE=channels/${channel}.json" >> "$GITHUB_ENV"
+
+      - name: Publish the channel
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE: ${{ steps.release.outputs.release }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add channels
+          # A promotion that changes nothing must not create an empty commit: the hosts read the
+          # commit graph to tell forwards from backwards, and a no-op commit would read as forwards.
+          git diff --cached --quiet && { echo "Channel already at $RELEASE"; exit 0; }
+          git commit -m "chore(deploy): ${CHANNEL_FILE} -> ${RELEASE}"
+          git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}" HEAD:deploy-state
+
+      - name: Wait for the environment to converge
+        if: ${{ !inputs.freeze }}
+        env:
+          EXPECTED: ${{ steps.release.outputs.version }}
+          HOSTNAME: ${{ vars.APP_HOSTNAME }}
+        run: |
+          set -euo pipefail
+          # The hosts pull, so nothing here can push them; the deploy is only observed. The webapp
+          # publishes the version it is running in its runtime config, which is what makes this
+          # observable at all without granting the runner any access to the host.
+          deadline=$(( SECONDS + 900 ))
+          while [ "$SECONDS" -lt "$deadline" ]; do
+            config=$(curl -fsS --max-time 20 "https://${HOSTNAME}/" |
+              grep -oE '/env-config\.[a-f0-9]{8}\.js' | head -1 || true)
+            if [ -n "$config" ]; then
+              running=$(curl -fsS --max-time 20 "https://${HOSTNAME}${config}" |
+                sed -nE 's/.*APPLICATION_VERSION: "([^"]*)".*/\1/p' | head -1 || true)
+              [ "$running" = "$EXPECTED" ] && { echo "Converged on $running"; exit 0; }
+            fi
+            sleep 20
+          done
+          echo "::error::${HOSTNAME} did not reach ${EXPECTED} within 15 minutes"
+          exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -516,19 +516,41 @@ jobs:
           [ "$(gh release view "$TAG_NAME" --repo "${{ github.repository }}" --json isImmutable --jq .isImmutable)" = true ] || {
             echo "::error::Repository immutable releases must be enabled before publishing"; exit 1; }
 
-  deploy-staging:
+  # Staging pulls: this asks for the promotion and waits for it, so production is still only offered
+  # a release staging is actually running. Nothing here reaches the host, and no deploy credential
+  # is involved — see ADR 0041.
+  promote-staging:
     needs: [release, tag-images, publish-release]
     if: needs.release.outputs.released == 'true'
-    uses: ./.github/workflows/deploy-staging.yml
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
+      actions: write
       contents: read
-      packages: read
-    with:
-      image-tag: ${{ needs.release.outputs.tag_name }}
-    secrets: inherit # zizmor: ignore[secrets-inherit]
+    steps:
+      - name: Promote staging and wait for it to converge
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE: ${{ needs.release.outputs.tag_name }}
+        run: |
+          set -euo pipefail
+          since=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          gh workflow run promote.yml --repo "$GITHUB_REPOSITORY" \
+            -f environment=Staging -f release="$RELEASE"
+          # The dispatch returns before the run exists, and picking the newest run blindly could
+          # watch someone else's promotion, so the run is matched on being newer than the request.
+          for _ in $(seq 1 30); do
+            run=$(gh run list --repo "$GITHUB_REPOSITORY" --workflow promote.yml --limit 10 \
+              --json databaseId,createdAt \
+              --jq "[.[] | select(.createdAt > \"$since\")] | sort_by(.createdAt) | .[0].databaseId // empty")
+            [ -n "$run" ] && break
+            sleep 5
+          done
+          [ -n "$run" ] || { echo "::error::promote.yml did not start"; exit 1; }
+          gh run watch "$run" --repo "$GITHUB_REPOSITORY" --exit-status
 
   deploy-production:
-    needs: [release, deploy-staging]
+    needs: [release, promote-staging]
     if: needs.release.outputs.released == 'true'
     uses: ./.github/workflows/deploy-prod.yml
     permissions:

--- a/docker/self-host/systemd/README.md
+++ b/docker/self-host/systemd/README.md
@@ -1,0 +1,18 @@
+# Self-updating host units
+
+A host that runs these keeps itself on the release its channel names, verifying both signatures
+itself. Nothing connects to the host.
+
+| File | Purpose |
+| --- | --- |
+| `hephaestus-reconcile.service` | one reconcile pass |
+| `hephaestus-reconcile.timer` | runs a pass every minute |
+| `hephaestus-reconcile-notify@.service` | posts the journal of a failed pass |
+| `reconcile.env.example` | the host's configuration |
+
+Installation, operation and the staleness alert you must configure are in
+[Pull-Based Deployment](https://docs.hephaestus.build/admin/pull-based-deployment).
+
+`Type=oneshot` here is deliberate and `RemainAfterExit=` is deliberately absent: it would leave the
+unit active after the first pass, and systemd does not restart a unit that is already active when
+its timer elapses, so every later tick would do nothing.

--- a/docker/self-host/systemd/hephaestus-reconcile-notify@.service
+++ b/docker/self-host/systemd/hephaestus-reconcile-notify@.service
@@ -1,0 +1,11 @@
+# Started by OnFailure= when a reconcile fails. systemd takes a unit here, not a command, which is
+# why this exists as its own template rather than an ExecStopPost= on the reconciler.
+[Unit]
+Description=Report a failed Hephaestus reconcile of %i
+
+[Service]
+Type=oneshot
+EnvironmentFile=/etc/hephaestus/reconcile.env
+ExecStart=/bin/sh -c 'test -n "$HEPHAESTUS_ALERT_WEBHOOK" || exit 0; \
+    journalctl --unit %i --lines 40 --no-pager | \
+    curl -fsS --max-time 20 --data-binary @- "$HEPHAESTUS_ALERT_WEBHOOK" >/dev/null'

--- a/docker/self-host/systemd/hephaestus-reconcile.service
+++ b/docker/self-host/systemd/hephaestus-reconcile.service
@@ -15,8 +15,10 @@ OnFailure=hephaestus-reconcile-notify@%n.service
 Type=oneshot
 EnvironmentFile=/etc/hephaestus/reconcile.env
 # systemd already refuses a second copy of a running oneshot; the lock covers direct invocation.
+# `env` rather than a hardcoded interpreter path: a distribution package puts node in /usr/bin and
+# an official tarball in /usr/local/bin, both of which are on systemd's default PATH.
 ExecStart=/usr/bin/flock --nonblock /run/lock/hephaestus-reconcile.lock \
-    /usr/bin/node ${HEPHAESTUS_CHECKOUT}/scripts/reconcile-deployment.ts
+    /usr/bin/env node ${HEPHAESTUS_CHECKOUT}/scripts/reconcile-deployment.ts
 TimeoutStartSec=30min
 
 NoNewPrivileges=yes

--- a/docker/self-host/systemd/hephaestus-reconcile.service
+++ b/docker/self-host/systemd/hephaestus-reconcile.service
@@ -14,8 +14,7 @@ OnFailure=hephaestus-reconcile-notify@%n.service
 # would silently do nothing.
 Type=oneshot
 EnvironmentFile=/etc/hephaestus/reconcile.env
-# systemd already refuses to start a second copy of a running oneshot. The lock is for the other
-# path: an operator or a stray cron entry invoking the script directly while a tick is in flight.
+# systemd already refuses a second copy of a running oneshot; the lock covers direct invocation.
 ExecStart=/usr/bin/flock --nonblock /run/lock/hephaestus-reconcile.lock \
     /usr/bin/node ${HEPHAESTUS_CHECKOUT}/scripts/reconcile-deployment.ts
 TimeoutStartSec=30min
@@ -34,10 +33,8 @@ LockPersonality=yes
 SystemCallFilter=@system-service
 SystemCallErrorNumber=EPERM
 
-# None of the above reduces what this unit can ultimately do: write access to the Docker socket is
-# root-equivalent on the host by design, so the hardening bounds this process, not the daemon it
-# asks to act. Rootless Podman with Quadlet is the only structural escape, and it is a migration
-# rather than a setting.
+# The hardening bounds this process, not the daemon: Docker socket access is root-equivalent by
+# design. Rootless Podman with Quadlet is the only structural escape, and it is a migration.
 
 [Install]
 WantedBy=multi-user.target

--- a/docker/self-host/systemd/hephaestus-reconcile.service
+++ b/docker/self-host/systemd/hephaestus-reconcile.service
@@ -1,0 +1,43 @@
+# Brings this host to the release its channel names. Install alongside hephaestus-reconcile.timer
+# and an environment file at /etc/hephaestus/reconcile.env; see docker/self-host/systemd/README.md.
+[Unit]
+Description=Reconcile this host to its Hephaestus release channel
+Documentation=https://docs.hephaestus.build/admin/pull-based-deployment
+Requires=docker.service
+After=docker.service network-online.target
+Wants=network-online.target
+OnFailure=hephaestus-reconcile-notify@%n.service
+
+[Service]
+# Deliberately not RemainAfterExit: that would leave the unit "active" after the first run, and
+# systemd does not restart a unit that is already active when its timer elapses — every later tick
+# would silently do nothing.
+Type=oneshot
+EnvironmentFile=/etc/hephaestus/reconcile.env
+# systemd already refuses to start a second copy of a running oneshot. The lock is for the other
+# path: an operator or a stray cron entry invoking the script directly while a tick is in flight.
+ExecStart=/usr/bin/flock --nonblock /run/lock/hephaestus-reconcile.lock \
+    /usr/bin/node ${HEPHAESTUS_CHECKOUT}/scripts/reconcile-deployment.ts
+TimeoutStartSec=30min
+
+NoNewPrivileges=yes
+ProtectSystem=strict
+ProtectHome=yes
+PrivateTmp=yes
+ReadWritePaths=/var/lib/hephaestus /run/lock
+# The Docker socket is reached over AF_UNIX; omitting it here breaks connect(2). Read-only
+# directory protections do not block Unix sockets, so ProtectSystem=strict leaves it reachable.
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+RestrictSUIDSGID=yes
+RestrictRealtime=yes
+LockPersonality=yes
+SystemCallFilter=@system-service
+SystemCallErrorNumber=EPERM
+
+# None of the above reduces what this unit can ultimately do: write access to the Docker socket is
+# root-equivalent on the host by design, so the hardening bounds this process, not the daemon it
+# asks to act. Rootless Podman with Quadlet is the only structural escape, and it is a migration
+# rather than a setting.
+
+[Install]
+WantedBy=multi-user.target

--- a/docker/self-host/systemd/hephaestus-reconcile.timer
+++ b/docker/self-host/systemd/hephaestus-reconcile.timer
@@ -1,0 +1,15 @@
+[Unit]
+Description=Poll the Hephaestus release channel
+Documentation=https://docs.hephaestus.build/admin/pull-based-deployment
+
+[Timer]
+# A minute is short enough that a promotion feels immediate and long enough that a host which
+# cannot reach GitHub is not hammering it. Most ticks read one commit and exit.
+OnBootSec=2min
+OnUnitActiveSec=1min
+# Spreads the tick across hosts so a fleet does not arrive at the registry together.
+RandomizedDelaySec=15s
+AccuracySec=10s
+
+[Install]
+WantedBy=timers.target

--- a/docker/self-host/systemd/reconcile.env.example
+++ b/docker/self-host/systemd/reconcile.env.example
@@ -1,0 +1,31 @@
+# Copy to /etc/hephaestus/reconcile.env (root:root, 0600) and adjust.
+
+# Which channel on the deploy-state branch this host follows.
+HEPHAESTUS_CHANNEL=staging
+
+# The stacks this host owns, in any order; the reconciler applies them in dependency order.
+# A host whose edge is owned by something else (a shared proxy, a PaaS) omits `proxy`.
+HEPHAESTUS_STACKS="core app"
+
+# A checkout of this repository. The reconciler only reads it and adds worktrees under the state
+# directory; it never changes the branch you leave it on.
+HEPHAESTUS_CHECKOUT=/opt/hephaestus/checkout
+
+# Where applied state, release worktrees and the verified channel are kept.
+HEPHAESTUS_STATE=/var/lib/hephaestus
+
+# Per-stack environment files: <stack>.env for every stack above, root-owned and 0600.
+HEPHAESTUS_SECRETS=/etc/hephaestus
+
+# The identity allowed to move this host. Must be the promotion workflow, on the default branch.
+HEPHAESTUS_PROMOTE_IDENTITY=https://github.com/hephaestus-build/Hephaestus/.github/workflows/promote.yml@refs/heads/main
+
+# Optional: a node_exporter textfile collector path, so "desired != applied" is alertable.
+HEPHAESTUS_METRICS_FILE=/var/lib/node_exporter/hephaestus_deploy.prom
+
+# Optional: where a failed reconcile posts its journal.
+HEPHAESTUS_ALERT_WEBHOOK=
+
+# How long to wait for a stack to report healthy. Must exceed each service's
+# start_period + interval x retries, or a slow boot reads as a failed deploy.
+HEPHAESTUS_WAIT_TIMEOUT=600

--- a/docs/admin/pull-based-deployment.mdx
+++ b/docs/admin/pull-based-deployment.mdx
@@ -1,0 +1,108 @@
+---
+id: pull-based-deployment
+title: Pull-Based Deployment
+description: Let a host keep itself on the release its channel names, verifying the signature itself, with nothing dialing in.
+---
+
+A host can upgrade itself. It polls a **channel** — one file naming a release — verifies the
+signatures, and applies the release's digest-pinned Compose stacks. Nothing connects *to* the host,
+so no deployment credential exists anywhere off it.
+
+This is the same verification the manual upgrade in [Install](./install.mdx#upgrades) performs, on a
+timer.
+
+## What the host trusts
+
+Two signatures, both checked on the host:
+
+| Artifact | Signed by | Answers |
+| --- | --- | --- |
+| The channel (`channels/<env>.json`) | the promotion workflow | *may this host move, and who said so* |
+| The release lock (`release-<version>.json`) | the release workflow | *which exact image digests are this release* |
+
+A signature proves who wrote something, never that it is the newest thing they wrote — a valid old
+channel replayed verifies perfectly. Freshness therefore comes from the commit graph: the channel
+lives on the `deploy-state` branch, and a commit that is an ancestor of the one already applied is a
+move backwards, refused unless the channel sets `allowRollback`.
+
+## The channel
+
+```json
+{ "release": "v1.2.3", "allowRollback": false, "freeze": false }
+```
+
+| Field | Effect |
+| --- | --- |
+| `release` | the immutable `vX.Y.Z` release this environment runs |
+| `allowRollback` | permits one deliberate move backwards |
+| `freeze` | holds the environment where it is, for an incident |
+
+## Install
+
+1. Put a checkout of this repository on the host. The reconciler only reads it, and creates release
+   worktrees under the state directory.
+2. Copy `docker/self-host/systemd/reconcile.env.example` to `/etc/hephaestus/reconcile.env`
+   (`root:root`, `0600`) and set the channel, the stacks this host owns, and the promotion identity.
+3. Put one `<stack>.env` per stack in `/etc/hephaestus`, `0600`. These hold the deployment secrets
+   and never leave the host.
+4. Install the units:
+
+   ```bash
+   sudo install -m 644 docker/self-host/systemd/hephaestus-reconcile.service \
+     docker/self-host/systemd/hephaestus-reconcile.timer \
+     docker/self-host/systemd/hephaestus-reconcile-notify@.service /etc/systemd/system/
+   sudo systemctl daemon-reload
+   sudo systemctl enable --now hephaestus-reconcile.timer
+   ```
+
+5. Watch the first run: `journalctl -fu hephaestus-reconcile.service`.
+
+`HEPHAESTUS_STACKS` is what a host owns. A host whose edge belongs to something else — a shared
+proxy, or a PaaS serving preview environments beside it — omits `proxy` and keeps `core app`.
+
+## Operating it
+
+| You want to | Do this |
+| --- | --- |
+| Move an environment | Run the **Promote** workflow: pick the environment and release |
+| Roll back | Promote the older release with **allow-rollback** |
+| Hold an environment | Promote with **freeze** |
+| Stop the host reconciling, right now | `sudo systemctl disable --now hephaestus-reconcile.timer` |
+| See what a host runs | `cat /var/lib/hephaestus/applied.json` |
+
+:::warning Disable the timer before hand-patching a host
+A reconciler reapplies its channel. Manual changes to a stack it owns are reverted at the next tick,
+which during an incident is the last thing you want. Disable the timer first, and re-enable it when
+the fix has landed in a release.
+:::
+
+## Watching it
+
+With `HEPHAESTUS_METRICS_FILE` set, each run writes to the node_exporter textfile collector:
+
+```text
+hephaestus_deploy_info{channel="staging",release="v1.2.3",channel_commit="…"} 1
+hephaestus_deploy_reconcile_success 1
+hephaestus_deploy_reconcile_timestamp_seconds …
+hephaestus_deploy_last_success_timestamp_seconds …
+```
+
+**Alert on staleness.** A host that stops reconciling is silent, not loud — that is the one real cost
+of pulling instead of being pushed to. Alert when
+`time() - hephaestus_deploy_last_success_timestamp_seconds` exceeds ten minutes, or when
+`hephaestus_deploy_reconcile_success` is `0`. Without that alert, a host can sit on an old release
+indefinitely and nothing will say so.
+
+The promotion workflow also waits for the environment to report the new version before it goes
+green, so an unconverged deploy fails in Actions as well.
+
+## What it will not do
+
+**It does not roll back a failed deploy.** A failed apply stops and alerts. Schema changes here are
+forward-only, so putting the previous images back would leave old code on a migrated database — the
+failure the rollback was meant to prevent. Recover by promoting a release that fixes the problem, or
+by restoring from a backup if the database itself is wrong; see
+[Backup & Restore](./backup-restore.mdx).
+
+**It does not manage anything it does not own.** The reconciler touches only the Compose projects
+named in `HEPHAESTUS_STACKS`. Containers belonging to anything else on the host are left alone.

--- a/docs/admin/pull-based-deployment.mdx
+++ b/docs/admin/pull-based-deployment.mdx
@@ -37,6 +37,15 @@ move backwards, refused unless the channel sets `allowRollback`.
 | `allowRollback` | permits one deliberate move backwards |
 | `freeze` | holds the environment where it is, for an incident |
 
+## Requirements
+
+On the host: Docker Engine with Compose v2, `git`, `flock`, `cosign`, and Node.js at the version in
+`.node-version`. Outbound HTTPS to `github.com` and `ghcr.io` is the only network access needed —
+nothing has to reach the host, which is the point.
+
+Pin what you install. `cosign` verifies the release, so fetch it by checksum from its own release
+page rather than from a convenience script.
+
 ## Install
 
 1. Put a checkout of this repository on the host. The reconciler only reads it, and creates release

--- a/docs/decisions/0041-hosts-pull-their-own-releases.md
+++ b/docs/decisions/0041-hosts-pull-their-own-releases.md
@@ -1,0 +1,73 @@
+# 0041. Hosts pull their own releases
+
+Date: 2026-09-03
+
+## Status
+
+Accepted. Supersedes the SSH-push half of ADR 0005's deployment story; the release evidence and
+image-lock decisions it builds on are unchanged.
+
+## Context
+
+Deployments pushed from CI over SSH through a jump host. That path put two long-lived private keys
+in GitHub environment secrets, required an internet-reachable SSH entry point, and rendered roughly
+fifteen production secrets onto a third-party runner's disk on every deploy. Anyone able to run a
+workflow in the deploy environment, or to exfiltrate through a compromised action, held a shell on
+production.
+
+It also broke. The repository's transfer between organisations did not carry org-level variables and
+secrets; they were recreated with a hostname that resolves nowhere, a user the host refuses to log
+in as, and a jump-host key that does not authenticate. Staging could not be deployed at all. None of
+those failures were detectable before a deploy attempt, because the credentials only exist inside CI.
+
+The project already produces everything a host needs to deploy itself: a cosign-signed release lock
+naming every image by digest, and `prepare-release-lock.ts`, which verifies that signature and
+renders the lock. Self-hosters already upgrade this way by hand.
+
+## Decision
+
+A host polls a channel and applies the release it names. Nothing connects to the host.
+
+**The channel is a commit.** Each environment has one file on the `deploy-state` branch naming a
+release. The branch carries no code and triggers no workflow.
+
+**Freshness comes from the commit graph.** A signature proves authorship, not currency: a valid old
+channel, replayed, verifies. The reconciler refuses a channel commit that is an ancestor of the one
+it applied, unless the channel declares the rollback. This is the property TUF builds timestamp and
+snapshot roles for, taken from a history the repository already keeps — which is also why the
+channel is not an OCI artifact under a mutable tag, where no such order exists and where GHCR offers
+no tag immutability.
+
+**Approval is bound by identity, not by claim.** Fulcio does record GitHub's `environment` claim, but
+cosign exposes no way to verify it, so requiring "signed by a job in the Production environment" is
+not something a verifier can express today. Instead the hosts pin the identity of `promote.yml`, and
+a GitHub environment gates that workflow: a signature carrying that identity is proof the reviewers
+approved. This holds only while `promote.yml` stays non-reusable — a `workflow_call` trigger would
+let any caller mint the same identity.
+
+**A failed apply stops.** It does not roll back. Schema changes are forward-only here, so restoring
+the previous images would leave old code on a migrated database. The reconciler alerts instead.
+
+**Feedback is observed, not reported.** Because nothing can push the hosts, the promotion workflow
+polls the environment's public runtime configuration until it reports the promoted version. A deploy
+that does not converge fails in Actions, and a host that stops reconciling raises a staleness alert
+from its textfile metrics. Without that alert this design trades a loud failure for a silent one.
+
+## Consequences
+
+Both deploy keys, the jump host, and the deployment secrets leave CI; secrets live only on the host
+that uses them. Promotion becomes one gated workflow run, and the git history of `deploy-state` is
+the deployment audit log.
+
+The reconciler is as privileged as the SSH user it replaces: write access to the Docker socket is
+root-equivalent, and no systemd hardening changes that. What changes is that no remote party holds
+it. Rootless Podman with Quadlet would close the remaining gap and is not attempted here.
+
+An operator must disable the timer before hand-patching a host, or the next tick reverts the fix.
+
+Preview environments are unaffected. They are ephemeral, per-pull-request, and managed by Coolify on
+the staging host; the reconciler owns only the Compose projects it is configured for, so the two
+manage disjoint resources.
+
+Production adopts this after its outstanding version gap is closed by hand; the mechanism is proven
+on staging first.

--- a/docs/sidebars.admin.ts
+++ b/docs/sidebars.admin.ts
@@ -26,6 +26,7 @@ const sidebars: SidebarsConfig = {
 		{ type: "doc", id: "configuration-readiness", label: "Configuration Readiness" },
 		{ type: "doc", id: "threat-model", label: "Threat Model" },
 		{ type: "doc", id: "release-image-lock", label: "Release image lock" },
+		{ type: "doc", id: "pull-based-deployment", label: "Pull-Based Deployment" },
 		{ type: "doc", id: "buildpacks-cds-decision", label: "Server image build (Buildpacks + CDS)" },
 		{ type: "doc", id: "legal-pages", label: "Legal Pages" },
 		{

--- a/scripts/prepare-release-lock.ts
+++ b/scripts/prepare-release-lock.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rename, rm } from "node:fs/promises";
+import { mkdtemp, rename, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { basename, dirname, join } from "node:path";
 
@@ -12,27 +12,34 @@ const [release, output = join(repositoryRoot, "docker/self-host/release-lock.env
 	process.argv.slice(2);
 if (!release || !isRelease(release)) throw new Error("usage: prepare-release-lock vX.Y.Z [output]");
 
+/**
+ * A published release's assets are plain HTTPS downloads, so verifying one needs no credential and
+ * no GitHub CLI — which is what lets a deployment host, or a self-hoster, upgrade without holding an
+ * account that could also change the release it is verifying.
+ */
+async function downloadReleaseAsset(
+	repository: string,
+	tag: string,
+	name: string,
+	into: string,
+): Promise<void> {
+	const url = `https://github.com/${repository}/releases/download/${tag}/${name}`;
+	const response = await fetch(url);
+	if (!response.ok) throw new Error(`GET ${url} returned ${response.status}`);
+	await writeFile(join(into, name), Buffer.from(await response.arrayBuffer()));
+}
+
 const directory = await mkdtemp(join(tmpdir(), "hephaestus-release-"));
 const outputDirectory = dirname(output);
 const outputTempDirectory = await mkdtemp(join(outputDirectory, `.${basename(output)}-`));
 const temporaryOutput = join(outputTempDirectory, "lock.env");
 const asset = `release-${release}.json`;
 try {
-	await run("gh", [
-		"release",
-		"download",
-		release,
-		"--repo",
-		releaseSignerRepository(process.env),
-		"--dir",
-		directory,
-		"--pattern",
-		asset,
-		"--pattern",
-		`${asset}.sigstore.json`,
-		"--pattern",
-		"manifest.json",
-	]);
+	await Promise.all(
+		[asset, `${asset}.sigstore.json`, "manifest.json"].map((name) =>
+			downloadReleaseAsset(releaseSignerRepository(process.env), release, name, directory),
+		),
+	);
 	await run("cosign", [
 		"verify-blob",
 		"--bundle",

--- a/scripts/reconcile-deployment.test.ts
+++ b/scripts/reconcile-deployment.test.ts
@@ -1,7 +1,13 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
-import { decide, parseChannel, parseStacks, renderMetrics } from "./reconcile-deployment.ts";
+import {
+	decide,
+	parseChannel,
+	parseStacks,
+	renderMetrics,
+	unlockedImages,
+} from "./reconcile-deployment.ts";
 
 const applied = {
 	release: "v0.75.2",
@@ -95,4 +101,20 @@ await test("a failed run still publishes a series, or silence and failure look a
 	});
 	assert.match(metrics, /hephaestus_deploy_reconcile_success 0/);
 	assert.doesNotMatch(metrics, /last_success/);
+});
+
+await test("an image the release lock does not cover is refused", () => {
+	const lock = [
+		"HEPHAESTUS_IMAGE_APPLICATION_SERVER=ghcr.io/o/application-server@sha256:aaa",
+		"HEPHAESTUS_IMAGE_POSTGRES=ghcr.io/o/postgres@sha256:bbb",
+		"IMAGE_TAG=v1.2.3",
+	].join("\n");
+	assert.deepEqual(
+		unlockedImages(
+			["ghcr.io/o/application-server@sha256:aaa", "ghcr.io/o/postgres@sha256:bbb"],
+			lock,
+		),
+		[],
+	);
+	assert.deepEqual(unlockedImages(["ghcr.io/o/webapp:latest"], lock), ["ghcr.io/o/webapp:latest"]);
 });

--- a/scripts/reconcile-deployment.test.ts
+++ b/scripts/reconcile-deployment.test.ts
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { decide, parseChannel, parseStacks, renderMetrics } from "./reconcile-deployment.ts";
+
+const applied = {
+	release: "v0.75.2",
+	channelCommit: "b".repeat(40),
+	appliedAt: "2026-09-03T20:00:00.000Z",
+};
+
+await test("a channel names an immutable release", () => {
+	assert.deepEqual(parseChannel({ release: "v1.2.3" }), {
+		release: "v1.2.3",
+		allowRollback: false,
+		freeze: false,
+	});
+	assert.throws(() => parseChannel({ release: "main" }), /immutable vX\.Y\.Z tag/);
+	assert.throws(() => parseChannel({ release: "v1.2.3-rc.1" }), /immutable vX\.Y\.Z tag/);
+	assert.throws(() => parseChannel({}), /channel\.release/);
+});
+
+await test("an unchanged channel is a no-op, so most ticks do nothing", () => {
+	assert.deepEqual(decide({ release: "v0.75.2" }, applied, applied.channelCommit, false), {
+		action: "noop",
+		reason: "already running v0.75.2",
+	});
+});
+
+await test("a newer channel commit applies", () => {
+	assert.deepEqual(decide({ release: "v0.75.3" }, applied, "c".repeat(40), false), {
+		action: "apply",
+		release: "v0.75.3",
+	});
+});
+
+await test("a rewind is refused, because a replayed pointer verifies as well as a current one", () => {
+	const decision = decide({ release: "v0.75.1" }, applied, "a".repeat(40), true);
+	assert.equal(decision.action, "refuse");
+});
+
+await test("a rewind the promotion declares is allowed", () => {
+	assert.deepEqual(
+		decide({ release: "v0.75.1", allowRollback: true }, applied, "a".repeat(40), true),
+		{ action: "apply", release: "v0.75.1" },
+	);
+});
+
+await test("a frozen channel holds the host where it is, even against a newer release", () => {
+	assert.deepEqual(decide({ release: "v0.99.0", freeze: true }, applied, "c".repeat(40), false), {
+		action: "noop",
+		reason: "channel is frozen",
+	});
+});
+
+await test("a host with no state converges on its first run", () => {
+	assert.deepEqual(decide({ release: "v0.75.2" }, undefined, "a".repeat(40), false), {
+		action: "apply",
+		release: "v0.75.2",
+	});
+});
+
+await test("stacks come up in dependency order regardless of how they were configured", () => {
+	assert.deepEqual(parseStacks("app core"), ["core", "app"]);
+	assert.deepEqual(parseStacks("app, core, proxy"), ["proxy", "core", "app"]);
+	assert.throws(() => parseStacks("app database"), /unknown stack/);
+	assert.throws(() => parseStacks(""), /at least one stack/);
+});
+
+await test("the version rides in labels so a dashboard can group by it", () => {
+	const metrics = renderMetrics({
+		channel: "staging",
+		release: "v0.75.2",
+		commit: "abc",
+		success: true,
+		now: new Date("2026-09-03T21:00:00.000Z"),
+		lastSuccessAt: new Date("2026-09-03T21:00:00.000Z"),
+	});
+	assert.match(
+		metrics,
+		/hephaestus_deploy_info\{channel="staging",release="v0\.75\.2",channel_commit="abc"\} 1/,
+	);
+	assert.match(metrics, /hephaestus_deploy_reconcile_success 1/);
+	assert.match(metrics, /hephaestus_deploy_last_success_timestamp_seconds 1788469200/);
+	assert.ok(metrics.endsWith("\n"));
+});
+
+await test("a failed run still publishes a series, or silence and failure look alike", () => {
+	const metrics = renderMetrics({
+		channel: "production",
+		release: "none",
+		commit: "none",
+		success: false,
+		now: new Date("2026-09-03T21:00:00.000Z"),
+	});
+	assert.match(metrics, /hephaestus_deploy_reconcile_success 0/);
+	assert.doesNotMatch(metrics, /last_success/);
+});

--- a/scripts/reconcile-deployment.ts
+++ b/scripts/reconcile-deployment.ts
@@ -1,31 +1,22 @@
 /**
- * Brings one host to the release its channel names. Runs from a systemd timer; the host dials out
- * and nothing dials in, so no deploy credential exists off the host to be stolen or to expire.
+ * Brings one host to the release its channel names, on a timer. Nothing dials in, so no deployment
+ * credential exists off the host.
  *
- * The channel is a commit on the `deploy-state` branch, and that is what makes the pointer safe to
- * act on. A signature proves who wrote a pointer, never that it is the *current* one — a valid old
- * pointer replayed under a moving tag verifies perfectly — so freshness has to come from somewhere
- * with an order. Git has one: a channel commit that is an ancestor of the applied commit is a move
- * backwards, and is refused unless the pointer says the rollback is deliberate. That is the whole of
- * the rollback protection TUF builds timestamp and snapshot roles for, borrowed from a history the
- * repository already keeps.
+ * A signature proves authorship, never currency: a valid old channel, replayed, verifies perfectly.
+ * Freshness therefore comes from the commit graph — a channel commit that is an ancestor of the
+ * applied one is a rewind, and is refused unless the channel declares it.
  *
- * Two verifications, not one: the pointer is signed by the promotion workflow (which a GitHub
- * environment gates, so a signature from that identity is proof the approval happened), and the
- * release lock is signed by the release workflow. The lock is what pins every image by digest.
- *
- * A failed apply stops here and says so. It does not roll back: schema changes are forward-only in
- * this project, so putting the previous images back would leave old code on a migrated database —
- * the failure mode the rollback was supposed to prevent. Alerting a human is the honest response.
+ * A failed apply stops and alerts rather than reverting. Schema changes here only move forward, so
+ * restoring the previous images would leave old code on a migrated database.
  */
+import { existsSync } from "node:fs";
 import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
 import { asRecord, asString, parseJson } from "./lib/json.ts";
 import { output, run, succeeds } from "./lib/process.ts";
 
-/** A stack is a Compose project this host owns. The name is also the Compose project name, so the
- * containers a previous deploy created are adopted rather than duplicated. */
+/** Also the Compose project name, so an earlier deploy's containers are adopted, not duplicated. */
 export type Stack = "proxy" | "core" | "app";
 
 const STACK_ORDER: readonly Stack[] = ["proxy", "core", "app"];
@@ -64,11 +55,7 @@ export function parseChannel(value: unknown): Channel {
 	};
 }
 
-/**
- * `rewinds` answers "is the channel commit an ancestor of the one already applied", which the caller
- * resolves with git. Passing it in keeps the decision itself free of process calls, so every branch
- * below is covered by a test rather than by a deployment.
- */
+/** `rewinds` is "the channel commit is an ancestor of the applied one", which git answers. */
 export function decide(
 	channel: Channel,
 	applied: AppliedState | undefined,
@@ -86,11 +73,7 @@ export function decide(
 	return { action: "apply", release: channel.release };
 }
 
-/**
- * The value carries no information a label cannot, so the series is a constant 1 and everything
- * interesting rides in labels — the `_info` convention Prometheus uses for build metadata, which
- * keeps the version out of the metric name where a dashboard cannot group by it.
- */
+/** Version and commit ride in labels, not the metric name, so a dashboard can group by them. */
 export function renderMetrics(state: {
 	channel: string;
 	release: string;
@@ -135,8 +118,6 @@ export function parseStacks(value: string | undefined): Stack[] {
 	return STACK_ORDER.filter((stack) => names.includes(stack));
 }
 
-/** Everything below this line touches the host. */
-
 interface HostConfig {
 	channel: string;
 	stacks: Stack[];
@@ -175,13 +156,12 @@ async function readApplied(file: string): Promise<AppliedState | undefined> {
 			appliedAt: asString(record.appliedAt, "applied.appliedAt"),
 		};
 	} catch {
-		// A host that has never converged has no state, which is not an error — it is the first run.
+		// No state is the first run, not a failure.
 		return undefined;
 	}
 }
 
-/** Written to a temporary file and renamed, because the textfile collector reads whole files and a
- * scrape landing mid-write would publish a truncated series. */
+/** Renamed into place: a scrape landing mid-write would otherwise publish a truncated series. */
 async function writeAtomic(file: string, contents: string): Promise<void> {
 	const temporary = `${file}.tmp`;
 	await writeFile(temporary, contents, { mode: 0o644 });
@@ -196,8 +176,6 @@ async function main(): Promise<void> {
 
 	await mkdir(config.stateDirectory, { recursive: true });
 
-	// The channel branch carries no code and is never merged, so fetching it costs one commit and
-	// cannot drag the checkout's working tree along with it.
 	await run(
 		"git",
 		["fetch", "--quiet", "origin", "+refs/heads/deploy-state:refs/remotes/origin/deploy-state"],
@@ -205,9 +183,13 @@ async function main(): Promise<void> {
 			cwd: config.checkout,
 		},
 	);
-	const channelCommit = await output("git", ["rev-parse", "refs/remotes/origin/deploy-state"], {
-		cwd: config.checkout,
-	});
+	// Trimmed because the SHA is compared and interpolated; the blobs below are not, since the
+	// channel must reach cosign byte for byte as it was signed.
+	const channelCommit = (
+		await output("git", ["rev-parse", "refs/remotes/origin/deploy-state"], {
+			cwd: config.checkout,
+		})
+	).trim();
 	const channelPath = `channels/${config.channel}.json`;
 	const channelJson = await output("git", ["show", `${channelCommit}:${channelPath}`], {
 		cwd: config.checkout,
@@ -225,10 +207,8 @@ async function main(): Promise<void> {
 		"verify-blob",
 		"--bundle",
 		join(scratch, "channel.sigstore.json"),
-		// The promotion workflow is the only identity allowed to move an environment, and a GitHub
-		// environment gates that workflow — so a signature from it is proof the approval happened.
-		// Cosign cannot read the certificate's environment claim, which is why the identity is the
-		// workflow file itself rather than the environment name.
+		// Cosign cannot verify the certificate's environment claim, so the gate is expressed as the
+		// identity of the workflow the environment protects: only an approved run can produce it.
 		"--certificate-identity",
 		config.promoteIdentity,
 		"--certificate-oidc-issuer",
@@ -263,13 +243,12 @@ async function main(): Promise<void> {
 		return;
 	}
 
-	// The compose files must come from the release being deployed, not from whatever the checkout
-	// happens to sit on, so each release is materialised as its own worktree.
+	// Compose files must come from the release being deployed, not from wherever the checkout sits.
 	const releaseTree = join(config.stateDirectory, "releases", decision.release);
 	await run("git", ["fetch", "--quiet", "origin", "tag", decision.release, "--no-tags"], {
 		cwd: config.checkout,
 	});
-	if (!(await succeeds("test", ["-d", releaseTree])))
+	if (!existsSync(releaseTree))
 		await run("git", ["worktree", "add", "--detach", "--quiet", releaseTree, decision.release], {
 			cwd: config.checkout,
 		});
@@ -300,8 +279,7 @@ async function main(): Promise<void> {
 				"--detach",
 				"--wait",
 				`--wait-timeout=${config.waitTimeoutSeconds}`,
-				// Without this a service removed by the release keeps running, unmanaged, until
-				// someone notices it in `docker ps`.
+				// A service the release removed would otherwise keep running, unmanaged.
 				"--remove-orphans",
 			],
 			{ cwd: releaseTree },
@@ -328,10 +306,7 @@ async function main(): Promise<void> {
 	console.log(`Applied ${decision.release} to ${config.stacks.join(", ")}`);
 }
 
-/**
- * A failed run must still publish a series, or the alert that matters — "this host has not converged
- * in N minutes" — cannot tell a broken reconcile from a host that stopped running one at all.
- */
+/** Without a series on failure, a broken reconcile is indistinguishable from a host running none. */
 async function reportFailure(): Promise<void> {
 	const metricsFile = process.env.HEPHAESTUS_METRICS_FILE;
 	const channel = process.env.HEPHAESTUS_CHANNEL;
@@ -356,9 +331,8 @@ if (process.argv[1] === import.meta.filename) {
 	try {
 		await main();
 	} catch (error) {
-		await reportFailure().catch(() => {
-			// A metric that cannot be written must not replace the error that caused the failure.
-		});
+		// An unwritable metric must not replace the error that caused the failure.
+		await reportFailure().catch(() => {});
 		throw error;
 	}
 }

--- a/scripts/reconcile-deployment.ts
+++ b/scripts/reconcile-deployment.ts
@@ -1,0 +1,364 @@
+/**
+ * Brings one host to the release its channel names. Runs from a systemd timer; the host dials out
+ * and nothing dials in, so no deploy credential exists off the host to be stolen or to expire.
+ *
+ * The channel is a commit on the `deploy-state` branch, and that is what makes the pointer safe to
+ * act on. A signature proves who wrote a pointer, never that it is the *current* one — a valid old
+ * pointer replayed under a moving tag verifies perfectly — so freshness has to come from somewhere
+ * with an order. Git has one: a channel commit that is an ancestor of the applied commit is a move
+ * backwards, and is refused unless the pointer says the rollback is deliberate. That is the whole of
+ * the rollback protection TUF builds timestamp and snapshot roles for, borrowed from a history the
+ * repository already keeps.
+ *
+ * Two verifications, not one: the pointer is signed by the promotion workflow (which a GitHub
+ * environment gates, so a signature from that identity is proof the approval happened), and the
+ * release lock is signed by the release workflow. The lock is what pins every image by digest.
+ *
+ * A failed apply stops here and says so. It does not roll back: schema changes are forward-only in
+ * this project, so putting the previous images back would leave old code on a migrated database —
+ * the failure mode the rollback was supposed to prevent. Alerting a human is the honest response.
+ */
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { asRecord, asString, parseJson } from "./lib/json.ts";
+import { output, run, succeeds } from "./lib/process.ts";
+
+/** A stack is a Compose project this host owns. The name is also the Compose project name, so the
+ * containers a previous deploy created are adopted rather than duplicated. */
+export type Stack = "proxy" | "core" | "app";
+
+const STACK_ORDER: readonly Stack[] = ["proxy", "core", "app"];
+
+export interface Channel {
+	/** The release this environment should run, as an immutable `vX.Y.Z` tag. */
+	release: string;
+	/** Set when a promotion deliberately moves backwards; without it a rewind is refused. */
+	allowRollback?: boolean;
+	/** Set to hold the environment where it is, for an incident. */
+	freeze?: boolean;
+}
+
+export interface AppliedState {
+	release: string;
+	channelCommit: string;
+	appliedAt: string;
+}
+
+export type Decision =
+	| { action: "apply"; release: string }
+	| { action: "noop"; reason: string }
+	| { action: "refuse"; reason: string };
+
+const RELEASE_TAG = /^v\d+\.\d+\.\d+$/;
+
+export function parseChannel(value: unknown): Channel {
+	const record = asRecord(value, "channel");
+	const release = asString(record.release, "channel.release");
+	if (!RELEASE_TAG.test(release))
+		throw new Error(`channel.release must be an immutable vX.Y.Z tag, not ${release}`);
+	return {
+		release,
+		allowRollback: record.allowRollback === true,
+		freeze: record.freeze === true,
+	};
+}
+
+/**
+ * `rewinds` answers "is the channel commit an ancestor of the one already applied", which the caller
+ * resolves with git. Passing it in keeps the decision itself free of process calls, so every branch
+ * below is covered by a test rather than by a deployment.
+ */
+export function decide(
+	channel: Channel,
+	applied: AppliedState | undefined,
+	channelCommit: string,
+	rewinds: boolean,
+): Decision {
+	if (channel.freeze) return { action: "noop", reason: "channel is frozen" };
+	if (applied?.release === channel.release && applied.channelCommit === channelCommit)
+		return { action: "noop", reason: `already running ${channel.release}` };
+	if (rewinds && !channel.allowRollback)
+		return {
+			action: "refuse",
+			reason: `channel commit ${channelCommit.slice(0, 8)} precedes the applied one; set allowRollback to move back deliberately`,
+		};
+	return { action: "apply", release: channel.release };
+}
+
+/**
+ * The value carries no information a label cannot, so the series is a constant 1 and everything
+ * interesting rides in labels — the `_info` convention Prometheus uses for build metadata, which
+ * keeps the version out of the metric name where a dashboard cannot group by it.
+ */
+export function renderMetrics(state: {
+	channel: string;
+	release: string;
+	commit: string;
+	success: boolean;
+	now: Date;
+	lastSuccessAt?: Date;
+}): string {
+	const seconds = (date: Date) => Math.floor(date.getTime() / 1000);
+	const lines = [
+		"# HELP hephaestus_deploy_info The release this host currently runs.",
+		"# TYPE hephaestus_deploy_info gauge",
+		`hephaestus_deploy_info{channel="${state.channel}",release="${state.release}",channel_commit="${state.commit}"} 1`,
+		"# HELP hephaestus_deploy_reconcile_success Whether the last reconcile attempt succeeded.",
+		"# TYPE hephaestus_deploy_reconcile_success gauge",
+		`hephaestus_deploy_reconcile_success ${state.success ? 1 : 0}`,
+		"# HELP hephaestus_deploy_reconcile_timestamp_seconds When the last reconcile attempt ran.",
+		"# TYPE hephaestus_deploy_reconcile_timestamp_seconds gauge",
+		`hephaestus_deploy_reconcile_timestamp_seconds ${seconds(state.now)}`,
+	];
+	if (state.lastSuccessAt) {
+		lines.push(
+			"# HELP hephaestus_deploy_last_success_timestamp_seconds When this host last converged.",
+			"# TYPE hephaestus_deploy_last_success_timestamp_seconds gauge",
+			`hephaestus_deploy_last_success_timestamp_seconds ${seconds(state.lastSuccessAt)}`,
+		);
+	}
+	return `${lines.join("\n")}\n`;
+}
+
+function isStack(name: string): name is Stack {
+	return STACK_ORDER.some((stack) => stack === name);
+}
+
+export function parseStacks(value: string | undefined): Stack[] {
+	const names = (value ?? "").split(/[\s,]+/).filter(Boolean);
+	if (names.length === 0) throw new Error("HEPHAESTUS_STACKS must name at least one stack");
+	const unknown = names.filter((name) => !isStack(name));
+	if (unknown.length > 0) throw new Error(`unknown stack(s): ${unknown.join(", ")}`);
+	// Order is the dependency order, not the order the operator happened to type: the broker comes
+	// up before the application that waits on it, and the edge before either.
+	return STACK_ORDER.filter((stack) => names.includes(stack));
+}
+
+/** Everything below this line touches the host. */
+
+interface HostConfig {
+	channel: string;
+	stacks: Stack[];
+	checkout: string;
+	stateDirectory: string;
+	secretsDirectory: string;
+	metricsFile?: string;
+	waitTimeoutSeconds: number;
+	promoteIdentity: string;
+}
+
+function hostConfig(environment: NodeJS.ProcessEnv): HostConfig {
+	const required = (name: string): string => {
+		const value = environment[name];
+		if (!value) throw new Error(`${name} must be set`);
+		return value;
+	};
+	return {
+		channel: required("HEPHAESTUS_CHANNEL"),
+		stacks: parseStacks(environment.HEPHAESTUS_STACKS),
+		checkout: required("HEPHAESTUS_CHECKOUT"),
+		stateDirectory: environment.HEPHAESTUS_STATE ?? "/var/lib/hephaestus",
+		secretsDirectory: environment.HEPHAESTUS_SECRETS ?? "/etc/hephaestus",
+		metricsFile: environment.HEPHAESTUS_METRICS_FILE,
+		waitTimeoutSeconds: Number(environment.HEPHAESTUS_WAIT_TIMEOUT ?? 600),
+		promoteIdentity: required("HEPHAESTUS_PROMOTE_IDENTITY"),
+	};
+}
+
+async function readApplied(file: string): Promise<AppliedState | undefined> {
+	try {
+		const record = asRecord(parseJson(await readFile(file, "utf8")), "applied state");
+		return {
+			release: asString(record.release, "applied.release"),
+			channelCommit: asString(record.channelCommit, "applied.channelCommit"),
+			appliedAt: asString(record.appliedAt, "applied.appliedAt"),
+		};
+	} catch {
+		// A host that has never converged has no state, which is not an error — it is the first run.
+		return undefined;
+	}
+}
+
+/** Written to a temporary file and renamed, because the textfile collector reads whole files and a
+ * scrape landing mid-write would publish a truncated series. */
+async function writeAtomic(file: string, contents: string): Promise<void> {
+	const temporary = `${file}.tmp`;
+	await writeFile(temporary, contents, { mode: 0o644 });
+	await rename(temporary, file);
+}
+
+async function main(): Promise<void> {
+	const config = hostConfig(process.env);
+	const appliedFile = join(config.stateDirectory, "applied.json");
+	const applied = await readApplied(appliedFile);
+	const startedAt = new Date();
+
+	await mkdir(config.stateDirectory, { recursive: true });
+
+	// The channel branch carries no code and is never merged, so fetching it costs one commit and
+	// cannot drag the checkout's working tree along with it.
+	await run(
+		"git",
+		["fetch", "--quiet", "origin", "+refs/heads/deploy-state:refs/remotes/origin/deploy-state"],
+		{
+			cwd: config.checkout,
+		},
+	);
+	const channelCommit = await output("git", ["rev-parse", "refs/remotes/origin/deploy-state"], {
+		cwd: config.checkout,
+	});
+	const channelPath = `channels/${config.channel}.json`;
+	const channelJson = await output("git", ["show", `${channelCommit}:${channelPath}`], {
+		cwd: config.checkout,
+	});
+	const signature = await output("git", ["show", `${channelCommit}:${channelPath}.sigstore.json`], {
+		cwd: config.checkout,
+	});
+
+	// Verifying before parsing keeps unverified bytes from reaching any decision.
+	const scratch = join(config.stateDirectory, "channel");
+	await mkdir(scratch, { recursive: true });
+	await writeFile(join(scratch, "channel.json"), channelJson);
+	await writeFile(join(scratch, "channel.sigstore.json"), signature);
+	await run("cosign", [
+		"verify-blob",
+		"--bundle",
+		join(scratch, "channel.sigstore.json"),
+		// The promotion workflow is the only identity allowed to move an environment, and a GitHub
+		// environment gates that workflow — so a signature from it is proof the approval happened.
+		// Cosign cannot read the certificate's environment claim, which is why the identity is the
+		// workflow file itself rather than the environment name.
+		"--certificate-identity",
+		config.promoteIdentity,
+		"--certificate-oidc-issuer",
+		"https://token.actions.githubusercontent.com",
+		join(scratch, "channel.json"),
+	]);
+
+	const channel = parseChannel(parseJson(channelJson));
+	const rewinds = applied
+		? await succeeds("git", ["merge-base", "--is-ancestor", channelCommit, applied.channelCommit], {
+				cwd: config.checkout,
+			})
+		: false;
+	const decision = decide(channel, applied, channelCommit, rewinds);
+
+	if (decision.action === "refuse") throw new Error(decision.reason);
+	if (decision.action === "noop") {
+		console.log(`No change: ${decision.reason}`);
+		if (config.metricsFile && applied) {
+			await writeAtomic(
+				config.metricsFile,
+				renderMetrics({
+					channel: config.channel,
+					release: applied.release,
+					commit: applied.channelCommit,
+					success: true,
+					now: startedAt,
+					lastSuccessAt: new Date(applied.appliedAt),
+				}),
+			);
+		}
+		return;
+	}
+
+	// The compose files must come from the release being deployed, not from whatever the checkout
+	// happens to sit on, so each release is materialised as its own worktree.
+	const releaseTree = join(config.stateDirectory, "releases", decision.release);
+	await run("git", ["fetch", "--quiet", "origin", "tag", decision.release, "--no-tags"], {
+		cwd: config.checkout,
+	});
+	if (!(await succeeds("test", ["-d", releaseTree])))
+		await run("git", ["worktree", "add", "--detach", "--quiet", releaseTree, decision.release], {
+			cwd: config.checkout,
+		});
+
+	const lockFile = join(releaseTree, "release-lock.env");
+	await run(
+		process.execPath,
+		[join(releaseTree, "scripts/prepare-release-lock.ts"), decision.release, lockFile],
+		{
+			cwd: releaseTree,
+		},
+	);
+
+	for (const stack of config.stacks) {
+		await run(
+			"docker",
+			[
+				"compose",
+				"--project-name",
+				stack,
+				"--env-file",
+				join(config.secretsDirectory, `${stack}.env`),
+				"--env-file",
+				lockFile,
+				"--file",
+				join(releaseTree, `docker/compose.${stack}.yaml`),
+				"up",
+				"--detach",
+				"--wait",
+				`--wait-timeout=${config.waitTimeoutSeconds}`,
+				// Without this a service removed by the release keeps running, unmanaged, until
+				// someone notices it in `docker ps`.
+				"--remove-orphans",
+			],
+			{ cwd: releaseTree },
+		);
+	}
+
+	const finishedAt = new Date();
+	await writeAtomic(
+		appliedFile,
+		`${JSON.stringify({ release: decision.release, channelCommit, appliedAt: finishedAt.toISOString() }, null, "\t")}\n`,
+	);
+	if (config.metricsFile)
+		await writeAtomic(
+			config.metricsFile,
+			renderMetrics({
+				channel: config.channel,
+				release: decision.release,
+				commit: channelCommit,
+				success: true,
+				now: finishedAt,
+				lastSuccessAt: finishedAt,
+			}),
+		);
+	console.log(`Applied ${decision.release} to ${config.stacks.join(", ")}`);
+}
+
+/**
+ * A failed run must still publish a series, or the alert that matters — "this host has not converged
+ * in N minutes" — cannot tell a broken reconcile from a host that stopped running one at all.
+ */
+async function reportFailure(): Promise<void> {
+	const metricsFile = process.env.HEPHAESTUS_METRICS_FILE;
+	const channel = process.env.HEPHAESTUS_CHANNEL;
+	if (!metricsFile || !channel) return;
+	const applied = await readApplied(
+		join(process.env.HEPHAESTUS_STATE ?? "/var/lib/hephaestus", "applied.json"),
+	);
+	await writeAtomic(
+		metricsFile,
+		renderMetrics({
+			channel,
+			release: applied?.release ?? "none",
+			commit: applied?.channelCommit ?? "none",
+			success: false,
+			now: new Date(),
+			lastSuccessAt: applied ? new Date(applied.appliedAt) : undefined,
+		}),
+	);
+}
+
+if (process.argv[1] === import.meta.filename) {
+	try {
+		await main();
+	} catch (error) {
+		await reportFailure().catch(() => {
+			// A metric that cannot be written must not replace the error that caused the failure.
+		});
+		throw error;
+	}
+}

--- a/scripts/reconcile-deployment.ts
+++ b/scripts/reconcile-deployment.ts
@@ -104,6 +104,20 @@ export function renderMetrics(state: {
 	return `${lines.join("\n")}\n`;
 }
 
+/**
+ * The lock only guarantees anything if nothing the release renders escapes it: a compose file that
+ * hardcoded a tag would otherwise deploy an image no signature covers.
+ */
+export function unlockedImages(rendered: readonly string[], lockEnv: string): string[] {
+	const locked = new Set(
+		lockEnv
+			.split("\n")
+			.map((line) => line.slice(line.indexOf("=") + 1).trim())
+			.filter((value) => value.includes("@sha256:")),
+	);
+	return rendered.filter((image) => !locked.has(image));
+}
+
 function isStack(name: string): name is Stack {
 	return STACK_ORDER.some((stack) => stack === name);
 }
@@ -262,19 +276,37 @@ async function main(): Promise<void> {
 		},
 	);
 
+	const lockEnv = await readFile(lockFile, "utf8");
 	for (const stack of config.stacks) {
+		const composeArgs = [
+			"compose",
+			"--project-name",
+			stack,
+			"--env-file",
+			join(config.secretsDirectory, `${stack}.env`),
+			"--env-file",
+			lockFile,
+			"--file",
+			join(releaseTree, `docker/compose.${stack}.yaml`),
+		];
+		const rendered = asRecord(
+			parseJson(
+				await output("docker", [...composeArgs, "config", "--format", "json"], {
+					cwd: releaseTree,
+				}),
+			),
+			`${stack} configuration`,
+		);
+		const images = Object.values(asRecord(rendered.services, `${stack}.services`)).map((service) =>
+			asString(asRecord(service, `${stack} service`).image, `${stack} service image`),
+		);
+		const unlocked = unlockedImages(images, lockEnv);
+		if (unlocked.length > 0)
+			throw new Error(`${stack} renders images outside the release lock: ${unlocked.join(", ")}`);
 		await run(
 			"docker",
 			[
-				"compose",
-				"--project-name",
-				stack,
-				"--env-file",
-				join(config.secretsDirectory, `${stack}.env`),
-				"--env-file",
-				lockFile,
-				"--file",
-				join(releaseTree, `docker/compose.${stack}.yaml`),
+				...composeArgs,
 				"up",
 				"--detach",
 				"--wait",


### PR DESCRIPTION
## What changed and why

Deployments are pushed from CI over SSH through a jump host. That puts two long-lived private keys
in environment secrets, needs an internet-reachable SSH entry point, and renders roughly fifteen
production secrets onto a third-party runner's disk on every deploy — anyone who can run a workflow
in the deploy environment holds a shell on production.

The organisation transfer then showed how brittle it is. Org-level variables and secrets do not move
with a repository; the recreated ones name a host that resolves nowhere (`hephaestus-staging.aet…`,
which only exists in the box's own `/etc/hosts`), a user the machine refuses (`PermitRootLogin no`),
and a jump-host key that does not authenticate. Staging has been undeployable all evening, and none
of it was visible before a deploy attempt, because the credentials only exist inside CI.

A host now polls a **channel** naming a release, verifies it, and applies that release's
digest-pinned stacks. The verification is the one `prepare-release-lock.ts` already performs for
self-hosters — this puts it on a timer.

### The three decisions worth reviewing

**Freshness comes from the commit graph, not from a signature.** A signature proves authorship,
never currency: a valid old channel, replayed, verifies perfectly. The channel is therefore a commit
on `deploy-state`, and a commit that is an ancestor of the applied one is a rewind, refused unless
the channel declares it. This is what TUF builds timestamp and snapshot roles for, taken from a
history we already keep — and the reason the channel is *not* an OCI artifact on a mutable tag,
where no such order exists and GHCR offers no tag immutability.

**Approval is bound by identity, because it cannot be bound by claim.** Fulcio does record GitHub's
`environment` claim (OID `1.3.6.1.4.1.57264.1.23`, added Nov 2025), but cosign exposes no way to
verify it. So the hosts pin the identity of `promote.yml`, which a GitHub environment gates: a
signature carrying that identity is proof the reviewers approved. **This holds only while
`promote.yml` stays non-reusable** — a `workflow_call` trigger would let any caller mint the same
identity. That constraint is stated in the file itself.

**A failed apply stops; it does not roll back.** Schema changes here are forward-only, so restoring
the previous images would leave old code on a migrated database — the failure the rollback was meant
to prevent. It alerts instead, via `OnFailure=` and a `success 0` metric.

### Keeping the feedback CI would otherwise lose

Nothing can push the hosts, so the promotion workflow *observes*: the webapp already publishes
`APPLICATION_VERSION` in its runtime config (verified against production, which reports `0.63.1`),
and the workflow polls it until it matches, failing after 15 minutes. A host that stops reconciling
raises a staleness alert from its textfile metrics. Both matter — silent failure is the documented
weakness of pull-based deployment, and without them this trades a loud failure for a quiet one.

## How to test

- `vp run check` — green.
- `node --test scripts/reconcile-deployment.test.ts` — 10 tests over every decision branch: no-op,
  apply, rewind refused, rewind allowed, freeze, first run, stack ordering, metric shape.
- Not exercised end to end yet: that needs the `deploy-state` branch and the units on staging, which
  is the follow-up below.

## Release impact

Minor, with a changeset. Opt-in: nothing changes until an operator installs the units. Self-hosters
get an automatic, signature-verified upgrade path built from the manual one they already have.

## Notes for reviewers

`Type=oneshot` with **no** `RemainAfterExit=` is deliberate — with it the unit stays active, and
systemd will not restart an already-active unit when its timer elapses, so every tick after the
first would silently do nothing.

Honest about what this does not fix: write access to the Docker socket is root-equivalent, and no
systemd directive changes that. The reconciler is exactly as privileged as the SSH user it replaces;
what changes is that no *remote* party holds that privilege. Rootless Podman with Quadlet is the
structural escape and is not attempted here.

Follow-ups, deliberately not in this PR: create the orphan `deploy-state` branch with initial
channels, install on staging, then migrate production once its 0.63.1 → current jump is done by
hand. `deploy-locked-compose.yml` and the `VM_*`/`DEPLOYMENT_GATEWAY_*` secrets are deleted only
after both environments have moved.