### PR TITLE
fix(ci): make dependency severity policy effective

### DIFF
--- a/.github/dependency-review-config.yml
+++ b/.github/dependency-review-config.yml
@@ -1,0 +1,14 @@
+# The Security workflow's dependency vulnerability gate owns the severity verdict, over every
+# dependency in the checkout rather than only the ones a pull request changes. This review reports
+# what a pull request introduces so a reviewer sees it with its advisory and patched version, and
+# holds no second verdict with a second exception path. `fail-on-severity` would be inert here:
+# `warn-only` reports every severity.
+warn-only: true
+# Build tooling can affect shipped artifacts; unclassified dependencies are reported too.
+fail-on-scopes:
+  - runtime
+  - development
+  - unknown
+license-check: true
+vulnerability-check: true
+show-patched-versions: true

--- a/.github/workflows/ci-security-scan.yml
+++ b/.github/workflows/ci-security-scan.yml
@@ -67,15 +67,15 @@ jobs:
     permissions:
       contents: read
     steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
       - name: Review dependency changes
         uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
-          fail-on-severity: high
-          # CI tooling is part of the release trust boundary.
-          fail-on-scopes: runtime, development, unknown
-          license-check: true
-          show-patched-versions: true
-          vulnerability-check: true
+          config-file: ./.github/dependency-review-config.yml
 
   security-scan:
     name: "Dependencies, secrets, and policy"
@@ -91,6 +91,8 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      # SARIF output reports every severity whatever `severity` says, so this pass carries no
+      # severity or exit code: it is the code-scanning feed, and the pass below is the verdict.
       - name: Trivy dependency scan
         id: dependencies
         continue-on-error: true
@@ -107,6 +109,24 @@ jobs:
         uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           sarif_file: "trivy-results.sarif"
+
+      # Every dependency in the checkout, not only the ones a pull request changes, so an advisory
+      # published against an untouched pin fails this job on the next push to main. `skip-setup-trivy`
+      # reuses the binary the scan above installed.
+      - name: Enforce dependency vulnerability policy
+        id: dependency-policy
+        continue-on-error: true
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: "fs"
+          scan-ref: "."
+          format: "table"
+          scanners: "vuln"
+          severity: "HIGH,CRITICAL"
+          ignore-unfixed: true
+          exit-code: "1"
+          trivyignores: "security/trivy-dependency-ignore.yaml"
+          skip-setup-trivy: true
 
       - name: Secret detection
         id: secrets
@@ -144,11 +164,12 @@ jobs:
         continue-on-error: true
         env:
           DEPENDENCIES: ${{ steps.dependencies.outcome }}
+          DEPENDENCY_POLICY: ${{ steps.dependency-policy.outcome }}
           SECRETS: ${{ steps.secrets.outcome }}
           POLICY: ${{ steps.policy.outcome }}
         run: |
           failed=false
-          for result in "$DEPENDENCIES" "$SECRETS" "$POLICY"; do
+          for result in "$DEPENDENCIES" "$DEPENDENCY_POLICY" "$SECRETS" "$POLICY"; do
             if [ "$result" != "success" ]; then failed=true; fi
           done
           if [ "$failed" = "true" ]; then

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -251,6 +251,9 @@ jobs:
             security-config:
               - '.github/workflows/cicd.yml'
               - '.github/workflows/ci-security-scan.yml'
+              - '.github/dependency-review-config.yml'
+              # A suppression has to re-run the gate it suppresses.
+              - 'security/trivy-dependency-ignore.yaml'
             release-images:
               # The pinned upstream digests need no build, so the pull request that edits them —
               # a Renovate digest bump included — is the one that scans them (#1741). The script

--- a/docs/contributor/ci-cd.mdx
+++ b/docs/contributor/ci-cd.mdx
@@ -59,7 +59,7 @@ published.
 | Build → App Server image | `pack build` from the packaged JAR, signed, attested and policy-scanned | — |
 | Test → App Server: Unit and architecture, App Server: Integration | compiled from source | `vp run test:server:verification`, `test:server:integration` |
 | Security → New dependency risk | dependency review; pull requests only | — |
-| Security → Dependencies, secrets, and policy | Trivy filesystem scan, TruffleHog, `security.txt` expiry, changelog immutability guard, legacy-reference guards | — |
+| Security → Dependencies, secrets, and policy | Trivy filesystem scan, dependency vulnerability gate, TruffleHog, `security.txt` expiry, changelog immutability guard, legacy-reference guards | — |
 | Changesets → Verify changesets | policy tests, verified-revert detection, release-note presence, `MIGRATION.md` freeze | `vp run gate:changesets` |
 | Compose → Render compose stacks | the self-hosted, preview and reference stacks render | `vp run gate:preview-stack` |
 | Docker → Webapp, Agent: Pi, Postgres (pg_partman), Tag unchanged images | Dockerfile images; aliases for unchanged ones | — |
@@ -105,14 +105,29 @@ changesets rather than adding one. [Release management](./release-management.mdx
 
 | Control | Timing | Enforcement | Destination |
 | --- | --- | --- | --- |
-| GitHub dependency review | pull requests | blocks new high or critical findings in runtime, development, and unknown scopes | required Security workflow |
+| Dependency vulnerability gate | Security workflow | owns the dependency verdict; blocks fixable high or critical findings in every dependency the checkout resolves | required Security workflow |
+| GitHub dependency review | pull requests | reports the advisories a pull request introduces, with their patched versions; holds no verdict | Security workflow summary |
 | CodeQL default setup | managed by GitHub | repository SAST policy | code scanning |
 | TruffleHog and GitHub push protection | pull requests and pushes | block verified secrets | Security workflow and repository protection |
-| Trivy filesystem scan | Security workflow | a scanner error fails the job; findings are uploaded and do not block | code scanning |
+| Trivy filesystem scan | Security workflow | a scanner error blocks; findings of every severity are report-only | code scanning |
 | Image vulnerability policy | image build and release | blocks fixable high or critical findings | build summary and release evidence |
 | Weekly image rescans | `rescan-main-images.yml`, `rescan-release-images.yml` | the `main` rescan upserts one tracking issue; the release rescan fails and comments on the vulnerability response issue | issues and run artifacts |
 | OpenSSF Scorecard | `main` pushes, branch-protection changes, and weekly; never on pull requests | reports | code scanning and a run artifact |
 | Renovate | configured schedule and vulnerability alerts | pull requests require normal review and CI | dependency dashboard |
+
+One check owns the dependency verdict: the dependency vulnerability gate in `ci-security-scan.yml`,
+a second Trivy pass in `table` format over the same checkout. It runs on pull requests and on `main`
+pushes and evaluates every dependency the lockfiles resolve, so an advisory published against a pin
+no pull request touches fails the next run rather than waiting for someone to open the code-scanning
+dashboard. It applies the severity policy in [vulnerability
+remediation](./vulnerability-remediation.mdx) — fixable high or critical — and its exceptions are the
+one exception path for a dependency finding, recorded in `security/trivy-dependency-ignore.yaml`.
+
+Dependency review sees only the manifests a pull request changes, so it cannot hold that verdict; it
+reports what the pull request introduces and fails nothing. The first Trivy pass is the
+code-scanning feed: SARIF output reports every severity whatever `severity` is set to, so the pass
+that publishes it carries neither `severity` nor `exit-code`, and it keeps Trivy's secret scanner,
+which covers the whole tree where TruffleHog covers a pull request's own commits.
 
 Renovate groups routine updates only when they share a review and verification boundary. Production
 dependencies remain separate unless Renovate identifies a package family that must move together.
@@ -126,7 +141,8 @@ request; the toolchain checks reject a version that reads differently in any of 
 provisions the Node it runs lockfile updates with from `engines`, so `engines.node` restates
 `devEngines.runtime` exactly rather than the supported line.
 
-[Vulnerability remediation](./vulnerability-remediation.mdx) owns the blocking and exception policy.
+[Vulnerability remediation](./vulnerability-remediation.mdx) owns the severity policy and the shape,
+ceiling and approval of an exception, for images and dependencies alike.
 [Release management](./release-management.mdx#supply-chain-evidence) owns artifact signing, provenance,
 SBOM, and release-verification guarantees.
 

--- a/docs/contributor/vulnerability-remediation.mdx
+++ b/docs/contributor/vulnerability-remediation.mdx
@@ -21,10 +21,12 @@ non-empty `FixedVersion`. MEDIUM and below never block, at any scan.
 An unfixable HIGH is not an exception and does not need one. It remains recorded, but without a
 patched version there is no upgrade for the gate to require.
 
-Unfixable findings stay in the scan report and in the `highCritical` list of the `.policy.json`
-attached to the release; the filter is in the evaluator, not a `--ignore-unfixed` flag.
+Unfixable findings stay in an image scan report and in the `highCritical` list of the `.policy.json`
+attached to the release; that filter is in the evaluator, not a `--ignore-unfixed` flag. The
+dependency gate reaches the same verdict through Trivy's own `--ignore-unfixed`, and the SARIF pass
+beside it still records what the gate filtered out.
 
-## Where the gate runs
+## Where the image gate runs
 
 | When | Subject | Effect |
 | --- | --- | --- |
@@ -61,7 +63,7 @@ pinned upstream digest there is no rebuild, the fix is a digest bump nobody can 
 publishes one, and the bump arrives in a pull request — so an arm64-only finding has to fail that
 pull request rather than the release.
 
-## Exceptions
+## Image exceptions
 
 An exception lets one fixable finding through for at most 90 days. It is an entry in
 `security/vulnerability-policy.json`, and `security/` has no CODEOWNERS rule of its own, so the default
@@ -97,3 +99,31 @@ did.
 A value outside those five is a malformed policy and throws. An `affected` exception carries no
 category — it defers a risk we concede applies, and claiming non-exploitability at the same time is a
 contradiction.
+
+## Dependency exceptions
+
+The dependency gate in `ci-security-scan.yml` reads `security/trivy-dependency-ignore.yaml`, Trivy's
+YAML ignore format, and it is the only place a dependency finding is excepted — dependency review
+holds no verdict to except. An entry carries the same ceiling and accountability as an image
+exception:
+
+- `id` — the vulnerability the exception is for.
+- `purls` — the package URLs it applies to, so it dies when the dependency moves.
+- `expired_at` — `YYYY-MM-DD`, in the future, at most 90 days out; `scripts/ci-contract.test.ts`
+  fails the pull request that writes a longer one, and Trivy stops honouring the entry once it
+  lapses.
+- `statement` — why the risk is accepted, in prose a reviewer can weigh.
+
+The file sits under `security/`, so the same default CODEOWNERS rule applies, and the security path
+filter in `.github/workflows/cicd.yml` names it, so the pull request that adds a suppression re-runs
+the gate it suppresses.
+
+To reproduce a finding, run the gate over a clean checkout:
+
+```bash
+trivy fs --scanners vuln --severity HIGH,CRITICAL --ignore-unfixed --exit-code 1 \
+  --ignorefile security/trivy-dependency-ignore.yaml .
+```
+
+The job installs nothing before it scans, so a working tree carrying `node_modules/` or `target/`
+reports lockfiles vendored inside dependencies that the gate itself never sees.

--- a/scripts/ci-contract.test.ts
+++ b/scripts/ci-contract.test.ts
@@ -148,6 +148,37 @@ function namedStep(workflow: Document, jobPath: string[], name: string): YAMLMap
 	throw new Error(`${jobPath.join(".")} has no ${name} step`);
 }
 
+/**
+ * Why one entry of `security/trivy-dependency-ignore.yaml` is not a usable exception, or `undefined`
+ * when it is. Trivy honours an entry it can parse and says nothing about the rest, so an exception
+ * that names no package or expires in 2099 suppresses the gate silently — the fields and the 90-day
+ * ceiling are `docs/contributor/vulnerability-remediation.mdx` § Dependency exceptions.
+ */
+function exceptionFault(entry: unknown, now: number): string | undefined {
+	if (!isRecord(entry)) return "is not a mapping";
+	if (typeof entry.id !== "string" || entry.id.trim() === "") return "names no vulnerability id";
+	if (
+		!Array.isArray(entry.purls) ||
+		entry.purls.length === 0 ||
+		!entry.purls.every((purl) => typeof purl === "string" && purl.startsWith("pkg:"))
+	)
+		return "names no package URLs";
+	if (typeof entry.statement !== "string" || entry.statement.trim() === "")
+		return "carries no statement";
+	if (typeof entry.expired_at !== "string" || !/^\d{4}-\d{2}-\d{2}$/.test(entry.expired_at))
+		return "has no YYYY-MM-DD expired_at";
+	if (Date.parse(`${entry.expired_at}T00:00:00Z`) - now > 90 * 24 * 60 * 60 * 1000)
+		return "expires more than 90 days out";
+	return undefined;
+}
+
+/** A step's `with` map. */
+function stepInputs(declaration: YAMLMap): YAMLMap {
+	const map = declaration.get("with");
+	assert.ok(isMap(map), "step declares no inputs");
+	return map;
+}
+
 /** The shell a named `run` step ships. */
 function runScript(workflow: Document, jobPath: string[], name: string): string {
 	const shell = namedStep(workflow, jobPath, name).get("run");
@@ -1163,16 +1194,106 @@ void describe("CI contract", () => {
 	});
 
 	void test("blocks dependency regressions across the release trust boundary", async () => {
+		const orchestrator = await readFile(".github/workflows/cicd.yml", "utf8");
+		const securityConfig = pathFilter(orchestrator, "security-config");
+		assert.match(securityConfig, /- '\.github\/dependency-review-config\.yml'/);
+		assert.match(
+			securityConfig,
+			/- 'security\/trivy-dependency-ignore\.yaml'/,
+			"a pull request that suppresses a finding has to select the job that would have reported it",
+		);
 		const workflow = parseDocument(
 			await readFile(".github/workflows/ci-security-scan.yml", "utf8"),
 		);
-		const jobPath = ["jobs", "dependency-review"];
+		const reviewPath = ["jobs", "dependency-review"];
 		assert.ok(
-			String(workflow.getIn([...jobPath, "if"])).includes("github.event_name == 'pull_request'"),
+			String(workflow.getIn([...reviewPath, "if"])).includes("github.event_name == 'pull_request'"),
 		);
-		const review = step(workflow, jobPath, "actions/dependency-review-action");
-		assert.equal(review.get("fail-on-severity"), "high");
-		assert.equal(review.get("fail-on-scopes"), "runtime, development, unknown");
+		const review = step(workflow, reviewPath, "actions/dependency-review-action");
+		assert.equal(review.get("config-file"), "./.github/dependency-review-config.yml");
+
+		const config = parseDocument(await readFile(".github/dependency-review-config.yml", "utf8"));
+		assert.equal(config.get("warn-only"), true);
+		assert.ok(
+			!config.has("fail-on-severity"),
+			"warn-only reports every severity, so a threshold here names a policy the action does not apply",
+		);
+		const scopes = config.get("fail-on-scopes");
+		assert.ok(isSeq(scopes));
+		assert.deepEqual(
+			new Set(scopes.items.map((scope) => (isScalar(scope) ? scope.value : undefined))),
+			new Set(["runtime", "development", "unknown"]),
+		);
+
+		const scanPath = ["jobs", "security-scan"];
+		const report = stepInputs(namedStep(workflow, scanPath, "Trivy dependency scan"));
+		assert.equal(report.get("format"), "sarif");
+		assert.ok(
+			!report.has("severity"),
+			"SARIF output reports every severity unless limit-severities-for-sarif is true, so a filter here states a policy Trivy does not apply",
+		);
+		assert.ok(
+			!report.has("exit-code"),
+			"the SARIF pass is the code-scanning feed; the pass below is the verdict",
+		);
+		assert.ok(
+			!report.has("scanners"),
+			"trivy fs defaults to vuln,secret, and narrowing this pass drops tree-wide secret findings from code scanning",
+		);
+
+		const gateStep = namedStep(workflow, scanPath, "Enforce dependency vulnerability policy");
+		const gate = stepInputs(gateStep);
+		assert.equal(gate.get("format"), "table");
+		assert.equal(gate.get("scanners"), "vuln");
+		assert.equal(gate.get("severity"), "HIGH,CRITICAL");
+		assert.equal(gate.get("ignore-unfixed"), true);
+		assert.equal(gate.get("exit-code"), "1");
+		assert.equal(gate.get("trivyignores"), "security/trivy-dependency-ignore.yaml");
+		assert.equal(gate.get("skip-setup-trivy"), true);
+
+		// The step is continue-on-error so the table reaches the log; the aggregator is what turns
+		// its outcome into the job's verdict.
+		assert.equal(gateStep.get("id"), "dependency-policy");
+		const aggregator = namedStep(workflow, scanPath, "Evaluate security checks");
+		const env = aggregator.get("env");
+		assert.ok(isMap(env));
+		assert.match(
+			String(env.get("DEPENDENCY_POLICY")),
+			/^\${{ steps\.dependency-policy\.outcome }}$/,
+		);
+		assert.match(String(aggregator.get("run")), /for result in [^\n]*"\$DEPENDENCY_POLICY"/);
+
+		const ignore: unknown = parseDocument(
+			await readFile("security/trivy-dependency-ignore.yaml", "utf8"),
+		).toJS();
+		assert.ok(isRecord(ignore) && Array.isArray(ignore.vulnerabilities));
+		const now = Date.now();
+		for (const entry of ignore.vulnerabilities) {
+			const fault = exceptionFault(entry, now);
+			assert.equal(fault, undefined, `security/trivy-dependency-ignore.yaml entry ${fault}`);
+		}
+	});
+
+	void test("rejects a dependency exception that names no subject or outlives the ceiling", () => {
+		const now = Date.parse("2026-01-01T00:00:00Z");
+		const exception = {
+			id: "CVE-2026-0001",
+			purls: ["pkg:npm/example@1.3.0"],
+			statement: "Upstream has no release carrying the fix; the risk issue tracks the upgrade.",
+			expired_at: "2026-03-01",
+		};
+		assert.equal(exceptionFault(exception, now), undefined);
+		for (const [fault, malformed] of [
+			["is not a mapping", "CVE-2026-0001"],
+			["names no vulnerability id", { ...exception, id: "" }],
+			["names no package URLs", { ...exception, purls: [] }],
+			["names no package URLs", { ...exception, purls: ["example@1.3.0"] }],
+			["carries no statement", { ...exception, statement: "  " }],
+			["has no YYYY-MM-DD expired_at", { ...exception, expired_at: "March 2026" }],
+			["expires more than 90 days out", { ...exception, expired_at: "2026-06-01" }],
+		] as const) {
+			assert.equal(exceptionFault(malformed, now), fault);
+		}
 	});
 
 	void test("publishes repository posture outside the pull-request path", async () => {

--- a/security/trivy-dependency-ignore.yaml
+++ b/security/trivy-dependency-ignore.yaml
@@ -1,0 +1,5 @@
+# Temporary dependency exceptions, in Trivy's YAML ignore format. Each entry names `id`, the
+# `purls` it applies to, an `expired_at` at most 90 days out, and a `statement` saying why the
+# risk is accepted — the same ceiling and accountability the image policy carries.
+# `docs/contributor/vulnerability-remediation.mdx` § Dependency exceptions.
+vulnerabilities: []


### PR DESCRIPTION
## Problem

`ci-security-scan.yml` ran Trivy in SARIF mode carrying `severity: "HIGH,CRITICAL"` and
`exit-code: "1"`. SARIF output reports every severity unless `limit-severities-for-sarif` is true, so
the filter was inert while the exit code was not: the job was set to fail on the first LOW or UNKNOWN
advisory in any transitive dependency, with no `ignore-unfixed` and no exception path. The
configuration stated a policy the tool does not apply, and the contract test asserted the two
literals rather than the behaviour, so it passed while the policy was wrong.

Underneath that, nothing owned the dependency verdict. `dependency-review-action` only runs on pull
requests and only sees dependencies the diff changes, so a high-severity advisory published against a
pinned dependency nobody is touching was caught by no required check at all.

## Solution

Split reporting from enforcement, and give the verdict one owner.

- The Trivy SARIF pass is the code-scanning feed and carries neither `severity` nor `exit-code`. It
  keeps Trivy's default scanners, so its whole-tree secret findings still reach code scanning —
  TruffleHog only inspects a pull request's own commits.
- A second pass, `Enforce dependency vulnerability policy`, is the gate: `format: table`,
  `severity: HIGH,CRITICAL`, `scanners: vuln`, `ignore-unfixed`, `exit-code: 1`. It runs on pull
  requests and on `main` pushes over every dependency the lockfiles resolve, which is what closes the
  unchanged-pinned-dependency hole, and its outcome is wired into the job's aggregator so it is a
  gate rather than a log. `skip-setup-trivy` reuses the binary the first pass installed.
- Exceptions have one home, `security/trivy-dependency-ignore.yaml`, with the same 90-day ceiling
  the image policy carries. It is in the security path filter, so a pull request that adds a
  suppression re-runs the gate it suppresses.
- Dependency review keeps reporting what a pull request introduces, with advisories and patched
  versions, and holds no second verdict with a second exception path — `warn-only: true` in the new
  `.github/dependency-review-config.yml`. It also stops blocking on unfixable findings, which
  `vulnerability-remediation.mdx` says must never block, so the repository now applies one severity
  policy to images and dependencies alike.

The dependency gate is green on this branch: `0` findings across `pnpm-lock.yaml`,
`docker/agents/pi/pnpm-lock.yaml` and the three `pom.xml` files.

## How to test

- `vp run check` — includes the CI contract suite.
- The contract test asserts the *absence* of `severity`, `exit-code` and `scanners` on the SARIF
  pass, not just the presence of the gate's inputs, so reintroducing the inert filter fails the
  build. Re-adding `severity: "HIGH,CRITICAL"` to the SARIF step turns the suite red; so does
  deleting the gating step, unwiring its outcome from the aggregator, dropping the ignore file from
  the path filter, or writing an exception that expires more than 90 days out.
- To reproduce the gate itself, from a clean checkout:
  `trivy fs --scanners vuln --severity HIGH,CRITICAL --ignore-unfixed --exit-code 1 --ignorefile security/trivy-dependency-ignore.yaml .`

## Review checklist

- [x] The dependency verdict has exactly one owner, named in `docs/contributor/ci-cd.mdx`, with one
      exception path.
- [x] The gate covers dependencies no pull request changed, on `main` pushes as well as pull
      requests.
- [x] Code scanning keeps every severity and keeps Trivy's secret findings.
- [x] Exceptions expire, and a test enforces the ceiling.
- [x] No changeset: no shipped code changes.

Fixes #1803
