### PR TITLE
docs: renumber the colliding ADR 0041 and gate the index

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -517,7 +517,7 @@ jobs:
 
   # Staging pulls: this asks for the promotion and waits for it, so production is still only offered
   # a release staging is actually running. Nothing here reaches the host, and no deploy credential
-  # is involved — see ADR 0041.
+  # is involved — see ADR 0042.
   promote-staging:
     needs: [release, tag-images, publish-release]
     if: needs.release.outputs.released == 'true'

--- a/docs/decisions/0042-hosts-pull-their-own-releases.md
+++ b/docs/decisions/0042-hosts-pull-their-own-releases.md
@@ -1,4 +1,4 @@
-# 0041. Hosts pull their own releases
+# ADR 0042: Hosts pull their own releases
 
 Date: 2026-09-03
 

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -80,5 +80,6 @@ do, its home is the Admin Guide (`docs/admin/`) and the runbook links to it.
 | [0039](0039-git-and-postgresql-own-evidence.md) | Git owns repository evidence; PostgreSQL owns captured payloads and references | Accepted (amended 2026-09-03 #1719 — evidence retention and replay superseded by [0041](0041-compose-1x-kubernetes-2.md)) |
 | [0040](0040-vite-plus-is-the-command-surface.md) | Vite+ is the command surface; pnpm stays the package manager | Accepted |
 | [0041](0041-compose-1x-kubernetes-2.md) | Compose for 1.x; Kubernetes only for 2.0 | Accepted |
+| [0042](0042-hosts-pull-their-own-releases.md) | Hosts pull their own releases | Accepted |
 
 Template: [0000-template.md](0000-template.md).

--- a/scripts/decisions-index.test.ts
+++ b/scripts/decisions-index.test.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import { readdir, readFile } from "node:fs/promises";
+import { test } from "node:test";
+
+const directory = "docs/decisions";
+
+// The template is the shape an ADR is copied from, not a decision: its `NNNN` is a placeholder, so
+// it is neither numbered nor listed in the index.
+const files = (await readdir(directory))
+	.filter((entry) => /^\d{4}-.+\.md$/.test(entry) && entry !== "0000-template.md")
+	.toSorted();
+
+void test("ADR numbers are unique", () => {
+	const numbers = files.map((file) => file.slice(0, 4));
+	const duplicated = numbers.filter((number, index) => numbers.indexOf(number) !== index);
+
+	assert.deepEqual(duplicated, [], "two ADR files claim the same number");
+});
+
+void test("each ADR heading states its own number", async () => {
+	for (const file of files) {
+		const [heading = ""] = (await readFile(`${directory}/${file}`, "utf8")).split("\n", 1);
+
+		assert.match(heading, new RegExp(`^# ADR ${file.slice(0, 4)}: \\S`), file);
+	}
+});
+
+void test("the ADR index lists exactly the ADR files, each under its own number", async () => {
+	const index = await readFile(`${directory}/README.md`, "utf8");
+	const rows = [...index.matchAll(/^\| \[\d{4}\]\(\d{4}-[^)]+\.md\)/gm)].map(([row]) => row);
+
+	assert.deepEqual(
+		new Set(rows),
+		new Set(files.map((file) => `| [${file.slice(0, 4)}](${file})`)),
+		"every ADR file needs one index row, and a row's number must match the file it links",
+	);
+});


### PR DESCRIPTION
## What changed and why

Two accepted decision records reached `main` under the same number. `docs/decisions/` currently holds
both `0041-compose-1x-kubernetes-2.md` (#1779) and `0041-hosts-pull-their-own-releases.md` (#1794),
because the two pull requests were open at the same time and nothing checks the numbering. The second
record was also missing from `docs/decisions/README.md` entirely, and its heading was the only one of
42 that did not follow `# ADR NNNN: Title`.

`0041-hosts-pull-their-own-releases.md` is renumbered to `0042`. It is the one to move: it had a
single inbound reference, while `0041-compose-1x-kubernetes-2.md` is cited by nine other decision
records and by an absolute URL in the Admin Guide. The file is renamed, not rewritten — the only
change inside it is the heading, now `# ADR 0042: Hosts pull their own releases`. The index gains its
row, and the `promote-staging` comment in `.github/workflows/release.yml` — the one inbound
reference — points at ADR 0042.

`scripts/decisions-index.test.ts` is what stops this recurring. It asserts three independent facts:

- ADR numbers are unique.
- Each record's heading states its own number.
- The index lists exactly the ADR files, and each row's number matches the file it links.

## How to test

```bash
vp run check
```

The new test reaches `check` through `test:tooling`, which runs `node --test scripts/*.test.ts`.

All three assertions fail against `main`'s `docs/decisions/`, each for a different reason — the
duplicate `0041`, the non-conforming `# 0041. Hosts pull their own releases` heading, and 42 numbered
files against 41 index rows:

```
$ node --test scripts/decisions-index.test.ts     # main's docs/decisions/, this branch's test
✖ ADR numbers are unique
    AssertionError: two ADR files claim the same number
    actual: [ '0041' ]   expected: []
✖ each ADR heading states its own number
    AssertionError: 0041-hosts-pull-their-own-releases.md
    actual: '# 0041. Hosts pull their own releases'   expected: /^# ADR 0041: \S/
✖ the ADR index lists exactly the ADR files, each under its own number
    AssertionError: every ADR file needs one index row, and a row's number must match the file it links
    Set(41) vs Set(42)
```

On this branch all three pass.

## Release impact

No changeset. This changes contributor documentation and a repository policy check; the shipped
server, web application, container images and operator-facing configuration are untouched.

## Notes for reviewers

The rename and the gate have to land in the same commit, or the gate lands red on a `main` that still
carries the duplicate.

The gate runs on each pull request's own head, so two pull requests concurrently claiming the same
number both pass and `main` goes red when the second merges — which is exactly how this collision
happened. That is the intended safety net as long as `check` also runs on the merged result in the
merge queue; otherwise it catches the collision immediately after the fact rather than before.

The ADR's body is unchanged. In particular it still records that production adopts pull-based deploy
only after its outstanding version gap is closed by hand, which is still true: `release.yml`'s
`deploy-production` job runs the SSH-push path today, and this is the only place in the repository
that says so.
