### PR TITLE
fix(docker): send HSTS from the router, not the edge

### DIFF
--- a/.changeset/hsts-behind-any-proxy.md
+++ b/.changeset/hsts-behind-any-proxy.md
@@ -1,0 +1,9 @@
+---
+"hephaestus": patch
+---
+
+An instance now sends `Strict-Transport-Security` whatever proxy sits in front of it. The header was
+attached to the reverse proxy shipped with Hephaestus, so a deployment fronted by a different proxy —
+a PaaS, or an existing ingress — served without it, and the omission was easy to miss because every
+other security header comes from the responses themselves. Nothing changes for a deployment that uses
+the bundled proxy.

--- a/.github/workflows/ci-compose-validate.yml
+++ b/.github/workflows/ci-compose-validate.yml
@@ -74,12 +74,23 @@ jobs:
           jq -e '
             .services.webapp.labels["traefik.http.middlewares.webapp-body-limit.buffering.maxRequestBodyBytes"] == "26214400" and
             .services.webapp.labels["traefik.http.middlewares.webapp-body-limit.buffering.memRequestBodyBytes"] == "1048576" and
-            .services.webapp.labels["traefik.http.routers.https-webapp.middlewares"] == "webapp-body-limit" and
+            (.services.webapp.labels["traefik.http.routers.https-webapp.middlewares"] | split(",") | index("webapp-body-limit")) != null and
             .services["webhook-server"].labels["traefik.http.middlewares.webhook-body-limit.buffering.maxRequestBodyBytes"] == "26214400" and
             .services["webhook-server"].labels["traefik.http.middlewares.webhook-body-limit.buffering.memRequestBodyBytes"] == "1048576" and
-            .services["webhook-server"].labels["traefik.http.routers.https-webhook-server.middlewares"] == "webhook-body-limit,gzip"
+            (.services["webhook-server"].labels["traefik.http.routers.https-webhook-server.middlewares"] | split(",") | index("webhook-body-limit") != null and index("gzip") != null)
           ' <<< "$rendered_json" >/dev/null || {
             echo "::error::webapp and webhook request-body limits are not attached to their routers"; exit 1; }
+
+          # HSTS is the one security header a response cannot set for itself, and the entrypoint
+          # that used to carry it exists only where the proxy stack is the edge. Behind any other
+          # proxy the header simply vanished, so each router that terminates a public request
+          # carries it now, and this is what keeps that true.
+          jq -e '
+            [ .services | to_entries[] | .value.labels // {} | to_entries[]
+              | select(.key | test("^traefik\\.http\\.routers\\.https-[a-z-]+\\.middlewares$"))
+              | select((.value | split(",") | any(test("hsts"))) | not) | .key ] | length == 0
+          ' <<< "$rendered_json" >/dev/null || {
+            echo "::error::an https router would serve without HSTS behind a proxy that is not ours"; exit 1; }
           for required in \
             'entrypoints.https.http.middlewares=security-headers@docker' \
             'providers.file.filename=/etc/traefik/dynamic.yml' \

--- a/docker/compose.app.yaml
+++ b/docker/compose.app.yaml
@@ -91,7 +91,7 @@ services:
       - "traefik.http.middlewares.canonical-host.redirectregex.replacement=https://${APP_HOSTNAME}/$${1}"
       - "traefik.http.middlewares.canonical-host.redirectregex.permanent=true"
       - "traefik.http.routers.https-canonical.entryPoints=https"
-      - "traefik.http.routers.https-canonical.middlewares=canonical-host"
+      - "traefik.http.routers.https-canonical.middlewares=app-hsts,canonical-host"
       - "traefik.http.routers.https-canonical.rule=(${APP_HOST_MATCH:-Host(`${APP_HOSTNAME}`)}) && !Host(`${APP_HOSTNAME}`) && PathPrefix(`/`)"
       - "traefik.http.routers.https-canonical.service=https-webapp"
       # No certresolver here on purpose: ACME derives a router's domains from its rule and does not

--- a/docker/compose.app.yaml
+++ b/docker/compose.app.yaml
@@ -65,9 +65,15 @@ services:
       - "traefik.http.routers.https-webapp.entryPoints=https"
       # Keep buffering off the /api router because it would hold SSE responses until they close.
       # Define this middleware with its router so the app stack does not depend on the proxy stack.
+      # HSTS rides on the router, not on the entrypoint: an entrypoint middleware exists only when
+      # this deployment's edge is the proxy stack, and behind someone else's proxy the header
+      # would silently go missing. The other security headers are set by the responses
+      # themselves, so this is the one that has nowhere else to come from.
+      - traefik.http.middlewares.app-hsts.headers.stsSeconds=2592000
+      - traefik.http.middlewares.app-hsts.headers.stsIncludeSubdomains=true
       - traefik.http.middlewares.webapp-body-limit.buffering.maxRequestBodyBytes=26214400
       - traefik.http.middlewares.webapp-body-limit.buffering.memRequestBodyBytes=1048576
-      - "traefik.http.routers.https-webapp.middlewares=webapp-body-limit"
+      - "traefik.http.routers.https-webapp.middlewares=app-hsts,webapp-body-limit"
       - "traefik.http.routers.https-webapp.rule=(${APP_HOST_MATCH:-Host(`${APP_HOSTNAME}`)}) && PathPrefix(`/`)"
       - "traefik.http.routers.https-webapp.service=https-webapp"
       - "traefik.http.routers.https-webapp.tls.certresolver=letsencrypt"
@@ -312,7 +318,7 @@ services:
       - "traefik.http.routers.http-application-server.rule=(${APP_HOST_MATCH:-Host(`${APP_HOSTNAME}`)}) && PathPrefix(`/api`)"
       - "traefik.http.routers.http-application-server.service=http-application-server"
       - "traefik.http.routers.https-application-server.entryPoints=https"
-      - "traefik.http.routers.https-application-server.middlewares=edge-api-rate-limit,https-application-server-stripprefix"
+      - "traefik.http.routers.https-application-server.middlewares=app-hsts,edge-api-rate-limit,https-application-server-stripprefix"
       - "traefik.http.routers.https-application-server.rule=(${APP_HOST_MATCH:-Host(`${APP_HOSTNAME}`)}) && PathPrefix(`/api`)"
       - "traefik.http.routers.https-application-server.tls.certresolver=letsencrypt"
       - "traefik.http.routers.https-application-server.tls=true"

--- a/docker/compose.core.yaml
+++ b/docker/compose.core.yaml
@@ -125,9 +125,15 @@ services:
       # filter + security chain all bind to /webhooks/**). Stripping it would 404 every delivery.
       # Match the receiver's 25 MiB limit here, not on the shared entrypoint where buffering would
       # hold /api SSE responses. Keeping it with this router avoids a dependency on the proxy stack.
+      # HSTS rides on the router, not on the entrypoint: an entrypoint middleware exists only when
+      # this deployment's edge is the proxy stack, and behind someone else's proxy the header
+      # would silently go missing. The other security headers are set by the responses
+      # themselves, so this is the one that has nowhere else to come from.
+      - traefik.http.middlewares.core-hsts.headers.stsSeconds=2592000
+      - traefik.http.middlewares.core-hsts.headers.stsIncludeSubdomains=true
       - traefik.http.middlewares.webhook-body-limit.buffering.maxRequestBodyBytes=26214400
       - traefik.http.middlewares.webhook-body-limit.buffering.memRequestBodyBytes=1048576
-      - "traefik.http.routers.https-webhook-server.middlewares=webhook-body-limit,gzip"
+      - "traefik.http.routers.https-webhook-server.middlewares=core-hsts,webhook-body-limit,gzip"
       - "traefik.http.routers.https-webhook-server.rule=(${APP_HOST_MATCH:-Host(`${APP_HOSTNAME}`)}) && PathPrefix(`/webhooks`)"
       - "traefik.http.routers.https-webhook-server.tls.certresolver=letsencrypt"
       - "traefik.http.routers.https-webhook-server.tls=true"

--- a/scripts/compose-host-routing.test.ts
+++ b/scripts/compose-host-routing.test.ts
@@ -110,3 +110,25 @@ await test("what an operator is told to copy is one host per Host()", () => {
 		}
 	}
 });
+
+await test("every https router sets HSTS itself, not through the edge", () => {
+	// The proxy stack puts security-headers on its https entrypoint, which covers a deployment whose
+	// edge is that stack. Staging and every preview run behind someone else's proxy, where no
+	// entrypoint middleware of ours exists — and the omission is invisible, because the webapp's
+	// nginx sets the other security headers on its own responses. HSTS is the one no response can
+	// set for itself, so each router that terminates a public request carries it.
+	for (const stack of ["app", "core"] as const) {
+		const file = readFileSync(new URL(`../docker/compose.${stack}.yaml`, import.meta.url), "utf8");
+		const routers = [...file.matchAll(/traefik\.http\.routers\.(https-[a-z-]+)\.rule=/g)].map(
+			([, name]) => name,
+		);
+		assert.ok(routers.length > 0, `${stack} declares no https router`);
+		for (const router of routers) {
+			const attached = new RegExp(`routers\\.${router}\\.middlewares=([^"\n]*)`).exec(file)?.[1];
+			assert.ok(
+				attached?.includes("hsts"),
+				`${stack}/${router} would serve without HSTS behind a proxy that is not ours`,
+			);
+		}
+	}
+});


### PR DESCRIPTION
## Problem

`security-headers` is attached to the proxy stack's https **entrypoint**, so it exists only where
that stack is the edge. Staging and every preview run behind Coolify's Traefik, where no entrypoint
middleware of ours exists — so they serve no `Strict-Transport-Security` at all.

Measured against the live staging response headers after the domain cutover:

```
content-security-policy: default-src 'self'; ...
x-content-type-options: nosniff
x-frame-options: DENY
(no strict-transport-security)
```

The gap is easy to miss precisely because everything else is present: the webapp's nginx sets CSP,
nosniff, frame-options, referrer-policy and permissions-policy on its own responses. HSTS is the one
header no response can meaningfully set for itself, so it is the only one that disappears — and it
disappears silently.

## What changed

The app and core stacks each define their own HSTS middleware and attach it to the routers they own,
for the same reason #1802 moved the request-body limits off the entrypoint: a stack must not depend
on the proxy stack being the thing in front of it. Behind the bundled proxy the header is set with
the same value it already had, so that deployment is unchanged.

## Verification

`scripts/compose-host-routing.test.ts` asserts every https router in the app and core stacks attaches
HSTS. I checked the test fails when the middleware is removed from a router — without that it would
only be restating the file:

```
app/https-webapp would serve without HSTS behind a proxy that is not ours
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - HSTS headers are now applied consistently to HTTPS application, API, and webhook traffic, including deployments behind alternate proxies.
  - HSTS policies include subdomains and a 30-day duration.

- **Tests**
  - Added coverage to verify that all HTTPS routes apply the required HSTS protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->