### PR TITLE
fix(docker): converge a reconciled host and bound the edge's backend wait

### DIFF
--- a/.changeset/edge-bounds-the-backend-wait.md
+++ b/.changeset/edge-bounds-the-backend-wait.md
@@ -1,0 +1,5 @@
+---
+"hephaestus": patch
+---
+
+Restores the timeouts the bundled edge applies to the application server, so a backend that accepts a connection but never answers releases the browser with an error page instead of leaving requests and mentor chat streams hanging indefinitely. A host that keeps itself on its channel now starts the stacks in the order the migration requires, converges again when you promote the release it already runs, and no longer refuses to retry after a partly-applied deploy. Rolling back to a release published before GitHub offered immutable tags works again.

--- a/.github/workflows/ci-compose-validate.yml
+++ b/.github/workflows/ci-compose-validate.yml
@@ -83,6 +83,8 @@ jobs:
           for required in \
             'entrypoints.https.http.middlewares=security-headers@docker' \
             'providers.file.filename=/etc/traefik/dynamic.yml' \
+            'serversTransport.forwardingTimeouts.dialTimeout=10s' \
+            'serversTransport.forwardingTimeouts.responseHeaderTimeout=30s' \
             'contentsecuritypolicy' \
             'default-src' \
             'stsseconds' \
@@ -126,4 +128,15 @@ jobs:
           for stack in proxy core app; do
             docker compose -f "compose.${stack}.yaml" \
               --env-file self-host/.env --env-file self-host/release-lock.env config --quiet
+          done
+          # No service names a serversTransport, because only the file provider can define one and
+          # the app stack must render without the proxy stack. The backend timeouts therefore have
+          # to reach default@internal from the edge's own static configuration, or they are absent.
+          proxy=$(docker compose -f compose.proxy.yaml \
+            --env-file self-host/.env --env-file self-host/release-lock.env config)
+          for required in \
+            'serversTransport.forwardingTimeouts.dialTimeout=10s' \
+            'serversTransport.forwardingTimeouts.responseHeaderTimeout=30s'; do
+            grep -Fq "$required" <<< "$proxy" || {
+              echo "::error::the bundled edge does not bound the backend wait ('$required')"; exit 1; }
           done

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -60,11 +60,11 @@ jobs:
           release="$REQUESTED"
           [[ "$release" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]] || {
             echo "::error::Promote an immutable vX.Y.Z release, not '$release'"; exit 1; }
-          metadata=$(gh release view "$release" --repo "$GITHUB_REPOSITORY" --json isDraft,isImmutable)
-          [ "$(jq -r .isDraft <<<"$metadata")" = false ] || {
+          # GitHub tag immutability is not a gate here: the host takes the source commit and every
+          # image digest from the cosign-signed release lock, so a moved tag changes nothing that is
+          # deployed. Requiring it would refuse the older releases a rollback exists to reach.
+          [ "$(gh release view "$release" --repo "$GITHUB_REPOSITORY" --json isDraft --jq .isDraft)" = false ] || {
             echo "::error::$release is still a draft"; exit 1; }
-          [ "$(jq -r .isImmutable <<<"$metadata")" = true ] || {
-            echo "::error::$release is not immutable"; exit 1; }
           echo "release=$release" >> "$GITHUB_OUTPUT"
           echo "version=${release#v}" >> "$GITHUB_OUTPUT"
 

--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ dist/
 # Django stuff:
 .dmypy.json
 dmypy.json
+docker/letsencrypt/
 docker/self-host/letsencrypt/
 docs/_build/
 downloads/

--- a/diagram.apollon
+++ b/diagram.apollon
@@ -1,9 +1,0 @@
-{
-  "version": "4.0.0",
-  "id": "25b6587c-070b-406c-b23a-b7fa928d84e1",
-  "title": "diagram",
-  "type": "ClassDiagram",
-  "nodes": [],
-  "edges": [],
-  "assessments": {}
-}

--- a/docker/compose.proxy.yaml
+++ b/docker/compose.proxy.yaml
@@ -32,6 +32,14 @@ services:
       # above the 20s heartbeat — if heartbeats stop, the proxy reaps within 5 minutes.
       - "--entryPoints.http.transport.respondingTimeouts.idleTimeout=300s"
       - "--entryPoints.https.transport.respondingTimeouts.idleTimeout=300s"
+      # Backend timeouts belong in static configuration: a serversTransport is definable only by the
+      # file provider, so a router that named one would break whenever this stack is not deployed.
+      # These land on default@internal, which every service that names no transport uses. Traefik
+      # ships dialTimeout=30s and responseHeaderTimeout=0 — no timeout — so an application-server
+      # that accepts the connection and never answers would otherwise hold the client forever. Only
+      # the wait for response headers is bounded, so SSE response bodies are unaffected.
+      - "--serversTransport.forwardingTimeouts.dialTimeout=10s"
+      - "--serversTransport.forwardingTimeouts.responseHeaderTimeout=30s"
       - "--providers.docker.exposedbydefault=false"
       - "--certificatesresolvers.letsencrypt.acme.httpchallenge=true"
       - "--certificatesresolvers.letsencrypt.acme.storage=/letsencrypt/acme.json"

--- a/docker/self-host/compose.single-host.yaml
+++ b/docker/self-host/compose.single-host.yaml
@@ -54,6 +54,10 @@ services:
       # 300s leaves margin above Traefik's 180s default.
       - "--entryPoints.http.transport.respondingTimeouts.idleTimeout=300s"
       - "--entryPoints.https.transport.respondingTimeouts.idleTimeout=300s"
+      # Backend timeouts, same as the reference. `command:` is !override, so nothing here is
+      # inherited. Traefik's default transport waits forever for response headers.
+      - "--serversTransport.forwardingTimeouts.dialTimeout=10s"
+      - "--serversTransport.forwardingTimeouts.responseHeaderTimeout=30s"
       - "--providers.docker=true"
       - "--providers.docker.exposedbydefault=false"
       - "--certificatesresolvers.letsencrypt.acme.httpchallenge=true"

--- a/docs/admin/pull-based-deployment.mdx
+++ b/docs/admin/pull-based-deployment.mdx
@@ -82,13 +82,15 @@ proxy, or a PaaS serving preview environments beside it — omits `proxy` and ke
 | Move an environment | Run the **Promote** workflow: pick the environment and release |
 | Roll back | Promote the older release with **allow-rollback** |
 | Hold an environment | Promote with **freeze** |
+| Put a hand-patched host back on its release | Promote the release it already runs |
 | Stop the host reconciling, right now | `sudo systemctl disable --now hephaestus-reconcile.timer` |
 | See what a host runs | `cat /var/lib/hephaestus/applied.json` |
 
 :::warning Disable the timer before hand-patching a host
-A reconciler reapplies its channel. Manual changes to a stack it owns are reverted at the next tick,
-which during an incident is the last thing you want. Disable the timer first, and re-enable it when
-the fix has landed in a release.
+A reconciler reapplies its channel. Manual changes to a stack it owns are reverted the next time the
+channel moves — including a promotion of the release the host already runs, which is how you put a
+drifted host back. During an incident that is the last thing you want, so disable the timer first,
+and re-enable it when the fix has landed in a release.
 :::
 
 ## Watching it

--- a/docs/contributor/ci-cd.mdx
+++ b/docs/contributor/ci-cd.mdx
@@ -144,8 +144,10 @@ SBOM, and release-verification guarantees.
 2. Create `Staging` (no rules)
 3. Create `Production` with **Required reviewers**
 
-A deploy brings up `core`, then `app`, then `proxy`, so every router is complete before the bundled
-edge reloads; the `proxy` stack publishes :80 and :443. An environment whose host already has an
+A deploy brings up `app`, then `core`, then `proxy`: the application server runs the Liquibase
+migration the webhook runtime in `core` reads, and the edge starts last, against routers that are
+already complete. Both deploy paths use this order — the push workflow and the pull reconciler.
+The `proxy` stack publishes :80 and :443. An environment whose host already has an
 edge in front of it sets the environment variable `DEPLOY_EDGE_PROXY=false`, which leaves `proxy`
 out of both the render and the deploy; anything else, including an unset variable, deploys all
 three. Staging sets it, because it shares a host with the Coolify instance that serves preview

--- a/scripts/reconcile-deployment.test.ts
+++ b/scripts/reconcile-deployment.test.ts
@@ -40,6 +40,13 @@ await test("an unchanged channel is a no-op, so most ticks do nothing", () => {
 	});
 });
 
+await test("re-promoting the release a host already runs re-applies it, so drift converges", () => {
+	assert.deepEqual(decide({ release: applied.release }, applied, "c".repeat(40), true), {
+		action: "apply",
+		release: applied.release,
+	});
+});
+
 await test("a descendant channel commit applies", () => {
 	assert.deepEqual(decide({ release: "v0.75.3" }, applied, "c".repeat(40), true), {
 		action: "apply",
@@ -99,9 +106,9 @@ await test("only a missing applied-state file means first run", async () => {
 	}
 });
 
-await test("stacks publish dependencies and routes before the edge reloads", () => {
-	assert.deepEqual(parseStacks("app core"), ["core", "app"]);
-	assert.deepEqual(parseStacks("app, core, proxy"), ["core", "app", "proxy"]);
+await test("stacks come up in dependency order regardless of how they were configured", () => {
+	assert.deepEqual(parseStacks("core app"), ["app", "core"]);
+	assert.deepEqual(parseStacks("proxy, core, app"), ["app", "core", "proxy"]);
 	assert.throws(() => parseStacks("app database"), /unknown stack/);
 	assert.throws(() => parseStacks(""), /at least one stack/);
 });

--- a/scripts/reconcile-deployment.ts
+++ b/scripts/reconcile-deployment.ts
@@ -7,16 +7,19 @@ import { output, run, succeeds } from "./lib/process.ts";
 
 export type Stack = "proxy" | "core" | "app";
 
-const STACK_ORDER: readonly Stack[] = ["core", "app", "proxy"];
+/**
+ * The application server runs the Liquibase migration the webhook runtime in `core` reads, and the
+ * edge comes last so it never routes to a stack that is still starting. The push deploy declares the
+ * same order in `.github/workflows/deploy-locked-compose.yml`, and one test holds the two together.
+ */
+const STACK_ORDER: readonly Stack[] = ["app", "core", "proxy"];
 
 /**
- * The database and the broker, which both applications need before either can pass a health gate:
- * the receiver in `core` cannot build its JPA context without PostgreSQL in `app`, and the server in
- * `app` never reports ready without NATS in `core`. Compose cannot express a dependency across
- * projects, and no stack order resolves a cycle, so these come up first and the applications follow.
+ * The application server never reports ready without the broker, and the broker lives in the `core`
+ * project, which Compose cannot express as a dependency. PostgreSQL needs no entry: it sits in `app`
+ * beside the services that declare `depends_on` on it.
  */
 const FOUNDATION: Partial<Record<Stack, readonly string[]>> = {
-	app: ["postgres"],
 	core: ["nats-server"],
 };
 
@@ -83,7 +86,9 @@ export function decide(
 			reason: `channel commit ${channelCommit.slice(0, 8)} does not descend from the last accepted channel`,
 		};
 	if (channel.freeze) return { action: "noop", reason: "channel is frozen" };
-	if (applied?.release === channel.release)
+	// A new channel commit naming the release already applied is a re-promotion, and re-applying is
+	// how a host that was hand-patched during an incident converges again.
+	if (applied?.release === channel.release && applied.channelCommit === channelCommit)
 		return { action: "noop", reason: `already running ${channel.release}` };
 	if (applied && compareReleases(channel.release, applied.release) < 0 && !channel.allowRollback)
 		return {
@@ -330,10 +335,16 @@ async function main(): Promise<void> {
 			cwd: config.checkout,
 		});
 	}
+	// Tracked content only: Compose writes into the worktree it renders from — the proxy stack's ACME
+	// store is `docker/letsencrypt/` — so counting untracked files would turn every retry after a
+	// partial apply into a permanent refusal. An untracked file cannot alter a tracked Compose file,
+	// and anyone who can write here already has the Docker socket.
 	const worktreeChanges = await output(
 		"git",
-		["status", "--porcelain=v1", "--untracked-files=all", "--ignored=matching"],
-		{ cwd: releaseTree },
+		["status", "--porcelain=v1", "--untracked-files=no"],
+		{
+			cwd: releaseTree,
+		},
 	);
 	if (worktreeChanges) throw new Error(`${releaseTree} differs from ${decision.release}`);
 
@@ -363,23 +374,9 @@ async function main(): Promise<void> {
 		join(releaseTree, `docker/compose.${stack}.yaml`),
 	];
 
-	for (const stack of config.stacks) {
-		const foundation = FOUNDATION[stack];
-		if (!foundation) continue;
-		await run(
-			"docker",
-			[
-				...composeFor(stack),
-				"up",
-				"--detach",
-				"--wait",
-				`--wait-timeout=${config.waitTimeoutSeconds}`,
-				...foundation,
-			],
-			{ cwd: releaseTree },
-		);
-	}
-
+	// Every stack is verified before any container starts, so a release that renders an unlocked image
+	// cannot get one running in the window before the guard refuses it.
+	const composeArgsByStack = new Map<Stack, string[]>();
 	for (const stack of config.stacks) {
 		const composeArgs = composeFor(stack);
 		const rendered = asRecord(
@@ -396,6 +393,27 @@ async function main(): Promise<void> {
 		const unlocked = unlockedImages(images, lockEnv);
 		if (unlocked.length > 0)
 			throw new Error(`${stack} renders images outside the release lock: ${unlocked.join(", ")}`);
+		composeArgsByStack.set(stack, composeArgs);
+	}
+
+	for (const [stack, composeArgs] of composeArgsByStack) {
+		const foundation = FOUNDATION[stack];
+		if (!foundation) continue;
+		await run(
+			"docker",
+			[
+				...composeArgs,
+				"up",
+				"--detach",
+				"--wait",
+				`--wait-timeout=${config.waitTimeoutSeconds}`,
+				...foundation,
+			],
+			{ cwd: releaseTree },
+		);
+	}
+
+	for (const [, composeArgs] of composeArgsByStack) {
 		await run(
 			"docker",
 			[

--- a/scripts/release-deployment-policy.test.ts
+++ b/scripts/release-deployment-policy.test.ts
@@ -4,6 +4,7 @@ import { test } from "node:test";
 
 import { releaseSignerIdentity, releaseSignerRepository } from "./lib/release-signer.ts";
 import { SMOKE_HOSTNAME } from "./prepare-host-smoke-env.ts";
+import { parseStacks } from "./reconcile-deployment.ts";
 
 const release = readFileSync(".github/workflows/release.yml", "utf8");
 const deployment = readFileSync(".github/workflows/deploy-locked-compose.yml", "utf8");
@@ -25,7 +26,7 @@ await test("deployment uses Compose metadata, waits for readiness, and preserves
 	assert.doesNotMatch(deployment, /docker image prune/);
 });
 
-await test("a deployment starts the broker before the stacks that talk to it", () => {
+await test("both deploy paths start the stacks in the same order", () => {
 	const configured = /^\s+STACKS: (.+)$/m.exec(deployment)?.[1];
 	assert.ok(configured, "the deploy job must declare the stacks and their order in STACKS");
 	// Every stack list the expression can yield: one per environment shape it selects between.
@@ -42,6 +43,13 @@ await test("a deployment starts the broker before the stacks that talk to it", (
 		);
 		// The edge comes last, so it never routes to a stack that is still starting.
 		if (stacks.includes("proxy")) assert.equal(stacks.at(-1), "proxy");
+		// The pull reconciler decides its own order from the same stack names, and a host that
+		// migrates after it starts the webhook runtime serves deliveries against a stale schema.
+		assert.deepEqual(
+			parseStacks(stacks.join(" ")),
+			stacks,
+			"the pull reconciler must order stacks the way the push deploy does",
+		);
 	}
 
 	const script = deployment.slice(deployment.indexOf("envs: STACKS"));
@@ -120,9 +128,11 @@ await test("verification identity is the release's own: run context now, the map
 	);
 });
 
-await test("promotion accepts only immutable releases and the host supplies the verifier", () => {
-	assert.match(promotion, /--json isDraft,isImmutable/);
-	assert.match(promotion, /\.isImmutable/);
+await test("promotion refuses a draft but reaches any published release, and the host verifies", () => {
+	assert.match(promotion, /--json isDraft --jq \.isDraft/);
+	// Releases published before GitHub offered tag immutability are the ones a rollback reaches, and
+	// the signed lock names the source commit and every digest, so tag mutability changes nothing.
+	assert.doesNotMatch(promotion, /isImmutable/);
 	assert.match(reconciler, /join\(config\.checkout, "scripts\/prepare-release-lock\.ts"\)/);
 	assert.doesNotMatch(reconciler, /join\(releaseTree, "scripts\/prepare-release-lock\.ts"\)/);
 });


### PR DESCRIPTION
## What changed and why

These are defects in two pull requests that merged to `main` while they were still under review —
[#1801](https://github.com/hephaestus-build/Hephaestus/pull/1801) and
[#1802](https://github.com/hephaestus-build/Hephaestus/pull/1802). They cannot be un-merged, so this
is the follow-up. Each one was re-confirmed against `main` at `3f52b667` before it was touched; all
six still reproduced. They are one concern: the deployment path a host reconciles itself along, and
the edge that fronts it.

**The reconciler wedged any host that owns its edge.** The worktree-cleanliness check counted
untracked and ignored files. `docker/compose.proxy.yaml` bind-mounts `./letsencrypt`, so Compose
creates `<releaseTree>/docker/letsencrypt/` and Traefik writes `acme.json` into it. After a
partially-failed apply — `app` missing its wait timeout on a slow migration, say — `applied.json` is
never written, the next tick decides to apply the same release, finds that untracked file, and
throws `… differs from <release>` forever. Every subsequent tick throws the same thing, and the
message points at tampering rather than at what happened. It now checks tracked content only: an
untracked file cannot alter a tracked Compose file, the worktree `HEAD` is already asserted against
the cosign-signed release commit, and anyone who can write into the state directory already has the
Docker socket. Deleting and re-adding the worktree each apply was the alternative; it would destroy
the ACME store on every deploy and walk into Let's Encrypt's duplicate-certificate limit.
`docker/letsencrypt/` also joins `.gitignore`, which only covered the self-host copy.

**The reconciler stopped re-converging.** `decide()` had lost its channel-commit comparison, so
re-promoting the release a host already runs was a no-op and a drifted host never came back —
while `docs/admin/pull-based-deployment.mdx` told operators the opposite. The comparison is
restored, which is the behaviour the design promises, and the admin doc now says exactly how an
operator triggers it.

**The two deploy paths disagreed about migration ordering.** `STACK_ORDER` was
`["core", "app", "proxy"]`, which starts the webhook runtime before the Liquibase migration it
reads — `SPRING_LIQUIBASE_ENABLED: "false"` on `webhook-server`, so it boots on a stale schema and
errors at query time on deliveries that push events cannot redeliver. The push path asserts the
opposite in `release-deployment-policy.test.ts`. The reconciler now matches, and one test asserts
the ordering for **both** paths — it parses the workflow's `STACKS` expression and feeds each order
through the reconciler's own `parseStacks`, so the two cannot diverge again. With `app` first the
`FOUNDATION` pre-pass no longer needs `postgres`: it sits in the `app` project beside the services
that `depends_on` it. Only the broker still crosses a project boundary.

**Promote refused the releases a rollback exists to reach.** The `isImmutable == true` gate rejects
every release predating GitHub's immutable releases — `v0.74.0` and `v0.70.0` are `isImmutable:
false` today — so the rollback row in `docs/admin/pull-based-deployment.mdx` could not be followed
from the only supported UI. The gate also buys nothing: the host takes the source commit and every
image digest from the cosign-signed lock and refuses a worktree that does not match, so a moved tag
changes nothing that is deployed. Dropped, and the code and the docs now agree without the doc
changing.

**The edge lost its backend timeouts.** Removing `serversTransport=application@file` from the `/api`
service removed its definition too, so `dialTimeout: 10s` and `responseHeaderTimeout: 30s` went away
in the **bundled-proxy topology as well** — the production reference deployment and the self-host
single-host merge, not just the standalone case. Traefik's `default@internal` ships
`dialTimeout=30s` and `responseHeaderTimeout=0`, and zero means no timeout: an `application-server`
that accepts the connection and never writes headers now holds the client indefinitely instead of
releasing it to the maintenance page. `https-application-server` is the `/api` router, so that is
every SPA call and every mentor chat stream. The timeouts return as static
`--serversTransport.forwardingTimeouts.*` flags on the proxy, which land on `default@internal` and
therefore need no service to name a transport the docker provider cannot define — the app and core
stacks keep rendering standalone. `compose.single-host.yaml`'s `command:` is `!override`, so it
carries its own copy. Only the wait for response headers is bounded, so SSE bodies are unaffected.

**`diagram.apollon`** was a stray nine-line scratch file committed at the repo root. Deleted. It is
an external editor's artefact — nothing in this repository produces `.apollon` files — so it gets no
`.gitignore` rule.

Two things were plainly wrong and cheap to correct in files already open, so they are in here:
`docs/contributor/ci-cd.mdx` still documented a stack order neither deploy path shipped, and the
`FOUNDATION` pre-pass started containers *before* the release-lock check in the next loop, so a
release rendering an unlocked image got one running before the guard refused it. Every stack is now
verified before anything starts.

Out of scope on purpose: the reviews' remaining Major findings about comment restorations, ADR
amendment shape, change-detector tests and the merged PRs' body wording. This is a defect follow-up.

## How to test

```bash
vp run check                                                   # exit 0
node --test scripts/reconcile-deployment.test.ts scripts/release-deployment-policy.test.ts
```

Every new or changed assertion was run against `main`'s source to confirm it fails there. Restoring
`main`'s `scripts/reconcile-deployment.ts` and `.github/workflows/promote.yml` under this branch's
tests fails exactly four, one per defect:

- `re-promoting the release a host already runs re-applies it, so drift converges`
- `stacks come up in dependency order regardless of how they were configured`
- `both deploy paths start the stacks in the same order` (the cross-path guard)
- `promotion refuses a draft but reaches any published release, and the host verifies`

Docker is available on this host, so both topologies were rendered rather than assumed:

```bash
cd docker && for stack in proxy core app; do
  docker compose -f "compose.${stack}.yaml" \
    --env-file self-host/.env --env-file self-host/release-lock.env config
done
cd docker/self-host && docker compose config          # the merged single-host stack
```

Both the standalone `proxy` render and the merged single-host render carry
`--serversTransport.forwardingTimeouts.dialTimeout=10s` and `…responseHeaderTimeout=30s` alongside
the pre-existing `respondingTimeouts.idleTimeout=300s`; `core` and `app` still render clean on their
own and name no transport. Against `main`'s compose files the same greps find nothing, which is the
defect. The two new `ci-compose-validate.yml` gates therefore fail on `main` and pass here.

The flag names were checked against the pinned image rather than from memory:
`docker run --rm traefik:v3.7 traefik --help` documents
`--serverstransport.forwardingtimeouts.dialtimeout` (default `30`) and
`…responseheadertimeout` (default `0`). Traefik 3.7.12 starts cleanly with the exact command list,
and a deliberately misspelled sibling flag is rejected with `field not found`, so the names are
right at the pinned version.

## Release impact

`.changeset/edge-bounds-the-backend-wait.md`, `patch`. The edge timeouts are shipped code under
`docker/`, which is what requires it. No operator action: no new variable, no migration, and the
reconciler and promote changes are behaviour an operator gets by upgrading.

## Notes for reviewers

`scripts/reconcile-deployment.ts` is the place to start — four of the six fixes are there.

The reordered loops in `main()` are worth a second look: rendering and verifying every stack up
front means a host with several stacks now runs `docker compose config` for all of them before the
first container starts, which is a slightly longer window between the lock check and the `up`, in
exchange for no unlocked image ever running.

Judgement call worth confirming: `parseStacks("core app")` now returns `["app", "core"]`, so a host
whose `HEPHAESTUS_STACKS` lists `core` first silently gets the corrected order rather than an error.
That matches the push path, which canonicalises the same way, and is the reason the shared test can
compare them at all.
