### PR TITLE
test(config): run the hook install test against its own clone

### DIFF
--- a/scripts/enable-hooks.test.ts
+++ b/scripts/enable-hooks.test.ts
@@ -11,6 +11,15 @@ const REPO_ROOT = resolve(import.meta.dirname, "..");
 const SCRIPT = join(REPO_ROOT, "scripts", "enable-hooks.ts");
 const repositories: string[] = [];
 
+/**
+ * Git exports `GIT_DIR` and its siblings to every hook process, and they outrank a child's `cwd`.
+ * Inherited, they would point both the script under test and the assertions at the repository the
+ * hook is running in rather than at the clone made below.
+ */
+const ENV = Object.fromEntries(
+	Object.entries(process.env).filter(([key]) => !key.startsWith("GIT_")),
+);
+
 after(() => {
 	for (const repository of repositories) rmSync(repository, { recursive: true, force: true });
 });
@@ -24,9 +33,7 @@ function clone(): { repository: string; git: (...args: string[]) => string } {
 			cwd: repository,
 			encoding: "utf8",
 			maxBuffer: CAPTURE_LIMIT_BYTES,
-			env: Object.fromEntries(
-				Object.entries(process.env).filter(([key]) => !key.startsWith("GIT_")),
-			),
+			env: ENV,
 		}).trim();
 	git("init", "--quiet");
 	git("config", "core.hooksPath", ".husky/_");
@@ -40,10 +47,11 @@ void test("an install moves Git from an earlier hooks directory to the dispatche
 		cwd: repository,
 		encoding: "utf8",
 		maxBuffer: CAPTURE_LIMIT_BYTES,
+		env: ENV,
 	});
 	assert.equal(result.status, 0, `${result.stdout}${result.stderr}`);
 	assert.equal(git("config", "core.hooksPath"), ".vite-hooks/_");
-	const again = spawnSync("node", [SCRIPT], { cwd: repository, encoding: "utf8" });
+	const again = spawnSync("node", [SCRIPT], { cwd: repository, encoding: "utf8", env: ENV });
 	assert.equal(again.status, 0, `${again.stdout}${again.stderr}`);
 	assert.equal(git("config", "core.hooksPath"), ".vite-hooks/_");
 });


### PR DESCRIPTION
## What changed and why

`vp run gate:tooling` fails inside any Git hook, so no local `git push` from a clean checkout of `main` succeeds.

`scripts/enable-hooks.test.ts` strips `GIT_*` from the environment for its own `git` assertions, but the child process running `scripts/enable-hooks.ts` inherited it. Git exports `GIT_DIR` to every hook process, and `GIT_DIR` outranks a child's working directory — so under `pre-push` the script configured the repository being pushed instead of the temporary clone the test created, then read back that repository's `core.hooksPath` and failed the assertion.

The filtered environment is now built once and passed to both `spawnSync` calls, so the script under test always operates on the clone the test gave it.

## How to test

- `node --test scripts/enable-hooks.test.ts` — passes, as before.
- `GIT_DIR=$(git rev-parse --absolute-git-dir) node --test scripts/enable-hooks.test.ts` — passes now, fails on `main`.
- `git push` from any branch: the pre-push hook completes instead of failing in `gate:tooling`.

## Release impact

No changeset: this changes a repository tooling test, not shipped code. No operator action.

## Notes for reviewers

Landing this first keeps four open pull requests from each carrying their own copy of the same repair, which is what they need today to be pushable at all.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test environment consistency by using the same filtered environment for Git and script execution checks.
  * Ensured all tested processes run without inherited `GIT_`-prefixed variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->