### PR TITLE
ci: prove pre-push through the dispatcher

### DIFF
--- a/.github/workflows/ci-quality-gates.yml
+++ b/.github/workflows/ci-quality-gates.yml
@@ -129,8 +129,8 @@ jobs:
         if: env.RUN == 'true' && matrix.leg == 'server' && inputs.pmd_canary == 'true'
         run: vp run gate:pmd-canary
 
-      # CI installs with --ignore-scripts, so prepare never runs: the dispatcher is proven here instead.
-      - name: Hook dispatcher
+      # CI installs with --ignore-scripts, so prepare never runs: both hooks are dispatched here instead.
+      - name: Commit-msg hook
         if: env.RUN == 'true' && matrix.hooks && !cancelled()
         run: |
           node scripts/enable-hooks.ts
@@ -142,6 +142,32 @@ jobs:
             exit 1
           fi
           git commit --allow-empty --quiet -m "chore(ci): probe the commit-msg hook"
+
+      # The dispatcher prepends node_modules/.bin to PATH, so the launcher is shadowed there; the
+      # gate itself must not run a second time.
+      - name: Pre-push hook
+        if: env.RUN == 'true' && matrix.hooks && !cancelled()
+        run: |
+          node scripts/enable-hooks.ts
+          probe="$(mktemp)"
+          remote="$(mktemp -d)"
+          launcher=node_modules/.bin/vp
+          # Nothing else in CI runs the local launcher: GitHub does not put node_modules/.bin on PATH.
+          "$launcher" --version > /dev/null
+          mv "$launcher" "$launcher.real"
+          trap 'mv "$launcher.real" "$launcher"; rm -f "$probe"; rm -rf "$remote"' EXIT
+          cat > "$launcher" <<'EOF'
+          #!/bin/sh
+          if [ "$#" -ne 2 ] || [ "$1" != run ] || [ "$2" != check ]; then
+            exit 1
+          fi
+          printf 'ran\n' > "$PRE_PUSH_PROBE"
+          EOF
+          chmod +x "$launcher"
+          export PRE_PUSH_PROBE="$probe"
+          git init --bare --quiet "$remote"
+          git push --dry-run --quiet "$remote" HEAD:refs/heads/pre-push-probe
+          test "$(cat "$probe")" = ran
 
       - name: Upload webapp unit-test results
         if: env.RUN == 'true' && matrix.leg == 'webapp' && !cancelled()

--- a/scripts/ci-contract.test.ts
+++ b/scripts/ci-contract.test.ts
@@ -1436,6 +1436,8 @@ void test("installs dependencies in every job that calls vp", async () => {
 // a contributor runs from a clone that has nothing but the launcher.
 void test("proves the toolchain on Windows and from a clean clone", async () => {
 	const source = await readFile(".github/workflows/ci-quality-gates.yml", "utf8");
+	const workflow = parseDocument(source);
+	const qualityPath = ["jobs", "quality"];
 	const quality = job(source, "quality");
 	assert.match(quality, /runs-on: \$\{\{ matrix\.os \}\}/);
 	assert.match(quality, /shell: bash/);
@@ -1448,12 +1450,19 @@ void test("proves the toolchain on Windows and from a clean clone", async () => 
 	assert.doesNotMatch(install, /setup-toolchain|pnpm\/setup/);
 	assert.match(install, /vp install --frozen-lockfile/);
 	assert.match(install, /vp run gate:toolchain/);
-	// The legs that own hooks install them the way an install does, then fire the commit-msg hook
-	// on a message commitlint rejects and on one it accepts.
-	assert.match(quality, /if: env\.RUN == 'true' && matrix\.hooks && !cancelled\(\)/);
-	assert.match(quality, /node scripts\/enable-hooks\.ts/);
-	assert.match(quality, /git config core\.hooksPath/);
-	assert.equal((quality.match(/git commit --allow-empty/g) ?? []).length, 2);
+	const hookCondition = "env.RUN == 'true' && matrix.hooks && !cancelled()";
+	for (const name of ["Commit-msg hook", "Pre-push hook"])
+		assert.equal(namedStep(workflow, qualityPath, name).get("if"), hookCondition);
+	const commitHook = runScript(workflow, qualityPath, "Commit-msg hook");
+	assert.match(commitHook, /node scripts\/enable-hooks\.ts/);
+	assert.match(commitHook, /git config core\.hooksPath/);
+	assert.equal((commitHook.match(/git commit --allow-empty/g) ?? []).length, 2);
+	const prePushHook = runScript(workflow, qualityPath, "Pre-push hook");
+	assert.match(prePushHook, /node scripts\/enable-hooks\.ts/);
+	assert.match(prePushHook, /git push --dry-run\b/);
+	// The step moves the launcher aside, so it must put it back however it exits.
+	assert.match(prePushHook, /trap .*EXIT/);
+	assert.doesNotMatch(prePushHook, /^\s*vp run check\s*$/m);
 });
 
 void test("a change to the task graph or the hooks selects every quality leg", async () => {

--- a/scripts/enable-hooks.test.ts
+++ b/scripts/enable-hooks.test.ts
@@ -16,9 +16,9 @@ const repositories: string[] = [];
  * Inherited, they would point both the script under test and the assertions at the repository the
  * hook is running in rather than at the clone made below.
  */
-const ENV = Object.fromEntries(
-	Object.entries(process.env).filter(([key]) => !key.startsWith("GIT_")),
-);
+function hookFreeEnv(): NodeJS.ProcessEnv {
+	return Object.fromEntries(Object.entries(process.env).filter(([key]) => !key.startsWith("GIT_")));
+}
 
 after(() => {
 	for (const repository of repositories) rmSync(repository, { recursive: true, force: true });
@@ -33,7 +33,7 @@ function clone(): { repository: string; git: (...args: string[]) => string } {
 			cwd: repository,
 			encoding: "utf8",
 			maxBuffer: CAPTURE_LIMIT_BYTES,
-			env: ENV,
+			env: hookFreeEnv(),
 		}).trim();
 	git("init", "--quiet");
 	git("config", "core.hooksPath", ".husky/_");
@@ -47,11 +47,36 @@ void test("an install moves Git from an earlier hooks directory to the dispatche
 		cwd: repository,
 		encoding: "utf8",
 		maxBuffer: CAPTURE_LIMIT_BYTES,
-		env: ENV,
+		env: hookFreeEnv(),
 	});
 	assert.equal(result.status, 0, `${result.stdout}${result.stderr}`);
 	assert.equal(git("config", "core.hooksPath"), ".vite-hooks/_");
-	const again = spawnSync("node", [SCRIPT], { cwd: repository, encoding: "utf8", env: ENV });
+	const again = spawnSync("node", [SCRIPT], {
+		cwd: repository,
+		encoding: "utf8",
+		env: hookFreeEnv(),
+	});
 	assert.equal(again.status, 0, `${again.stdout}${again.stderr}`);
 	assert.equal(git("config", "core.hooksPath"), ".vite-hooks/_");
+});
+
+// Git exports `GIT_DIR` to a hook only when the push runs from a linked worktree, so no CI push can
+// reach this state; setting it here is the whole reproduction.
+void test("an install under a hook's GIT_DIR configures the clone it runs in", () => {
+	const decoy = clone();
+	const { repository, git } = clone();
+	process.env.GIT_DIR = join(decoy.repository, ".git");
+	try {
+		const result = spawnSync("node", [SCRIPT], {
+			cwd: repository,
+			encoding: "utf8",
+			maxBuffer: CAPTURE_LIMIT_BYTES,
+			env: hookFreeEnv(),
+		});
+		assert.equal(result.status, 0, `${result.stdout}${result.stderr}`);
+	} finally {
+		delete process.env.GIT_DIR;
+	}
+	assert.equal(git("config", "core.hooksPath"), ".vite-hooks/_");
+	assert.equal(decoy.git("config", "core.hooksPath"), ".husky/_");
 });


### PR DESCRIPTION
## What changed and why

The `pre-push` hook stands between every contributor and a broken push, and CI proved only its file
mode. A step on the tooling and Windows quality legs now fires it for real: it enables the
dispatcher, starts the repository's own `vp` launcher to prove it runs, shadows that launcher with a
stub that accepts exactly `run check`, and performs an object-free dry-run push to a temporary bare
repository. The hook not firing, or asking for a different command, fails the leg. The full quality
gate does not run a second time.

Shadowing the launcher is what makes that affordable, and it is also the one thing the probe cannot
prove: a launcher that resolves but cannot start would pass. So the step starts the real one first,
before moving it aside, and an `EXIT` trap puts it back.

A push probe cannot cover everything about hooks. Git exports `GIT_DIR` into a `pre-push` hook only
when the push runs from a linked worktree — never from the plain clone `actions/checkout` produces —
and `GIT_DIR` outranks a child process's working directory. That is how `scripts/enable-hooks.test.ts`
came to configure the repository being pushed instead of its own temporary clone. Nothing guarded
that. A second case in that test now reproduces it directly: it exports a decoy repository's
`GIT_DIR`, runs the script in a different clone, and asserts the clone was configured and the decoy
was not.

The contract assertions for the probe were rewritten to describe the contract — a dry-run push, a
restoring `EXIT` trap, no second `vp run check` — instead of the stub's shell source.

Fixes #1792.

## How to test

- `vp run format`
- `vp run check`
- `node --test scripts/enable-hooks.test.ts`
- `node --test scripts/ci-contract.test.ts`
- To see the new case bite, replace the body of `hookFreeEnv()` with `return process.env;` and rerun
  the first command: it fails with the decoy's `core.hooksPath`, which is the defect it guards.

## Release impact

None. This changes repository CI and repository tests only, so it needs no changeset and no operator
action.

## Notes for reviewers

The probe replaces `node_modules/.bin/vp` in place because the dispatcher prepends that directory to
`PATH`; a fake binary prepended elsewhere would not intercept the hook's command. Nothing else in CI
executes that launcher — GitHub does not put `node_modules/.bin` on `PATH` — which is why the step
starts it once before shadowing it.
