### PR TITLE
build(config): enforce the Vite+ task naming contract

### DIFF
--- a/.github/workflows/ci-profile.yml
+++ b/.github/workflows/ci-profile.yml
@@ -53,7 +53,7 @@ jobs:
         if: always()
         continue-on-error: true
         run: >-
-          vp run summarize:test-results "Server Integration Profile"
+          vp run report:test-results "Server Integration Profile"
           server/application/target/surefire-reports ci-metrics/server-integration-profile.json
           ci-metrics/server-integration.log ci-metrics/server-integration-resource.txt
 

--- a/.github/workflows/ci-quality-gates.yml
+++ b/.github/workflows/ci-quality-gates.yml
@@ -181,7 +181,7 @@ jobs:
       - name: Summarize webapp unit tests
         if: env.RUN == 'true' && matrix.leg == 'webapp' && !cancelled()
         continue-on-error: true
-        run: vp run summarize:test-results "Webapp Unit" webapp/test-results ci-metrics/webapp-unit.json
+        run: vp run report:test-results "Webapp Unit" webapp/test-results ci-metrics/webapp-unit.json
 
       - name: Upload webapp test metrics
         if: env.RUN == 'true' && matrix.leg == 'webapp' && !cancelled()

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -778,8 +778,8 @@ jobs:
               echo "|-------|-------------|" >> $GITHUB_STEP_SUMMARY
               echo "| Formatting errors | \`vp run format\` |" >> $GITHUB_STEP_SUMMARY
               echo "| TypeScript errors | \`vp run typecheck\` |" >> $GITHUB_STEP_SUMMARY
-              echo "| Lint errors (webapp) | \`vp run check:webapp:fix\` |" >> $GITHUB_STEP_SUMMARY
-              echo "| Lint errors (outside webapp) | \`vp run check:agents:fix\` |" >> $GITHUB_STEP_SUMMARY
+              echo "| Lint errors (webapp) | \`vp run fix:webapp\` |" >> $GITHUB_STEP_SUMMARY
+              echo "| Lint errors (outside webapp) | \`vp run fix:agents\` |" >> $GITHUB_STEP_SUMMARY
               echo "| Java formatting | \`vp run format:java\` |" >> $GITHUB_STEP_SUMMARY
               echo "| Java lint (PMD) | \`vp run lint:java:report\` |" >> $GITHUB_STEP_SUMMARY
               echo "| Storybook sidebar order | \`vp run gate:story-sort\` |" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/version-pr.yml
+++ b/.github/workflows/version-pr.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Maintain Version PR
         uses: changesets/action@8488615a623b1b9c987934bb89eae8af6a946ac1 # v2.1.1
         with:
-          version-script: vp run changeset:version
+          version-script: vp run release:version
           pr-title: "chore(release): version packages"
           commit-message: "chore(release): version packages"
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.migration/README.md
+++ b/.migration/README.md
@@ -3,5 +3,5 @@
 Add `.migration/<changeset-slug>.md` only when an upgrade requires operator action. The file is the
 complete migration-guide entry, begins with a `#### 🔴 …` heading, and has the same slug as the
 changeset whose summary contains `**Operators:**`. Never edit `MIGRATION.md`'s `### Next release`
-section. `vp run changeset:version` sorts fragments by filename, inserts them under a new version
+section. `vp run release:version` sorts fragments by filename, inserts them under a new version
 heading below the unchanged `### Next release` anchor, and then removes them.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,10 +173,39 @@ for byte and `gate:instructions` fails when a half drifts. Copy a skill nowhere 
 | `vp run test:agents` | Agent runtime and precompute specs, on Node |
 | `vp run test:server:unit` | Server unit tests — the other tiers are in `server/AGENTS.md` § Test tiers |
 
-Naming: `format` applies, `format:check` verifies read-only for CI, `lint` lints, `check` is the
-quality gate. A `gate:` name is one leaf verdict, what CI annotates and what `check` is made of. A
-`:webapp`, `:server` or `:agents` suffix scopes any of them; `:java` scopes `format` and `lint`, and
-the Java leg of `check` is `gate:server`.
+### Task vocabulary
+
+Task names are lowercase colon-separated words; a word may also contain digits or hyphens. The
+first word says what kind of task it is, and only these prefixes are allowed:
+
+| Prefix | Meaning |
+|---|---|
+| `affected` | Internal groups selected by `check:affected` for one changed tree |
+| `build` | Produce a distributable artifact |
+| `check` | Run an uncached read-only check or a group of checks; `check` is the local quality entry point |
+| `ci` | Internal groups shaped for CI jobs and runner platforms |
+| `db` | Inspect or update the development database schema and its generated documentation |
+| `dev` | Start, stop, reset, or configure local development infrastructure |
+| `docs` | Build, serve, or lint the documentation site |
+| `fix` | Apply formatting and safe lint fixes |
+| `format` | Apply formatting; a final `check` segment makes the operation read-only |
+| `gate` | Produce one verdict that CI can annotate; every gate belongs to `quality` unless explicitly CI-only in the task contract test |
+| `generate` | Regenerate a committed artifact from its authoritative source |
+| `lint` | Run a linter; a final `fix` segment applies safe fixes and `report` writes a report |
+| `prepare` | Produce an uncommitted prerequisite needed by another task |
+| `quality` | Internal graph containing every local quality gate; use `check` at the command line |
+| `release` | Prepare or publish a release version |
+| `report` | Turn existing results into a human- or machine-readable report |
+| `schema` | Refresh a checked-in external integration schema or contract fixture |
+| `sync` | Reconcile checked-in values with an authoritative local source |
+| `test` | Execute a test suite |
+| `typecheck` | Run a language type checker without emitting artifacts |
+| `verification` | Run credential-free builds and test suites beyond `quality`; the bare name is the internal graph |
+| `verify` | Run the complete credential-free local verification entry point |
+
+Segments after the prefix identify the subject and specialization, such as
+`test:server:integration`. `:webapp`, `:server` and `:agents` are the tree scopes; `:java` scopes
+only `format` and `lint`, and the Java leg of `check` is `gate:server`.
 
 ### Lint and format
 

--- a/docs/contributor/ai-agent-workflow.mdx
+++ b/docs/contributor/ai-agent-workflow.mdx
@@ -49,8 +49,10 @@ endpoint you added, a query confirming the row was written, the logs after the c
 Parallel work stays parallel only when contributors avoid manufacturing shared diffs:
 
 1. **Reserve hot-file lanes at assignment time.** Only one in-flight PR may write each lane:
-   `.github/workflows/**` and `.github/actions/**`; root `package.json` with `pnpm-lock.yaml`;
-   `CHANGELOG.md` and `MIGRATION.md` (release automation only); `webapp/src/api/**`; and
+   `.github/workflows/**` and `.github/actions/**`; `vite.config.ts` with
+   `scripts/ci-contract.test.ts`, which the task graph and its contract keep in step; root
+   `package.json` with `pnpm-lock.yaml`; `CHANGELOG.md` and `MIGRATION.md` (release automation
+   only); `webapp/src/api/**`; and
    `server/application/src/main/resources/db/master.xml`. Migration fragments remove `MIGRATION.md`
    from feature work, but release automation still owns it exclusively. Dependent changes use
    `/gh-stack`; otherwise, do not make one PR wait for another.

--- a/docs/contributor/ci-cd.mdx
+++ b/docs/contributor/ci-cd.mdx
@@ -392,7 +392,7 @@ and `vp run test:server:integration`; `vp run verify` runs the credential-free s
 ```bash
 # Webapp
 vp run check:webapp          # vp check: format and lint
-vp run check:webapp:fix      # Same, applying every safe fix
+vp run fix:webapp           # check:webapp, applying every safe fix
 vp run typecheck:webapp      # A separate leg — check:webapp does not run it
 vp run test:webapp           # Unit tests
 
@@ -403,14 +403,14 @@ vp run test:server:unit      # Unit tests
 # Agent runtime (Node) — the Pi runner and the practice precompute scripts
 vp run test:agents           # Runner + precompute specs
 vp run check:agents           # Format check, oxlint, both typechecks, release-image inventory, scripts/*.test.ts
-vp run check:agents:fix      # Same, applying every safe fix
+vp run fix:agents            # check:agents, applying every safe fix
 vp run typecheck:agents      # Agent + precompute TypeScript
 ```
 
 | Issue | Solution |
 | --- | --- |
 | Formatting errors | Run `vp run format` |
-| Lint errors (agent runtime, precompute, `scripts/`) | Run `vp run check:agents:fix`, then fix what remains |
+| Lint errors (agent runtime, precompute, `scripts/`) | Run `vp run fix:agents`, then fix what remains |
 | TypeScript errors | Run `vp run typecheck` to see details |
 | OpenAPI out of sync | Run `vp run generate:api` |
 | Database schema drift | Run `vp run db:draft-changelog` |

--- a/docs/contributor/e2e-testing.md
+++ b/docs/contributor/e2e-testing.md
@@ -41,7 +41,7 @@ read -rsp "LLM key: " E2E_LLM_KEY && echo && export E2E_LLM_KEY
 export E2E_LLM_PRICING_MODE=PRICED
 export E2E_LLM_INPUT_USD="$YOUR_CONTRACT_INPUT_RATE_PER_1M"
 export E2E_LLM_OUTPUT_USD="$YOUR_CONTRACT_OUTPUT_RATE_PER_1M"
-vp run e2e:setup \
+vp run dev:e2e:setup \
   --account-login group/subgroup \
   --repo group/subgroup/project \
   --llm-base-url https://llm.example/v1 \

--- a/docs/contributor/local-development.mdx
+++ b/docs/contributor/local-development.mdx
@@ -51,7 +51,7 @@ Run the same checks from the shell with:
 
 ```bash
 vp run check:agents          # Format check, lint, and both typechecks outside the webapp
-vp run check:agents:fix      # Apply every safe fix
+vp run fix:agents            # check:agents, applying every safe fix
 vp run check:webapp          # The SPA's format and lint checks
 vp run typecheck:webapp      # The SPA's typecheck — a separate leg, not part of check:webapp
 vp run check                 # Complete local quality gate
@@ -308,7 +308,7 @@ the stored configuration. New connections and models start inactive. Test the co
 its price (or explicitly mark it as having no metered API cost), then activate it and bind it to a
 purpose (`PRACTICE_REVIEW` or `MENTOR`) on the workspace's **AI models** page.
 
-For an automated local end-to-end setup, use `vp run e2e:setup`. It creates the connection,
+For an automated local end-to-end setup, use `vp run dev:e2e:setup`. It creates the connection,
 model, and agent binding through the application API and keeps provider credentials out of source
 control and command-line history by reading them from `E2E_*` environment variables.
 

--- a/docs/contributor/sync-lifecycle.md
+++ b/docs/contributor/sync-lifecycle.md
@@ -21,8 +21,8 @@ only transport policy — retries, rate-limit accounting, pagination bounds, ten
 | Slack | Official SDK | `com.slack.api:bolt` |
 | Outline | OpenAPI spec | `openapi-generator-maven-plugin` → `spec3.yml` + `outline-supplement.yaml` |
 
-Schemas and specs are refreshed by `vp run github:update-schema`, `gitlab:update-schema`, and
-`outline:update-spec`. No integration hand-rolls a vendor DTO.
+Schemas and specs are refreshed by `vp run schema:github`, `schema:gitlab`, and `schema:outline`.
+No integration hand-rolls a vendor DTO.
 
 ## The matrix
 

--- a/docs/contributor/testing.mdx
+++ b/docs/contributor/testing.mdx
@@ -102,7 +102,7 @@ The `hephaestus.tenancy.enforcement: throw` setting in `application-test.yml` fa
 Reusable webhook JSON lives in `server/application/src/test/resources/github`, named after the event it records. Load one with a `ClassPathResource`, or extract new samples with:
 
 ```bash
-vp run nats:extract-examples
+vp run schema:nats
 ```
 
 Available examples include `label.created`, `repository.created`, `create`, `push`, and more – consult the folder before recording new payloads.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -18,12 +18,12 @@ Substantive developer orchestration under `scripts/` uses typed Node.js entry po
 | `vp run check:ports` | Validate configured local ports and report listeners. |
 | `vp run db:draft-changelog` | Rebuild a disposable database and generate a Liquibase diff. |
 | `vp run db:generate-erd-docs` | Apply migrations and regenerate the Mermaid ERD. |
-| `vp run e2e:setup <options>` | Configure a local E2E workspace against the selected SCM and model provider. Secrets are environment-only. |
-| `vp run jean:public-test <command>` | Manage the machine-local public test route. |
+| `vp run dev:e2e:setup <options>` | Configure a local E2E workspace against the selected SCM and model provider. Secrets are environment-only. |
+| `vp run dev:public-test <command>` | Manage the machine-local public test route. |
 
 The database commands require Docker with the Compose plugin.
 
-`jean:public-test` accepts `start`, `stop`, `status`, `smoke`, and `seed-status`. The route is
+`dev:public-test` accepts `start`, `stop`, `status`, `smoke`, and `seed-status`. The route is
 internet-facing and requires Docker, the machine's Coolify network and Traefik configuration
 directory, and `server/.env`.
 
@@ -55,9 +55,9 @@ vp run format:achievements
 Extract webhook payloads from NATS JetStream for test fixtures:
 
 ```bash
-vp run nats:extract-examples
+vp run schema:nats
 # With options:
-vp run nats:extract-examples --event push --event pull_request:opened
+vp run schema:nats --event push --event pull_request:opened
 ```
 
 **Environment variables:**

--- a/scripts/ci-contract.test.ts
+++ b/scripts/ci-contract.test.ts
@@ -55,6 +55,10 @@ async function readSources(files: string[]): Promise<Map<string, string>> {
 const TASK_INVOCATION =
 	/\bvp run (?:(?:--(?!filter\b)[\w-]+|\$\{\{ *matrix\.\w+ *\}\}) +)*((?:[\w:-]|\$\{\{ *matrix\.\w+ *\}\})+)/g;
 
+// The two gates `check` cannot run: the k6 syntax check needs the pinned container, and the PMD
+// canary runs only when CI decides PMD inputs changed. Every other CI gate is part of `check`.
+const CI_ONLY_GATES = new Set(["gate:load-syntax", "gate:pmd-canary"]);
+
 /** The task names one job's steps invoke, with a `${{ matrix.<key> }}` resolved from its matrix. */
 function invokedTasks(definition: YAMLMap): string[] {
 	const names: string[] = [];
@@ -253,29 +257,68 @@ function render(
 	});
 }
 
+function taskClosure(tasks: Record<string, unknown>, roots: Iterable<string>): Set<string> {
+	const closure = new Set<string>();
+	const expand = (name: string): void => {
+		if (closure.has(name)) return;
+		assert.ok(name in tasks, `${name} is named as a dependency but is not a task`);
+		closure.add(name);
+		const task = asRecord(tasks[name], name);
+		if (Array.isArray(task.dependsOn))
+			for (const dependency of task.dependsOn)
+				if (typeof dependency === "string") expand(dependency);
+		for (const command of commandsOf(task)) {
+			const nested = /^vp run ([\w:-]+)$/.exec(command)?.[1];
+			if (nested !== undefined) expand(nested);
+		}
+	};
+	for (const root of roots) expand(root);
+	return closure;
+}
+
 void describe("CI contract", () => {
+	void test("task names follow the vocabulary in AGENTS.md", async () => {
+		const tasks = await loadTasks();
+		const instructions = await readFile("AGENTS.md", "utf8");
+		const vocabulary = /^### Task vocabulary\n([\s\S]*?)(?=^###? )/m.exec(instructions)?.[1];
+		assert.ok(vocabulary, "AGENTS.md § Verifying must contain the task vocabulary");
+		const allowedPrefixes = new Set(
+			[...vocabulary.matchAll(/^\| `([a-z]+)` \|/gm)].map((match) => match[1] ?? ""),
+		);
+		assert.ok(allowedPrefixes.size > 0, "AGENTS.md task vocabulary lists no prefixes");
+		const used = new Set<string>();
+		for (const name of Object.keys(tasks).toSorted()) {
+			assert.match(name, /^[a-z]+(?::[a-z0-9-]+)*$/, `${name} is not a valid task name`);
+			const prefix = name.split(":", 1)[0] ?? "";
+			assert.ok(
+				allowedPrefixes.has(prefix),
+				`${name} does not use a task prefix listed in AGENTS.md § Verifying`,
+			);
+			used.add(prefix);
+		}
+		assert.deepEqual(
+			[...allowedPrefixes].filter((prefix) => !used.has(prefix)),
+			[],
+			"AGENTS.md § Verifying lists a task prefix no task uses",
+		);
+	});
+
+	void test("every gate belongs to quality or the CI-only inventory", async () => {
+		const tasks = await loadTasks();
+		const reachable = taskClosure(tasks, ["quality"]);
+		assert.deepEqual(
+			Object.keys(tasks)
+				.filter((taskName) => taskName.startsWith("gate:") && !reachable.has(taskName))
+				.toSorted(),
+			[...CI_ONLY_GATES].toSorted(),
+			"every gate must be reachable from quality or listed as CI-only",
+		);
+	});
+
 	void test("every local gate runs in a workflow, and every CI gate is a local gate", async () => {
 		const tasks = await loadTasks();
-		const dependencies = (name: string): string[] => {
-			const task = tasks[name];
-			return isRecord(task) && Array.isArray(task.dependsOn)
-				? task.dependsOn.filter((entry): entry is string => typeof entry === "string")
-				: [];
-		};
-		// A workflow may run a gate directly or through a group; the graph decides what a
-		// `vp run <task>` covers, so it is expanded here rather than pattern-matched in YAML.
-		const expand = (name: string, into: Set<string>): void => {
-			if (into.has(name)) return;
-			into.add(name);
-			for (const dependency of dependencies(name)) expand(dependency, into);
-			for (const command of commandsOf(tasks[name])) {
-				const nested = /^vp run ([\w:-]+)$/.exec(command)?.[1];
-				if (nested !== undefined) expand(nested, into);
-			}
-		};
-		const local = new Set<string>();
-		expand("quality", local);
-		const ci = new Set<string>();
+		const local = taskClosure(tasks, ["quality"]);
+		const ciRoots = new Set<string>();
 		for (const [file, source] of await workflowSources()) {
 			const jobs = parseDocument(source).get("jobs");
 			if (!isMap(jobs)) continue;
@@ -283,24 +326,25 @@ void describe("CI contract", () => {
 				if (!isMap(entry.value)) continue;
 				for (const name of invokedTasks(entry.value)) {
 					assert.ok(name in tasks, `${file} runs ${name}, which is not a task`);
-					expand(name, ci);
+					ciRoots.add(name);
 				}
 			}
 		}
+		const ci = taskClosure(tasks, ciRoots);
 		const gates = (names: Set<string>): string[] =>
-			[...names]
-				.filter((name) => name.startsWith("gate:") && !name.startsWith("gate:verify:"))
-				.toSorted();
+			[...names].filter((name) => name.startsWith("gate:")).toSorted();
 		assert.deepEqual(
 			gates(local).filter((gate) => !ci.has(gate)),
 			[],
 		);
-		// Builds and tests that only CI runs (`gate:webapp-tests`, `gate:load-syntax`) are the
-		// exceptions the verification graph owns; every other CI gate is part of `check`.
-		const ciOnly = new Set(["gate:webapp-tests", "gate:load-syntax", "gate:pmd-canary"]);
 		assert.deepEqual(
-			gates(ci).filter((gate) => !local.has(gate) && !ciOnly.has(gate)),
+			gates(ci).filter((gate) => !local.has(gate) && !CI_ONLY_GATES.has(gate)),
 			[],
+		);
+		assert.deepEqual(
+			[...CI_ONLY_GATES].filter((gate) => !ci.has(gate)),
+			[],
+			"every CI-only gate must run in CI",
 		);
 	});
 
@@ -1491,6 +1535,13 @@ void test("the task graph keeps its cache posture", async () => {
 		// Shell parameter expansion is outside the runner contract (scripts/check-runner-contract.ts).
 		for (const command of commands)
 			assert.doesNotMatch(command, /\$/, `${name} must not rely on shell expansion`);
+		// A `check:` name is a read-only entry point a contributor types: it either collects gates,
+		// which carry the verdicts and the caching, or it runs uncached.
+		if (name === "check" || name.startsWith("check:")) {
+			const isGroup =
+				commands.length === 0 && Array.isArray(task.dependsOn) && task.dependsOn.length > 0;
+			assert.ok(isGroup || task.cache === false, `${name} must be a group or uncached`);
+		}
 	}
 	// One Maven process per checkout: the two Maven gates run one after another, the install PMD
 	// needs is an uncached dependency because no cache replays it, and both name the JDK they read.

--- a/scripts/update-gitlab-schema.ts
+++ b/scripts/update-gitlab-schema.ts
@@ -54,7 +54,7 @@ function parseArgs(): { url: string; token?: string } {
 	if (args.includes("--help") || args.includes("-h")) {
 		console.log(`Update GitLab GraphQL schema via introspection
 
-Usage: vp run gitlab:update-schema [--url <gitlab-url>] [--token <pat>]
+Usage: vp run schema:gitlab [--url <gitlab-url>] [--token <pat>]
 
 Default: ${DEFAULT_GITLAB_URL} (public introspection)
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -115,7 +115,13 @@ const policyGates = [
 	"gate:env",
 ];
 const serverGates = ["gate:java-nullness", "gate:server"];
-const webappGates = ["gate:webapp", "gate:components", "gate:stories", "gate:story-sort"];
+const webappGates = [
+	"gate:webapp",
+	"gate:webapp-format",
+	"gate:components",
+	"gate:stories",
+	"gate:story-sort",
+];
 const agentGates = ["gate:agents", "gate:agent-tests"];
 const docsGates = ["gate:docs", "gate:diagrams", "gate:docs-tokens"];
 const loadGates = ["gate:load-format"];
@@ -145,12 +151,12 @@ export default defineConfig({
 			// Each leg saturates the machine on its own, so they run one after another.
 			verification: run([
 				"vp run quality",
-				"vp run gate:webapp-tests",
-				"vp run gate:verify:storybook-tests",
-				"vp run gate:verify:server",
-				"vp run gate:verify:webapp-build",
-				"vp run gate:verify:storybook-build",
-				"vp run gate:verify:docs-build",
+				"vp run verification:webapp-tests",
+				"vp run verification:storybook-tests",
+				"vp run verification:server-tests",
+				"vp run verification:webapp-build",
+				"vp run verification:storybook-build",
+				"vp run verification:docs-build",
 			]),
 			"check:affected": run("node scripts/check-affected.ts"),
 
@@ -201,13 +207,9 @@ export default defineConfig({
 			"typecheck:scripts": group(["gate:scripts-typecheck"]),
 			"typecheck:agents": group(["gate:agents-typecheck"]),
 			"check:webapp": run("vp -C webapp check"),
-			"check:webapp:fix": run("vp -C webapp check --fix"),
+			"fix:webapp": run("vp -C webapp check --fix"),
 			"check:agents": group(["gate:agents"]),
-			"check:agents:fix": run([
-				"vp run format:agents",
-				"vp run format:config",
-				"vp run lint:agents:fix",
-			]),
+			"fix:agents": run(["vp run format:agents", "vp run format:config", "vp run lint:agents:fix"]),
 
 			// Repository policy
 			"gate:toolchain": run("node scripts/check-toolchain.ts"),
@@ -266,7 +268,9 @@ export default defineConfig({
 			"test:postgres-upgrade": run("node scripts/postgres-major-upgrade-test.ts"),
 
 			// Webapp
-			"gate:webapp": cached("vp -C webapp check"),
+			// `vp check` is format plus lint; the format half is `gate:webapp-format`, so one failure
+			// stays one verdict.
+			"gate:webapp": cached("vp -C webapp check --no-fmt"),
 			"gate:webapp-format": cached(`vp fmt --check ${webappSources}`),
 			"gate:components": cached("node scripts/check-presentational-components.ts"),
 			"gate:stories": cached("node scripts/check-story-prose.ts"),
@@ -274,7 +278,7 @@ export default defineConfig({
 			"gate:docs-tokens": cached(
 				"node scripts/check-docs-tokens.ts && node --test scripts/check-docs-tokens.test.ts",
 			),
-			"gate:webapp-tests": group(["test:webapp"]),
+			"verification:webapp-tests": group(["test:webapp"]),
 			"test:webapp": run("vp run --filter webapp test"),
 			"test:webapp:stories": run("vp run --filter webapp test:storybook"),
 			"build:webapp": run("vp -C webapp build"),
@@ -336,10 +340,10 @@ export default defineConfig({
 				...loadGates,
 				"gate:load-syntax",
 			]),
-			"ci:webapp:static": group([...webappGates, "gate:docs-tokens", "gate:webapp-tests"]),
+			"ci:webapp:static": group([...webappGates, "gate:docs-tokens", "verification:webapp-tests"]),
 			// The build regenerates the route tree, so it never runs beside a gate that reads it. A
 			// second name after `vp run` is an argument, not a second task, so the two are separate.
-			"ci:webapp": run(["vp run ci:webapp:static", "vp run gate:verify:webapp-build"]),
+			"ci:webapp": run(["vp run ci:webapp:static", "vp run verification:webapp-build"]),
 			"ci:windows": group(checkTasks.filter((gate) => !linuxOnly.includes(gate))),
 
 			// Scoped selections for check:affected
@@ -349,11 +353,11 @@ export default defineConfig({
 			"affected:webapp": group(webappGates),
 
 			// The credential-free builds and suites that verification adds to quality
-			"gate:verify:storybook-tests": group(["test:webapp:stories"]),
-			"gate:verify:webapp-build": run("node scripts/verify-webapp-build.ts"),
-			"gate:verify:storybook-build": run("vp run --filter webapp build-storybook"),
-			"gate:verify:docs-build": group(["docs:build"]),
-			"gate:verify:server": group(["test:server:verification"]),
+			"verification:storybook-tests": group(["test:webapp:stories"]),
+			"verification:webapp-build": run("node scripts/verify-webapp-build.ts"),
+			"verification:storybook-build": run("vp run --filter webapp build-storybook"),
+			"verification:docs-build": group(["docs:build"]),
+			"verification:server-tests": group(["test:server:verification"]),
 
 			// Generated artefacts, schema and integration schemas
 			"generate:api": run(["vp run generate:api:specs", "vp run generate:api:client"]),
@@ -364,12 +368,12 @@ export default defineConfig({
 			"db:draft-changelog": run("node scripts/db-utils.ts draft-changelog"),
 			"db:check-drift": run("node scripts/db-utils.ts check-drift"),
 			"db:generate-erd-docs": run("node scripts/db-utils.ts generate-erd"),
-			"github:update-schema": run("node scripts/update-github-schema.ts"),
-			"gitlab:update-schema": run("node scripts/update-gitlab-schema.ts"),
-			"outline:update-spec": run("node scripts/update-outline-spec.ts"),
-			"nats:extract-examples": run("node scripts/nats-extract-examples.ts"),
-			"summarize:test-results": run("node scripts/summarize-test-results.ts"),
-			"changeset:version": run("changeset version && node scripts/sync-release-version.ts"),
+			"schema:github": run("node scripts/update-github-schema.ts"),
+			"schema:gitlab": run("node scripts/update-gitlab-schema.ts"),
+			"schema:outline": run("node scripts/update-outline-spec.ts"),
+			"schema:nats": run("node scripts/nats-extract-examples.ts"),
+			"report:test-results": run("node scripts/summarize-test-results.ts"),
+			"release:version": run("changeset version && node scripts/sync-release-version.ts"),
 
 			// Local development
 			dev: run("mprocs"),
@@ -387,8 +391,8 @@ export default defineConfig({
 				dependsOn: ["dev:compose:e2e", "prepare:server:generated"],
 			}),
 			"check:ports": run("node scripts/check-ports.ts"),
-			"e2e:setup": run("node scripts/e2e-setup.ts"),
-			"jean:public-test": run("node scripts/jean-public-test.ts"),
+			"dev:e2e:setup": run("node scripts/e2e-setup.ts"),
+			"dev:public-test": run("node scripts/jean-public-test.ts"),
 		},
 	},
 });


### PR DESCRIPTION
## What changed and why

`vite.config.ts` is the one home of every repository command, and it had grown 126 tasks under 26
prefixes — 14 of them naming a single task. A contributor adding a task had a written rule for
`format`, `lint`, `check` and `gate`, and nothing for anything else.

`AGENTS.md` § Verifying now carries a task vocabulary: the name shape, the 22 allowed prefixes and
what each one means, and what the segments after the prefix are for. The singletons are folded —
the four integration schema tasks into `schema:`, `e2e` and `jean` into `dev:`, `summarize` into
`report:`, `changeset` into `release:` — and each survivor states its meaning, which is the
justification for keeping it. `check:webapp:fix` and `check:agents:fix` become `fix:webapp` and
`fix:agents`, so a mutating task no longer hides under a read-only prefix. The old names were
removed rather than aliased: one vocabulary means one name.

Two new contract tests in `scripts/ci-contract.test.ts`, plus one rule added to the test that
already owns the graph's cache posture, keep it true. Task names must match
`^[a-z]+(:[a-z0-9-]+)*$` and use a prefix the test *parses out of `AGENTS.md`*, in both directions,
so neither the document nor the graph can drift from the other. Every `gate:` task must be reachable
from `quality` or be one of the two gates `check` cannot run, and every CI-only gate must actually
run in CI. A `check:` task must be a group or uncached, which is asserted where the graph's other
cache rules already are.

That reachability assertion found `gate:webapp-format`, which belonged to no gate group. Wiring it
in exposed the reason it had been overlooked: `vp -C webapp check` is format plus lint, so the
webapp was about to be format-checked twice — the same 1125 files, two gate names, two annotations
for one failure. `gate:webapp` now runs `--no-fmt`, so `gate:webapp-format` owns the formatting
verdict and `gate:webapp` owns the rest, which is the shape every other tree already had.

`vite.config.ts` and `scripts/ci-contract.test.ts` are added to the hot-file lanes in
`docs/contributor/ai-agent-workflow.mdx`; they had four and six concurrent writers this round and
have to move together.

Fixes #1790.

## How to test

- `vp run format`
- `vp run check` — green, and its log now shows one webapp format pass rather than two.
- `node --test scripts/ci-contract.test.ts`
- To see the contract bite: rename any task to `Verify:All`, add a `gate:` task to no group, give a
  `check:` task a cached command, or delete every `report:` task — each fails with the name and the
  rule it broke.

## Release impact

No changeset is needed. This renames repository tasks and their call sites in CI, contributor docs
and repository tooling; nothing shipped to a user or an operator changes.

## Notes for reviewers

The rename touches four workflows, seven contributor pages, two READMEs and the `--help` text of
`scripts/update-gitlab-schema.ts`. `git grep -F` for each old name over all tracked files finds no
survivor. The one behaviour change hiding in a naming PR is `gate:webapp` gaining `--no-fmt`; the
file counts above are the evidence that it removes a duplicate verdict rather than coverage.
