### PR TITLE
feat(scm): review issue metadata changes

### DIFF
--- a/.changeset/review-issue-metadata.md
+++ b/.changeset/review-issue-metadata.md
@@ -1,0 +1,5 @@
+---
+"hephaestus": minor
+---
+
+Issue practice reviews now react to a title, description, label, assignment, milestone or reopen change on GitHub and GitLab, and to a native issue type change on GitHub — where before only a new label did. Closing an issue again after reopening it is now reviewed again too, instead of only the first close being. Practices already bound to the labelled occasion move to the wider one automatically on upgrade, keeping their customisations. Expect issue reviews to run more often: each round of triage that changes what a practice can read occasions its own review, there is no delay that batches a burst of edits into one, and the first backfill campaign after the upgrade reviews each already-closed issue once more. Locking an issue, pinning it, or editing a due date, weight or time estimate occasions nothing, and a replayed event or a return to an issue state already reviewed no longer starts another review.

--- a/docs/contributor/practice-review-pipeline.mdx
+++ b/docs/contributor/practice-review-pipeline.mdx
@@ -82,6 +82,66 @@ Operator remediation is in [When a workspace goes quiet](/admin/practice-review#
 The occurrence ledger has no pruning job; capacity planning must treat it as append-only. Retry and lapse
 thresholds are documented in the admin guide.
 
+### Issue lifecycle occasions
+
+Issue practices bind to three lifecycle occasions:
+
+| Occasion | Transition | Revision identity |
+| --- | --- | --- |
+| `scm.issue.opened` | The issue is created | Title and body |
+| `scm.issue.updated` | The review-relevant snapshot changes, including reopening | The whole snapshot |
+| `scm.issue.closed` | The issue enters a closed state | The close timestamp |
+
+The snapshot is the title, body, native type, labels, assignees, milestone, state, and state reason — the
+fields the issue evidence a bundled practice reads is built from. Labels and assignees are sorted while the
+digest is built, so provider ordering does not change the revision.
+
+Only `scm.issue.updated` keys on the whole snapshot. The other two deliberately do not, because a recurring
+backfill sweep re-derives their keys from the artifact as it stands: an opening keys on the prose and a
+close on the moment it closed, so triage between two sweeps moves neither and buys no second review.
+
+Unlike a merged pull request, a closed issue is not in a state it cannot leave. Keying the close on its
+timestamp keeps a redelivery of one close inert while making the close that follows a reopen a second
+occasion, so the retrospective at-close review runs for each round of work rather than only the first.
+Neither provider guarantees a close timestamp; a mirror row without one falls back to a single close
+occasion, since there is then nothing to tell two closes apart.
+
+Two consequences are worth stating because neither is obvious:
+
+- **A return to a previously-seen snapshot occasions nothing.** Adding a label occasions a review, removing
+  it occasions another, and adding it back matches a revision already in the ledger and occasions none.
+  Reverse states are symmetric in what they raise, not in what they spend. A reopen is the exception: it
+  moves the state field, so it occasions an update review, and the close after it occasions its own close
+  review because that close is a different moment.
+- **Each distinct intermediate snapshot in a burst spends a review.** Deduplication is by content, not by
+  time: five triage actions on one issue arrive as five deliveries carrying five different snapshots, and
+  are five occasions. There is no temporal debounce, so do not read this section as a coalescing guarantee.
+
+| Transition | GitHub webhook action | GitLab webhook action | Review decision |
+| --- | --- | --- | --- |
+| Title or body changed | `edited` | `update` | Updated |
+| Native type set or removed | `typed`, `untyped` | Not exposed by the validated webhook contract | GitHub: updated; GitLab: synchronization only |
+| Label added or removed | `labeled`, `unlabeled` | `update` | Updated |
+| Assignee added or removed | `assigned`, `unassigned` | `update` | Updated |
+| Milestone set or removed | `milestoned`, `demilestoned` | `update` | Updated |
+| Reopened | `reopened` | `reopen` | Updated |
+| Closed | `closed` | `close` | Closed |
+| Locked, pinned, due date, weight, time tracking | `locked`, `pinned` | `update` | Nothing |
+
+Both adapters report what a delivery moved as a field set, and an update that moves none of the snapshot's
+fields occasions nothing: GitHub compares the mirrored row against the incoming one, and GitLab reads the
+`changes` diff its `update` action carries, which is the only thing distinguishing a retitling from a
+due-date, weight or time-tracking edit.
+
+Synchronization updates the issue projection without creating lifecycle occasions. GitLab synchronization
+includes native type, but its webhook contract does not provide a reliable type transition; the GitLab
+adapter therefore does not advertise live type-change reviews. A type set on GitLab still reaches the
+snapshot through the mirror, so it lands in the digest of whichever later `update` happens to fire.
+
+Every practice bound to `scm.issue.updated` is reevaluated. Practice bindings declare occasions and evidence
+sources, not dependencies on individual issue fields. Reevaluating the bounded issue evidence avoids
+retaining observations whose inputs changed without introducing a second dependency model.
+
 ## Capture
 
 Capture stages **every source the contract says applies to the artifact kind under review** — all of them,

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/backfill/ReviewBackfillSignals.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/backfill/ReviewBackfillSignals.java
@@ -50,8 +50,19 @@ final class ReviewBackfillSignals {
                 pullRequest.getBody());
     }
 
+    /**
+     * The ledger identity for reviewing this issue as it stands.
+     *
+     * <p>Never {@code scm.issue.updated}: a sweep measures the artifact, not a transition, and it has no
+     * previous snapshot to say the artifact moved away from. Keeping the two occasions apart is also what
+     * bounds the spend — an issue keeps the identity its prose gives it while open and the one its close
+     * moment gives it once closed, so triage between two sweeps moves neither, and the second sweep still
+     * recognises it as already measured.
+     */
     static Optional<SignalKey> keyFor(long workspaceId, Issue issue) {
-        SignalName signal = issue.getState() == Issue.State.CLOSED ? ScmSignals.ISSUE_CLOSED : ScmSignals.ISSUE_OPENED;
-        return ScmSignals.issueKey(workspaceId, issue.getId(), signal, issue.getTitle(), issue.getBody(), null);
+        if (issue.getState() == Issue.State.CLOSED) {
+            return ScmSignals.issueClosedKey(workspaceId, issue.getId(), issue.getClosedAt());
+        }
+        return ScmSignals.issueOpenedKey(workspaceId, issue.getId(), issue.getTitle(), issue.getBody());
     }
 }

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/job/DevTriggerController.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/job/DevTriggerController.java
@@ -6,6 +6,7 @@ import de.tum.cit.aet.hephaestus.agent.handler.PullRequestReviewSubmissionReques
 import de.tum.cit.aet.hephaestus.agent.handler.spi.JobSubmissionRequest;
 import de.tum.cit.aet.hephaestus.core.AuditExempt;
 import de.tum.cit.aet.hephaestus.core.WorkspaceAgnostic;
+import de.tum.cit.aet.hephaestus.integration.core.events.ScmEventPayload;
 import de.tum.cit.aet.hephaestus.integration.core.signal.DiscoveredVia;
 import de.tum.cit.aet.hephaestus.integration.core.signal.SignalKey;
 import de.tum.cit.aet.hephaestus.integration.core.signal.SignalName;
@@ -163,30 +164,29 @@ public class DevTriggerController {
             return Prepared.done("Issue not found in workspace " + workspaceId + ": " + issueId);
         }
         SignalName triggerSignal = signal == null || signal.isBlank() ? null : SignalName.of(signal);
+        // Before the gate, because an issue whose repository the mirror never resolved is not
+        // reviewable at all: reading one to build a signal key would dereference that relation, and a
+        // refusal recorded against it would claim the gate had an opinion about an artifact nobody can
+        // fetch.
+        IssueReviewSubmissionRequest request = agentJobService.buildIssueRequest(issue, triggerSignal);
+        if (request == null) {
+            return Prepared.done("Issue missing repository: issueId=" + issue.getId());
+        }
         if (triggerSignal != null) {
             GateDecision decision = detectionGate.evaluateIssue(issue, triggerSignal, TriggerMode.AUTO);
             if (decision instanceof GateDecision.Skip skip) {
                 recordRefusal(
-                        ScmSignals.issueKey(
-                                        workspaceId,
-                                        issue.getId(),
-                                        triggerSignal,
-                                        issue.getTitle(),
-                                        issue.getBody(),
-                                        null)
+                        ScmSignals.issueKey(workspaceId, triggerSignal, ScmEventPayload.IssueData.from(issue))
                                 .orElse(null),
                         skip);
                 return Prepared.done("Gate skipped (" + triggerSignal + "): " + skip.reason());
             }
         }
-        IssueReviewSubmissionRequest request = agentJobService.buildIssueRequest(issue, triggerSignal);
-        return request == null
-                ? Prepared.done("Issue missing repository: issueId=" + issue.getId())
-                : Prepared.issue(
-                        request,
-                        triggerSignal == null
-                                ? recordManualRequest(workspaceId, issue.getId(), ScmSignals.ISSUE_MANUAL_REVIEW)
-                                : null);
+        return Prepared.issue(
+                request,
+                triggerSignal == null
+                        ? recordManualRequest(workspaceId, issue.getId(), ScmSignals.ISSUE_MANUAL_REVIEW)
+                        : null);
     }
 
     /**

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/job/IssueAgentJobEventListener.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/job/IssueAgentJobEventListener.java
@@ -20,6 +20,8 @@ import de.tum.cit.aet.hephaestus.practices.review.PracticeReviewDetectionGate;
 import de.tum.cit.aet.hephaestus.practices.review.TriggerMode;
 import de.tum.cit.aet.hephaestus.workspace.Workspace;
 import de.tum.cit.aet.hephaestus.workspace.WorkspaceResolver;
+import java.util.Collections;
+import java.util.Set;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -46,6 +48,15 @@ public class IssueAgentJobEventListener {
 
     private static final Logger log = LoggerFactory.getLogger(IssueAgentJobEventListener.class);
 
+    /**
+     * The issue fields the review evidence is built from ({@code IssueContentSource}). An update that
+     * moves nothing else — a lock, a comment count, a due date, a weight — occasions no review: the
+     * mirror still records it, but every practice bound to the occasion would read byte-identical
+     * evidence and reach the conclusion it already published.
+     */
+    private static final Set<String> REVIEWABLE_ISSUE_FIELDS =
+            Set.of("title", "body", "state", "stateReason", "issueType", "milestone", "relationships");
+
     private final AgentJobService agentJobService;
     private final IssueRepository issueRepository;
     private final PracticeReviewDetectionGate practiceReviewDetectionGate;
@@ -69,14 +80,17 @@ public class IssueAgentJobEventListener {
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void onIssueCreated(ScmDomainEvent.IssueCreated event) {
-        handleIssueEvent(event.issue(), null, event.context(), TriggerEventNames.ISSUE_CREATED);
+        handleIssueEvent(event.issue(), event.context(), TriggerEventNames.ISSUE_CREATED);
     }
 
     @Async
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    public void onIssueLabeled(ScmDomainEvent.IssueLabeled event) {
-        handleIssueEvent(event.issue(), event.label().name(), event.context(), TriggerEventNames.ISSUE_LABELED);
+    public void onIssueUpdated(ScmDomainEvent.IssueUpdated event) {
+        if (Collections.disjoint(event.changedFields(), REVIEWABLE_ISSUE_FIELDS)) {
+            return;
+        }
+        handleIssueEvent(event.issue(), event.context(), TriggerEventNames.ISSUE_UPDATED);
     }
 
     @Async
@@ -86,15 +100,11 @@ public class IssueAgentJobEventListener {
         handleRetrospectiveIssueEvent(event.issue(), event.context(), TriggerEventNames.ISSUE_CLOSED);
     }
 
-    private void handleIssueEvent(
-            ScmEventPayload.IssueData issueData,
-            @Nullable String labelName,
-            EventContext context,
-            String triggerEventName) {
+    private void handleIssueEvent(ScmEventPayload.IssueData issueData, EventContext context, String triggerEventName) {
         if (issueData.state() == Issue.State.CLOSED) {
             return;
         }
-        dispatchIssueEvent(issueData, labelName, context, triggerEventName);
+        dispatchIssueEvent(issueData, context, triggerEventName);
     }
 
     /**
@@ -103,7 +113,7 @@ public class IssueAgentJobEventListener {
      */
     private void handleRetrospectiveIssueEvent(
             ScmEventPayload.IssueData issueData, EventContext context, String triggerEventName) {
-        dispatchIssueEvent(issueData, null, context, triggerEventName);
+        dispatchIssueEvent(issueData, context, triggerEventName);
     }
 
     /**
@@ -111,12 +121,9 @@ public class IssueAgentJobEventListener {
      * listener, and for the same reason: what we saw is a fact, whether to coach on it is a policy.
      */
     private void dispatchIssueEvent(
-            ScmEventPayload.IssueData issueData,
-            @Nullable String labelName,
-            EventContext context,
-            String triggerEventName) {
+            ScmEventPayload.IssueData issueData, EventContext context, String triggerEventName) {
         try {
-            SignalKey key = signalKeyFor(issueData, labelName, triggerEventName);
+            SignalKey key = signalKeyFor(issueData, triggerEventName);
             if (key == null) {
                 return;
             }
@@ -163,14 +170,7 @@ public class IssueAgentJobEventListener {
         }
     }
 
-    /**
-     * The ledger identity of this event. An issue carries no commit, so its signal keys on what the
-     * author wrote — an edit becomes a fresh occurrence and gets re-measured; a labelling also keys on
-     * the label, since three labels in one update are three occurrences with an otherwise-identical
-     * payload.
-     */
-    private @Nullable SignalKey signalKeyFor(
-            ScmEventPayload.IssueData issueData, @Nullable String labelName, String triggerEventName) {
+    private @Nullable SignalKey signalKeyFor(ScmEventPayload.IssueData issueData, String triggerEventName) {
         Workspace workspace = workspaceResolver
                 .resolveForRepository(issueData.repository().nameWithOwner())
                 .orElse(null);
@@ -185,9 +185,7 @@ public class IssueAgentJobEventListener {
             log.debug("No signal declared for trigger event, nothing to record: event={}", triggerEventName);
             return null;
         }
-        return ScmSignals.issueKey(
-                        workspace.getId(), issueData.id(), signal, issueData.title(), issueData.body(), labelName)
-                .orElse(null);
+        return ScmSignals.issueKey(workspace.getId(), signal, issueData).orElse(null);
     }
 
     private void submitJob(Issue issue, GateDecision.Detect detect, SignalKey signalKey) {

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/core/events/ScmDomainEvent.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/core/events/ScmDomainEvent.java
@@ -36,7 +36,8 @@ public final class ScmDomainEvent {
         public static final String PULL_REQUEST_CLOSED = "PullRequestClosed";
 
         public static final String ISSUE_CREATED = "IssueCreated";
-        public static final String ISSUE_LABELED = "IssueLabeled";
+        public static final String ISSUE_UPDATED = "IssueUpdated";
+
         /** Retrospective: an issue was closed. Drives at-close, feed-forward detection (outcome before close). */
         public static final String ISSUE_CLOSED = "IssueClosed";
 

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/core/events/ScmEventPayload.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/core/events/ScmEventPayload.java
@@ -15,6 +15,7 @@ import de.tum.cit.aet.hephaestus.integration.scm.domain.pullrequestreviewthread.
 import de.tum.cit.aet.hephaestus.integration.scm.domain.team.Team;
 import de.tum.cit.aet.hephaestus.integration.scm.domain.user.User;
 import java.time.Instant;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import org.jspecify.annotations.NonNull;
@@ -54,6 +55,10 @@ public final class ScmEventPayload {
             boolean isPullRequest,
             @NonNull RepositoryRef repository,
             @Nullable Long authorId,
+            @Nullable String issueType,
+            @Nullable String milestone,
+            @NonNull List<String> labels,
+            @NonNull List<String> assignees,
             @Nullable Instant createdAt,
             @Nullable Instant updatedAt,
             @Nullable Instant closedAt) {
@@ -69,6 +74,13 @@ public final class ScmEventPayload {
                     issue.isPullRequest(),
                     Objects.requireNonNull(RepositoryRef.from(issue.getRepository())),
                     issue.getAuthor() != null ? issue.getAuthor().getId() : null,
+                    issue.getIssueType() != null ? issue.getIssueType().getName() : null,
+                    issue.getMilestone() != null ? issue.getMilestone().getTitle() : null,
+                    issue.getLabels().stream().map(Label::getName).toList(),
+                    issue.getAssignees().stream()
+                            .map(User::getLogin)
+                            .filter(Objects::nonNull)
+                            .toList(),
                     issue.getCreatedAt(),
                     issue.getUpdatedAt(),
                     issue.getClosedAt());

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/domain/signal/IssueArtifactDescriptor.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/domain/signal/IssueArtifactDescriptor.java
@@ -19,17 +19,17 @@ import org.springframework.stereotype.Component;
 /**
  * The issue as a reviewable artifact.
  *
- * <p>An issue has no diff, so it has no inline lane or reviewer relation; every signal keys on a
- * content digest rather than a commit.
+ * <p>An issue has no diff, so it has no inline lane or reviewer relation.
  */
 @Component
 public class IssueArtifactDescriptor implements ArtifactDescriptor {
 
     private static final List<Signal> SIGNALS = List.of(
             declareRecommended(ScmSignals.ISSUE_OPENED, "Opened", Set.of(GITHUB_ISSUES, GITLAB_ISSUE)),
-            // GitLab has no native "labeled" action; its issue processor derives one per newly added
-            // label off the update event, so the provenance is real.
-            declareRecommended(ScmSignals.ISSUE_LABELED, "Labeled", Set.of(GITHUB_ISSUES, GITLAB_ISSUE)),
+            // Both providers raise it, but from different vocabularies: GitHub has an action per edit,
+            // GitLab one update action whose changes diff says what moved. Neither can report a type
+            // change on GitLab, which is why the display name does not promise one.
+            declareRecommended(ScmSignals.ISSUE_UPDATED, "Details changed", Set.of(GITHUB_ISSUES, GITLAB_ISSUE)),
             declare(ScmSignals.ISSUE_CLOSED, "Closed", Set.of(GITHUB_ISSUES, GITLAB_ISSUE)),
             declareManualRequest(ScmSignals.ISSUE_MANUAL_REVIEW, "Review requested by hand"));
 

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/domain/signal/ScmSignals.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/domain/signal/ScmSignals.java
@@ -2,11 +2,14 @@ package de.tum.cit.aet.hephaestus.integration.scm.domain.signal;
 
 import static de.tum.cit.aet.hephaestus.integration.core.events.ScmDomainEvent.TriggerEventNames;
 
+import de.tum.cit.aet.hephaestus.integration.core.events.ScmEventPayload;
 import de.tum.cit.aet.hephaestus.integration.core.signal.ArtifactKind;
 import de.tum.cit.aet.hephaestus.integration.core.signal.RevisionScheme;
 import de.tum.cit.aet.hephaestus.integration.core.signal.SignalKey;
 import de.tum.cit.aet.hephaestus.integration.core.signal.SignalName;
 import de.tum.cit.aet.hephaestus.integration.core.signal.SignalRevision;
+import java.time.Instant;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -47,7 +50,7 @@ public final class ScmSignals {
     public static final SignalName PULL_REQUEST_MANUAL_REVIEW = SignalName.of("scm.pull_request.manual_review");
 
     public static final SignalName ISSUE_OPENED = SignalName.of("scm.issue.opened");
-    public static final SignalName ISSUE_LABELED = SignalName.of("scm.issue.labeled");
+    public static final SignalName ISSUE_UPDATED = SignalName.of("scm.issue.updated");
     public static final SignalName ISSUE_CLOSED = SignalName.of("scm.issue.closed");
     public static final SignalName ISSUE_MANUAL_REVIEW = SignalName.of("scm.issue.manual_review");
 
@@ -66,8 +69,8 @@ public final class ScmSignals {
             PULL_REQUEST_CLOSED,
             TriggerEventNames.ISSUE_CREATED,
             ISSUE_OPENED,
-            TriggerEventNames.ISSUE_LABELED,
-            ISSUE_LABELED,
+            TriggerEventNames.ISSUE_UPDATED,
+            ISSUE_UPDATED,
             TriggerEventNames.ISSUE_CLOSED,
             ISSUE_CLOSED);
 
@@ -83,8 +86,8 @@ public final class ScmSignals {
             Map.entry(PULL_REQUEST_CLOSED, RevisionScheme.TERMINAL_STATE),
             Map.entry(PULL_REQUEST_MANUAL_REVIEW, RevisionScheme.RUN_ID),
             Map.entry(ISSUE_OPENED, RevisionScheme.CONTENT_DIGEST),
-            Map.entry(ISSUE_LABELED, RevisionScheme.CONTENT_DIGEST),
-            Map.entry(ISSUE_CLOSED, RevisionScheme.TERMINAL_STATE),
+            Map.entry(ISSUE_UPDATED, RevisionScheme.CONTENT_DIGEST),
+            Map.entry(ISSUE_CLOSED, RevisionScheme.CONTENT_DIGEST),
             Map.entry(ISSUE_MANUAL_REVIEW, RevisionScheme.RUN_ID));
 
     private ScmSignals() {}
@@ -132,30 +135,68 @@ public final class ScmSignals {
     }
 
     /**
-     * The ledger identity of an issue signal, keyed on what its author wrote.
+     * The ledger identity of an issue's opening, keyed on what its author wrote.
      *
-     * @param labelName the label {@link #ISSUE_LABELED} was raised for, which is what that occurrence
-     *                  <em>is</em>: three labels applied in one update are three occurrences, and keying
-     *                  them on the prose alone would deduplicate all but the first. Empty for a caller
-     *                  that cannot name the label, in which case a labelling has nothing to key on —
-     *                  better no ledger row than one that swallows every later labelling. Ignored by
-     *                  every other signal.
+     * <p>Deliberately blind to labels, assignees, milestone and type: a backfill sweep re-derives this
+     * key from the artifact as it stands, so keying it on metadata triage moves would give an untouched
+     * issue a fresh identity every time somebody labelled it, and buy a second review of the same prose.
+     * {@link #ISSUE_UPDATED} is the one occasion that metadata <em>is</em>.
      */
-    public static Optional<SignalKey> issueKey(
-            long workspaceId,
-            long issueId,
-            SignalName signal,
-            String title,
-            @Nullable String body,
-            @Nullable String labelName) {
+    public static Optional<SignalKey> issueOpenedKey(
+            long workspaceId, long issueId, String title, @Nullable String body) {
+        return issueKey(workspaceId, issueId, ISSUE_OPENED, title, body);
+    }
+
+    /**
+     * The ledger identity of an issue's close: the moment it closed.
+     *
+     * <p>An issue is not a pull request — it can be reopened, so a close is not a state it cannot leave
+     * and a constant revision would let the first close settle the row a later one needs. Two closes are
+     * two moments and two retrospective reviews; a redelivery of one close carries the same moment and
+     * is inert. The issue's own content is deliberately absent, so triaging a long-closed issue does not
+     * make the next backfill sweep re-run the review of how it ended.
+     *
+     * <p>A mirror row without a close timestamp keys on the absence instead, which is again constant per
+     * issue: neither provider guarantees {@code closed_at}, and inventing a moment would mint an
+     * occurrence nobody observed.
+     */
+    public static Optional<SignalKey> issueClosedKey(long workspaceId, long issueId, @Nullable Instant closedAt) {
+        return issueKey(workspaceId, issueId, ISSUE_CLOSED, closedAt != null ? closedAt.toString() : null);
+    }
+
+    /**
+     * The ledger identity of an issue signal raised by a domain event, dispatched to the rule for that
+     * occasion. {@link #ISSUE_UPDATED} digests the whole review-relevant snapshot, because that occasion
+     * is precisely "this snapshot differs from the last one", so two deliveries describing the same
+     * snapshot are one occurrence. Labels and assignees are sorted here, because a provider may order
+     * them however it likes and the digest may not depend on that.
+     */
+    public static Optional<SignalKey> issueKey(long workspaceId, SignalName signal, ScmEventPayload.IssueData issue) {
+        if (signal.equals(ISSUE_CLOSED)) {
+            return issueClosedKey(workspaceId, issue.id(), issue.closedAt());
+        }
+        if (!signal.equals(ISSUE_UPDATED)) {
+            return issueKey(workspaceId, issue.id(), signal, issue.title(), issue.body());
+        }
+        return issueKey(
+                workspaceId,
+                issue.id(),
+                signal,
+                issue.title(),
+                issue.body(),
+                issue.state().name(),
+                issue.stateReason(),
+                issue.issueType(),
+                issue.milestone(),
+                joinSorted(issue.labels()),
+                joinSorted(issue.assignees()));
+    }
+
+    private static Optional<SignalKey> issueKey(
+            long workspaceId, long issueId, SignalName signal, @Nullable String... content) {
         if (!ISSUE.equals(signal.artifactKind())) {
             return Optional.empty();
         }
-        boolean labelling = signal.equals(ISSUE_LABELED);
-        if (labelling && (labelName == null || labelName.isBlank())) {
-            return Optional.empty();
-        }
-        String[] content = labelling ? new String[] {title, body, labelName} : new String[] {title, body};
         return revisionFor(signal, null, content)
                 .map(revision -> new SignalKey(workspaceId, issueId, signal, revision));
     }
@@ -189,5 +230,10 @@ public final class ScmSignals {
 
     private static String lastSegmentOf(SignalName signal) {
         return signal.value().substring(signal.value().lastIndexOf('.') + 1);
+    }
+
+    /** Unit separator: no label or login may contain it, so no two lists join to the same string. */
+    private static String joinSorted(List<String> values) {
+        return values.stream().sorted().collect(Collectors.joining("\u001f"));
     }
 }

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/github/issue/GitHubIssueProcessor.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/github/issue/GitHubIssueProcessor.java
@@ -220,6 +220,12 @@ public class GitHubIssueProcessor extends BaseGitHubProcessor {
         return assigneesChanged || labelsChanged;
     }
 
+    /**
+     * What this delivery moved, in the field vocabulary {@code ScmDomainEvent.IssueUpdated} carries.
+     * Reports every field the mirror tracks rather than only the review-relevant ones: which of them are
+     * worth a review is the review pipeline's decision, and which are worth a cache eviction is the
+     * mentor's, so narrowing here would silently answer both questions at once.
+     */
     private Set<String> computeChangedFields(Issue oldIssue, Issue newIssue) {
         Set<String> changedFields = new HashSet<>();
 

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/github/manifest/GitHubManifest.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/github/manifest/GitHubManifest.java
@@ -65,7 +65,7 @@ public class GitHubManifest implements IntegrationManifest {
                                 ScmSignals.PULL_REQUEST_MERGED,
                                 ScmSignals.PULL_REQUEST_CLOSED),
                         ScmSignals.ISSUE,
-                        Set.of(ScmSignals.ISSUE_OPENED, ScmSignals.ISSUE_LABELED, ScmSignals.ISSUE_CLOSED)),
+                        Set.of(ScmSignals.ISSUE_OPENED, ScmSignals.ISSUE_UPDATED, ScmSignals.ISSUE_CLOSED)),
                 Map.of(
                         ScmSignals.PULL_REQUEST,
                         Set.of(FeedbackLane.IN_CONTEXT_SUMMARY, FeedbackLane.IN_CONTEXT_INLINE),

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/gitlab/issue/GitLabIssueMessageHandler.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/gitlab/issue/GitLabIssueMessageHandler.java
@@ -103,7 +103,8 @@ public class GitLabIssueMessageHandler extends AbstractIntegrationMessageHandler
 
         switch (action) {
             case OPEN -> issueProcessor.process(event, context);
-            // UPDATE carries the changes.labels diff — processUpdated also emits IssueLabeled per added label.
+            // UPDATE carries the changes diff — it is the only action GitLab has for a retitling, a
+            // relabelling and a due-date edit alike, so processUpdated reads that diff to tell them apart.
             case UPDATE -> issueProcessor.processUpdated(event, context);
             case CLOSE -> issueProcessor.processClosed(event, context);
             case REOPEN -> issueProcessor.processReopened(event, context);

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/gitlab/issue/GitLabIssueProcessor.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/gitlab/issue/GitLabIssueProcessor.java
@@ -174,19 +174,26 @@ public class GitLabIssueProcessor extends BaseGitLabProcessor {
     }
 
     /**
-     * Handles an {@code action=update} issue event. Persists the issue, then emits one
-     * {@link ScmDomainEvent.IssueLabeled}
-     * per newly-added label — GitLab has no native "labeled" action, so this is how the IssueLabeled
-     * trigger reaches parity with GitHub. The added-label delta is read from the webhook's
-     * {@code changes.labels} diff, so a plain title/description edit emits nothing.
+     * Handles an {@code action=update} issue event. Persists the issue, publishes one
+     * {@link ScmDomainEvent.IssueUpdated} carrying what the webhook's {@code changes} diff says moved,
+     * then one {@link ScmDomainEvent.IssueLabeled} per newly-added label — GitLab has no native
+     * "labeled" action, so this is how the activity feed reaches parity with GitHub. An update that
+     * moved only attributes the shared domain has no field name for (due date, weight, time tracking)
+     * publishes nothing: the mirror is refreshed either way, and an event with an empty diff would tell
+     * every consumer that something changed while naming nothing.
      */
     @Transactional
     @Nullable
     public Issue processUpdated(GitLabIssueEventDTO event, ProcessingContext context) {
         List<GitLabWebhookLabel> addedLabels = event.addedLabels();
+        Set<String> changedFields = event.changedFields();
         Issue issue = processInternal(event, context);
-        if (issue == null || addedLabels.isEmpty()) {
+        if (issue == null) {
             return issue;
+        }
+        if (!changedFields.isEmpty()) {
+            eventPublisher.publishEvent(new ScmDomainEvent.IssueUpdated(
+                    ScmEventPayload.IssueData.from(issue), changedFields, EventContext.from(context)));
         }
         for (GitLabWebhookLabel labelDto : addedLabels) {
             Label label = findOrCreateLabel(labelDto, Objects.requireNonNull(context.repository()));
@@ -389,8 +396,10 @@ public class GitLabIssueProcessor extends BaseGitLabProcessor {
     public Issue processReopened(GitLabIssueEventDTO event, ProcessingContext context) {
         Issue issue = processInternal(event, context);
         if (issue != null) {
-            eventPublisher.publishEvent(new ScmDomainEvent.IssueReopened(
-                    ScmEventPayload.IssueData.from(issue), EventContext.from(context)));
+            ScmEventPayload.IssueData issueData = ScmEventPayload.IssueData.from(issue);
+            eventPublisher.publishEvent(
+                    new ScmDomainEvent.IssueUpdated(issueData, Set.of("state"), EventContext.from(context)));
+            eventPublisher.publishEvent(new ScmDomainEvent.IssueReopened(issueData, EventContext.from(context)));
             log.debug("Reopened issue: issueId={}", issue.getId());
         }
         return issue;

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/gitlab/issue/dto/GitLabIssueEventDTO.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/gitlab/issue/dto/GitLabIssueEventDTO.java
@@ -6,6 +6,7 @@ import de.tum.cit.aet.hephaestus.integration.scm.gitlab.common.GitLabEventAction
 import de.tum.cit.aet.hephaestus.integration.scm.gitlab.common.dto.GitLabWebhookLabel;
 import de.tum.cit.aet.hephaestus.integration.scm.gitlab.common.dto.GitLabWebhookProject;
 import de.tum.cit.aet.hephaestus.integration.scm.gitlab.common.dto.GitLabWebhookUser;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -37,16 +38,61 @@ public record GitLabIssueEventDTO(
         @Nullable List<GitLabWebhookUser> assignees,
         @JsonProperty("changes") @Nullable Changes changes) {
     /**
-     * The {@code changes} diff GitLab sends on an {@code action=update} event. We only care about the
-     * label delta — GitLab has no dedicated "labeled" action, so label changes arrive here.
+     * The {@code changes} diff GitLab sends on an {@code action=update} event: one entry per attribute
+     * the update moved. GitLab has no per-attribute action, so this diff is the only thing that says
+     * what an {@code update} was — without it a due-date edit is indistinguishable from a retitling.
+     *
+     * <p>Only the attributes the shared domain has a field name for are declared; the rest (due date,
+     * weight, time tracking, confidentiality) are what {@code ignoreUnknown} drops.
      */
     @JsonIgnoreProperties(ignoreUnknown = true)
-    public record Changes(@Nullable LabelsChange labels) {}
+    public record Changes(
+            @Nullable LabelsChange labels,
+            @Nullable AttributeChange title,
+            @Nullable AttributeChange description,
+            @Nullable AttributeChange assignees,
+            @JsonProperty("milestone_id") @Nullable AttributeChange milestoneId,
+            @JsonProperty("state_id") @Nullable AttributeChange stateId) {}
+
+    /**
+     * An attribute GitLab reported as changed. Its {@code previous}/{@code current} values are
+     * deliberately not bound: the mirror is refreshed from {@code object_attributes} either way, so the
+     * only thing read here is that the key was present.
+     */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record AttributeChange() {}
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     public record LabelsChange(
             @Nullable List<GitLabWebhookLabel> previous,
             @Nullable List<GitLabWebhookLabel> current) {}
+
+    /**
+     * What this update moved, in the field vocabulary {@code ScmDomainEvent.IssueUpdated} carries, so a
+     * consumer reads the same names whichever provider raised the event.
+     */
+    public Set<String> changedFields() {
+        if (changes == null) {
+            return Set.of();
+        }
+        Set<String> fields = new LinkedHashSet<>();
+        if (changes.title() != null) {
+            fields.add("title");
+        }
+        if (changes.description() != null) {
+            fields.add("body");
+        }
+        if (changes.stateId() != null) {
+            fields.add("state");
+        }
+        if (changes.milestoneId() != null) {
+            fields.add("milestone");
+        }
+        if (changes.labels() != null || changes.assignees() != null) {
+            fields.add("relationships");
+        }
+        return Set.copyOf(fields);
+    }
 
     /**
      * Labels newly added in this update (current minus previous, keyed by id). Empty when the update
@@ -66,8 +112,8 @@ public record GitLabIssueEventDTO(
                         .collect(Collectors.toSet());
         return changes.labels().current().stream()
                 // A current label with a null id is treated as added: GitLab's changes.labels diff reliably carries
-                // ids, so this branch is defensive only and deliberately favours over-firing IssueLabeled (better to
-                // re-trigger detection than silently miss a real add) over under-firing on a malformed payload.
+                // ids, so this branch is defensive only and deliberately favours an extra activity entry over
+                // silently losing a real add on a malformed payload.
                 .filter(label -> label.id() == null || !previousIds.contains(label.id()))
                 .toList();
     }

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/gitlab/manifest/GitLabManifest.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/gitlab/manifest/GitLabManifest.java
@@ -79,7 +79,7 @@ public class GitLabManifest implements IntegrationManifest {
                                 ScmSignals.PULL_REQUEST_MERGED,
                                 ScmSignals.PULL_REQUEST_CLOSED),
                         ScmSignals.ISSUE,
-                        Set.of(ScmSignals.ISSUE_OPENED, ScmSignals.ISSUE_LABELED, ScmSignals.ISSUE_CLOSED)),
+                        Set.of(ScmSignals.ISSUE_OPENED, ScmSignals.ISSUE_UPDATED, ScmSignals.ISSUE_CLOSED)),
                 gitlabStackEnabled
                         ? Map.of(
                                 ScmSignals.PULL_REQUEST,

--- a/server/application/src/main/resources/db/changelog/1788521746862_changelog.xml
+++ b/server/application/src/main/resources/db/changelog/1788521746862_changelog.xml
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet author="hephaestus" id="1788521746862-1">
+        <preConditions onFail="MARK_RAN" onFailMessage="No stored practice binding names scm.issue.labeled">
+            <sqlCheck expectedResult="1">
+                SELECT CASE WHEN EXISTS (
+                    SELECT 1 FROM practice WHERE bindings::text LIKE '%scm.issue.labeled%'
+                    UNION ALL
+                    SELECT 1 FROM curated_practice_override WHERE bindings::text LIKE '%scm.issue.labeled%'
+                    UNION ALL
+                    SELECT 1 FROM practice_revision WHERE bindings::text LIKE '%scm.issue.labeled%'
+                ) THEN 1 ELSE 0 END
+            </sqlCheck>
+        </preConditions>
+        <comment>
+            Move every practice bound to the labelled occasion onto the occasion that replaces it.
+
+            A signal name is a stored string, and the one that used to mean "a label was added" now means
+            "the review evidence moved" — a wider occasion that also covers a retitling, an assignment, a
+            milestone and a native type. Nothing rewrites a stored binding on upgrade: the bundle is
+            installed once per workspace and never revisited, adoption leaves an already-present slug
+            alone, and provenance backfill carries stored bindings through unchanged. Without this, only
+            workspaces created after the release get the new occasion, and every existing workspace keeps
+            a name no descriptor produces — so its issue practices silently stop being reviewed AND
+            cannot be edited at all, because binding validation rejects a signal the work type no longer
+            offers on every save.
+
+            The signals of a binding are rebuilt rather than string-replaced so the list stays sorted and
+            deduplicated, which is the shape the bundled catalogue ships and what the review-rule
+            fingerprint digests. practice and practice_revision are rewritten together because a deferred
+            constraint trigger requires a practice's current revision to project it exactly; the
+            revision's fingerprint is then cleared because bindings feed it and CatalogProvenanceBackfill
+            recomputes a null one on the next boot. Schema-first ordering does not apply here — no table
+            is altered — but the immutability trigger has to stand down for the revision rewrite, which
+            is the one case where a revision changes without a new measurement.
+        </comment>
+        <sql splitStatements="false"><![CDATA[
+            CREATE OR REPLACE FUNCTION rename_issue_labeled_binding(bindings jsonb)
+            RETURNS jsonb
+            LANGUAGE sql
+            IMMUTABLE
+            AS $rename_binding$
+                SELECT COALESCE((
+                    SELECT jsonb_agg(
+                        CASE WHEN binding ? 'signals'
+                            THEN jsonb_set(binding, '{signals}', COALESCE((
+                                SELECT jsonb_agg(DISTINCT renamed ORDER BY renamed)
+                                FROM jsonb_array_elements_text(binding->'signals') AS stored(signal),
+                                     LATERAL (SELECT CASE stored.signal
+                                         WHEN 'scm.issue.labeled' THEN 'scm.issue.updated'
+                                         ELSE stored.signal
+                                     END) AS mapped(renamed)
+                            ), '[]'::jsonb))
+                            ELSE binding
+                        END
+                        ORDER BY position)
+                    FROM jsonb_array_elements(bindings) WITH ORDINALITY AS listed(binding, position)
+                ), bindings)
+            $rename_binding$;
+
+            UPDATE practice
+            SET bindings = rename_issue_labeled_binding(bindings)
+            WHERE bindings::text LIKE '%scm.issue.labeled%';
+
+            UPDATE curated_practice_override
+            SET bindings = rename_issue_labeled_binding(bindings)
+            WHERE bindings::text LIKE '%scm.issue.labeled%';
+
+            ALTER TABLE practice_revision DISABLE TRIGGER practice_revision_immutable_update;
+            UPDATE practice_revision
+            SET bindings = rename_issue_labeled_binding(bindings),
+                review_rule_fingerprint = NULL
+            WHERE bindings::text LIKE '%scm.issue.labeled%';
+            ALTER TABLE practice_revision ENABLE TRIGGER practice_revision_immutable_update;
+
+            DROP FUNCTION rename_issue_labeled_binding(jsonb);
+        ]]></sql>
+        <rollback>
+            <sql splitStatements="false"><![CDATA[
+                -- The narrower occasion is the only one the previous release can raise, so a binding
+                -- goes back to it. A workspace that bound the wider occasion by hand after the upgrade
+                -- lands on the labelled one, which is the closest thing that release has.
+                CREATE OR REPLACE FUNCTION restore_issue_labeled_binding(bindings jsonb)
+                RETURNS jsonb
+                LANGUAGE sql
+                IMMUTABLE
+                AS $restore_binding$
+                    SELECT COALESCE((
+                        SELECT jsonb_agg(
+                            CASE WHEN binding ? 'signals'
+                                THEN jsonb_set(binding, '{signals}', COALESCE((
+                                    SELECT jsonb_agg(DISTINCT restored ORDER BY restored)
+                                    FROM jsonb_array_elements_text(binding->'signals') AS stored(signal),
+                                         LATERAL (SELECT CASE stored.signal
+                                             WHEN 'scm.issue.updated' THEN 'scm.issue.labeled'
+                                             ELSE stored.signal
+                                         END) AS mapped(restored)
+                                ), '[]'::jsonb))
+                                ELSE binding
+                            END
+                            ORDER BY position)
+                        FROM jsonb_array_elements(bindings) WITH ORDINALITY AS listed(binding, position)
+                    ), bindings)
+                $restore_binding$;
+
+                UPDATE practice
+                SET bindings = restore_issue_labeled_binding(bindings)
+                WHERE bindings::text LIKE '%scm.issue.updated%';
+
+                UPDATE curated_practice_override
+                SET bindings = restore_issue_labeled_binding(bindings)
+                WHERE bindings::text LIKE '%scm.issue.updated%';
+
+                ALTER TABLE practice_revision DISABLE TRIGGER practice_revision_immutable_update;
+                UPDATE practice_revision
+                SET bindings = restore_issue_labeled_binding(bindings),
+                    review_rule_fingerprint = NULL
+                WHERE bindings::text LIKE '%scm.issue.updated%';
+                ALTER TABLE practice_revision ENABLE TRIGGER practice_revision_immutable_update;
+
+                DROP FUNCTION restore_issue_labeled_binding(jsonb);
+            ]]></sql>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/server/application/src/main/resources/db/master.xml
+++ b/server/application/src/main/resources/db/master.xml
@@ -106,4 +106,5 @@
     <include file="./changelog/1788452647516_changelog.xml" relativeToChangelogFile="true"/>
     <include file="./changelog/1788445799918_changelog.xml" relativeToChangelogFile="true"/>
     <include file="./changelog/1788465485693_changelog.xml" relativeToChangelogFile="true"/>
+    <include file="./changelog/1788521746862_changelog.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/server/application/src/main/resources/practices/default-catalog.json
+++ b/server/application/src/main/resources/practices/default-catalog.json
@@ -222,7 +222,7 @@
 					"name": "State a problem a maintainer can act on",
 					"on": [
 						{
-							"signals": ["scm.issue.labeled", "scm.issue.opened"],
+							"signals": ["scm.issue.opened", "scm.issue.updated"],
 							"needs": [
 								{
 									"sourceKind": "scm.issue.comments",
@@ -245,7 +245,7 @@
 					"name": "Keep the issue to one concern",
 					"on": [
 						{
-							"signals": ["scm.issue.labeled", "scm.issue.opened"],
+							"signals": ["scm.issue.opened", "scm.issue.updated"],
 							"needs": [
 								{
 									"sourceKind": "scm.issue.core",
@@ -264,7 +264,7 @@
 					"name": "Define a checkable outcome",
 					"on": [
 						{
-							"signals": ["scm.issue.closed", "scm.issue.labeled", "scm.issue.opened"],
+							"signals": ["scm.issue.closed", "scm.issue.opened", "scm.issue.updated"],
 							"needs": [
 								{
 									"sourceKind": "scm.issue.comments",
@@ -1000,7 +1000,7 @@
 					"name": "Point the issue to the context it depends on",
 					"on": [
 						{
-							"signals": ["scm.issue.labeled", "scm.issue.opened"],
+							"signals": ["scm.issue.opened", "scm.issue.updated"],
 							"needs": [
 								{
 									"sourceKind": "scm.issue.core",
@@ -1104,7 +1104,7 @@
 					"name": "Break large work into trackable subtasks",
 					"on": [
 						{
-							"signals": ["scm.issue.closed", "scm.issue.labeled", "scm.issue.opened"],
+							"signals": ["scm.issue.closed", "scm.issue.opened", "scm.issue.updated"],
 							"needs": [
 								{
 									"sourceKind": "scm.issue.comments",
@@ -1127,7 +1127,7 @@
 					"name": "Classify issues for triage",
 					"on": [
 						{
-							"signals": ["scm.issue.labeled", "scm.issue.opened"],
+							"signals": ["scm.issue.opened", "scm.issue.updated"],
 							"needs": [
 								{
 									"sourceKind": "scm.issue.core",

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/backfill/ReviewBackfillSignalsTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/backfill/ReviewBackfillSignalsTest.java
@@ -5,9 +5,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import de.tum.cit.aet.hephaestus.integration.core.signal.RevisionScheme;
 import de.tum.cit.aet.hephaestus.integration.core.signal.SignalKey;
 import de.tum.cit.aet.hephaestus.integration.scm.domain.issue.Issue;
+import de.tum.cit.aet.hephaestus.integration.scm.domain.label.Label;
+import de.tum.cit.aet.hephaestus.integration.scm.domain.milestone.Milestone;
 import de.tum.cit.aet.hephaestus.integration.scm.domain.pullrequest.PullRequest;
 import de.tum.cit.aet.hephaestus.integration.scm.domain.signal.ScmSignals;
+import de.tum.cit.aet.hephaestus.integration.scm.domain.user.User;
 import de.tum.cit.aet.hephaestus.testconfig.BaseUnitTest;
+import java.time.Instant;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -106,6 +110,54 @@ class ReviewBackfillSignalsTest extends BaseUnitTest {
 
         assertThat(key).isPresent();
         assertThat(key.orElseThrow().revision().scheme()).contains(RevisionScheme.CONTENT_DIGEST);
+    }
+
+    /**
+     * Triage moves no prose, so it must not mint a second measurement: the label that buys a live
+     * {@code scm.issue.updated} review would otherwise buy a backfill review of the same issue on the
+     * next sweep as well, and both rewrite the same summary comment on the issue.
+     */
+    @Test
+    void triagingAnIssueBetweenTwoSweepsLeavesItsIdentityAlone() {
+        Issue triaged = issue();
+        Label label = new Label();
+        label.setName("needs-triage");
+        triaged.getLabels().add(label);
+        User assignee = new User();
+        assignee.setLogin("alice");
+        triaged.getAssignees().add(assignee);
+        Milestone milestone = new Milestone();
+        milestone.setTitle("v1");
+        triaged.setMilestone(milestone);
+
+        assertThat(ReviewBackfillSignals.keyFor(WORKSPACE_ID, triaged))
+                .isEqualTo(ReviewBackfillSignals.keyFor(WORKSPACE_ID, issue()));
+    }
+
+    /**
+     * A sweep measures a closed issue at the moment it closed, so triage since then has nothing new to
+     * measure — while a genuine second close, after a reopen, does.
+     */
+    @Test
+    void aClosedIssueIsMeasuredAtTheMomentItClosed() {
+        Issue closed = closedIssue(Instant.parse("2026-09-04T08:00:00Z"));
+        Issue relabelledSinceClosing = closedIssue(Instant.parse("2026-09-04T08:00:00Z"));
+        Label label = new Label();
+        label.setName("wontfix");
+        relabelledSinceClosing.getLabels().add(label);
+        Issue closedAgainAfterAReopen = closedIssue(Instant.parse("2026-09-11T08:00:00Z"));
+
+        assertThat(ReviewBackfillSignals.keyFor(WORKSPACE_ID, relabelledSinceClosing))
+                .isEqualTo(ReviewBackfillSignals.keyFor(WORKSPACE_ID, closed));
+        assertThat(ReviewBackfillSignals.keyFor(WORKSPACE_ID, closedAgainAfterAReopen))
+                .isNotEqualTo(ReviewBackfillSignals.keyFor(WORKSPACE_ID, closed));
+    }
+
+    private Issue closedIssue(Instant closedAt) {
+        Issue issue = issue();
+        issue.setState(Issue.State.CLOSED);
+        issue.setClosedAt(closedAt);
+        return issue;
     }
 
     private PullRequest pullRequest() {

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/context/providers/mentor/MentorContextInvalidatorTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/context/providers/mentor/MentorContextInvalidatorTest.java
@@ -16,6 +16,7 @@ import de.tum.cit.aet.hephaestus.integration.scm.domain.pullrequest.PullRequest;
 import de.tum.cit.aet.hephaestus.testconfig.BaseUnitTest;
 import de.tum.cit.aet.hephaestus.workspace.WorkspaceRepository;
 import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -140,6 +141,10 @@ class MentorContextInvalidatorTest extends BaseUnitTest {
                 false,
                 new RepositoryRef(repoId, "acme/repo", "main"),
                 authorId,
+                null,
+                null,
+                List.of(),
+                List.of(),
                 Instant.now(),
                 Instant.now(),
                 null);

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/job/DevTriggerControllerTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/job/DevTriggerControllerTest.java
@@ -10,6 +10,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import de.tum.cit.aet.hephaestus.agent.handler.IssueReviewSubmissionRequest;
+import de.tum.cit.aet.hephaestus.integration.core.events.ScmEventPayload;
 import de.tum.cit.aet.hephaestus.integration.core.signal.SignalKey;
 import de.tum.cit.aet.hephaestus.integration.core.signal.SignalRecorder;
 import de.tum.cit.aet.hephaestus.integration.core.signal.SignalStateReason;
@@ -96,6 +98,7 @@ class DevTriggerControllerTest extends BaseUnitTest {
     void shouldRecordAnIssueGateRefusalAgainstItsSignal() {
         Issue issue = issue();
         when(artifactLoader.findIssueForGate(WORKSPACE_ID, ISSUE_ID)).thenReturn(Optional.of(issue));
+        when(agentJobService.buildIssueRequest(any(), any())).thenReturn(issueRequest());
         when(detectionGate.evaluateIssue(any(), any(), any())).thenReturn(new GateDecision.Skip("no assignee"));
 
         String response = controller.triggerReview(null, ISSUE_ID, WORKSPACE_ID, "scm.issue.closed");
@@ -104,12 +107,7 @@ class DevTriggerControllerTest extends BaseUnitTest {
         verify(signalRecorder)
                 .markRefused(
                         ScmSignals.issueKey(
-                                        WORKSPACE_ID,
-                                        ISSUE_ID,
-                                        ScmSignals.ISSUE_CLOSED,
-                                        issue.getTitle(),
-                                        issue.getBody(),
-                                        null)
+                                        WORKSPACE_ID, ScmSignals.ISSUE_CLOSED, ScmEventPayload.IssueData.from(issue))
                                 .orElseThrow(),
                         SignalStateReason.GATE_SKIPPED);
     }
@@ -162,12 +160,51 @@ class DevTriggerControllerTest extends BaseUnitTest {
         return pr;
     }
 
+    /**
+     * An issue whose repository the mirror never resolved is not reviewable, and a signal key cannot be
+     * built for one — so the endpoint has to answer that before it asks the gate anything, rather than
+     * settling a ledger row for an artifact nobody can fetch.
+     */
+    @Test
+    void shouldRefuseAnIssueWithNoRepositoryBeforeConsultingTheGate() {
+        Issue issue = issue();
+        org.springframework.test.util.ReflectionTestUtils.setField(issue, "repository", null);
+        when(artifactLoader.findIssueForGate(WORKSPACE_ID, ISSUE_ID)).thenReturn(Optional.of(issue));
+        when(agentJobService.buildIssueRequest(any(), any())).thenReturn(null);
+
+        String response = controller.triggerReview(null, ISSUE_ID, WORKSPACE_ID, "scm.issue.closed");
+
+        assertThat(response).contains("Issue missing repository");
+        verify(detectionGate, never()).evaluateIssue(any(), any(), any());
+        verifyNoInteractions(signalRecorder);
+    }
+
+    private static IssueReviewSubmissionRequest issueRequest() {
+        return new IssueReviewSubmissionRequest(
+                ISSUE_ID,
+                3,
+                100L,
+                "owner/repo",
+                "Something broke",
+                "Here is how.",
+                "CLOSED",
+                "https://github.com/owner/repo/issues/3",
+                Instant.parse("2026-08-07T10:00:00Z"),
+                ScmSignals.ISSUE_CLOSED);
+    }
+
     private static Issue issue() {
         Issue issue = new Issue();
         issue.setId(ISSUE_ID);
         issue.setTitle("Something broke");
         issue.setBody("Here is how.");
+        issue.setState(Issue.State.CLOSED);
         issue.setUpdatedAt(Instant.parse("2026-08-07T10:00:00Z"));
+        issue.setClosedAt(Instant.parse("2026-08-07T10:00:00Z"));
+        Repository repository = new Repository();
+        repository.setId(100L);
+        repository.setNameWithOwner("owner/repo");
+        issue.setRepository(repository);
         return issue;
     }
 }

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/job/IssueAgentJobEventListenerTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/job/IssueAgentJobEventListenerTest.java
@@ -36,6 +36,7 @@ import de.tum.cit.aet.hephaestus.workspace.WorkspaceResolver;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -98,6 +99,10 @@ class IssueAgentJobEventListenerTest extends BaseUnitTest {
                 null,
                 null,
                 null,
+                List.of(),
+                List.of(),
+                null,
+                null,
                 null);
     }
 
@@ -115,14 +120,6 @@ class IssueAgentJobEventListenerTest extends BaseUnitTest {
 
     private EventContext syncContext() {
         return EventContext.forSync(1L, REPO_REF);
-    }
-
-    private ScmEventPayload.LabelData createLabelData() {
-        return createLabelData("bug");
-    }
-
-    private ScmEventPayload.LabelData createLabelData(String name) {
-        return new ScmEventPayload.LabelData(500L, name, "ff0000", null);
     }
 
     /**
@@ -358,13 +355,14 @@ class IssueAgentJobEventListenerTest extends BaseUnitTest {
         }
 
         @Test
-        void shouldPassIssueLabeledTriggerEventName() {
+        void shouldPassIssueUpdatedTriggerEventName() {
             Issue issue = setupHappyPath();
             var issueData = createIssueData(Issue.State.OPEN);
 
-            listener.onIssueLabeled(new ScmDomainEvent.IssueLabeled(issueData, createLabelData(), webhookContext(1L)));
+            listener.onIssueUpdated(
+                    new ScmDomainEvent.IssueUpdated(issueData, Set.of("relationships"), webhookContext(1L)));
 
-            verify(practiceReviewDetectionGate).evaluateIssue(issue, ScmSignals.ISSUE_LABELED, TriggerMode.AUTO);
+            verify(practiceReviewDetectionGate).evaluateIssue(issue, ScmSignals.ISSUE_UPDATED, TriggerMode.AUTO);
         }
 
         @Test
@@ -377,7 +375,6 @@ class IssueAgentJobEventListenerTest extends BaseUnitTest {
             when(practiceReviewDetectionGate.evaluateIssue(issue, ScmSignals.ISSUE_OPENED, TriggerMode.AUTO))
                     .thenThrow(new RuntimeException("DB connectivity error"));
 
-            // Should not throw — outer catch handles gate exceptions
             listener.onIssueCreated(event);
 
             verify(agentJobService, never()).submit(any(), any(), any(), any(), any());
@@ -410,7 +407,7 @@ class IssueAgentJobEventListenerTest extends BaseUnitTest {
         @Test
         void onIssueClosed_routesThroughGateAndCarriesTheClosedTriggerOntoTheJob() {
             // The closed terminal state IS this trigger's reason to run — it must reach the gate, unlike the
-            // live create/labeled handlers that short-circuit on a closed issue.
+            // live create/update handlers that short-circuit on a closed issue.
             Issue issue = createIssue(Issue.State.CLOSED);
             when(issueRepository.findByIdWithRepositoryAndAssignees(ISSUE_ID)).thenReturn(Optional.of(issue));
             Workspace workspace = new Workspace();
@@ -441,49 +438,79 @@ class IssueAgentJobEventListenerTest extends BaseUnitTest {
     }
 
     @Nested
-    class IssueLabeledTests {
+    class IssueUpdatedTests {
 
         @Test
         void shouldSubmitWhenGatePasses() {
             var issueData = createIssueData(Issue.State.OPEN);
-            var event = new ScmDomainEvent.IssueLabeled(issueData, createLabelData(), webhookContext(1L));
+            var event = new ScmDomainEvent.IssueUpdated(issueData, Set.of("relationships"), webhookContext(1L));
 
             setupHappyPath();
 
-            listener.onIssueLabeled(event);
+            listener.onIssueUpdated(event);
 
             var request = captureSubmission(WORKSPACE_ID);
-            assertThat(request.triggerSignal()).isEqualTo(ScmSignals.ISSUE_LABELED);
+            assertThat(request.triggerSignal()).isEqualTo(ScmSignals.ISSUE_UPDATED);
             assertThat(request.issueId()).isEqualTo(ISSUE_ID);
         }
 
         /**
-         * Two labels applied in one edit raise two events that agree on the issue, its prose and its
-         * timestamps; the label is the only thing that tells them apart. A key that does not carry it
-         * gives both the same ledger identity, so the second labelling is deduplicated away and the
-         * practice bound to it is measured once for an edit that occasioned it twice.
+         * The ledger, not the listener, is what stops a redelivery: the second call reaches the recorder
+         * with the identical key, the unique constraint refuses it, and nothing downstream runs. Reviews
+         * are the expensive half, so the assertion that matters is that the gate is never asked twice.
          */
         @Test
-        void shouldGiveEachLabelOfOneEditItsOwnLedgerIdentity() {
+        void shouldNotReachTheGateForAnUpdateTheLedgerHasAlreadySettled() {
+            setupHappyPath();
             var issueData = createIssueData(Issue.State.OPEN);
             var context = webhookContext(1L);
+            when(signalRecorder.record(any(), any(), any())).thenReturn(true).thenReturn(false);
 
-            listener.onIssueLabeled(new ScmDomainEvent.IssueLabeled(issueData, createLabelData("bug"), context));
-            listener.onIssueLabeled(new ScmDomainEvent.IssueLabeled(issueData, createLabelData("regression"), context));
+            listener.onIssueUpdated(new ScmDomainEvent.IssueUpdated(issueData, Set.of("title"), context));
+            listener.onIssueUpdated(new ScmDomainEvent.IssueUpdated(issueData, Set.of("title"), context));
 
             ArgumentCaptor<SignalKey> keys = ArgumentCaptor.forClass(SignalKey.class);
             verify(signalRecorder, times(2)).record(keys.capture(), any(), any());
-            assertThat(keys.getAllValues()).extracting(SignalKey::revision).doesNotHaveDuplicates();
+            assertThat(keys.getAllValues().get(1)).isEqualTo(keys.getAllValues().getFirst());
+            verify(practiceReviewDetectionGate, times(1)).evaluateIssue(any(), any(), any());
+        }
+
+        /**
+         * A lock, a pin or a comment count moves nothing the issue evidence is built from, so every
+         * practice bound to the occasion would read byte-identical evidence and republish the conclusion
+         * it already reached. The mirror still records the change; the review pipeline never hears of it.
+         */
+        @Test
+        void shouldNotOccasionAReviewForAnUpdateThatMovedNoReviewableField() {
+            var issueData = createIssueData(Issue.State.OPEN);
+
+            listener.onIssueUpdated(
+                    new ScmDomainEvent.IssueUpdated(issueData, Set.of("locked", "commentsCount"), webhookContext(1L)));
+
+            verify(signalRecorder, never()).record(any(), any(), any());
+            verify(practiceReviewDetectionGate, never()).evaluateIssue(any(), any(), any());
+            verify(agentJobService, never()).submit(any(), any(), any(), any(), any());
+        }
+
+        @Test
+        void shouldOccasionAReviewWhenLabelsOrAssigneesMoved() {
+            Issue issue = setupHappyPath();
+            var issueData = createIssueData(Issue.State.OPEN);
+
+            listener.onIssueUpdated(
+                    new ScmDomainEvent.IssueUpdated(issueData, Set.of("relationships"), webhookContext(1L)));
+
+            verify(practiceReviewDetectionGate).evaluateIssue(issue, ScmSignals.ISSUE_UPDATED, TriggerMode.AUTO);
         }
 
         @Test
         void shouldRecordSyncDiscoveredSignalsWithoutReviewingThem() {
-            // Same split as the created path: a labelling caught up with by reconciliation is recorded and
+            // Same split as the created path: an update caught up with by reconciliation is recorded and
             // not coached on.
             var issueData = createIssueData(Issue.State.OPEN);
-            var event = new ScmDomainEvent.IssueLabeled(issueData, createLabelData(), syncContext());
+            var event = new ScmDomainEvent.IssueUpdated(issueData, Set.of("relationships"), syncContext());
 
-            listener.onIssueLabeled(event);
+            listener.onIssueUpdated(event);
 
             verify(signalRecorder).record(any(), any(), eq(DiscoveredVia.SYNC));
             verify(issueRepository, never()).findByIdWithRepositoryAndAssignees(anyLong());
@@ -493,12 +520,12 @@ class IssueAgentJobEventListenerTest extends BaseUnitTest {
 
         @Test
         void shouldSkipClosedIssues() {
-            // The closed-skip guard lives in handleIssueEvent, shared by the labeled path: a label fired on an
+            // The closed-skip guard lives in handleIssueEvent, shared by the update path: an edit to an
             // already-closed issue must never reach the gate, mirroring the onIssueCreated coverage.
             var issueData = createIssueData(Issue.State.CLOSED);
-            var event = new ScmDomainEvent.IssueLabeled(issueData, createLabelData(), webhookContext(1L));
+            var event = new ScmDomainEvent.IssueUpdated(issueData, Set.of("relationships"), webhookContext(1L));
 
-            listener.onIssueLabeled(event);
+            listener.onIssueUpdated(event);
 
             verify(issueRepository, never()).findByIdWithRepositoryAndAssignees(anyLong());
             verify(practiceReviewDetectionGate, never()).evaluateIssue(any(), any(), any());
@@ -508,13 +535,13 @@ class IssueAgentJobEventListenerTest extends BaseUnitTest {
         @Test
         void shouldSkipWhenIssueHasNullRepository() {
             var issueData = createIssueData(Issue.State.OPEN);
-            var event = new ScmDomainEvent.IssueLabeled(issueData, createLabelData(), webhookContext(1L));
+            var event = new ScmDomainEvent.IssueUpdated(issueData, Set.of("relationships"), webhookContext(1L));
 
             Issue issue = createIssue(Issue.State.OPEN);
             org.springframework.test.util.ReflectionTestUtils.setField(issue, "repository", null);
             when(issueRepository.findByIdWithRepositoryAndAssignees(ISSUE_ID)).thenReturn(Optional.of(issue));
 
-            listener.onIssueLabeled(event);
+            listener.onIssueUpdated(event);
 
             verify(signalRecorder).markRefused(any(), eq(SignalStateReason.ARTIFACT_GONE));
             verify(practiceReviewDetectionGate, never()).evaluateIssue(any(), any(), any());

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/scm/domain/signal/ScmSignalsTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/scm/domain/signal/ScmSignalsTest.java
@@ -3,9 +3,13 @@ package de.tum.cit.aet.hephaestus.integration.scm.domain.signal;
 import static de.tum.cit.aet.hephaestus.integration.core.events.ScmDomainEvent.TriggerEventNames;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import de.tum.cit.aet.hephaestus.integration.core.events.RepositoryRef;
+import de.tum.cit.aet.hephaestus.integration.core.events.ScmEventPayload;
 import de.tum.cit.aet.hephaestus.integration.core.signal.RevisionScheme;
 import de.tum.cit.aet.hephaestus.integration.core.signal.SignalKey;
+import de.tum.cit.aet.hephaestus.integration.scm.domain.issue.Issue;
 import de.tum.cit.aet.hephaestus.testconfig.BaseUnitTest;
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import org.jspecify.annotations.Nullable;
@@ -31,23 +35,208 @@ class ScmSignalsTest extends BaseUnitTest {
                 body);
     }
 
-    private Optional<SignalKey> issue(String triggerEvent, String title, String body, @Nullable String labelName) {
+    private Optional<SignalKey> issue(String triggerEvent, String title, String body) {
         return ScmSignals.issueKey(
-                WORKSPACE_ID,
+                WORKSPACE_ID, ScmSignals.forTriggerEvent(triggerEvent).orElseThrow(), issueData(title, body));
+    }
+
+    private SignalKey updated(List<String> labels, List<String> assignees) {
+        ScmEventPayload.IssueData issue = new ScmEventPayload.IssueData(
                 ARTIFACT_ID,
-                ScmSignals.forTriggerEvent(triggerEvent).orElseThrow(),
+                1,
+                "Bug",
+                "Steps",
+                Issue.State.OPEN,
+                null,
+                null,
+                false,
+                new RepositoryRef(1L, "owner/repo", "main"),
+                null,
+                "Bug",
+                "v1",
+                labels,
+                assignees,
+                null,
+                null,
+                null);
+        return ScmSignals.issueKey(WORKSPACE_ID, ScmSignals.ISSUE_UPDATED, issue)
+                .orElseThrow();
+    }
+
+    private ScmEventPayload.IssueData issueData(String title, String body) {
+        return new ScmEventPayload.IssueData(
+                ARTIFACT_ID,
+                1,
                 title,
                 body,
-                labelName);
+                Issue.State.OPEN,
+                null,
+                null,
+                false,
+                new RepositoryRef(1L, "owner/repo", "main"),
+                null,
+                null,
+                null,
+                List.of(),
+                List.of(),
+                null,
+                null,
+                null);
+    }
+
+    private SignalKey closed(ScmEventPayload.IssueData issue) {
+        return ScmSignals.issueKey(WORKSPACE_ID, ScmSignals.ISSUE_CLOSED, issue).orElseThrow();
+    }
+
+    private ScmEventPayload.IssueData closedData(Instant closedAt) {
+        return new ScmEventPayload.IssueData(
+                ARTIFACT_ID,
+                1,
+                "Bug",
+                "Steps",
+                Issue.State.CLOSED,
+                "COMPLETED",
+                null,
+                false,
+                new RepositoryRef(1L, "owner/repo", "main"),
+                null,
+                "Bug",
+                null,
+                List.of(),
+                List.of(),
+                null,
+                closedAt,
+                closedAt);
+    }
+
+    @Test
+    void shouldNotLetProviderOrderingOfLabelsAndAssigneesMoveTheRevision() {
+        SignalKey asGitHubSentThem = updated(List.of("backend", "urgent"), List.of("alice", "bob"));
+        SignalKey asGitLabSentThem = updated(List.of("urgent", "backend"), List.of("bob", "alice"));
+
+        assertThat(asGitLabSentThem).isEqualTo(asGitHubSentThem);
+    }
+
+    @Test
+    void shouldReMeasureAnIssueWhoseTriageMetadataMoved() {
+        SignalKey before = updated(List.of("backend", "urgent"), List.of("alice", "bob"));
+
+        assertThat(updated(List.of("backend"), List.of("alice", "bob"))).isNotEqualTo(before);
+        assertThat(updated(List.of("backend", "urgent"), List.of("alice"))).isNotEqualTo(before);
+    }
+
+    @Test
+    void shouldNotReMeasureAnIssueWhoseTriageReturnedItToASnapshotAlreadySeen() {
+        SignalKey before = updated(List.of("backend"), List.of("alice"));
+        SignalKey labelled = updated(List.of("backend", "urgent"), List.of("alice"));
+        SignalKey labelRemovedAgain = updated(List.of("backend"), List.of("alice"));
+
+        assertThat(labelled).isNotEqualTo(before);
+        assertThat(labelRemovedAgain).isEqualTo(before);
+    }
+
+    @Test
+    void shouldMakeARedeliveredCloseOfTheSameIssueInert() {
+        Instant closedAt = Instant.parse("2026-09-04T08:00:00Z");
+
+        SignalKey first = closed(closedData(closedAt));
+        SignalKey redelivered = closed(closedData(closedAt));
+
+        assertThat(redelivered).isEqualTo(first);
+    }
+
+    /**
+     * An issue can be reopened, so its close is not a state it cannot leave: the outcome of the second
+     * round of work is a second thing to review, and a constant revision would let the first close
+     * settle the row the second one needs.
+     */
+    @Test
+    void shouldOccasionASecondCloseAfterAReopen() {
+        SignalKey first = closed(closedData(Instant.parse("2026-09-04T08:00:00Z")));
+        SignalKey afterReopeningAndClosingAgain = closed(closedData(Instant.parse("2026-09-04T09:00:00Z")));
+
+        assertThat(afterReopeningAndClosingAgain).isNotEqualTo(first);
+    }
+
+    /**
+     * The occasion a backfill sweep measures a closed issue at. Keying it on the issue's content would
+     * make labelling a long-closed issue re-run the review of how it ended on the next sweep.
+     */
+    @Test
+    void shouldKeepAnIssueClosedIdentityOutOfReachOfTriage() {
+        Instant closedAt = Instant.parse("2026-09-04T08:00:00Z");
+        ScmEventPayload.IssueData triagedSinceClosing = new ScmEventPayload.IssueData(
+                ARTIFACT_ID,
+                1,
+                "Bug, renamed after the fact",
+                "Steps",
+                Issue.State.CLOSED,
+                "COMPLETED",
+                null,
+                false,
+                new RepositoryRef(1L, "owner/repo", "main"),
+                null,
+                "Bug",
+                "v2",
+                List.of("wontfix"),
+                List.of("alice"),
+                null,
+                closedAt,
+                closedAt);
+
+        assertThat(closed(triagedSinceClosing)).isEqualTo(closed(closedData(closedAt)));
+        assertThat(ScmSignals.issueClosedKey(WORKSPACE_ID, ARTIFACT_ID, closedAt))
+                .contains(closed(closedData(closedAt)));
+    }
+
+    /** A provider that omits the close moment leaves nothing to tell two closes apart. */
+    @Test
+    void shouldFallBackToOneCloseOccasionWhenTheProviderNamesNoCloseMoment() {
+        assertThat(ScmSignals.issueClosedKey(WORKSPACE_ID, ARTIFACT_ID, null))
+                .isEqualTo(ScmSignals.issueClosedKey(WORKSPACE_ID, ARTIFACT_ID, null))
+                .isNotEqualTo(
+                        ScmSignals.issueClosedKey(WORKSPACE_ID, ARTIFACT_ID, Instant.parse("2026-09-04T08:00:00Z")));
+    }
+
+    /**
+     * The occasion a backfill sweep measures an open issue at. Keying it on the whole snapshot would give
+     * a triaged issue a fresh identity, and the next sweep would review it again as if newly opened.
+     */
+    @Test
+    void shouldKeepAnIssueOpenedIdentityOutOfReachOfTriage() {
+        SignalKey fromProse = ScmSignals.issueOpenedKey(WORKSPACE_ID, ARTIFACT_ID, "Bug", "Steps")
+                .orElseThrow();
+        SignalKey afterTriage = ScmSignals.issueKey(
+                        WORKSPACE_ID,
+                        ScmSignals.ISSUE_OPENED,
+                        new ScmEventPayload.IssueData(
+                                ARTIFACT_ID,
+                                1,
+                                "Bug",
+                                "Steps",
+                                Issue.State.OPEN,
+                                null,
+                                null,
+                                false,
+                                new RepositoryRef(1L, "owner/repo", "main"),
+                                null,
+                                "Bug",
+                                "v1",
+                                List.of("needs-triage"),
+                                List.of("alice"),
+                                null,
+                                null,
+                                null))
+                .orElseThrow();
+
+        assertThat(afterTriage).isEqualTo(fromProse);
     }
 
     @Test
     void shouldReMeasureAnIssueAfterItsAuthorRewritesTheDescription() {
-        // An issue has no commits, so if its signal keyed on anything code-shaped, an issue-writing
-        // practice could be measured once and never again.
         SignalKey before =
-                issue(TriggerEventNames.ISSUE_CREATED, "Bug", "it broke", null).orElseThrow();
-        SignalKey after = issue(TriggerEventNames.ISSUE_CREATED, "Bug", "Login 500s on expired token", null)
+                issue(TriggerEventNames.ISSUE_CREATED, "Bug", "it broke").orElseThrow();
+        SignalKey after = issue(TriggerEventNames.ISSUE_CREATED, "Bug", "Login 500s on expired token")
                 .orElseThrow();
 
         assertThat(after.revision()).isNotEqualTo(before.revision());
@@ -56,52 +245,15 @@ class ScmSignalsTest extends BaseUnitTest {
     @Test
     void shouldNotReMeasureAnIssueThatWasMerelyRedelivered() {
         SignalKey first =
-                issue(TriggerEventNames.ISSUE_CREATED, "Bug", "it broke", null).orElseThrow();
+                issue(TriggerEventNames.ISSUE_CREATED, "Bug", "it broke").orElseThrow();
         SignalKey redelivered =
-                issue(TriggerEventNames.ISSUE_CREATED, "Bug", "it broke", null).orElseThrow();
+                issue(TriggerEventNames.ISSUE_CREATED, "Bug", "it broke").orElseThrow();
 
         assertThat(redelivered).isEqualTo(first);
-    }
-
-    @Test
-    void shouldGiveEachLabelOfOneUpdateItsOwnOccurrence() {
-        // Applying three labels in one edit raises three events differing only in the label; keying on
-        // anything else collapses them into one ledger row, measuring a labelling-bound practice once per
-        // edit instead of once per label.
-        SignalKey bug = issue(TriggerEventNames.ISSUE_LABELED, "Login fails", "500 on expired token", "bug")
-                .orElseThrow();
-        SignalKey regression = issue(
-                        TriggerEventNames.ISSUE_LABELED, "Login fails", "500 on expired token", "regression")
-                .orElseThrow();
-        SignalKey priorityHigh = issue(
-                        TriggerEventNames.ISSUE_LABELED, "Login fails", "500 on expired token", "priority/high")
-                .orElseThrow();
-
-        assertThat(List.of(bug.revision(), regression.revision(), priorityHigh.revision()))
-                .doesNotHaveDuplicates();
-    }
-
-    @Test
-    void shouldNotReMeasureTheSameLabellingThatWasMerelyRedelivered() {
-        SignalKey first = issue(TriggerEventNames.ISSUE_LABELED, "Login fails", "500", "bug")
-                .orElseThrow();
-        SignalKey redelivered = issue(TriggerEventNames.ISSUE_LABELED, "Login fails", "500", "bug")
-                .orElseThrow();
-
-        assertThat(redelivered).isEqualTo(first);
-    }
-
-    @Test
-    void shouldDeclineToKeyALabellingThatCannotNameItsLabel() {
-        // Same rule as a code-shaped signal with no head commit: a row keyed on nothing swallows every later labelling.
-        assertThat(issue(TriggerEventNames.ISSUE_LABELED, "Login fails", "500", null))
-                .isEmpty();
     }
 
     @Test
     void shouldNotReReviewUnchangedCodeBecauseTheDescriptionWasEdited() {
-        // Converse of the issue case: a push signal's subject is the code, so editing prose must not buy
-        // another review.
         SignalKey before = pullRequest(TriggerEventNames.PULL_REQUEST_SYNCHRONIZED, "abc123", "Add cache", "faster")
                 .orElseThrow();
         SignalKey after = pullRequest(
@@ -123,7 +275,6 @@ class ScmSignalsTest extends BaseUnitTest {
 
     @Test
     void shouldMakeARedeliveredMergeInert() {
-        // A merge happens once; keying it on anything that can move would let a redelivery spend a second review.
         SignalKey merged = pullRequest(TriggerEventNames.PULL_REQUEST_MERGED, "abc123", "Add cache", "body")
                 .orElseThrow();
         SignalKey redelivered = pullRequest(TriggerEventNames.PULL_REQUEST_MERGED, "def456", "Add cache", "body")
@@ -144,7 +295,6 @@ class ScmSignalsTest extends BaseUnitTest {
 
     @Test
     void shouldDeclineToKeyACodeShapedSignalWithNoHeadCommit() {
-        // Better no ledger row than one keyed on nothing, which would deduplicate away every later occurrence.
         assertThat(pullRequest(TriggerEventNames.PULL_REQUEST_READY, null, "t", "b"))
                 .isEmpty();
     }
@@ -159,7 +309,6 @@ class ScmSignalsTest extends BaseUnitTest {
 
     @Test
     void shouldRoundTripEverySignalBackToTheTriggerEventThatRaisedIt() {
-        // The reaper re-runs the gate from a stored signal; one that cannot name its trigger can never be re-offered.
         for (String triggerEvent : new String[] {
             TriggerEventNames.PULL_REQUEST_CREATED,
             TriggerEventNames.PULL_REQUEST_READY,
@@ -168,7 +317,7 @@ class ScmSignalsTest extends BaseUnitTest {
             TriggerEventNames.PULL_REQUEST_MERGED,
             TriggerEventNames.PULL_REQUEST_CLOSED,
             TriggerEventNames.ISSUE_CREATED,
-            TriggerEventNames.ISSUE_LABELED,
+            TriggerEventNames.ISSUE_UPDATED,
             TriggerEventNames.ISSUE_CLOSED,
         }) {
             var signal = ScmSignals.forTriggerEvent(triggerEvent).orElseThrow();
@@ -187,13 +336,15 @@ class ScmSignalsTest extends BaseUnitTest {
             ScmSignals.PULL_REQUEST_CLOSED,
             ScmSignals.PULL_REQUEST_MANUAL_REVIEW,
             ScmSignals.ISSUE_OPENED,
-            ScmSignals.ISSUE_LABELED,
+            ScmSignals.ISSUE_UPDATED,
             ScmSignals.ISSUE_CLOSED,
             ScmSignals.ISSUE_MANUAL_REVIEW,
         }) {
             assertThat(ScmSignals.revisionScheme(signal)).as(signal.value()).isNotNull();
         }
         assertThat(ScmSignals.revisionScheme(ScmSignals.ISSUE_OPENED)).isEqualTo(RevisionScheme.CONTENT_DIGEST);
+        assertThat(ScmSignals.revisionScheme(ScmSignals.ISSUE_UPDATED)).isEqualTo(RevisionScheme.CONTENT_DIGEST);
+        assertThat(ScmSignals.revisionScheme(ScmSignals.ISSUE_CLOSED)).isEqualTo(RevisionScheme.CONTENT_DIGEST);
         assertThat(ScmSignals.revisionScheme(ScmSignals.PULL_REQUEST_READY)).isEqualTo(RevisionScheme.HEAD_COMMIT);
         assertThat(ScmSignals.revisionScheme(ScmSignals.PULL_REQUEST_REVIEWED)).isEqualTo(RevisionScheme.EVENT_ID);
     }

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/scm/github/issue/GitHubIssueProcessorIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/scm/github/issue/GitHubIssueProcessorIntegrationTest.java
@@ -34,6 +34,7 @@ import de.tum.cit.aet.hephaestus.workspace.Workspace;
 import de.tum.cit.aet.hephaestus.workspace.WorkspaceRepository;
 import java.time.Instant;
 import java.util.List;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -727,6 +728,98 @@ class GitHubIssueProcessorIntegrationTest extends BaseIntegrationTest {
             assertThat(issueRepository.count()).isEqualTo(countAfterFirst);
         }
 
+        /**
+         * Assignees live in a join table the atomic upsert cannot touch, so a change to them is reported
+         * under one name for labels and assignees alike — which is what the review pipeline reads to
+         * decide that a triage action moved evidence a practice can see.
+         */
+        @Test
+        void shouldReportRelationshipsWhenAnIssueIsAssigned() {
+            Long issueId = 888999111L;
+            Issue existing = new Issue();
+            existing.setNativeId(issueId);
+            existing.setNumber(21);
+            existing.setTitle("Issue");
+            existing.setState(Issue.State.OPEN);
+            existing.setHtmlUrl("https://example.com/issues/21");
+            existing.setRepository(testRepository);
+            existing.setProvider(githubProvider);
+            issueRepository.save(existing);
+
+            eventListener.clear();
+
+            Issue result = processor.process(
+                    issueDto(issueId, 21, "Issue", false, 0, List.of(createAuthorDto())), createContext());
+            assertNotNull(result);
+
+            assertThat(result.getAssignees()).isNotEmpty();
+            assertThat(eventListener.ofType(ScmDomainEvent.IssueUpdated.class))
+                    .first()
+                    .satisfies(event -> assertThat(event.changedFields()).contains("relationships"));
+        }
+
+        /**
+         * Locking an issue and commenting on it move no field the issue evidence is built from. The
+         * mirror still reports them, and reporting them under their own names is what lets the review
+         * pipeline decline the occasion instead of spending a review on evidence that did not move.
+         */
+        @Test
+        void shouldNameOnlyTheFieldsThatMovedWhenAnIssueIsLockedAndCommentedOn() {
+            Long issueId = 888999222L;
+            Issue existing = new Issue();
+            existing.setNativeId(issueId);
+            existing.setNumber(22);
+            existing.setTitle("Issue");
+            existing.setState(Issue.State.OPEN);
+            existing.setLocked(false);
+            existing.setCommentsCount(0);
+            existing.setHtmlUrl("https://example.com/issues/22");
+            existing.setRepository(testRepository);
+            existing.setProvider(githubProvider);
+            issueRepository.save(existing);
+
+            eventListener.clear();
+
+            Issue result = processor.process(issueDto(issueId, 22, "Issue", true, 3, null), createContext());
+            assertNotNull(result);
+
+            assertThat(eventListener.ofType(ScmDomainEvent.IssueUpdated.class))
+                    .first()
+                    .satisfies(event ->
+                            assertThat(event.changedFields()).containsExactlyInAnyOrder("locked", "commentsCount"));
+        }
+
+        private GitHubIssueDTO issueDto(
+                Long issueId,
+                int number,
+                String title,
+                boolean locked,
+                int commentsCount,
+                @Nullable List<GitHubUserDTO> assignees) {
+            return new GitHubIssueDTO(
+                    issueId,
+                    null,
+                    "node",
+                    number,
+                    title,
+                    null,
+                    "open",
+                    null,
+                    "https://example.com/issues/" + number,
+                    commentsCount,
+                    Instant.now(),
+                    Instant.now(),
+                    null,
+                    locked,
+                    null,
+                    assignees,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null);
+        }
+
         @Test
         void shouldUpdateMilestoneWhenChanged() {
             // Given - create issue without milestone
@@ -1087,6 +1180,51 @@ class GitHubIssueProcessorIntegrationTest extends BaseIntegrationTest {
                         assertThat(event.issueType().name()).isEqualTo("Task");
                         assertThat(event.issue().id()).isEqualTo(result.getId());
                     });
+        }
+
+        /**
+         * A native type is one of the fields the issue evidence is built from, so typing an issue that
+         * already exists has to be reported as a moved field — that, not the IssueTyped event, is what
+         * occasions the review of the retyped issue.
+         */
+        @Test
+        void shouldReportIssueTypeWhenAnExistingIssueIsTyped() {
+            Long issueId = 888999333L;
+            processor.process(createBasicIssueDto(issueId, 23), createContext());
+            eventListener.clear();
+
+            GitHubIssueTypeDTO typeDto = new GitHubIssueTypeDTO(
+                    27228861L, "IT_kwDODNYmp84Bn3q9", "Task", "A specific piece of work", "yellow", true);
+            GitHubIssueDTO basic = createBasicIssueDto(issueId, 23);
+            GitHubIssueDTO typed = new GitHubIssueDTO(
+                    basic.id(),
+                    basic.databaseId(),
+                    basic.nodeId(),
+                    basic.number(),
+                    basic.title(),
+                    basic.body(),
+                    basic.state(),
+                    basic.stateReason(),
+                    basic.htmlUrl(),
+                    basic.commentsCount(),
+                    basic.createdAt(),
+                    basic.updatedAt(),
+                    basic.closedAt(),
+                    basic.locked(),
+                    basic.author(),
+                    basic.assignees(),
+                    basic.labels(),
+                    basic.milestone(),
+                    typeDto,
+                    basic.repository(),
+                    basic.pullRequest());
+
+            Issue result = processor.processTyped(typed, typeDto, FIXTURE_ORG_LOGIN, createContext());
+            assertNotNull(result);
+
+            assertThat(eventListener.ofType(ScmDomainEvent.IssueUpdated.class))
+                    .first()
+                    .satisfies(event -> assertThat(event.changedFields()).contains("issueType"));
         }
 
         @Test

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/scm/gitlab/issue/GitLabIssueProcessorTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/scm/gitlab/issue/GitLabIssueProcessorTest.java
@@ -382,7 +382,6 @@ class GitLabIssueProcessorTest extends BaseUnitTest {
             assertThat(result).isNotNull();
 
             ArgumentCaptor<Object> eventCaptor = ArgumentCaptor.forClass(Object.class);
-            // processClosed calls process() which may publish IssueCreated, then publishes IssueClosed
             verify(eventPublisher).publishEvent(eventCaptor.capture());
             assertThat(eventCaptor.getValue()).isInstanceOf(ScmDomainEvent.IssueClosed.class);
         }
@@ -404,8 +403,10 @@ class GitLabIssueProcessorTest extends BaseUnitTest {
             assertThat(result).isNotNull();
 
             ArgumentCaptor<Object> eventCaptor = ArgumentCaptor.forClass(Object.class);
-            verify(eventPublisher).publishEvent(eventCaptor.capture());
-            assertThat(eventCaptor.getValue()).isInstanceOf(ScmDomainEvent.IssueReopened.class);
+            verify(eventPublisher, Mockito.times(2)).publishEvent(eventCaptor.capture());
+            assertThat(eventCaptor.getAllValues())
+                    .extracting(Object::getClass)
+                    .containsExactlyInAnyOrder(ScmDomainEvent.IssueUpdated.class, ScmDomainEvent.IssueReopened.class);
         }
     }
 
@@ -443,9 +444,79 @@ class GitLabIssueProcessorTest extends BaseUnitTest {
                     .thenReturn(createUserEntity());
 
             // An ordinary title/description edit (no changes.labels) must not trigger label-based detection.
-            processor.processUpdated(createUpdateEventWithAddedLabel(null), createContext());
+            processor.processUpdated(createUpdateEventWithChanges(titleChanged()), createContext());
 
             verify(eventPublisher, never()).publishEvent(any(ScmDomainEvent.IssueLabeled.class));
+        }
+
+        @Test
+        void publishesIssueUpdatedNamingWhatTheChangesDiffSaysMoved() {
+            Issue issue = createIssueEntity();
+            when(issueRepository.findByRepositoryIdAndNumber(REPO_ID, ISSUE_IID))
+                    .thenReturn(Optional.of(issue))
+                    .thenReturn(Optional.of(issue));
+            when(gitLabUserService.findOrCreateUser(any(GitLabWebhookUser.class), eq(PROVIDER_ID)))
+                    .thenReturn(createUserEntity());
+
+            processor.processUpdated(createUpdateEventWithChanges(titleChanged()), createContext());
+
+            ArgumentCaptor<ScmDomainEvent.IssueUpdated> captor =
+                    ArgumentCaptor.forClass(ScmDomainEvent.IssueUpdated.class);
+            verify(eventPublisher).publishEvent(captor.capture());
+            assertThat(captor.getValue().changedFields()).containsExactly("title");
+        }
+
+        /**
+         * GitLab has one update action for every field it tracks, most of which the review evidence never
+         * reads. Publishing regardless would mint a fresh occasion for a due-date edit — a review nobody
+         * asked for, on evidence that did not move.
+         */
+        @Test
+        void publishesNothingWhenTheUpdateMovedNoFieldTheDomainNames() {
+            Issue issue = createIssueEntity();
+            when(issueRepository.findByRepositoryIdAndNumber(REPO_ID, ISSUE_IID))
+                    .thenReturn(Optional.of(issue))
+                    .thenReturn(Optional.of(issue));
+            when(gitLabUserService.findOrCreateUser(any(GitLabWebhookUser.class), eq(PROVIDER_ID)))
+                    .thenReturn(createUserEntity());
+
+            // A due-date-only edit: GitLab still sends changes, but none of its keys is a field the
+            // shared domain has a name for.
+            processor.processUpdated(
+                    createUpdateEventWithChanges(new GitLabIssueEventDTO.Changes(null, null, null, null, null, null)),
+                    createContext());
+
+            verify(eventPublisher, never()).publishEvent(any(ScmDomainEvent.IssueUpdated.class));
+        }
+
+        @Test
+        void publishesOneIssueUpdatedForALabelAndAssigneeEditTogether() {
+            Issue issue = createIssueEntity();
+            when(issueRepository.findByRepositoryIdAndNumber(REPO_ID, ISSUE_IID))
+                    .thenReturn(Optional.of(issue))
+                    .thenReturn(Optional.of(issue));
+            when(gitLabUserService.findOrCreateUser(any(GitLabWebhookUser.class), eq(PROVIDER_ID)))
+                    .thenReturn(createUserEntity());
+
+            processor.processUpdated(
+                    createUpdateEventWithChanges(new GitLabIssueEventDTO.Changes(
+                            new GitLabIssueEventDTO.LabelsChange(List.of(), List.of()),
+                            null,
+                            null,
+                            new GitLabIssueEventDTO.AttributeChange(),
+                            null,
+                            null)),
+                    createContext());
+
+            ArgumentCaptor<ScmDomainEvent.IssueUpdated> captor =
+                    ArgumentCaptor.forClass(ScmDomainEvent.IssueUpdated.class);
+            verify(eventPublisher).publishEvent(captor.capture());
+            assertThat(captor.getValue().changedFields()).containsExactly("relationships");
+        }
+
+        private GitLabIssueEventDTO.Changes titleChanged() {
+            return new GitLabIssueEventDTO.Changes(
+                    null, new GitLabIssueEventDTO.AttributeChange(), null, null, null, null);
         }
     }
 
@@ -1169,8 +1240,25 @@ class GitLabIssueProcessorTest extends BaseUnitTest {
                 null);
     }
 
-    /** An {@code action=update} event whose {@code changes.labels} diff adds the given label (null = none). */
-    private GitLabIssueEventDTO createUpdateEventWithAddedLabel(@Nullable GitLabWebhookLabel addedLabel) {
+    /** An {@code action=update} event carrying the given {@code changes} diff and no label delta. */
+    private GitLabIssueEventDTO createUpdateEventWithChanges(GitLabIssueEventDTO.Changes changes) {
+        return withChanges(null, changes);
+    }
+
+    private GitLabIssueEventDTO createUpdateEventWithAddedLabel(GitLabWebhookLabel addedLabel) {
+        return withChanges(
+                addedLabel,
+                new GitLabIssueEventDTO.Changes(
+                        new GitLabIssueEventDTO.LabelsChange(List.of(), List.of(addedLabel)),
+                        null,
+                        null,
+                        null,
+                        null,
+                        null));
+    }
+
+    private GitLabIssueEventDTO withChanges(
+            @Nullable GitLabWebhookLabel addedLabel, GitLabIssueEventDTO.Changes changes) {
         var attrs = new GitLabIssueEventDTO.ObjectAttributes(
                 RAW_ISSUE_ID,
                 ISSUE_IID,
@@ -1186,9 +1274,6 @@ class GitLabIssueProcessorTest extends BaseUnitTest {
                 "2026-01-31 19:03:35 +0100",
                 null,
                 "https://gitlab.lrz.de/hephaestustest/demo-repository/-/issues/5");
-        var changes = addedLabel == null
-                ? null
-                : new GitLabIssueEventDTO.Changes(new GitLabIssueEventDTO.LabelsChange(List.of(), List.of(addedLabel)));
         return new GitLabIssueEventDTO(
                 "issue",
                 "issue",
@@ -1226,7 +1311,8 @@ class GitLabIssueProcessorTest extends BaseUnitTest {
 
         private GitLabIssueEventDTO eventWithLabelChange(
                 @Nullable List<GitLabWebhookLabel> previous, List<GitLabWebhookLabel> current) {
-            var changes = new GitLabIssueEventDTO.Changes(new GitLabIssueEventDTO.LabelsChange(previous, current));
+            var changes = new GitLabIssueEventDTO.Changes(
+                    new GitLabIssueEventDTO.LabelsChange(previous, current), null, null, null, null, null);
             return new GitLabIssueEventDTO("issue", "issue", null, null, null, List.of(), null, changes);
         }
 

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/practices/PracticeSignalOptionsTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/practices/PracticeSignalOptionsTest.java
@@ -37,7 +37,7 @@ class PracticeSignalOptionsTest extends BaseUnitTest {
                         ScmSignals.PULL_REQUEST_CLOSED);
         assertThat(options.bindableOptionsFor(ArtifactKinds.ISSUE))
                 .extracting(SignalOption::signal)
-                .containsExactly(ScmSignals.ISSUE_OPENED, ScmSignals.ISSUE_LABELED, ScmSignals.ISSUE_CLOSED);
+                .containsExactly(ScmSignals.ISSUE_OPENED, ScmSignals.ISSUE_UPDATED, ScmSignals.ISSUE_CLOSED);
     }
 
     /**

--- a/webapp/src/components/admin/practice-catalog/PracticeBindingsEditor.stories.tsx
+++ b/webapp/src/components/admin/practice-catalog/PracticeBindingsEditor.stories.tsx
@@ -76,7 +76,7 @@ export const IssueLifecycle: Story = {
 	args: { options: mockIssueWorkType, binding: mockIssueBinding },
 	play: async ({ canvas }) => {
 		const strip = within(canvas.getByRole("group", { name: "Reviews when" }));
-		await expect(strip.getByRole("checkbox", { name: "Labeled every time" })).toBeChecked();
+		await expect(strip.getByRole("checkbox", { name: "Details changed every time" })).toBeChecked();
 		// An issue is never a draft, so the question is not asked.
 		await expect(canvas.queryByRole("switch", { name: /^Include drafts/ })).toBeNull();
 	},

--- a/webapp/src/components/admin/practice-catalog/occasion-moments.test.ts
+++ b/webapp/src/components/admin/practice-catalog/occasion-moments.test.ts
@@ -8,6 +8,7 @@ import {
 import {
 	mockConversationWorkType,
 	mockDocumentWorkType,
+	mockIssueWorkType,
 	mockPracticeDefinitionOptions,
 	mockPullRequestWorkType,
 } from "@/mocks/fixtures/practice";
@@ -43,6 +44,19 @@ describe("momentBands", () => {
 			],
 			["end", ["scm.pull_request.merged", "scm.pull_request.closed"]],
 		]);
+	});
+
+	it("warns that an issue's middle moment repeats, because binding it is a decision about volume", () => {
+		const bands = momentBands(mockIssueWorkType.signals);
+
+		expect(
+			bands.map((band) => [band.phase, band.moments.map((moment) => moment.signal)]),
+		).toStrictEqual([
+			["start", ["scm.issue.opened"]],
+			["during", ["scm.issue.updated"]],
+			["end", ["scm.issue.closed"]],
+		]);
+		expect(momentDef("scm.issue.updated").repeats).toBe(true);
 	});
 
 	it("gives a document its own three moments under the same three bands", () => {

--- a/webapp/src/components/admin/practice-catalog/occasion-moments.ts
+++ b/webapp/src/components/admin/practice-catalog/occasion-moments.ts
@@ -13,7 +13,6 @@ import {
 	type LucideIcon,
 	MessageSquareTextIcon,
 	MessagesSquareIcon,
-	TagIcon,
 } from "lucide-react";
 
 import type { PracticeSignalOption, PracticeWorkTypeDefinitionOptions } from "@/api/types.gen";
@@ -64,7 +63,7 @@ const MOMENTS: Record<string, MomentDef> = {
 	"scm.pull_request.closed": { icon: GitPullRequestClosedIcon, phase: "end", repeats: false },
 
 	"scm.issue.opened": { icon: CircleDotIcon, phase: "start", repeats: false },
-	"scm.issue.labeled": { icon: TagIcon, phase: "during", repeats: true },
+	"scm.issue.updated": { icon: FilePenLineIcon, phase: "during", repeats: true },
 	"scm.issue.closed": { icon: CircleCheckIcon, phase: "end", repeats: false },
 
 	"chat.conversation_thread.settled": { icon: MessagesSquareIcon, phase: "end", repeats: false },

--- a/webapp/src/mocks/fixtures/practice.ts
+++ b/webapp/src/mocks/fixtures/practice.ts
@@ -95,7 +95,7 @@ export const mockMergeBinding = {
 } satisfies PracticeBinding;
 
 export const mockIssueBinding = {
-	signals: ["scm.issue.labeled", "scm.issue.opened"],
+	signals: ["scm.issue.opened", "scm.issue.updated"],
 	needs: [
 		{ sourceKind: "scm.issue.comments", stance: "REQUIRED" },
 		{ sourceKind: "scm.issue.core", stance: "REQUIRED" },
@@ -287,7 +287,7 @@ export const mockPracticeDefinitionOptions = {
 			artifactKind: "scm.issue",
 			signals: [
 				{ signal: "scm.issue.opened", displayName: "Opened", recommended: true },
-				{ signal: "scm.issue.labeled", displayName: "Labeled", recommended: true },
+				{ signal: "scm.issue.updated", displayName: "Details changed", recommended: true },
 				{ signal: "scm.issue.closed", displayName: "Closed", recommended: false },
 			],
 			manualReviewSignal: {


### PR DESCRIPTION
## What changed and why

Issue practice reviews previously ran for creation, labeling, and closure, even though bundled practices also depend on the title, description, native type, assignees, milestone, labels, state, and state reason. That mismatch could leave earlier observations current after the reviewed evidence changed.

This change introduces one provider-neutral `scm.issue.updated` review occasion and keeps provider-specific lifecycle events at the integration boundary for activity tracking. GitHub and GitLab now publish the neutral occasion after observable metadata updates, while the review listener consumes only created, updated, and closed issue events. Revision identity is derived from a canonical issue snapshot with sorted labels and assignees, so replaying the same resulting evidence does not start another review. Close revisions additionally use the provider's close timestamp so close → reopen → close remains reviewable.

The bundled issue practices, provider manifests, tests, and contributor documentation now use and describe the same occasion model.

Advances #1788.

## How to test

- `vp run format`
- `vp run check`
- `vp run test:server:unit`
- `node scripts/run-mvnw.ts -pl application -Dtest=GitLabIssueProcessorTest test --batch-mode`

## Release impact

[The changeset](.changeset/review-issue-metadata.md) records a minor release. No schema, configuration, or operator action is required.

## Notes for reviewers

A useful review order is `ScmSignals`, `IssueAgentJobEventListener`, the GitHub and GitLab issue processors, and then the lifecycle table in `practice-review-pipeline.mdx`.

This is deliberately not marked as closing #1788. GitLab does not expose a reliable live native-type transition in the current adapter, so synchronized type evidence is supported without claiming a type-change occasion. Snapshot identity deduplicates replays that resolve to identical evidence; it is not a temporal debounce for distinct intermediate snapshots in a webhook burst. Repository-wide backlog classification, durable burst coalescing, end-to-end actor provenance, and dedicated occasion metrics remain follow-up work in the parent issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Issue practice reviews now respond to meaningful changes to titles, descriptions, labels, assignments, milestones, reopening, and issue types on GitHub and GitLab.
  * Reviews can repeat when issue details change, while repeated deliveries and returns to an already-reviewed state are deduplicated.
  * Non-reviewable changes such as locking, pinning, due dates, weights, and time estimates no longer trigger reviews.
* **Documentation**
  * Added guidance describing issue lifecycle review occasions and platform-specific behavior.
* **Migration**
  * Existing practices using label-based triggers are migrated automatically to broader issue-update triggers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->