### PR TITLE
build(config): derive the configuration format set

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -198,8 +198,9 @@ Oxlint lints; oxfmt formats and sorts imports. Each tree states its rule set in 
 - **`vp run` does not give a command a POSIX shell on every platform.** So a command never contains
   `$`, which `scripts/ci-contract.test.ts` enforces, and what it reads from the environment is
   decided in `vite.config.ts` when the config loads. The runner facts the graph relies on are proven
-  in `scripts/check-runner-contract.ts`. oxfmt expands a pattern itself, always recursively, so a
-  root-only format task names its files.
+  in `scripts/check-runner-contract.ts`. An oxfmt pattern with no `/` matches a basename at any
+  depth and one with a `/` is anchored at the working directory, so a root-only pass pairs its
+  patterns with `!*/**`.
 
 ## Pull requests
 

--- a/scripts/check-runner-contract.ts
+++ b/scripts/check-runner-contract.ts
@@ -1,10 +1,13 @@
 /**
- * The task graph in `vite.config.ts` relies on how `vp run` executes a command. Those facts are
- * Vite+ behaviour, not documented guarantees, so this gate runs the pinned `vite-plus` against a
+ * The task graph in `vite.config.ts` relies on how `vp run` and its bundled tools execute a
+ * command. These are not documented guarantees, so this gate runs the pinned tools against a
  * scratch workspace outside the repository and fails on the first fact that no longer holds:
  *
  *   - array commands run in order, and an `&&` chain keeps its order;
  *   - a glob reaches the command as written, quoted or not; the runner never expands it;
+ *   - an oxfmt pattern with no slash matches a basename at any depth, and a negation confines a pass
+ *     to the directory it runs in; a pattern containing a slash is anchored there and reaches no
+ *     deeper;
  *   - an uncached task inherits the caller's environment; a cached task is given a filtered one and
  *     sees only what it names in `env`;
  *   - a task runs its `dependsOn` before its own command, and a group with no command runs its
@@ -22,7 +25,7 @@
  */
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { after, test } from "node:test";
@@ -36,7 +39,7 @@ const PROBE_ENV = 'node -e "console.log(JSON.stringify([process.env.PROBE ?? nul
 
 const workspace = mkdtempSync(join(tmpdir(), "runner-contract-"));
 mkdirSync(join(workspace, "node_modules"));
-for (const entry of ["vite-plus", ".bin"])
+for (const entry of ["vite-plus", "oxfmt", ".bin"])
 	symlinkSync(
 		join(REPO_ROOT, "node_modules", entry),
 		join(workspace, "node_modules", entry),
@@ -53,6 +56,9 @@ writeFileSync(
 );
 mkdirSync(join(workspace, "fixtures"));
 for (const name of ["a.json", "b.json"]) writeFileSync(join(workspace, "fixtures", name), "{}\n");
+// The formatter probes write what they format, so they run in a directory no other task declares.
+const probeRoot = join(workspace, "root-probe");
+mkdirSync(join(probeRoot, "nested", "deep"), { recursive: true });
 // Written as data, so a quote inside a command never has to survive a second layer of quoting.
 const tasks = {
 	order: {
@@ -68,6 +74,12 @@ const tasks = {
 		cache: false,
 	},
 	glob: { command: `${ARGV} fixtures/*.json 'fixtures/*.json'`, cache: false },
+	rootFormat: {
+		command: "vp fmt --write '*.{json,ts,code-workspace}' '!*/**'",
+		cwd: "root-probe",
+		cache: false,
+	},
+	nestedFormat: { command: "vp fmt --write 'nested/*.json'", cwd: "root-probe", cache: false },
 	env: { command: PROBE_ENV, cache: false },
 	cachedEnv: { command: PROBE_ENV, input: ["package.json"], output: [] },
 	declaredEnv: { command: PROBE_ENV, input: ["package.json"], output: [], env: ["PROBE"] },
@@ -130,6 +142,40 @@ void test("globs reach the command unexpanded, quoted or not", () => {
 	const { status, output } = run(["glob"]);
 	assert.equal(status, 0, output);
 	assert.deepEqual(printed(output), [["fixtures/*.json", "fixtures/*.json"]], output);
+});
+
+const UNFORMATTED_JSON = '{"probe":true}';
+const UNFORMATTED_TYPESCRIPT = "export default {probe:true}";
+
+void test("an oxfmt root pattern paired with !*/** reaches no subdirectory", () => {
+	const root = join(probeRoot, "root.json");
+	const rootTypeScript = join(probeRoot, "root.ts");
+	// `.code-workspace` is the one extension in the root set oxfmt has to recognise as JSON.
+	const rootWorkspace = join(probeRoot, "root.code-workspace");
+	const nested = join(probeRoot, "nested", "out-of-scope.json");
+	writeFileSync(root, UNFORMATTED_JSON);
+	writeFileSync(rootTypeScript, UNFORMATTED_TYPESCRIPT);
+	writeFileSync(rootWorkspace, UNFORMATTED_JSON);
+	writeFileSync(nested, UNFORMATTED_JSON);
+
+	const { status, output } = run(["rootFormat"]);
+	assert.equal(status, 0, output);
+	assert.notEqual(readFileSync(root, "utf8"), UNFORMATTED_JSON);
+	assert.notEqual(readFileSync(rootTypeScript, "utf8"), UNFORMATTED_TYPESCRIPT);
+	assert.notEqual(readFileSync(rootWorkspace, "utf8"), UNFORMATTED_JSON);
+	assert.equal(readFileSync(nested, "utf8"), UNFORMATTED_JSON);
+});
+
+void test("an oxfmt pattern containing a slash is anchored and reaches no deeper", () => {
+	const nested = join(probeRoot, "nested", "in-scope.json");
+	const deeper = join(probeRoot, "nested", "deep", "out-of-scope.json");
+	writeFileSync(nested, UNFORMATTED_JSON);
+	writeFileSync(deeper, UNFORMATTED_JSON);
+
+	const { status, output } = run(["nestedFormat"]);
+	assert.equal(status, 0, output);
+	assert.notEqual(readFileSync(nested, "utf8"), UNFORMATTED_JSON);
+	assert.equal(readFileSync(deeper, "utf8"), UNFORMATTED_JSON);
 });
 
 void test("an uncached task inherits the caller's environment", () => {

--- a/scripts/check-toolchain.ts
+++ b/scripts/check-toolchain.ts
@@ -89,18 +89,7 @@ if (!isDeepStrictEqual(Object.keys(scripts), ["prepare"]))
 	throw new Error(
 		"package.json#scripts must contain only prepare; commands live in vite.config.ts",
 	);
-// A root-level config file is formatted by name, so a new one must be added to `format:config`.
 const tasks = await loadTasks();
-const configFormat = new Set(commandsOf(tasks["format:config"]).join(" ").split(" "));
-const trackedConfig = execFileSync(
-	"git",
-	["ls-files", "-z", "*.json", "*.ts", ".vscode/*.json", ".changeset/*.cjs", ".changeset/*.json"],
-	{ encoding: "utf8", maxBuffer: CAPTURE_LIMIT_BYTES },
-)
-	.split("\0")
-	.filter((file) => file !== "" && (!file.includes("/") || /^\.(?:vscode|changeset)\//.test(file)));
-for (const file of [...trackedConfig, "scripts/tsconfig.json", "project.code-workspace"])
-	if (!configFormat.has(file)) throw new Error(`${file} is not in the format:config file set`);
 const usesTsx = (command: string): boolean => /(?:^|[;&|])\s*tsx(?:\s|$)/.test(command);
 for (const [name, task] of Object.entries(tasks)) {
 	for (const line of commandsOf(task))

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -57,9 +57,12 @@ const agentSources =
 	"'server/application/src/{main,test}/resources/agent/**/*.ts' 'server/application/src/main/resources/practices/precompute/**/*.ts' 'docker/agents/precompute/**/*.ts' 'scripts/**/*.ts'";
 const loadSources = "'load-tests/**/*.js'";
 const docsSources = "'docs/**/*.{js,jsx,ts,tsx,json,jsonc,css}'";
-// Named file by file: the runner hands a glob to oxfmt unexpanded, and oxfmt matches it recursively.
-const configFiles =
-	"package.json renovate.json tsconfig.json tsconfig.agents.json jean.json opencode.json openapitools.json vite.config.ts commitlint.config.ts .oxfmtrc.json .oxlintrc.json project.code-workspace .changeset/changelog.cjs .changeset/config.json .changeset/tsconfig.json .vscode/settings.json scripts/tsconfig.json";
+// Two passes: a negation applies to the whole invocation, so `!*/**` would also drop the nested set.
+const rootConfigSources = "'*.{json,ts,code-workspace}' '!*/**'";
+const nestedConfigSources = "'{.changeset,.vscode,scripts}/*.{cjs,json}'";
+// `as const` keeps the command a literal type, so `cached` can still read what it runs.
+const configFormatCommand = (mode: "--check" | "--write") =>
+	`vp fmt ${mode} ${rootConfigSources} && vp fmt ${mode} ${nestedConfigSources}` as const;
 const oxlintTargets = "server docker scripts .changeset .github commitlint.config.ts";
 // Decided when the config loads; a command never uses shell expansion.
 const oxlintFormat = process.env.GITHUB_ACTIONS === "true" ? "-f github " : "";
@@ -181,7 +184,7 @@ export default defineConfig({
 			"format:load:check": group(["gate:load-format"]),
 			"format:docs": run(`vp fmt --write ${docsSources}`),
 			"format:docs:check": group(["gate:docs-format"]),
-			"format:config": run(`vp fmt --write ${configFiles}`),
+			"format:config": run(configFormatCommand("--write")),
 			"format:config:check": group(["gate:config-format"]),
 			"format:achievements": run("node scripts/format-achievements.ts"),
 
@@ -282,7 +285,7 @@ export default defineConfig({
 
 			// Agent runtime, precompute, repository scripts and tooling config
 			"gate:agents-format": cached(`vp fmt --check ${agentSources}`),
-			"gate:config-format": cached(`vp fmt --check ${configFiles}`),
+			"gate:config-format": cached(configFormatCommand("--check")),
 			"gate:agents-lint": run(`vp exec oxlint ${oxlintFormat}${oxlintTargets}`),
 			"gate:agents-typecheck": cached("tsc -p tsconfig.agents.json --noEmit"),
 			"gate:scripts-typecheck": cached("tsc -p scripts/tsconfig.json --noEmit"),


### PR DESCRIPTION
## What changed and why

`format:config` named 17 files one by one — the last hand-maintained file set in the task graph.
Adding a root-level configuration file meant remembering to add it, and `check-toolchain.ts` carried
a completeness assertion whose only job was to catch the times nobody did.

The set is now derived from two oxfmt patterns. An oxfmt pattern with no slash matches a basename at
any depth, so `'*.{json,ts,code-workspace}'` paired with `'!*/**'` is exactly the repository root; a
pattern containing a slash is anchored where the command runs and reaches no deeper, so
`'{.changeset,.vscode,scripts}/*.{cjs,json}'` is exactly those three directories and cannot wander
into a package tree. The two run as separate invocations because a negation applies to the whole
invocation: `!*/**` in the same command would drop the nested set as well. Apply and check are built
by one command builder, so their scopes cannot drift, and the assertion in `check-toolchain.ts` goes
with the list it guarded.

None of that is documented by oxfmt, so the runner contract proves both halves against the pinned
binary: a root pass reaches no subdirectory, and a pass whose pattern contains a slash reaches no
deeper than the directory it names. Both probes run in their own directory, because they write what
they format and the scratch workspace's own `package.json` and `vite.config.ts` are declared inputs
of the caching tests in the same file.

`AGENTS.md` states the rule, once; `vite.config.ts` records only the decision it made — why there
are two passes.

Fixes #1793.

## How to test

```bash
vp run format
vp run check

The formatter contract on its own:

```bash
node --test scripts/check-runner-contract.ts

Drop `'!*/**'` from the `rootFormat` task and the root probe fails on a subdirectory file; widen
`nestedFormat` to `'*.json'` and the anchoring probe fails on the file one level deeper.

## Release impact

No changeset is needed. This changes contributor tooling only and has no effect on the shipped
application or on operator configuration.

## Notes for reviewers

Start at `rootConfigSources` in `vite.config.ts`, then read the two probes in
`scripts/check-runner-contract.ts` — they are where the undocumented oxfmt behaviour is pinned down.
The derived set matches the previous hand-written one exactly: 12 root files and 5 nested files
against the 17 that were named.
