### PR TITLE
fix(ci): keep registry blips out of the merge queue

### DIFF
--- a/.github/actions/setup-toolchain/action.yml
+++ b/.github/actions/setup-toolchain/action.yml
@@ -1,5 +1,5 @@
 name: "Setup toolchain"
-description: "The Node.js, pnpm and Vite+ versions package.json pins, with the pnpm store cached; install is none or frozen."
+description: "The Node.js, pnpm and Vite+ versions package.json pins, with the pinned pnpm executable and, for a frozen install, the pnpm store cached; install is none or frozen."
 inputs:
   install:
     description: "none, or frozen: pnpm install --frozen-lockfile --ignore-scripts. No lifecycle script runs in CI, so pnpm-workspace.yaml#allowBuilds is exercised only by a contributor's install."
@@ -8,20 +8,89 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - id: pnpm
+      shell: bash
+      run: |
+        echo "version=$(jq -r '.devEngines.packageManager.version' package.json)" >> "$GITHUB_OUTPUT"
+        # On Windows this shell is Git Bash, whose $HOME is an MSYS path that the Windows PATH
+        # cannot resolve. os.homedir() is what both pnpm/setup and actions/cache's `~` expand to, so
+        # asking Node keeps the destination, the cache path and PATH the same directory everywhere.
+        echo "dest=$(node -p 'require("node:path").join(require("node:os").homedir(), "setup-pnpm")')" >> "$GITHUB_OUTPUT"
+    # The path is pnpm/setup's own default destination, so the action does not restate it as `dest`;
+    # the version check below fails the job if that default ever moves.
+    - id: pnpm-cache
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ~/setup-pnpm
+        key: pnpm-bin-${{ runner.os }}-${{ runner.arch }}-${{ steps.pnpm.outputs.version }}
+    # A hit skips pnpm/setup, so it has to reproduce what that action exports: PNPM_HOME, and both
+    # the destination and its bin directory on PATH.
+    - if: steps.pnpm-cache.outputs.cache-hit == 'true'
+      shell: bash
+      env:
+        PNPM_DEST: ${{ steps.pnpm.outputs.dest }}
+      run: |
+        echo "PNPM_HOME=$PNPM_DEST" >> "$GITHUB_ENV"
+        echo "$PNPM_DEST/bin" >> "$GITHUB_PATH"
+        echo "$PNPM_DEST" >> "$GITHUB_PATH"
     - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version-file: package.json
+        cache: ${{ steps.pnpm-cache.outputs.cache-hit == 'true' && inputs.install == 'frozen' && 'pnpm' || '' }}
+        cache-dependency-path: pnpm-lock.yaml
     - if: inputs.install != 'none' && inputs.install != 'frozen'
       shell: bash
       run: |
         echo "::error::setup-toolchain: install must be none or frozen"
         exit 1
-    - uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
+    # GitHub Actions has no retry for a `uses:` step and pnpm/setup has no retry input, so the
+    # attempts are written out; a loop would mean re-implementing the installer and giving up npm's
+    # signature verification of the executable. pnpm/setup does not separate a registry blip from a
+    # bad pin, so a deterministic failure also costs all three attempts.
+    - id: pnpm-setup-1
+      if: steps.pnpm-cache.outputs.cache-hit != 'true'
+      continue-on-error: true
+      uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
       with:
         cache: ${{ inputs.install == 'frozen' }}
         cache-dependency-path: pnpm-lock.yaml
         install: false
         require-lockfile: true
+    - if: steps.pnpm-setup-1.outcome == 'failure'
+      shell: bash
+      run: sleep 5
+    - id: pnpm-setup-2
+      if: steps.pnpm-setup-1.outcome == 'failure'
+      continue-on-error: true
+      uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
+      with:
+        cache: ${{ inputs.install == 'frozen' }}
+        cache-dependency-path: pnpm-lock.yaml
+        install: false
+        require-lockfile: true
+    - if: steps.pnpm-setup-2.outcome == 'failure'
+      shell: bash
+      run: sleep 10
+    - if: steps.pnpm-setup-2.outcome == 'failure'
+      uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
+      with:
+        cache: ${{ inputs.install == 'frozen' }}
+        cache-dependency-path: pnpm-lock.yaml
+        install: false
+        require-lockfile: true
+    # A cache key cannot be overwritten, so one truncated save would poison every job until the pin
+    # moves. Answering here proves the restored tree and the PATH it was reached through, and holds
+    # the freshly installed tree to the pin before it is offered to anyone else.
+    - shell: bash
+      env:
+        PNPM_VERSION: ${{ steps.pnpm.outputs.version }}
+      run: test "$(pnpm --version)" = "$PNPM_VERSION"
+    # A cache saved on any ref other than the default branch is invisible to every other ref.
+    - if: steps.pnpm-cache.outputs.cache-hit != 'true' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+      uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ~/setup-pnpm
+        key: pnpm-bin-${{ runner.os }}-${{ runner.arch }}-${{ steps.pnpm.outputs.version }}
     - uses: voidzero-dev/setup-vp@1b32467adbe183473499fd9d5d372c3ed9641754 # v1.18.0
       with:
         node-manager: false

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -884,3 +884,34 @@ jobs:
               description: description,
               context: 'All CI Passed'
             });
+
+  report-unsuccessful-merge-group:
+    name: "Report unsuccessful merge group"
+    needs: [all-ci-passed]
+    # A merge queue regroups whenever the entries ahead change and cancels the runs it dissolves, so
+    # only a failure says anything about this pull request.
+    if: ${{ !cancelled() && github.event_name == 'merge_group' && needs.all-ci-passed.result == 'failure' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      pull-requests: write
+    steps:
+      - id: pull-request
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const ref = context.payload.merge_group?.head_ref ?? '';
+            const match = /^refs\/heads\/gh-readonly-queue\/[^/]+\/pr-(\d+)-/.exec(ref);
+            if (!match) {
+              core.setFailed(`Cannot identify the pull request from merge queue ref ${ref}`);
+              return;
+            }
+            core.setOutput('number', match[1]);
+
+      - uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
+        with:
+          header: merge-queue-failure
+          number_force: ${{ steps.pull-request.outputs.number }}
+          message: >-
+            The [combined merge-queue CI run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+            failed, so this pull request left the queue. Inspect the run before re-queueing it.

--- a/docs/contributor/ci-cd.mdx
+++ b/docs/contributor/ci-cd.mdx
@@ -81,6 +81,12 @@ workflows run again for the merge group, which includes the current base and que
 the pull request. Each required context is bound to the GitHub Actions integration rather than
 accepting a same-named external status.
 
+A failed merge group drops its pull requests from the queue without failing any check on them, so
+CI updates a comment on the pull request named by the merge group's head ref with the run link. It
+does not requeue automatically: the result does not say whether the failure was transient or
+deterministic. Regrouping the queue cancels the runs it dissolves, and a cancelled run is reported
+to nobody.
+
 Review is a native ruleset requirement with stale approvals dismissed on every push. Authors listed
 in `REVIEW_POLICY_MAINTAINERS` receive an automated approval; every other author needs a human with
 write access. Repository administrators own that allow-list. Remove the automation when independent
@@ -248,7 +254,7 @@ why the label is the authority, and which alternatives were priced and declined,
 
 | Action | Contract |
 | --- | --- |
-| `setup-toolchain` | Installs the Node.js and pnpm versions pinned in `package.json`, restores the pnpm store cache, and installs the launcher through the SHA-pinned `setup-vp` with `node-manager: false`, which then runs the lockfile's `vite-plus`; `install` is `none` or `frozen` |
+| `setup-toolchain` | Installs the Node.js and pnpm versions pinned in `package.json`, caching the pnpm executable by runner platform and pinned version and retrying its download twice on a miss, restores the pnpm store cache, and installs the launcher through the SHA-pinned `setup-vp` with `node-manager: false`, which then runs the lockfile's `vite-plus`; `install` is `none` or `frozen` |
 | `setup-caches` | Sets up the JDK from `.java-version` and restores the Maven dependency cache with a prefix fallback; `application-server-reactor` also restores the generated-client build cache and is the only type that writes caches, on default-branch push, schedule and dispatch runs |
 | `restore-server-build` | Downloads the packaged reactor and installs its generated-clients JAR and parent pom so single-module Maven goals resolve them; outputs the executable JAR path |
 | `setup-browsers` | Restores the exact Playwright browser version and installs Chromium system dependencies |
@@ -260,9 +266,10 @@ why the label is the authority, and which alternatives were priced and declined,
 
 A run restores caches from its own branch and from `main`, never from a sibling branch; within that
 scope the newest entry under the key prefix wins. Task-cache entries are content-addressed, so a
-pull request saves them for its own reruns; the Maven caches save only from `main` because their
-key is a pom hash. The JDK the caches depend on is pinned once, in `.java-version`, which every
-workflow provisions from.
+pull request saves them for its own reruns; the Maven caches and the pnpm executable cache save only
+from `main`, because every branch shares their key and a write from any other ref would be reused by
+nobody. The JDK the caches depend on is pinned once, in `.java-version`, which every workflow
+provisions from.
 
 Repository-local actions require checkout first. Jobs without checkout use the external SHA-pinned
 action directly rather than checking out the repository only to reach a wrapper.

--- a/scripts/check-toolchain.ts
+++ b/scripts/check-toolchain.ts
@@ -241,10 +241,94 @@ if (installInput.default !== "none")
 	throw new Error("setup-toolchain must install nothing unless a job asks");
 if (withOf(setupStep(usesAction("actions/setup-node")))["node-version-file"] !== "package.json")
 	throw new Error("setup-toolchain must provision package.json#devEngines.runtime");
-const pnpmSetup = withOf(setupStep(usesAction("pnpm/setup")));
+// Every expression below is derived from the id of the step it reads, so renaming a step is not a
+// drift; changing what a step does is.
+const steps = setupSteps.filter(isRecord);
+const idOf = (step: Record<string, unknown>): string => {
+	if (typeof step.id !== "string") throw new Error("setup-toolchain step must carry an id");
+	return step.id;
+};
+const pnpmPin = setupStep((step) => String(step.run).includes("devEngines.packageManager.version"));
+const versionOutput = `steps.${idOf(pnpmPin)}.outputs.version`;
+// Git Bash gives Windows an MSYS $HOME that the Windows PATH cannot resolve, so the destination has
+// to be resolved the way pnpm/setup and actions/cache resolve it.
+if (!String(pnpmPin.run).includes("dest=$(node "))
+	throw new Error("setup-toolchain must resolve the pnpm destination the way the runner expands ~");
+const destOutput = `\${{ steps.${idOf(pnpmPin)}.outputs.dest }}`;
+const pnpmCache = setupStep(usesAction("actions/cache/restore"));
+const cacheHit = `steps.${idOf(pnpmCache)}.outputs.cache-hit`;
+if (
+	withOf(pnpmCache).path !== "~/setup-pnpm" ||
+	!["runner.os", "runner.arch", versionOutput].every((part) =>
+		String(withOf(pnpmCache).key).includes(part),
+	)
+)
+	throw new Error("setup-toolchain must cache the platform-specific pinned pnpm binary");
+// Without PNPM_HOME and PATH the hit path leaves the job no pnpm at all, and setup-node's store
+// cache fails looking for it.
+const restored = steps.find((step) => step.if === `${cacheHit} == 'true'`) ?? {};
+if (
+	!String(restored.run).includes("PNPM_HOME=") ||
+	!String(restored.run).includes('>> "$GITHUB_PATH"')
+)
+	throw new Error("setup-toolchain must put the restored pnpm on PATH and in PNPM_HOME");
+if (
+	String(restored.run).includes("$HOME") ||
+	!Object.values(isRecord(restored.env) ? restored.env : {}).includes(destOutput)
+)
+	throw new Error(
+		"setup-toolchain must export the resolved pnpm destination, not the shell's HOME",
+	);
+const pnpmSetupOrder = steps.flatMap((step, index) =>
+	usesAction("pnpm/setup")(step) ? [index] : [],
+);
+if (pnpmSetupOrder.length !== 3)
+	throw new Error("setup-toolchain must retry pnpm setup twice before failing");
+const pnpmSetups = pnpmSetupOrder.map((index) => steps[index] ?? {});
+const firstAttempt = pnpmSetups[0] ?? {};
+if (firstAttempt.if !== `${cacheHit} != 'true'`)
+	throw new Error("setup-toolchain must skip pnpm setup entirely when the binary cache hits");
+for (const [attempt, index] of pnpmSetupOrder.slice(1).entries()) {
+	const previous = pnpmSetups[attempt] ?? {};
+	const guard = `steps.${idOf(previous)}.outcome == 'failure'`;
+	if (previous["continue-on-error"] !== true)
+		throw new Error("setup-toolchain must let a retried pnpm setup attempt fail without the job");
+	if (steps[index]?.if !== guard)
+		throw new Error("setup-toolchain must run each pnpm setup attempt only after the last failed");
+	const backoff = steps[index - 1] ?? {};
+	if (backoff.if !== guard || !/^sleep \d+$/.test(String(backoff.run)))
+		throw new Error("setup-toolchain must back off before each pnpm setup retry");
+}
+if ("continue-on-error" in (pnpmSetups[2] ?? {}))
+	throw new Error("setup-toolchain must fail the job when its last pnpm setup attempt fails");
+const pnpmSetup = withOf(firstAttempt);
 if (pnpmSetup.install !== false || pnpmSetup["require-lockfile"] !== true)
 	throw new Error(
 		"setup-toolchain must leave the install to its own step and require the lockfile",
+	);
+for (const step of pnpmSetups)
+	if (!isDeepStrictEqual(withOf(step), pnpmSetup))
+		throw new Error("setup-toolchain must retry the same pnpm setup operation");
+// A cache key cannot be overwritten, so an unproven tree saved once is served to every job.
+const proof = steps.find((step) => String(step.run).includes("pnpm --version")) ?? {};
+if ("if" in proof || !isRecord(proof.env) || proof.env.PNPM_VERSION !== `\${{ ${versionOutput} }}`)
+	throw new Error("setup-toolchain must prove the pinned pnpm answers on both setup paths");
+const pnpmCacheSave = setupStep(usesAction("actions/cache/save"));
+if (steps.indexOf(proof) > steps.indexOf(pnpmCacheSave))
+	throw new Error("setup-toolchain must prove the pnpm binary before it saves it");
+if (!isDeepStrictEqual(withOf(pnpmCacheSave), withOf(pnpmCache)))
+	throw new Error("setup-toolchain must save the pnpm binary under its exact restore identity");
+if (
+	pnpmCacheSave.if !==
+	`${cacheHit} != 'true' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)`
+)
+	throw new Error("setup-toolchain must write the pnpm binary cache only from the default branch");
+const nodeSetup = withOf(setupStep(usesAction("actions/setup-node")));
+if (
+	nodeSetup.cache !== `\${{ ${cacheHit} == 'true' && inputs.install == 'frozen' && 'pnpm' || '' }}`
+)
+	throw new Error(
+		"setup-toolchain must cache the pnpm store through setup-node exactly when pnpm/setup did not",
 	);
 const vpSetup = withOf(setupStep(usesAction("voidzero-dev/setup-vp")));
 if (vpSetup["node-manager"] !== false || vpSetup["run-install"] !== false)

--- a/scripts/ci-contract.test.ts
+++ b/scripts/ci-contract.test.ts
@@ -442,6 +442,19 @@ void describe("CI contract", () => {
 		assert.match(job(source, "Compose"), /uses: \.\/\.github\/workflows\/ci-compose-validate\.yml/);
 	});
 
+	void test("reports a failed merge-group run on its pull request, and only a failure", async () => {
+		const source = await readFile(".github/workflows/cicd.yml", "utf8");
+		const reporter = job(source, "report-unsuccessful-merge-group");
+		assert.match(reporter, /needs: \[all-ci-passed\]/);
+		assert.match(reporter, /github\.event_name == 'merge_group'/);
+		// A merge queue cancels the runs it regroups, which says nothing about the pull request.
+		assert.match(reporter, /needs\.all-ci-passed\.result == 'failure'/);
+		assert.doesNotMatch(reporter, /always\(\)/);
+		assert.match(reporter, /pull-requests: write/);
+		// A ref the job cannot read is a missing report, so it fails rather than commenting nowhere.
+		assert.match(reporter, /core\.setFailed/);
+	});
+
 	void test("decides an image's architectures once, for every image the run builds", async () => {
 		const source = await readFile(".github/workflows/cicd.yml", "utf8");
 		const caller = job(source, "Docker");


### PR DESCRIPTION
## What changed and why

Every CI job fetches the pinned pnpm executable from the npm registry through `pnpm/setup`, and
nothing retried it. A single timeout or 504 failed the job; in a merge-queue run it evicted the pull
request and the entries batched with it, leaving green checks on pull requests that had silently
stopped moving.

`setup-toolchain` now caches the pnpm executable by runner platform and pinned version, so a warm job
does not reach the registry for it at all, and retries `pnpm/setup` twice behind a 5 s and a 10 s
backoff when the cache misses. GitHub Actions has no retry for a `uses:` step and `pnpm/setup` has no
retry input, so the attempts are written out; the file says so, and says why a hand-rolled downloader
was rejected. The restored or freshly installed executable has to answer `pnpm --version` with the
pinned version before anything is cached, because a cache key cannot be overwritten and one bad save
would outlast the outage it replaced. Only default-branch runs write the cache, which is the rule
`setup-caches` already follows.

`cicd.yml` gains a job that comments on the pull request a **failed** merge group belongs to. It is
deliberately narrow: a merge queue regroups whenever the entries ahead of a pull request change and
cancels the runs it dissolves, so a cancelled run is reported to nobody.

### Related issues

Part of #1807.

All three of the issue's “Done when” bullets are met:

- *A single transient registry failure does not fail a job* — `pnpm/setup` was the only unretried
  call on the toolchain path. `actions/setup-node` already retries the Node download three times
  through `@actions/tool-cache`; `voidzero-dev/setup-vp` already retries the Vite+ install twice over
  each of two script hosts before falling back to a third; `pnpm install` already retries registry
  fetches (`fetchRetries`, default 2, with backoff). Only `pnpm/setup` had nothing, and both failures
  reported on the issue were there.
- *A job that has the pnpm binary cached does not contact the registry for it* — the cache-hit path
  skips all three attempts.
- *An eviction from the merge queue is visible without inspecting the queue by hand* — the new
  comment.

The issue stays open for its follow-up comment: `Validate title` still runs a frozen install, because
`vp exec commitlint` needs the workspace and the Conventional Commit rules live once, in
`commitlint.config.ts`. Giving that job a dependency-free path is a separate change.

### Changes

- `.github/actions/setup-toolchain/action.yml` — cache and restore `~/setup-pnpm` keyed by
  `runner.os`, `runner.arch` and the pinned pnpm version; reproduce `pnpm/setup`'s `PNPM_HOME` and
  `PATH` exports on a hit, from a destination Node resolves so Git Bash's MSYS `$HOME` never reaches
  the Windows `PATH`; three `pnpm/setup` attempts with a bounded backoff on a miss; prove
  `pnpm --version` on both paths before the save; save only from the default branch. `dest` dropped —
  it restated the action's default.
- `.github/workflows/cicd.yml` — `report-unsuccessful-merge-group` updates a sticky comment on the
  pull request named by the merge group's head ref, on a failure only.
- `scripts/check-toolchain.ts` — the gate now asserts the backoff steps, the cache-hit `PATH` export,
  the version proof and its position before the save, and the default-branch write. Every expression
  is derived from the id of the step it reads, so renaming a step is not a drift.
- `scripts/ci-contract.test.ts` — the merge-group reporter's contract instead of its wording.
- `docs/contributor/ci-cd.mdx` — the `setup-toolchain` contract row and the caches paragraph carry
  the new behaviour; the merge-group comment is described under § Merge policy, where the queue
  contract lives.

### How to test

- `vp run check` covers `gate:toolchain` and the CI contract suite.
- The warm-cache path is exercised on this pull request: `Quality / Windows` restores
  `pnpm-bin-Windows-X64-12.0.0`, skips all three `pnpm/setup` attempts and the save, exports
  `PNPM_HOME=C:\Users\runneradmin\setup-pnpm`, and passes the `pnpm --version` check before any
  task runs.
- After this lands, the first push to `main` writes the Linux entry from `Build` and `Docker`.
  `Quality / Windows` runs on `main` only on a version-bump push, so its entry is refreshed per
  release and it takes the retried cold path in between.
- The merge-group comment can only be exercised by a genuinely failing merge group.

### Notes for reviewers

- No changeset: this changes CI configuration and contributor documentation, not shipped code.
- The pnpm store is still cached by `pnpm/setup` on a cold executable cache and by `actions/setup-node`
  on a warm one. The two key schemes do not meet, so the first warm-executable run after a cold one
  re-downloads the dependency tree. Unifying them means either hand-rolling the store cache or
  reordering `actions/setup-node` past `pnpm/setup`, which also changes which of the two installs Node
  last — a separate change.
