### PR TITLE
build(config): reject commands the runner cannot cache

### DIFF
--- a/scripts/ci-contract.test.ts
+++ b/scripts/ci-contract.test.ts
@@ -1347,12 +1347,12 @@ void test("the task graph keeps its cache posture", async () => {
 	for (const [name, task] of Object.entries(tasks)) {
 		if (!isRecord(task)) continue;
 		const commands = commandsOf(task);
-		// A cached task owns its command: `vp run <task>` resolves to that node and never caches, and
-		// `vp exec` runs a bundled binary the runner does not fingerprint.
+		// The runner never caches a command that delegates (scripts/check-runner-contract.ts).
+		// vite.config.ts rejects the literal form, so only a command widened to string reaches here.
 		if (task.cache !== false)
 			for (const command of commands) {
-				assert.doesNotMatch(command, /^vp run /, `${name} must own its command to cache`);
-				assert.doesNotMatch(command, /^vp exec /, `${name} cannot cache through vp exec`);
+				assert.doesNotMatch(command, /\bvp run\b/, `${name} must own its command to cache`);
+				assert.doesNotMatch(command, /\bvp exec\b/, `${name} cannot cache through vp exec`);
 			}
 		// Shell parameter expansion is outside the runner contract (scripts/check-runner-contract.ts).
 		for (const command of commands)

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -21,5 +21,5 @@
 		"skipLibCheck": true,
 		"types": ["node"]
 	},
-	"include": ["./**/*.ts"]
+	"include": ["./**/*.ts", "../vite.config.ts"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -25,19 +25,26 @@ const run = (
 	command: string | string[],
 	{ cwd, dependsOn = [] }: { cwd?: string; dependsOn?: string[] } = {},
 ) => ({ command, cwd, dependsOn, cache: false as const });
+type CacheableCommand<Command extends string> =
+	Command extends `${string}vp ${"run" | "exec"}${string}` ? never : Command;
 // pnpm rewrites node_modules/.modules.yaml on every install; no verdict reads it.
-const cached = (command: string) => ({
+const cached = <Command extends string>(command: CacheableCommand<Command>) => ({
 	command,
 	input: [{ auto: true }, "!node_modules/.modules.yaml"],
 });
 // For a verdict the tracker cannot see through a subprocess: the inputs are named. A cached task
 // runs with a filtered environment, so anything the command reads from it is named in `env` and
 // becomes part of the fingerprint.
-const cachedOn = (
-	command: string,
+const cachedOn = <Command extends string>(
+	command: CacheableCommand<Command>,
 	input: string[],
 	{ env = [], dependsOn = [] }: { env?: string[]; dependsOn?: string[] } = {},
 ) => ({ command, input, output: [], env, dependsOn });
+// A rejection nothing exercises stops rejecting: these two calls must not compile.
+// @ts-expect-error `vp run <task>` resolves to another node, which the runner never caches
+void cached("vp run check");
+// @ts-expect-error `vp exec` runs a bundled binary the runner does not fingerprint, wherever it sits
+void cachedOn("node scripts/x.ts && vp exec oxlint .", ["package.json"]);
 // No command of its own: runs its dependencies in parallel and fails when any of them fails.
 const group = (dependsOn: readonly string[]) => ({
 	command: [],
@@ -276,7 +283,6 @@ export default defineConfig({
 			// Agent runtime, precompute, repository scripts and tooling config
 			"gate:agents-format": cached(`vp fmt --check ${agentSources}`),
 			"gate:config-format": cached(`vp fmt --check ${configFiles}`),
-			// A command that starts with `vp exec` is never cached — scripts/check-runner-contract.ts.
 			"gate:agents-lint": run(`vp exec oxlint ${oxlintFormat}${oxlintTargets}`),
 			"gate:agents-typecheck": cached("tsc -p tsconfig.agents.json --noEmit"),
 			"gate:scripts-typecheck": cached("tsc -p scripts/tsconfig.json --noEmit"),


### PR DESCRIPTION
## What changed and why

The cached task helpers in `vite.config.ts` accepted any string, so a task could be written to
delegate through `vp run` or `vp exec` — commands the runner never caches. The mistake was only
caught later, by a contract assertion that has to load the whole task graph first.

`cached()` and `cachedOn()` now take a template-literal conditional type that resolves to `never`
for any command containing `vp run` or `vp exec`, so the call site fails `tsc` — and the editor
shows it while typing. `scripts/tsconfig.json` names `vite.config.ts` explicitly, because
`scripts/lib/task-graph.ts` loads the config through a computed dynamic `import()` that TypeScript
cannot follow; without that entry the config was in no TypeScript project and the guard would be
checked by nothing.

Two `@ts-expect-error` calls sit beside the helpers so the rejection is itself under test: if the
type ever stops rejecting, the unused directives fail `gate:scripts-typecheck`, which runs in
`vp run check`.

The runtime assertion in `scripts/ci-contract.test.ts` stays as the backstop for commands that have
widened to `string`, and its comment now states the constraint and points at the type.

Fixes #1791.

## How to test

- `vp run check`
- `node --test scripts/ci-contract.test.ts`

To see the guard fail on the defect it targets, replace the body of `CacheableCommand` with
`Command` and run `vp run gate:scripts-typecheck`: it reports `TS2578: Unused '@ts-expect-error'
directive` twice and exits non-zero.

## Release impact

No changeset. This changes repository build configuration only and has no user-facing or
operator-facing effect.

## Notes for reviewers

Start with `CacheableCommand` and the two `@ts-expect-error` calls under `cachedOn`. The type
matches the two prefixes anywhere in a command, not only at the start, so a compound command like
`node scripts/x.ts && vp run y` is rejected as well; the graph assertion's regexes were widened to
match.

TypeScript can only see a command that is still a literal. #1810's `configFormatCommand` returns a
widened `string`, so `gate:config-format` will not be covered by this type once that PR lands — it
stays covered by the runtime graph assertion, which is why that assertion is kept rather than
replaced.
