### PR TITLE
feat(ci): link a promotion's deployment to the environment it moved

### DIFF
--- a/.changeset/deployments-link-their-environment.md
+++ b/.changeset/deployments-link-their-environment.md
@@ -1,0 +1,7 @@
+---
+---
+
+No release note: this only changes what a promotion reports back to GitHub. A promotion's deployment
+now carries the address of the environment it moved, so the environments page links to the running
+instance instead of recording that something was deployed and leaving no way to reach it. Nothing an
+operator runs or an instance serves changes.

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -38,7 +38,13 @@ jobs:
   promote:
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    environment: ${{ inputs.environment }}
+    environment:
+      name: ${{ inputs.environment }}
+      # GitHub records this as the deployment's environment_url, on the status it writes when the
+      # job ends. A status posted from inside the job would be superseded by that one, so the URL
+      # has to come from here rather than from a step. It is a step output because APP_HOSTNAME is
+      # scoped to the environment being resolved.
+      url: ${{ steps.release.outputs.environment_url }}
     permissions:
       contents: write
       id-token: write
@@ -55,6 +61,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           REQUESTED: ${{ inputs.release }}
+          HOSTNAME: ${{ vars.APP_HOSTNAME }}
         run: |
           set -euo pipefail
           release="$REQUESTED"
@@ -67,6 +74,7 @@ jobs:
             echo "::error::$release is not immutable"; exit 1; }
           echo "release=$release" >> "$GITHUB_OUTPUT"
           echo "version=${release#v}" >> "$GITHUB_OUTPUT"
+          echo "environment_url=https://${HOSTNAME}" >> "$GITHUB_OUTPUT"
 
       - name: Write and sign the channel
         env:


### PR DESCRIPTION
## Problem

A job declaring `environment:` already gets a deployment record and `queued → in_progress → success`
statuses for free — Staging and Production have 100+ each. They just say nothing useful. The latest
Staging record, from the API:

```
ref=main   sha=2acc8cda4   description=null   payload={}
statuses:  state=success   environment_url=(empty)
```

So the environments page reports that Staging was deployed and offers no way to reach it.

## What changed

One line of intent: the job's environment now carries a `url`.

```yaml
environment:
  name: ${{ inputs.environment }}
  url: ${{ steps.release.outputs.environment_url }}
```

[GitHub maps `environment.url` onto `environment_url`](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idenvironment)
for every deployment status it writes, including the one at the end of the job — which is the status
the page displays, since
[GitHub tracks the most recent status](https://docs.github.com/en/rest/deployments/statuses) for each
deployment.

## Why not write the status ourselves

That was this PR's first attempt, and it could not have worked. A status posted from inside the job
is superseded moments later by the `success` GitHub writes when the job ends, which carries no URL.
Only a status written after the job — from a second job — would survive, and that is a lot of
machinery to reproduce a documented field.

The URL comes from a step output rather than `vars.APP_HOSTNAME` directly because that variable is
scoped to the very environment being resolved; `url` accepts the `steps` context, and this is the
shape GitHub's own example uses.

## What this does and does not tell you

| Question | Answered |
| --- | --- |
| Did the promotion succeed or fail? | Yes — the job's outcome becomes the deployment status |
| Where is this environment? | Yes — the page now links to it |
| Which release is running? | No — the record's ref is the workflow's branch, which GitHub owns |
| Is it *still* healthy later? | No — that is the reconciler's staleness metric, by design (ADR 0041) |