### PR TITLE
fix(docker): let a preview reach its own database

### DIFF
--- a/.changeset/previews-can-boot.md
+++ b/.changeset/previews-can-boot.md
@@ -1,0 +1,9 @@
+---
+"hephaestus": patch
+---
+
+Pull-request previews start again. The application refuses to talk to a database it cannot recognise
+as local over an unencrypted connection, and a preview's database answers to a per-pull-request name
+rather than the one on that list, so every preview's application server failed to start and retried
+until the deployment was reported as failed. Previews now declare that their database is a sibling
+container on the deployment's own private network, which is the trust every other stack already has.

--- a/docker/preview/compose.app.yaml
+++ b/docker/preview/compose.app.yaml
@@ -246,6 +246,12 @@ services:
       # SERVICE_NAME_*, so the bare service name resolves to nothing inside a preview. The defaults
       # keep this file runnable on its own.
       DATABASE_URL: postgresql://${SERVICE_NAME_POSTGRES:-postgres}:5432/hephaestus?sslmode=disable
+      # That renaming is also why this is set. The transport guard allows plaintext to a database
+      # it can name as local, and `postgres` is on that list — but a preview's database answers
+      # to `postgres-pr-<id>`, so the guard reads a sibling container on the deployment's own
+      # private network as a remote host and refuses to start. The trust is identical to the
+      # reference stack's; only the name differs.
+      HEPHAESTUS_DATABASE_ALLOW_INSECURE_REMOTE: "true"
       DATABASE_USERNAME: hephaestus
       DATABASE_PASSWORD: ${POSTGRES_PASSWORD}
       # The integration consumer reads staging's JetStream, so a preview sees the events a shared


### PR DESCRIPTION
## Problem

Every pull-request preview has been failing since the database transport guard landed (#1661), and
the failure looked like a timeout rather than what it is.

`DatabaseTransportGuard` refuses plaintext to a host it cannot name as local, and its allowlist is
`localhost`, `127.0.0.1`, `::1`, `postgres`. Coolify renames each preview service, so a preview's
database answers to `postgres-pr-<id>`. The guard therefore read a sibling container on the
deployment's own private network as a remote host:

```
Caused by: java.lang.IllegalStateException: Remote PostgreSQL host 'postgres-pr-1817:5432' must use TLS.
```

The application server crash-looped through that on every boot, the webapp stayed in `Created`
because it waits for the application server to become healthy, and Coolify eventually reported the
deployment as failed.

## Why not just use the name on the allowlist

Because it resolves to nothing. Checked on the staging host against a live preview network:

```
getent hosts postgres           -> (no result)
getent hosts postgres-pr-1817   -> 172.21.0.3
aliases: [postgres-wg44k0ccsoscsgcco8swc4ks-pr-1817  postgres-pr-1817]
```

Hardcoding `postgres` would have replaced a guard failure with a connection failure.

## What changed

The preview stack declares that its database is a sibling container on the deployment's own private
network, through the escape hatch the guard documents. That is the same trust the reference stack
already gets from the `postgres` allowlist entry — the topology is identical and only the name
differs. No other stack changes, and the guard keeps failing closed everywhere else.

## Verification

The root cause was read off a live failing preview on the staging host: the guard's stack trace, the
crash-loop restart count, the webapp stuck in `Created`, and the DNS aliases above. Preview stack
drift checks pass.