### PR TITLE
build(config): finish the Renovate custom-manager contract

### DIFF
--- a/.changeset/renovate-node-datasource.md
+++ b/.changeset/renovate-node-datasource.md
@@ -1,0 +1,7 @@
+---
+---
+
+No release note: the one shipped file this pull request touches carries a comment change only — the
+agent image records which list of Node.js releases its pin is read from, so the three places that
+pin the same Node.js version are read from the same list. The image is built from the same version
+it was built from before.

--- a/docker/agents/pi/Dockerfile
+++ b/docker/agents/pi/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.26@sha256:ecfaec9ed6d810b56388c508f4121597bfbba70d41a6dfeee4d8cad5f295fc32
-# renovate: datasource=docker depName=node
+# renovate: datasource=node-version depName=node
 ARG NODE_VERSION=24.19.0
 FROM ghcr.io/pnpm/pnpm:12.0.0@sha256:bce5ae25ef95edd79e696d7fa8489b80561ef660100fd35bd0286d0f90db3dcc AS dependencies
 ARG NODE_VERSION

--- a/renovate.json
+++ b/renovate.json
@@ -136,6 +136,7 @@
 			"matchStrings": [
 				"# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\s+version: (?<currentValue>\\S+)"
 			],
+			"extractVersionTemplate": "^v(?<version>.*)$",
 			"versioningTemplate": "semver"
 		},
 		{

--- a/scripts/check-agent-runtime-pins.ts
+++ b/scripts/check-agent-runtime-pins.ts
@@ -92,7 +92,7 @@ if (!nodeBase) {
 }
 
 for (const marker of [
-	"datasource=docker depName=node",
+	"datasource=node-version depName=node",
 	"datasource=npm depName=@earendil-works/pi-coding-agent",
 ]) {
 	if (!dockerfile.includes(`# renovate: ${marker}`)) {

--- a/scripts/renovate-config.test.ts
+++ b/scripts/renovate-config.test.ts
@@ -12,6 +12,14 @@ assert.ok(Array.isArray(config.extends));
 assert.ok(config.extends.every((entry) => typeof entry === "string"));
 const extensions = config.extends;
 
+/**
+ * Datasources whose versions are release tags, which upstreams prefix with `v` while the pins here
+ * are bare. Unless a manager strips the prefix, the version Renovate resolves for a pin is the tag
+ * rather than the pin, so every rule that reads a version — `matchCurrentVersion` included — is
+ * matched against a string the file does not contain.
+ */
+const RELEASE_TAG_DATASOURCES = new Set(["github-releases", "github-tags"]);
+
 void test("Renovate creates bounded update PRs without a manual dispatch queue", () => {
 	assert.ok(extensions.includes("config:best-practices"));
 	assert.ok(!extensions.includes(":dependencyDashboardApproval"));
@@ -62,7 +70,7 @@ void test("every pin of one toolchain version moves in a single pull request", (
 	}
 });
 
-void test("Vercel AI SDK packages move together", () => {
+void test("Vercel AI SDK packages move together", async () => {
 	assert.ok(Array.isArray(config.packageRules));
 	const rules = config.packageRules.filter(isRecord);
 	const ruleIndex = rules.findLastIndex((rule) => rule.groupName === "Vercel AI SDK");
@@ -73,7 +81,17 @@ void test("Vercel AI SDK packages move together", () => {
 	assert.deepEqual(rule.matchFileNames, ["webapp/package.json"]);
 	assert.deepEqual(rule.matchPackageNames, ["ai", "@ai-sdk/react"]);
 	assert.equal(rule.matchUpdateTypes, undefined);
-	assert.equal(rule.minimumGroupSize, 2);
+	// Renovate creates no branch at all below `minimumGroupSize`, so a floor above the number of
+	// pins the rule can match would hold every update in the group back, security ones included.
+	const manifest: unknown = parseJson(await readFile("webapp/package.json", "utf8"));
+	assert.ok(isRecord(manifest));
+	const dependencies: unknown = manifest.dependencies;
+	assert.ok(isRecord(dependencies));
+	assert.ok(Array.isArray(rule.matchPackageNames));
+	const pinned = rule.matchPackageNames.filter(
+		(name) => typeof name === "string" && name in dependencies,
+	);
+	assert.equal(rule.minimumGroupSize, pinned.length);
 });
 
 void test("routine update groups preserve repository boundaries", () => {
@@ -111,7 +129,7 @@ void test("vulnerability remediation bypasses normal update latency", () => {
 	});
 });
 
-void test("every custom manager extracts a dependency from its real source", async () => {
+void test("every custom manager reads every file it claims to read", async () => {
 	const sources = new Map<string, string[]>([
 		["Track Dockerfile ARG version pins", ["docker/agents/pi/Dockerfile", "webapp/Dockerfile"]],
 		[
@@ -147,17 +165,50 @@ void test("every custom manager extracts a dependency from its real source", asy
 	for (const manager of config.customManagers) {
 		if (typeof manager.description !== "string") throw new TypeError("manager description");
 		const description = manager.description;
-		assert.ok(Array.isArray(manager.matchStrings));
+		assert.ok(Array.isArray(manager.matchStrings), `${description} declares no matchStrings`);
+		assert.ok(
+			manager.matchStrings.every((pattern) => typeof pattern === "string"),
+			`${description} declares a matchStrings entry that is not a string`,
+		);
+		assert.ok(
+			Array.isArray(manager.managerFilePatterns),
+			`${description} declares no managerFilePatterns`,
+		);
+		assert.ok(
+			manager.managerFilePatterns.every((pattern) => typeof pattern === "string"),
+			`${description} declares a managerFilePatterns entry that is not a string`,
+		);
 		const files = sources.get(description);
 		assert.ok(files);
-		const contents = await Promise.all(files.map((file) => readFile(file, "utf8")));
-		for (const pattern of manager.matchStrings) {
-			if (typeof pattern !== "string") throw new TypeError("manager match pattern");
+		const datasources = new Set(
+			typeof manager.datasourceTemplate === "string" ? [manager.datasourceTemplate] : [],
+		);
+		for (const file of files) {
 			assert.ok(
-				contents.some((content) => new RegExp(pattern, "m").test(content)),
-				`${description} no longer matches its source`,
+				// `managerFilePatterns` accepts a glob as well as a `/`-delimited regex; only the
+				// latter survives the slice, so anything else is not a pattern this check can read.
+				manager.managerFilePatterns.some(
+					(pattern) =>
+						pattern.startsWith("/") &&
+						pattern.endsWith("/") &&
+						new RegExp(pattern.slice(1, -1)).test(file),
+				),
+				`${description} does not select ${file}`,
 			);
+			const content = await readFile(file, "utf8");
+			assert.ok(
+				manager.matchStrings.some((pattern) => new RegExp(pattern, "m").test(content)),
+				`${description} no longer extracts a dependency from ${file}`,
+			);
+			for (const [, datasource = ""] of content.matchAll(/# renovate: datasource=(\S+)/g))
+				datasources.add(datasource);
 		}
+		if ([...datasources].some((datasource) => RELEASE_TAG_DATASOURCES.has(datasource)))
+			assert.ok(
+				manager.extractVersionTemplate === "^v(?<version>.*)$" ||
+					manager.matchStrings.some((pattern) => pattern.includes("(?<extractVersion>")),
+				`${description} reads release tags without stripping their v prefix`,
+			);
 	}
 });
 


### PR DESCRIPTION
## What changed and why

Renovate compared the bare Zizmor version pinned in `.github/workflows/cicd.yml` against
`v`-prefixed GitHub release tags without stripping the prefix, so the version it resolved for that
pin was the tag rather than the value in the file. Zizmor was the only release-based custom manager
in this configuration missing that extraction.

Zizmor now normalizes releases through Renovate's `extractVersionTemplate`, and the configuration
contract test enforces the rule rather than restating it: a manager whose datasource is a release
tag — read from the manager itself or from the `# renovate:` markers in the files it selects — must
strip the prefix. The Vercel AI SDK group floor is no longer a literal either; it is derived from
the packages the rule can actually match in `webapp/package.json`, so a floor can never exceed the
pin count and silently suppress the group's branch. Finally, the Pi agent image resolves its Node.js
pin from the same list as `webapp/Dockerfile` and `package.json#devEngines`, so the three pins that
must move together are read from one release list instead of two.

Fixes #1804

## How to test

- `vp run format`
- `vp run check`
- `renovate-config-validator renovate.json`

The three "Done when" bullets of #1804 were verified as follows.

*Every custom manager extracts a bare version, verified against a real Renovate dry run.* Renovate
44.61.6, `--platform=local --dry-run=full --repository-cache=disabled`:

zizmorcore/zizmor               currentValue=1.29.0   datasource=github-releases  extractVersion=^v(?<version>.*)$
anchore/syft                    currentValue=1.51.1   datasource=github-releases  extractVersion=^v(?<version>.*)$
aquasecurity/trivy              currentValue=0.74.0   datasource=github-releases  extractVersion=^v(?<version>.*)$
buildpacks/pack                 currentValue=0.40.9   datasource=github-releases  extractVersion=^v(?<version>.*)$
OpenAPITools/openapi-generator  currentValue=7.7.0    datasource=github-releases  extractVersion=^v(?<version>.*)$
node                            currentValue=24.19.0  datasource=node-version
pnpm                            currentValue=12.0.0   datasource=npm
@earendil-works/pi-coding-agent currentValue=0.84.3   datasource=npm

Zizmor resolves `currentVersion: "1.29.0"` and proposes `newValue: "1.30.0"`. Removing the template
and re-running makes Renovate resolve `currentVersion: "v1.29.0"` and `newVersion: "v1.30.0"` for a
file that says `1.29.0` — the tag, not the pin, is what every version-reading rule then sees,
including the `matchCurrentVersion: "/^0\\./"` rule that routes 0.x minors to the seven-day age and
the `breaking` label.

*The test asserts each `managerFilePatterns` selects the file its manager reads.* The per-file loop
does both halves — selection and extraction — so one matching source can no longer cover for a
sibling the manager has stopped selecting.

*Any group floor is derived from the extractable pin count, or there is none.* The Node, pnpm and Pi
SDK groups carry no floor. The Vercel AI SDK floor is derived from the group's packages that are
declared in `webapp/package.json`.

Each new assertion was mutation-checked: dropping the Zizmor template, dropping `@ai-sdk/react` from
`webapp/package.json`, and replacing a `managerFilePatterns` regex with a glob each turn the suite
red with a named verdict.

## Release impact

`.changeset/renovate-node-datasource.md`, an empty bump. The one shipped file this touches is a
comment in the Pi agent Dockerfile naming which list of Node.js releases the pin is read from; the
image builds from the same version as before and no operator action follows.

## Notes for reviewers

Start at `RELEASE_TAG_DATASOURCES` in `scripts/renovate-config.test.ts`: the assertion reads the
datasource out of each manager and out of the files it selects, so adding a fifth release-tag
manager is covered without editing a list of manager names. The Pi Dockerfile change needs the
matching marker string in `scripts/check-agent-runtime-pins.ts`, which asserts it verbatim; the
`FROM node:${NODE_VERSION}-slim@sha256:…` digest below it stays a Docker concern and is untouched.
