### PR TITLE
test(server): fix the nullness NullAway 0.14.1 finds in three tests

### DIFF
--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/runtime/NoPerRequestAccessLogTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/runtime/NoPerRequestAccessLogTest.java
@@ -56,12 +56,7 @@ class NoPerRequestAccessLogTest extends BaseUnitTest {
 
     @Test
     void maintenancePageNginxDisablesTheAccessLogForTheWholeServerBlock() throws Exception {
-        String conf = propertyIn(PROXY_COMPOSE, "configs.nginx-default-config.content");
-
-        assertThat(conf)
-                .as("docker/compose.proxy.yaml no longer inlines an nginx server config under that key")
-                .isNotNull();
-        assertThat(directivesAtServerLevel(conf))
+        assertThat(directivesAtServerLevel(maintenancePageConf()))
                 .as("the maintenance page answers on a catch-all Host rule whenever the webapp router is "
                         + "down, so the URL it would log is the deep link the contributor was reaching for")
                 .contains("access_log off");
@@ -75,9 +70,8 @@ class NoPerRequestAccessLogTest extends BaseUnitTest {
     @Test
     void noNginxLocationReEnablesTheAccessLog() throws Exception {
         List<String> reEnabling = new ArrayList<>();
-        for (String conf : List.of(
-                Files.readString(WEBAPP_NGINX_CONF, StandardCharsets.UTF_8),
-                propertyIn(PROXY_COMPOSE, "configs.nginx-default-config.content"))) {
+        for (String conf :
+                List.of(Files.readString(WEBAPP_NGINX_CONF, StandardCharsets.UTF_8), maintenancePageConf())) {
             conf.lines()
                     .map(NoPerRequestAccessLogTest::directive)
                     .filter(line -> line.startsWith("access_log") && !line.equals("access_log off"))
@@ -87,6 +81,20 @@ class NoPerRequestAccessLogTest extends BaseUnitTest {
         assertThat(reEnabling)
                 .as("every access_log directive in a shipped nginx config must be `off`")
                 .isEmpty();
+    }
+
+    /**
+     * The maintenance page's nginx config is inlined into the compose file rather than shipped as a
+     * file, so a key that stops resolving would silently narrow both tests that read it to the webapp
+     * config alone. Asserting here names that as the failure instead.
+     */
+    private static String maintenancePageConf() throws IOException {
+        String conf = propertyIn(PROXY_COMPOSE, "configs.nginx-default-config.content");
+
+        assertThat(conf)
+                .as("docker/compose.proxy.yaml no longer inlines an nginx server config under that key")
+                .isNotNull();
+        return conf;
     }
 
     /**

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/schema/ProductionSchemaContractIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/schema/ProductionSchemaContractIntegrationTest.java
@@ -115,7 +115,7 @@ class ProductionSchemaContractIntegrationTest {
 
     @Test
     void observationForeignKeysPreserveTenantAndProvenance() {
-        List<String> foreignKeys = jdbcTemplate.queryForList("""
+        List<@Nullable String> foreignKeys = jdbcTemplate.queryForList("""
             SELECT DISTINCT rc.constraint_name || ':' || parent.table_name || ':' || rc.delete_rule
             FROM information_schema.referential_constraints rc
             JOIN information_schema.key_column_usage child

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/practices/curated/CuratedCatalogAdminControllerIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/practices/curated/CuratedCatalogAdminControllerIntegrationTest.java
@@ -1003,7 +1003,7 @@ class CuratedCatalogAdminControllerIntegrationTest extends AbstractWorkspaceInte
         return rows;
     }
 
-    private List<String> auditValues(String entityType, String entityId) {
+    private List<@Nullable String> auditValues(String entityType, String entityId) {
         return jdbcTemplate.queryForList("""
             SELECT new_value::text
             FROM config_audit_event


### PR DESCRIPTION
## What changed and why

NullAway 0.14.1 ([#1796](https://github.com/hephaestus-build/Hephaestus/pull/1796)) fails
`maven-compiler-plugin:testCompile` with three errors. The bump is correct and wanted — 0.14.1 now
tracks nullable elements through enhanced-for loops (uber/NullAway#1748, #1749) and applies library
models when checking overrides (#1722, #1759), so it sees three things 0.14.0 did not. All three are
in test sources; `src/main/java` is unaffected.

**One of them is a real latent bug.** `NoPerRequestAccessLogTest.noNginxLocationReEnablesTheAccessLog`
passed the `@Nullable` result of `propertyIn(PROXY_COMPOSE, "configs.nginx-default-config.content")`
straight into `List.of(…)` and dereferenced the loop variable. `List.of` rejects a null element, so
had `docker/compose.proxy.yaml` ever stopped inlining that key the test would have died with a bare
`NullPointerException` — not with the named diagnostic its sibling test at the same key deliberately
produces, and not with any hint that the maintenance page had silently dropped out of the GDPR
access-log guard. The lookup and that assertion now live in one `maintenancePageConf()` helper both
tests call, so the missing key fails as itself and neither test can quietly narrow to the webapp
config alone.

The other two are the analyser catching up with Spring's contract, not defects.
`jdbcTemplate.queryForList(sql, String.class)` goes through `SingleColumnRowMapper`, which can yield
null elements, so the two call sites take the `List<@Nullable String>` they actually get — the form
`ObservationAssessmentBackfillIntegrationTest` already uses. No casts and no suppressions: the
assertions on both lists still hold as written.

Once this lands, #1796 goes green on its next rebase.

## How to test

Everything below ran from a clean clone of `main` with this branch applied. The version override
reproduces #1796 without checking its branch out.

Reproduce the failure on `main` (unmodified), then confirm it is gone:

```sh
cd server
MANAGEMENT_PORT=0 SERVER_PORT=0 ./mvnw -f application/pom.xml \
  -Dnullaway.version=0.14.1 test-compile --batch-mode -DskipTests
```

- On `main`: `BUILD FAILURE`, 3 errors — `NoPerRequestAccessLogTest:[81,17] dereferenced expression
  'conf' is @Nullable`, `ProductionSchemaContractIntegrationTest:[118,22]` and
  `CuratedCatalogAdminControllerIntegrationTest:[1007,41] List<@Nullable String> cannot be converted
  to List<String>` — byte for byte the three CI reports on #1796.
- On this branch: `BUILD SUCCESS`.

Safe to land before the bump — same command without the override, on the pinned 0.14.0:
`BUILD SUCCESS`.

Tests, all green:

```sh
cd server
MANAGEMENT_PORT=0 SERVER_PORT=0 ./mvnw -f application/pom.xml \
  -Dtest=NoPerRequestAccessLogTest -Dsurefire.includedGroups=unit test --batch-mode          # 4/4
MANAGEMENT_PORT=0 SERVER_PORT=0 ./mvnw -f application/pom.xml \
  -Dtest=CuratedCatalogAdminControllerIntegrationTest \
  -Dsurefire.includedGroups=integration test --batch-mode                                    # 23/23
MANAGEMENT_PORT=0 SERVER_PORT=0 ./mvnw -f application/pom.xml \
  -Dtest=ProductionSchemaContractIntegrationTest \
  -Dsurefire.includedGroups=database test --batch-mode                                       # 29/29
```

`vp run format:java` and `vp run gate:java-nullness` are clean (3418 handwritten sources, no NullAway
suppressions).

The new diagnostic was proved rather than assumed: pointing the helper at a key that does not exist
fails both tests with `[docker/compose.proxy.yaml no longer inlines an nginx server config under that
key]`, where the old code reached `NullPointerException` from `List.of`.

## Release impact

No changeset. `Verify changesets` excludes `server/application/src/test` from `SHIPPED_PATHS`
(`.github/workflows/verify-changesets.yml`), and all three files sit there — the diff changes no
shipped code, no schema and no operator-visible behaviour, so there is no release note to write.

## Notes for reviewers

Start with `NoPerRequestAccessLogTest`; the other two files are one type argument each.

`maintenancePageConf()` relies on `-XepOpt:NullAway:HandleTestAssertionLibraries=true`
(`server/application/pom.xml`) to refine the local after `assertThat(…).isNotNull()`, which is the
same mechanism the pre-existing `maintenancePageNginxDisablesTheAccessLogForTheWholeServerBlock` body
already depended on.

Out of scope, from the same review of #1796 and worth an issue rather than a change here: Renovate's
`"server build dependencies"` group structurally cannot match annotation processors, because
`<path>` nodes under `<annotationProcessorPaths>` get no `depType` in Renovate's maven manager.
`docs/contributor/ci-cd.mdx` and `scripts/renovate-config.test.ts` both describe that group without
recording the hole. Leaving it alone is the right call — isolating this breakage to a one-line
dependency diff is exactly why it was worth catching on its own PR — but the docs should say so.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved maintenance-page access-log validation by explicitly checking that the required proxy configuration is present.
  * Updated integration test handling to correctly allow nullable database query results.
  * Preserved existing test queries and behavior while improving null-value coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->