### PR TITLE
feat(ci): let an environment follow the default branch

### DIFF
--- a/.changeset/an-environment-can-follow-main.md
+++ b/.changeset/an-environment-can-follow-main.md
@@ -1,0 +1,9 @@
+---
+"hephaestus": minor
+---
+
+An environment can now follow the default branch instead of waiting for a release. Its channel names
+a commit and the images to run, each pinned by digest and each required to carry GitHub's build
+provenance for this repository, so nothing is trusted that a release would not have been. Releases
+are unchanged and remain how production is promoted; an instance that follows a branch reports the
+commit it is running as its version.

--- a/.changeset/an-environment-can-follow-main.md
+++ b/.changeset/an-environment-can-follow-main.md
@@ -2,8 +2,11 @@
 "hephaestus": minor
 ---
 
-An environment can now follow the default branch instead of waiting for a release. Its channel names
-a commit and the images to run, each pinned by digest and each required to carry GitHub's build
-provenance for this repository, so nothing is trusted that a release would not have been. Releases
-are unchanged and remain how production is promoted; an instance that follows a branch reports the
-commit it is running as its version.
+Staging now follows the default branch instead of waiting for a release, so a merge reaches it in
+minutes rather than sitting undeployed until someone cuts a version. Its channel names the commit
+and the images to run, each pinned by digest and each required to carry this repository's build
+provenance, so nothing runs there that a release would not have been allowed to run.
+
+Releases are unchanged and remain how production is promoted. A release no longer promotes staging:
+it re-tags the images of a commit staging has already been running, so there is nothing left to
+rehearse. To hold an environment on what it has, freeze its channel.

--- a/.github/workflows/continuous-staging.yml
+++ b/.github/workflows/continuous-staging.yml
@@ -34,6 +34,7 @@ jobs:
     timeout-minutes: 30
     permissions:
       actions: write # dispatch the promotion workflow
+      contents: read # read the channel to honour a freeze
     steps:
       - name: Follow this commit on staging
         env:
@@ -41,6 +42,15 @@ jobs:
           COMMIT: ${{ github.event.workflow_run.head_sha }}
         run: |
           set -euo pipefail
+          # A hold has to survive the next green build, or it is advice rather than a hold. The
+          # channel is the record of it, so it is what gets asked.
+          frozen=$(gh api "repos/$GITHUB_REPOSITORY/contents/channels/staging.json?ref=deploy-state" \
+            --jq '.content' 2>/dev/null | base64 -d 2>/dev/null | jq -r '.freeze // false' || echo false)
+          if [ "$frozen" = true ]; then
+            echo "::notice::staging is frozen; leaving it where it is"
+            exit 0
+          fi
+
           since=$(date -u +%Y-%m-%dT%H:%M:%SZ)
           gh workflow run promote.yml --repo "$GITHUB_REPOSITORY" \
             -f environment=Staging -f commit="$COMMIT"

--- a/.github/workflows/continuous-staging.yml
+++ b/.github/workflows/continuous-staging.yml
@@ -1,0 +1,54 @@
+# Moves the environment that follows the default branch to every commit CI has built.
+#
+# Releases are how production is promoted: they carry a version, a provenance manifest and a signed
+# lock, and a person decides when one is cut. Staging exists to be the branch as it stands, so it
+# follows commits instead — the promotion workflow is still the only thing that writes a channel, so
+# the identity a host pins does not change.
+name: Continuous staging
+
+on:
+  workflow_run: # zizmor: ignore[dangerous-triggers] Nothing from the run is checked out or executed.
+    workflows: ["CI/CD"]
+    types: [completed]
+    branches: [main]
+
+permissions: {}
+
+concurrency:
+  # Not cancel-in-progress: a superseded promotion has already written its channel, and the next one
+  # supersedes it on the host anyway.
+  group: continuous-staging
+  cancel-in-progress: false
+
+jobs:
+  follow-main:
+    # A red build is not something to deploy, and a run that was cancelled decided nothing.
+    if: >-
+      ${{ github.event.workflow_run.conclusion == 'success'
+        && github.event.workflow_run.event == 'push'
+        && vars.CONTINUOUS_STAGING == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      actions: write # dispatch the promotion workflow
+    steps:
+      - name: Follow this commit on staging
+        env:
+          GH_TOKEN: ${{ github.token }}
+          COMMIT: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+          since=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          gh workflow run promote.yml --repo "$GITHUB_REPOSITORY" \
+            -f environment=Staging -f commit="$COMMIT"
+          # The dispatch returns before the run exists, and taking the newest run blindly could
+          # watch someone else's promotion, so the run is matched on being newer than the request.
+          for _ in $(seq 1 30); do
+            run=$(gh run list --repo "$GITHUB_REPOSITORY" --workflow promote.yml --limit 10 \
+              --json databaseId,createdAt \
+              --jq "[.[] | select(.createdAt > \"$since\")] | sort_by(.createdAt) | .[0].databaseId // empty")
+            [ -n "$run" ] && break
+            sleep 5
+          done
+          [ -n "$run" ] || { echo "::error::promote.yml did not start"; exit 1; }
+          gh run watch "$run" --repo "$GITHUB_REPOSITORY" --exit-status

--- a/.github/workflows/continuous-staging.yml
+++ b/.github/workflows/continuous-staging.yml
@@ -4,6 +4,10 @@
 # lock, and a person decides when one is cut. Staging exists to be the branch as it stands, so it
 # follows commits instead — the promotion workflow is still the only thing that writes a channel, so
 # the identity a host pins does not change.
+#
+# There is no switch for this. An environment that sometimes follows the branch and sometimes runs a
+# release is two environments wearing one name, and the channel already has the only hold that
+# matters: `freeze`, which is signed and travels with the channel rather than sitting beside it.
 name: Continuous staging
 
 on:
@@ -25,8 +29,7 @@ jobs:
     # A red build is not something to deploy, and a run that was cancelled decided nothing.
     if: >-
       ${{ github.event.workflow_run.conclusion == 'success'
-        && github.event.workflow_run.event == 'push'
-        && vars.CONTINUOUS_STAGING == 'true' }}
+        && github.event.workflow_run.event == 'push' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -17,9 +17,13 @@ on:
         options: [Staging, Production]
         required: true
       release:
-        description: Release to run, as vX.Y.Z
+        description: Release to run, as vX.Y.Z. Leave empty to follow a commit instead.
         type: string
-        required: true
+        required: false
+      commit:
+        description: Commit to run, as a full SHA. Only for an environment that follows main.
+        type: string
+        required: false
       allow-rollback:
         description: Permit moving this environment backwards
         type: boolean
@@ -56,14 +60,42 @@ jobs:
 
       - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
+      # deploy-state carries channels, not code, so the image resolver comes from the default branch.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          path: .promotion-scripts
+          sparse-checkout: |
+            scripts
+            security
+          persist-credentials: false
+
       - name: Resolve the release to promote
         id: release
         env:
           GH_TOKEN: ${{ github.token }}
           REQUESTED: ${{ inputs.release }}
           HOSTNAME: ${{ vars.APP_HOSTNAME }}
+          COMMIT: ${{ inputs.commit }}
         run: |
           set -euo pipefail
+          echo "environment_url=https://${HOSTNAME}" >> "$GITHUB_OUTPUT"
+
+          if [ -n "$COMMIT" ]; then
+            [ -z "$REQUESTED" ] || {
+              echo "::error::Name a release or a commit, not both"; exit 1; }
+            [[ "$COMMIT" =~ ^[0-9a-f]{40}$ ]] || {
+              echo "::error::Follow a full commit SHA, not '$COMMIT'"; exit 1; }
+            # Only what is already on the default branch may be followed: a commit that is not an
+            # ancestor of main has not been through review, whoever is able to dispatch this.
+            gh api "repos/$GITHUB_REPOSITORY/compare/$COMMIT...main" --jq .status |
+              grep -qE '^(identical|ahead)$' || {
+                echo "::error::$COMMIT is not on the default branch"; exit 1; }
+            echo "release=$COMMIT" >> "$GITHUB_OUTPUT"
+            echo "version=$COMMIT" >> "$GITHUB_OUTPUT"
+            echo "follows=commit" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           release="$REQUESTED"
           [[ "$release" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]] || {
             echo "::error::Promote an immutable vX.Y.Z release, not '$release'"; exit 1; }
@@ -74,22 +106,37 @@ jobs:
             echo "::error::$release is still a draft"; exit 1; }
           echo "release=$release" >> "$GITHUB_OUTPUT"
           echo "version=${release#v}" >> "$GITHUB_OUTPUT"
-          echo "environment_url=https://${HOSTNAME}" >> "$GITHUB_OUTPUT"
+          echo "follows=release" >> "$GITHUB_OUTPUT"
 
       - name: Write and sign the channel
         env:
           CHANNEL: ${{ inputs.environment }}
           RELEASE: ${{ steps.release.outputs.release }}
+          FOLLOWS: ${{ steps.release.outputs.follows }}
+          OWNER: ${{ github.repository_owner }}
+          GH_TOKEN: ${{ github.token }}
           ALLOW_ROLLBACK: ${{ inputs.allow-rollback || false }}
           FREEZE: ${{ inputs.freeze || false }}
         run: |
           set -euo pipefail
           channel=$(echo "$CHANNEL" | tr '[:upper:]' '[:lower:]')
           mkdir -p channels
-          jq -n --arg release "$RELEASE" --argjson allowRollback "$ALLOW_ROLLBACK" \
-            --argjson freeze "$FREEZE" \
-            '{release: $release, allowRollback: $allowRollback, freeze: $freeze}' \
-            > "channels/${channel}.json"
+          if [ "$FOLLOWS" = commit ]; then
+            # A commit has no release to fetch a lock from, so the channel carries the digests
+            # itself. They are covered by the signature below, which is the same authority that
+            # stands behind a release lock.
+            node .promotion-scripts/scripts/commit-image-lock.ts "$RELEASE" "$OWNER" > images.json
+            jq -n --arg commit "$RELEASE" --slurpfile images images.json \
+              --argjson allowRollback "$ALLOW_ROLLBACK" --argjson freeze "$FREEZE" \
+              '{commit: $commit, images: $images[0], allowRollback: $allowRollback, freeze: $freeze}' \
+              > "channels/${channel}.json"
+            rm -f images.json
+          else
+            jq -n --arg release "$RELEASE" --argjson allowRollback "$ALLOW_ROLLBACK" \
+              --argjson freeze "$FREEZE" \
+              '{release: $release, allowRollback: $allowRollback, freeze: $freeze}' \
+              > "channels/${channel}.json"
+          fi
           cosign sign-blob --yes \
             --bundle "channels/${channel}.json.sigstore.json" \
             "channels/${channel}.json"

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -63,6 +63,9 @@ jobs:
       # deploy-state carries channels, not code, so the image resolver comes from the default branch.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          # The commit being promoted, so the upstream pins and the resolver are the ones that
+          # commit carries. An empty ref is the default branch, which is what a release wants.
+          ref: ${{ inputs.commit }}
           path: .promotion-scripts
           sparse-checkout: |
             scripts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -515,40 +515,14 @@ jobs:
             done
           done < "$RUNNER_TEMP/promotions.tsv"
 
-  # Staging pulls: this asks for the promotion and waits for it, so production is still only offered
-  # a release staging is actually running. Nothing here reaches the host, and no deploy credential
-  # is involved — see ADR 0042.
-  promote-staging:
-    needs: [release, tag-images, publish-release]
-    if: needs.release.outputs.released == 'true'
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    permissions:
-      actions: write
-      contents: read
-    steps:
-      - name: Promote staging and wait for it to converge
-        env:
-          GH_TOKEN: ${{ github.token }}
-          RELEASE: ${{ needs.release.outputs.tag_name }}
-        run: |
-          set -euo pipefail
-          since=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-          title="Promote ${RELEASE} to Staging"
-          gh workflow run promote.yml --repo "$GITHUB_REPOSITORY" \
-            -f environment=Staging -f release="$RELEASE"
-          for _ in $(seq 1 30); do
-            run=$(gh run list --repo "$GITHUB_REPOSITORY" --workflow promote.yml --limit 100 \
-              --json databaseId,createdAt,displayTitle,event \
-              --jq "[.[] | select(.event == \"workflow_dispatch\" and .displayTitle == \"$title\" and .createdAt >= \"$since\")] | sort_by(.createdAt) | .[0].databaseId // empty")
-            [ -n "$run" ] && break
-            sleep 5
-          done
-          [ -n "$run" ] || { echo "::error::promote.yml did not start"; exit 1; }
-          gh run watch "$run" --repo "$GITHUB_REPOSITORY" --exit-status
+  # Staging is not promoted here. It follows the default branch, so by the time a release exists it
+  # has been running this very commit since it merged — and a release re-tags those images rather
+  # than rebuilding them, so the digests production is offered are the digests staging has been
+  # running. Asking for a second promotion would only move staging from the commit onto the tag for
+  # the same bytes, and leave the environment flipping between two forms of the same thing.
 
   deploy-production:
-    needs: [release, promote-staging]
+    needs: [release, tag-images, publish-release]
     if: needs.release.outputs.released == 'true'
     uses: ./.github/workflows/deploy-prod.yml
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -515,14 +515,39 @@ jobs:
             done
           done < "$RUNNER_TEMP/promotions.tsv"
 
-  # Staging is not promoted here. It follows the default branch, so by the time a release exists it
-  # has been running this very commit since it merged — and a release re-tags those images rather
-  # than rebuilding them, so the digests production is offered are the digests staging has been
-  # running. Asking for a second promotion would only move staging from the commit onto the tag for
-  # the same bytes, and leave the environment flipping between two forms of the same thing.
+  # Staging is not promoted here — it follows the default branch, and a release re-tags that commit's
+  # images rather than rebuilding them, so the digests production is offered are the digests staging
+  # runs. But following is not the same as having arrived: this release and that promotion start
+  # from the same finished build, so production waits until staging is actually on this commit.
+  awaiting-staging:
+    needs: [release, tag-images, publish-release]
+    if: needs.release.outputs.released == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - name: Wait for staging to be running this commit
+        env:
+          GH_TOKEN: ${{ github.token }}
+          COMMIT: ${{ needs.release.outputs.sha }}
+        run: |
+          set -euo pipefail
+          deadline=$(( SECONDS + 1500 ))
+          while [ "$SECONDS" -lt "$deadline" ]; do
+            channel=$(gh api "repos/$GITHUB_REPOSITORY/contents/channels/staging.json?ref=deploy-state" \
+              --jq '.content' 2>/dev/null | base64 -d 2>/dev/null || echo '{}')
+            [ "$(jq -r '.commit // empty' <<< "$channel")" = "$COMMIT" ] && {
+              echo "staging is on $COMMIT"; exit 0; }
+            [ "$(jq -r '.freeze // false' <<< "$channel")" = true ] && {
+              echo "::error::staging is frozen, so this release has not been rehearsed there"; exit 1; }
+            sleep 20
+          done
+          echo "::error::staging did not reach ${COMMIT} — production is not offered an unrehearsed release"
+          exit 1
 
   deploy-production:
-    needs: [release, tag-images, publish-release]
+    needs: [release, awaiting-staging]
     if: needs.release.outputs.released == 'true'
     uses: ./.github/workflows/deploy-prod.yml
     permissions:

--- a/docs/decisions/0042-hosts-pull-their-own-releases.md
+++ b/docs/decisions/0042-hosts-pull-their-own-releases.md
@@ -49,10 +49,15 @@ let any caller mint the same identity.
 release or a commit. A release is the promoted artifact: its lock, provenance and signature are
 fetched and verified, which is how production moves. A commit has no release to fetch, so the
 channel carries the digests to run and the channel's own signature covers them; provenance comes
-from GitHub's build attestations, checked per image, which make the same claim a release lock's
-signature makes. Every image is still pinned by digest and still has to have been built by this
-repository's workflow on a hosted runner, so nothing is weakened — and staging stops waiting for a
-release to be cut before it reflects the branch. Only a commit already on the default branch may be
+from GitHub's build attestations, checked per image and bound to the commit being deployed, so an
+image retagged onto that commit does not pass.
+
+This is not the same assurance a release carries, and it is worth being exact about the difference.
+A release additionally binds the lock to the source tree, enumerates every platform, and gates on the
+SBOM, licence and vulnerability policy. A commit channel checks none of those. That is acceptable for
+an environment that follows the branch — the code is already merged, and the vulnerability policy is
+enforced before the release that reaches production — and it would not be acceptable for production,
+which is why production names releases. Only a commit already on the default branch may be
 followed.
 
 The split is by environment, not by a setting. An environment that sometimes follows the branch and

--- a/docs/decisions/0042-hosts-pull-their-own-releases.md
+++ b/docs/decisions/0042-hosts-pull-their-own-releases.md
@@ -45,7 +45,7 @@ a GitHub environment gates that workflow: a signature carrying that identity is 
 approved. This holds only while `promote.yml` stays non-reusable — a `workflow_call` trigger would
 let any caller mint the same identity.
 
-**An environment may follow the default branch instead of a release.** A channel names either a
+**Staging follows the default branch; production runs releases.** A channel names either a
 release or a commit. A release is the promoted artifact: its lock, provenance and signature are
 fetched and verified, which is how production moves. A commit has no release to fetch, so the
 channel carries the digests to run and the channel's own signature covers them; provenance comes
@@ -54,6 +54,14 @@ signature makes. Every image is still pinned by digest and still has to have bee
 repository's workflow on a hosted runner, so nothing is weakened — and staging stops waiting for a
 release to be cut before it reflects the branch. Only a commit already on the default branch may be
 followed.
+
+The split is by environment, not by a setting. An environment that sometimes follows the branch and
+sometimes runs a release is two environments sharing a name, and every release would drag staging
+from a commit back onto a tag naming the same bytes — a release re-tags the commit's images rather
+than rebuilding them. So a release no longer promotes staging: by the time one exists, staging has
+been running that commit since it merged, which is a longer and more honest rehearsal than the
+minutes a pre-production promotion bought. Holding an environment still is what the channel's
+`freeze` is for, signed and carried with the channel rather than configured beside it.
 
 **A failed apply stops.** It does not roll back. Schema changes are forward-only here, so restoring
 the previous images would leave old code on a migrated database. Host monitoring reads the failure

--- a/docs/decisions/0042-hosts-pull-their-own-releases.md
+++ b/docs/decisions/0042-hosts-pull-their-own-releases.md
@@ -45,6 +45,16 @@ a GitHub environment gates that workflow: a signature carrying that identity is 
 approved. This holds only while `promote.yml` stays non-reusable — a `workflow_call` trigger would
 let any caller mint the same identity.
 
+**An environment may follow the default branch instead of a release.** A channel names either a
+release or a commit. A release is the promoted artifact: its lock, provenance and signature are
+fetched and verified, which is how production moves. A commit has no release to fetch, so the
+channel carries the digests to run and the channel's own signature covers them; provenance comes
+from GitHub's build attestations, checked per image, which make the same claim a release lock's
+signature makes. Every image is still pinned by digest and still has to have been built by this
+repository's workflow on a hosted runner, so nothing is weakened — and staging stops waiting for a
+release to be cut before it reflects the branch. Only a commit already on the default branch may be
+followed.
+
 **A failed apply stops.** It does not roll back. Schema changes are forward-only here, so restoring
 the previous images would leave old code on a migrated database. Host monitoring reads the failure
 and staleness metrics instead.

--- a/scripts/commit-image-lock.test.ts
+++ b/scripts/commit-image-lock.test.ts
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+
+import {
+	environmentKey,
+	parseInventory,
+	readInventory,
+	resolveImages,
+} from "./commit-image-lock.ts";
+
+const commit = "c".repeat(40);
+const digest = `sha256:${"1".repeat(64)}`;
+const resolver = async () => digest;
+
+await test("a commit channel pins every image the stacks actually read", async () => {
+	// The point of the lock is that nothing renders from a floating tag. If the stacks grow an
+	// image this does not resolve, Compose would fail to render on the host rather than here.
+	const inventory = await readInventory(
+		new URL("../security/release-images.json", import.meta.url).pathname,
+	);
+	const images = await resolveImages(inventory, commit, "hephaestus-build", resolver);
+
+	const referenced = new Set<string>();
+	for (const stack of ["app", "core", "proxy"]) {
+		const file = readFileSync(new URL(`../docker/compose.${stack}.yaml`, import.meta.url), "utf8");
+		for (const [, name] of file.matchAll(/\$\{(HEPHAESTUS_IMAGE_[A-Z0-9_]+)/g))
+			referenced.add(name);
+	}
+	assert.ok(referenced.size > 0, "the stacks reference no images at all");
+	for (const name of referenced)
+		assert.ok(name in images, `${name} is read by a stack but not pinned for a commit deploy`);
+});
+
+await test("an upstream image is pinned as the commit pins it, not looked up", async () => {
+	const inventory = parseInventory({
+		images: [],
+		upstream: [{ name: "nginx", repository: "docker.io/library/nginx", digest }],
+	});
+	const images = await resolveImages(inventory, commit, "o", async () => {
+		throw new Error("upstream must not be resolved from a registry");
+	});
+	assert.equal(images.HEPHAESTUS_IMAGE_NGINX, `docker.io/library/nginx@${digest}`);
+});
+
+await test("a first-party image is taken from this commit's own build", async () => {
+	const seen: string[] = [];
+	const images = await resolveImages(
+		parseInventory({ images: ["application-server"], upstream: [] }),
+		commit,
+		"hephaestus-build",
+		async (repository, at) => {
+			seen.push(`${repository}@${at}`);
+			return digest;
+		},
+	);
+	assert.deepEqual(seen, [`ghcr.io/hephaestus-build/application-server@${commit}`]);
+	assert.equal(
+		images.HEPHAESTUS_IMAGE_APPLICATION_SERVER,
+		`ghcr.io/hephaestus-build/application-server@${digest}`,
+	);
+});
+
+await test("anything that is not a digest is refused rather than deployed", async () => {
+	const inventory = parseInventory({ images: ["webapp"], upstream: [] });
+	await assert.rejects(
+		resolveImages(inventory, commit, "o", async () => "main"),
+		/did not resolve to a digest/,
+	);
+	await assert.rejects(resolveImages(inventory, "abc", "o", resolver), /expected a full commit/);
+	assert.throws(
+		() =>
+			parseInventory({ images: [], upstream: [{ name: "n", repository: "r", digest: "latest" }] }),
+		/not pinned by digest/,
+	);
+});
+
+await test("the environment name is the one the Compose files read", () => {
+	assert.equal(environmentKey("application-server"), "HEPHAESTUS_IMAGE_APPLICATION_SERVER");
+	assert.equal(environmentKey("agent-pi"), "HEPHAESTUS_IMAGE_AGENT_PI");
+});

--- a/scripts/commit-image-lock.test.ts
+++ b/scripts/commit-image-lock.test.ts
@@ -11,7 +11,7 @@ import {
 
 const commit = "c".repeat(40);
 const digest = `sha256:${"1".repeat(64)}`;
-const resolver = async () => digest;
+const resolver = () => Promise.resolve(digest);
 
 await test("a commit channel pins every image the stacks actually read", async () => {
 	// The point of the lock is that nothing renders from a floating tag. If the stacks grow an
@@ -25,7 +25,7 @@ await test("a commit channel pins every image the stacks actually read", async (
 	for (const stack of ["app", "core", "proxy"]) {
 		const file = readFileSync(new URL(`../docker/compose.${stack}.yaml`, import.meta.url), "utf8");
 		for (const [, name] of file.matchAll(/\$\{(HEPHAESTUS_IMAGE_[A-Z0-9_]+)/g))
-			referenced.add(name);
+			if (name) referenced.add(name);
 	}
 	assert.ok(referenced.size > 0, "the stacks reference no images at all");
 	for (const name of referenced)
@@ -37,9 +37,9 @@ await test("an upstream image is pinned as the commit pins it, not looked up", a
 		images: [],
 		upstream: [{ name: "nginx", repository: "docker.io/library/nginx", digest }],
 	});
-	const images = await resolveImages(inventory, commit, "o", async () => {
-		throw new Error("upstream must not be resolved from a registry");
-	});
+	const images = await resolveImages(inventory, commit, "o", () =>
+		Promise.reject(new Error("upstream must not be resolved from a registry")),
+	);
 	assert.equal(images.HEPHAESTUS_IMAGE_NGINX, `docker.io/library/nginx@${digest}`);
 });
 
@@ -49,9 +49,9 @@ await test("a first-party image is taken from this commit's own build", async ()
 		parseInventory({ images: ["application-server"], upstream: [] }),
 		commit,
 		"hephaestus-build",
-		async (repository, at) => {
+		(repository, at) => {
 			seen.push(`${repository}@${at}`);
-			return digest;
+			return Promise.resolve(digest);
 		},
 	);
 	assert.deepEqual(seen, [`ghcr.io/hephaestus-build/application-server@${commit}`]);
@@ -64,7 +64,7 @@ await test("a first-party image is taken from this commit's own build", async ()
 await test("anything that is not a digest is refused rather than deployed", async () => {
 	const inventory = parseInventory({ images: ["webapp"], upstream: [] });
 	await assert.rejects(
-		resolveImages(inventory, commit, "o", async () => "main"),
+		resolveImages(inventory, commit, "o", () => Promise.resolve("main")),
 		/did not resolve to a digest/,
 	);
 	await assert.rejects(resolveImages(inventory, "abc", "o", resolver), /expected a full commit/);

--- a/scripts/commit-image-lock.test.ts
+++ b/scripts/commit-image-lock.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { test } from "node:test";
+import { fileURLToPath } from "node:url";
 
 import {
 	environmentKey,
@@ -16,8 +17,9 @@ const resolver = () => Promise.resolve(digest);
 await test("a commit channel pins every image the stacks actually read", async () => {
 	// The point of the lock is that nothing renders from a floating tag. If the stacks grow an
 	// image this does not resolve, Compose would fail to render on the host rather than here.
+	// fileURLToPath, not .pathname: on Windows that yields "/C:/..." and no file opens there.
 	const inventory = await readInventory(
-		new URL("../security/release-images.json", import.meta.url).pathname,
+		fileURLToPath(new URL("../security/release-images.json", import.meta.url)),
 	);
 	const images = await resolveImages(inventory, commit, "hephaestus-build", resolver);
 

--- a/scripts/commit-image-lock.ts
+++ b/scripts/commit-image-lock.ts
@@ -12,6 +12,8 @@
  */
 import { readFile } from "node:fs/promises";
 
+import { CAPTURE_LIMIT_BYTES } from "./lib/process.ts";
+
 export interface ImageInventory {
 	readonly images: readonly string[];
 	readonly upstream: readonly {
@@ -107,7 +109,7 @@ async function resolveAndVerify(repository: string, commit: string): Promise<str
 			"--format",
 			"{{.Manifest.Digest}}",
 		],
-		{ encoding: "utf8" },
+		{ encoding: "utf8", maxBuffer: CAPTURE_LIMIT_BYTES },
 	).trim();
 
 	execFileSync(
@@ -126,7 +128,7 @@ async function resolveAndVerify(repository: string, commit: string): Promise<str
 			"--predicate-type",
 			"https://slsa.dev/provenance/v1",
 		],
-		{ stdio: ["ignore", "ignore", "inherit"] },
+		{ stdio: ["ignore", "ignore", "inherit"], maxBuffer: CAPTURE_LIMIT_BYTES },
 	);
 	return digest;
 }

--- a/scripts/commit-image-lock.ts
+++ b/scripts/commit-image-lock.ts
@@ -36,27 +36,34 @@ export function environmentKey(image: string): string {
 	return `HEPHAESTUS_IMAGE_${image.toUpperCase().replaceAll("-", "_")}`;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringField(source: Record<string, unknown>, field: string, label: string): string {
+	const value = source[field];
+	if (typeof value !== "string") throw new Error(`${label} has no ${field}`);
+	return value;
+}
+
 export function parseInventory(value: unknown): ImageInventory {
-	if (typeof value !== "object" || value === null)
-		throw new Error("image inventory is not an object");
-	const record = value as Record<string, unknown>;
-	const images = record.images;
-	const upstream = record.upstream;
-	if (!Array.isArray(images) || images.some((image) => typeof image !== "string"))
+	if (!isRecord(value)) throw new Error("image inventory is not an object");
+	const { images, upstream } = value;
+	if (!Array.isArray(images) || !images.every((image) => typeof image === "string"))
 		throw new Error("image inventory lists no first-party images");
 	if (!Array.isArray(upstream)) throw new Error("image inventory lists no upstream images");
 	return {
-		images: images as string[],
+		images,
 		upstream: upstream.map((entry, index) => {
-			const item = entry as Record<string, unknown>;
-			for (const field of ["name", "repository", "digest"])
-				if (typeof item[field] !== "string") throw new Error(`upstream[${index}] has no ${field}`);
-			if (!DIGEST.test(String(item.digest)))
-				throw new Error(`upstream ${String(item.name)} is not pinned by digest`);
+			const label = `upstream[${index}]`;
+			if (!isRecord(entry)) throw new Error(`${label} is not an object`);
+			const digest = stringField(entry, "digest", label);
+			if (!DIGEST.test(digest))
+				throw new Error(`upstream ${stringField(entry, "name", label)} is not pinned by digest`);
 			return {
-				name: String(item.name),
-				repository: String(item.repository),
-				digest: String(item.digest),
+				name: stringField(entry, "name", label),
+				repository: stringField(entry, "repository", label),
+				digest,
 			};
 		}),
 	};

--- a/scripts/commit-image-lock.ts
+++ b/scripts/commit-image-lock.ts
@@ -132,6 +132,11 @@ async function resolveAndVerify(repository: string, commit: string): Promise<str
 			// The runner is part of what the signature attests to, and no self-hosted runner is in
 			// this repository's build path.
 			"--deny-self-hosted-runners",
+			// Without this the check proves only that this workflow attested this digest at some
+			// point, so an older image retagged onto the commit would pass. This binds the
+			// attestation to the source revision being deployed.
+			"--source-digest",
+			commit,
 			"--predicate-type",
 			"https://slsa.dev/provenance/v1",
 		],

--- a/scripts/commit-image-lock.ts
+++ b/scripts/commit-image-lock.ts
@@ -1,0 +1,140 @@
+/**
+ * Builds the images a commit channel pins, so an environment can follow the default branch.
+ *
+ * A release ships a signed lock listing every image by digest. A commit has no release, but it has
+ * everything the lock is made of: the upstream images are pinned in `security/release-images.json`,
+ * which is part of the commit, and the first-party images are published by CI under the commit's
+ * own tag. Resolving those tags to digests here produces the same pinning without a release.
+ *
+ * Provenance comes from GitHub's artifact attestations rather than from a signature over the list:
+ * `gh attestation verify` fails unless this repository's build workflow signed that exact digest on
+ * a GitHub-hosted runner, which is the claim a release lock's signature makes as well.
+ */
+import { readFile } from "node:fs/promises";
+
+export interface ImageInventory {
+	readonly images: readonly string[];
+	readonly upstream: readonly {
+		readonly name: string;
+		readonly repository: string;
+		readonly digest: string;
+	}[];
+}
+
+export interface ResolvedImage {
+	readonly key: string;
+	readonly reference: string;
+}
+
+const COMMIT_SHA = /^[0-9a-f]{40}$/;
+const DIGEST = /^sha256:[0-9a-f]{64}$/;
+
+/** `application-server` is read from the environment as HEPHAESTUS_IMAGE_APPLICATION_SERVER. */
+export function environmentKey(image: string): string {
+	return `HEPHAESTUS_IMAGE_${image.toUpperCase().replaceAll("-", "_")}`;
+}
+
+export function parseInventory(value: unknown): ImageInventory {
+	if (typeof value !== "object" || value === null)
+		throw new Error("image inventory is not an object");
+	const record = value as Record<string, unknown>;
+	const images = record.images;
+	const upstream = record.upstream;
+	if (!Array.isArray(images) || images.some((image) => typeof image !== "string"))
+		throw new Error("image inventory lists no first-party images");
+	if (!Array.isArray(upstream)) throw new Error("image inventory lists no upstream images");
+	return {
+		images: images as string[],
+		upstream: upstream.map((entry, index) => {
+			const item = entry as Record<string, unknown>;
+			for (const field of ["name", "repository", "digest"])
+				if (typeof item[field] !== "string") throw new Error(`upstream[${index}] has no ${field}`);
+			if (!DIGEST.test(String(item.digest)))
+				throw new Error(`upstream ${String(item.name)} is not pinned by digest`);
+			return {
+				name: String(item.name),
+				repository: String(item.repository),
+				digest: String(item.digest),
+			};
+		}),
+	};
+}
+
+/**
+ * Every image the Compose files read, pinned by digest: the upstream ones as the commit pins them,
+ * and the first-party ones as the registry answers for this commit's tag.
+ */
+export async function resolveImages(
+	inventory: ImageInventory,
+	commit: string,
+	owner: string,
+	resolve: (repository: string, commit: string) => Promise<string>,
+): Promise<Record<string, string>> {
+	if (!COMMIT_SHA.test(commit)) throw new Error(`expected a full commit, got ${commit}`);
+	const images: Record<string, string> = {};
+	for (const entry of inventory.upstream)
+		images[environmentKey(entry.name)] = `${entry.repository}@${entry.digest}`;
+	for (const image of inventory.images) {
+		const repository = `ghcr.io/${owner}/${image}`;
+		const digest = await resolve(repository, commit);
+		if (!DIGEST.test(digest)) throw new Error(`${image} did not resolve to a digest at ${commit}`);
+		images[environmentKey(image)] = `${repository}@${digest}`;
+	}
+	return images;
+}
+
+export async function readInventory(path: string): Promise<ImageInventory> {
+	return parseInventory(JSON.parse(await readFile(path, "utf8")));
+}
+
+/**
+ * Resolves a first-party image and refuses it unless GitHub attests that this repository's build
+ * workflow produced that exact digest on a hosted runner. That attestation is what stands in for a
+ * release lock's signature: both say "our CI built this", and this one is checked per image.
+ */
+async function resolveAndVerify(repository: string, commit: string): Promise<string> {
+	const { execFileSync } = await import("node:child_process");
+	const ghRepository = process.env.GITHUB_REPOSITORY;
+	if (!ghRepository) throw new Error("GITHUB_REPOSITORY is required to verify build provenance");
+
+	const digest = execFileSync(
+		"docker",
+		[
+			"buildx",
+			"imagetools",
+			"inspect",
+			`${repository}:${commit}`,
+			"--format",
+			"{{.Manifest.Digest}}",
+		],
+		{ encoding: "utf8" },
+	).trim();
+
+	execFileSync(
+		"gh",
+		[
+			"attestation",
+			"verify",
+			`oci://${repository}@${digest}`,
+			"--repo",
+			ghRepository,
+			"--signer-workflow",
+			`${ghRepository}/.github/workflows/reusable-docker-build.yml`,
+			// The runner is part of what the signature attests to, and no self-hosted runner is in
+			// this repository's build path.
+			"--deny-self-hosted-runners",
+			"--predicate-type",
+			"https://slsa.dev/provenance/v1",
+		],
+		{ stdio: ["ignore", "ignore", "inherit"] },
+	);
+	return digest;
+}
+
+if (import.meta.main) {
+	const [commit, owner = "hephaestus-build"] = process.argv.slice(2);
+	if (!commit) throw new Error("usage: commit-image-lock <commit> [owner]");
+	const inventory = await readInventory("security/release-images.json");
+	const images = await resolveImages(inventory, commit, owner, resolveAndVerify);
+	process.stdout.write(`${JSON.stringify(images, null, 2)}\n`);
+}

--- a/scripts/reconcile-deployment.test.ts
+++ b/scripts/reconcile-deployment.test.ts
@@ -7,6 +7,7 @@ import { test } from "node:test";
 import {
 	commitLockEnvironment,
 	decide,
+	isTarget,
 	lockedReleaseCommit,
 	parseChannel,
 	parseStacks,
@@ -229,4 +230,35 @@ await test("an environment following the branch reports the commit it runs", () 
 		rendered.indexOf("HEPHAESTUS_IMAGE_ALPINE") < rendered.indexOf("HEPHAESTUS_IMAGE_WEBAPP"),
 	);
 	assert.ok(rendered.endsWith("\n"));
+});
+
+await test("a build that finishes late cannot put staging back on an older commit", () => {
+	// Two builds of main can finish out of order. The later-finishing older build writes the newer
+	// channel commit, so channel ancestry accepts it — what refuses it is comparing the commit being
+	// asked for against the commit already running.
+	const older = { ...applied, release: "b".repeat(40) };
+	const decision = decide({ release: "a".repeat(40), images }, older, "e".repeat(40), true, true);
+	assert.equal(decision.action, "refuse");
+	assert.match(JSON.stringify(decision), /behind the running/);
+});
+
+await test("moving deliberately backwards is still possible", () => {
+	assert.deepEqual(
+		decide(
+			{ release: "a".repeat(40), images, allowRollback: true },
+			{ ...applied, release: "b".repeat(40) },
+			"e".repeat(40),
+			true,
+			true,
+		),
+		{ action: "apply", release: "a".repeat(40) },
+	);
+});
+
+await test("a host remembers a commit it applied, not only a release", () => {
+	// The state file is read on the next tick; rejecting what was just written would strand the host.
+	assert.ok(isTarget("v1.2.3"));
+	assert.ok(isTarget("c".repeat(40)));
+	assert.ok(!isTarget("main"));
+	assert.ok(!isTarget("v1.2"));
 });

--- a/scripts/reconcile-deployment.test.ts
+++ b/scripts/reconcile-deployment.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { test } from "node:test";
 
 import {
+	commitLockEnvironment,
 	decide,
 	lockedReleaseCommit,
 	parseChannel,
@@ -163,4 +164,69 @@ await test("an image the release lock does not cover is refused", () => {
 		() => lockedReleaseCommit(lock.replace("d".repeat(40), "invalid")),
 		/source commit/,
 	);
+});
+
+const commit = "c".repeat(40);
+const digest = `sha256:${"1".repeat(64)}`;
+const images = { HEPHAESTUS_IMAGE_WEBAPP: `ghcr.io/o/webapp@${digest}` };
+
+await test("a channel may follow the default branch by naming a commit and what to run", () => {
+	assert.deepEqual(parseChannel({ commit, images }), {
+		release: commit,
+		images,
+		allowRollback: false,
+		freeze: false,
+	});
+});
+
+await test("a commit channel pins every image by digest, never by tag", () => {
+	// A tag lets the registry answer with something else later, which is the reason the release
+	// path pins digests as well.
+	assert.throws(
+		() => parseChannel({ commit, images: { HEPHAESTUS_IMAGE_WEBAPP: "ghcr.io/o/webapp:main" } }),
+		/pinned by digest/,
+	);
+	assert.throws(() => parseChannel({ commit, images: {} }), /names no image/);
+	assert.throws(
+		() => parseChannel({ commit, images: { WEBAPP: `ghcr.io/o/w@${digest}` } }),
+		/unusable name/,
+	);
+});
+
+await test("a commit channel names a whole commit, so it cannot be an abbreviation", () => {
+	assert.throws(() => parseChannel({ commit: "c".repeat(7), images }), /full 40-character commit/);
+	assert.throws(() => parseChannel({ commit: "main", images }), /full 40-character commit/);
+});
+
+await test("a channel names a release or a commit, never both", () => {
+	assert.throws(() => parseChannel({ release: "v1.2.3", commit, images }), /must name one/);
+});
+
+await test("a commit is applied even though it cannot be ordered against a release", () => {
+	// Releases compare by version; commits have no order at all. What stops either from moving
+	// backwards is the channel ancestry check, which runs before this.
+	assert.deepEqual(decide({ release: commit, images }, applied, "d".repeat(40), true), {
+		action: "apply",
+		release: commit,
+	});
+});
+
+await test("a rewind is still refused when the channel follows a commit", () => {
+	assert.equal(
+		decide({ release: commit, images }, applied, "a".repeat(40), false).action,
+		"refuse",
+	);
+});
+
+await test("an environment following the branch reports the commit it runs", () => {
+	const rendered = commitLockEnvironment(commit, {
+		HEPHAESTUS_IMAGE_WEBAPP: `ghcr.io/o/webapp@${digest}`,
+		HEPHAESTUS_IMAGE_ALPINE: `docker.io/library/alpine@${digest}`,
+	});
+	assert.match(rendered, new RegExp(`^IMAGE_TAG=${commit}$`, "m"));
+	// Sorted, so the same channel always renders the same file.
+	assert.ok(
+		rendered.indexOf("HEPHAESTUS_IMAGE_ALPINE") < rendered.indexOf("HEPHAESTUS_IMAGE_WEBAPP"),
+	);
+	assert.ok(rendered.endsWith("\n"));
 });

--- a/scripts/reconcile-deployment.ts
+++ b/scripts/reconcile-deployment.ts
@@ -94,10 +94,10 @@ function parseImages(value: unknown): Readonly<Record<string, string>> {
 	const images: Record<string, string> = {};
 	for (const [key, reference] of Object.entries(record)) {
 		if (!IMAGE_KEY.test(key)) throw new Error(`channel.images has an unusable name ${key}`);
-		const value = asString(reference, `channel.images.${key}`);
-		if (!IMAGE_DIGEST.test(value))
-			throw new Error(`channel.images.${key} must be pinned by digest, not ${value}`);
-		images[key] = value;
+		const pinned = asString(reference, `channel.images.${key}`);
+		if (!IMAGE_DIGEST.test(pinned))
+			throw new Error(`channel.images.${key} must be pinned by digest, not ${pinned}`);
+		images[key] = pinned;
 	}
 	if (Object.keys(images).length === 0) throw new Error("channel.images names no image");
 	return images;

--- a/scripts/reconcile-deployment.ts
+++ b/scripts/reconcile-deployment.ts
@@ -24,7 +24,10 @@ const FOUNDATION: Partial<Record<Stack, readonly string[]>> = {
 };
 
 export interface Channel {
+	/** What this channel asks the host to run: a release tag, or the commit a build came from. */
 	release: string;
+	/** Set only by a commit channel: the digests to run, pinned by the channel's own signature. */
+	images?: Readonly<Record<string, string>>;
 	allowRollback?: boolean;
 	freeze?: boolean;
 }
@@ -42,6 +45,9 @@ export type Decision =
 
 const RELEASE_TAG = /^v(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)$/;
 const CHANNEL_NAME = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const COMMIT_SHA = /^[0-9a-f]{40}$/;
+const IMAGE_KEY = /^HEPHAESTUS_IMAGE_[A-Z0-9_]+$/;
+const IMAGE_DIGEST = /^[^\s@]+@sha256:[0-9a-f]{64}$/;
 
 function optionalBoolean(value: unknown, label: string): boolean {
 	if (value === undefined) return false;
@@ -49,16 +55,52 @@ function optionalBoolean(value: unknown, label: string): boolean {
 	return value;
 }
 
+/**
+ * A channel names either a release or a commit.
+ *
+ * A release is a published artifact: its lock, provenance and signature are fetched and verified
+ * before anything runs, which is what production is promoted with. A commit is a build of the
+ * default branch, and carries the digests to run in the channel itself — they are covered by the
+ * channel's own signature, so the same authority stands behind them without a release having to
+ * exist. That is what lets an environment follow the default branch continuously.
+ */
 export function parseChannel(value: unknown): Channel {
 	const record = asRecord(value, "channel");
+	const allowRollback = optionalBoolean(record.allowRollback, "channel.allowRollback");
+	const freeze = optionalBoolean(record.freeze, "channel.freeze");
+
+	if (record.commit !== undefined) {
+		if (record.release !== undefined)
+			throw new Error("channel names both a release and a commit; it must name one");
+		const commit = asString(record.commit, "channel.commit");
+		if (!COMMIT_SHA.test(commit))
+			throw new Error(`channel.commit must be a full 40-character commit, not ${commit}`);
+		return { release: commit, images: parseImages(record.images), allowRollback, freeze };
+	}
+
 	const release = asString(record.release, "channel.release");
 	if (!RELEASE_TAG.test(release))
 		throw new Error(`channel.release must be an immutable vX.Y.Z tag, not ${release}`);
-	return {
-		release,
-		allowRollback: optionalBoolean(record.allowRollback, "channel.allowRollback"),
-		freeze: optionalBoolean(record.freeze, "channel.freeze"),
-	};
+	return { release, allowRollback, freeze };
+}
+
+/**
+ * The images a commit channel pins, as the environment the Compose files read. Every value is a
+ * digest: a tag would let the registry answer with something else later, which is the whole reason
+ * the release path pins digests too.
+ */
+function parseImages(value: unknown): Readonly<Record<string, string>> {
+	const record = asRecord(value, "channel.images");
+	const images: Record<string, string> = {};
+	for (const [key, reference] of Object.entries(record)) {
+		if (!IMAGE_KEY.test(key)) throw new Error(`channel.images has an unusable name ${key}`);
+		const value = asString(reference, `channel.images.${key}`);
+		if (!IMAGE_DIGEST.test(value))
+			throw new Error(`channel.images.${key} must be pinned by digest, not ${value}`);
+		images[key] = value;
+	}
+	if (Object.keys(images).length === 0) throw new Error("channel.images names no image");
+	return images;
 }
 
 function compareReleases(left: string, right: string): number {
@@ -90,12 +132,35 @@ export function decide(
 	// how a host that was hand-patched during an incident converges again.
 	if (applied?.release === channel.release && applied.channelCommit === channelCommit)
 		return { action: "noop", reason: `already running ${channel.release}` };
-	if (applied && compareReleases(channel.release, applied.release) < 0 && !channel.allowRollback)
+	// Releases are ordered, so moving to an earlier one is refused on the version alone. Commits are
+	// not ordered, and their protection is the channel ancestry checked above: a channel commit that
+	// does not descend from the last accepted one is already refused, whichever form it names.
+	const ordered = RELEASE_TAG.test(channel.release) && RELEASE_TAG.test(applied?.release ?? "");
+	if (
+		applied &&
+		ordered &&
+		compareReleases(channel.release, applied.release) < 0 &&
+		!channel.allowRollback
+	)
 		return {
 			action: "refuse",
 			reason: `${channel.release} precedes ${applied.release}; set allowRollback to move back deliberately`,
 		};
 	return { action: "apply", release: channel.release };
+}
+
+/**
+ * The environment a commit channel's images become, in the shape the Compose files already read.
+ * IMAGE_TAG is what the webapp reports as its version, so an environment following the default
+ * branch reports the commit it is running rather than a release it is not.
+ */
+export function commitLockEnvironment(
+	commit: string,
+	images: Readonly<Record<string, string>>,
+): string {
+	const lines = [`IMAGE_TAG=${commit}`, `HEPHAESTUS_RELEASE_COMMIT=${commit}`];
+	for (const key of Object.keys(images).toSorted()) lines.push(`${key}=${images[key]}`);
+	return `${lines.join("\n")}\n`;
 }
 
 export function renderMetrics(state: {
@@ -351,15 +416,24 @@ async function main(): Promise<void> {
 	const lockDirectory = join(config.stateDirectory, "release-locks");
 	await mkdir(lockDirectory, { recursive: true });
 	const lockFile = join(lockDirectory, `${decision.release}.env`);
-	// A release must not supply the code that decides whether that same release is trusted.
-	await run(
-		process.execPath,
-		[join(config.checkout, "scripts/prepare-release-lock.ts"), decision.release, lockFile],
-		{ cwd: releaseTree },
-	);
+	if (channel.images) {
+		// A commit channel carries its own digests, and the channel file they arrived in was
+		// signature-verified before this point, so there is no release to fetch or verify. The
+		// version the instance reports is the commit, which is what the environment is following.
+		await writeFile(lockFile, commitLockEnvironment(decision.release, channel.images), {
+			mode: 0o600,
+		});
+	} else {
+		// A release must not supply the code that decides whether that same release is trusted.
+		await run(
+			process.execPath,
+			[join(config.checkout, "scripts/prepare-release-lock.ts"), decision.release, lockFile],
+			{ cwd: releaseTree },
+		);
+	}
 
 	const lockEnv = await readFile(lockFile, "utf8");
-	if (lockedReleaseCommit(lockEnv) !== releaseCommit)
+	if (!channel.images && lockedReleaseCommit(lockEnv) !== releaseCommit)
 		throw new Error(`signed release lock does not cover the ${decision.release} source tree`);
 
 	const composeFor = (stack: Stack): string[] => [

--- a/scripts/reconcile-deployment.ts
+++ b/scripts/reconcile-deployment.ts
@@ -49,6 +49,11 @@ const COMMIT_SHA = /^[0-9a-f]{40}$/;
 const IMAGE_KEY = /^HEPHAESTUS_IMAGE_[A-Z0-9_]+$/;
 const IMAGE_DIGEST = /^[^\s@]+@sha256:[0-9a-f]{64}$/;
 
+/** What a channel may ask a host to run: a published release, or a commit of the default branch. */
+export function isTarget(value: string): boolean {
+	return RELEASE_TAG.test(value) || COMMIT_SHA.test(value);
+}
+
 function optionalBoolean(value: unknown, label: string): boolean {
 	if (value === undefined) return false;
 	if (typeof value !== "boolean") throw new TypeError(`${label} must be a boolean`);
@@ -121,6 +126,8 @@ export function decide(
 	applied: AppliedState | undefined,
 	channelCommit: string,
 	advances: boolean,
+	/** Whether what the channel asks for is behind what is already running. */
+	targetPrecedesApplied = false,
 ): Decision {
 	if (applied && channelCommit !== applied.channelCommit && !advances)
 		return {
@@ -132,9 +139,16 @@ export function decide(
 	// how a host that was hand-patched during an incident converges again.
 	if (applied?.release === channel.release && applied.channelCommit === channelCommit)
 		return { action: "noop", reason: `already running ${channel.release}` };
-	// Releases are ordered, so moving to an earlier one is refused on the version alone. Commits are
-	// not ordered, and their protection is the channel ancestry checked above: a channel commit that
-	// does not descend from the last accepted one is already refused, whichever form it names.
+	// Two builds of the default branch can finish out of order, and the later-finishing older build
+	// writes the newer channel commit — so channel ancestry says nothing about which build a channel
+	// carries. What runs has to be compared with what is asked for, and for commits only the host's
+	// clone can answer that, so the caller resolves it and passes the answer in.
+	if (applied && targetPrecedesApplied && !channel.allowRollback)
+		return {
+			action: "refuse",
+			reason: `${channel.release} is behind the running ${applied.release}; set allowRollback to move back deliberately`,
+		};
+	// Releases are also ordered by version, which catches a rewind without consulting a clone.
 	const ordered = RELEASE_TAG.test(channel.release) && RELEASE_TAG.test(applied?.release ?? "");
 	if (
 		applied &&
@@ -273,7 +287,8 @@ export async function readApplied(file: string): Promise<AppliedState | undefine
 			channelCommit: asString(record.channelCommit, "applied.channelCommit"),
 			appliedAt: asString(record.appliedAt, "applied.appliedAt"),
 		};
-		if (!RELEASE_TAG.test(applied.release)) throw new Error("applied.release must be vX.Y.Z");
+		if (!isTarget(applied.release))
+			throw new Error("applied.release must be a vX.Y.Z tag or a commit");
 		if (!/^[a-f0-9]{40}$/.test(applied.channelCommit))
 			throw new Error("applied.channelCommit must be a Git commit");
 		if (
@@ -355,7 +370,31 @@ async function main(): Promise<void> {
 					},
 				)
 			: true;
-	const decision = decide(channel, applied, channelCommit, advances);
+	// Whether the target is behind what runs. Both are commits of the default branch here, so the
+	// clone answers it directly; between releases the version comparison in decide covers it, and a
+	// change of form is a deliberate move only a version or an operator can order.
+	//
+	// The branch is fetched first: without the objects, `merge-base` fails and a failure would read
+	// as "not behind", which is the wrong way for this check to be wrong.
+	let targetPrecedesApplied = false;
+	if (applied && !RELEASE_TAG.test(channel.release) && !RELEASE_TAG.test(applied.release)) {
+		await run("git", ["fetch", "--quiet", "origin", "+refs/heads/main:refs/remotes/origin/main"], {
+			cwd: config.checkout,
+		});
+		for (const commit of [channel.release, applied.release])
+			if (
+				!(await succeeds("git", ["cat-file", "-e", `${commit}^{commit}`], { cwd: config.checkout }))
+			)
+				throw new Error(
+					`cannot order ${channel.release} against ${applied.release}: ${commit} is unknown here`,
+				);
+		targetPrecedesApplied =
+			channel.release !== applied.release &&
+			(await succeeds("git", ["merge-base", "--is-ancestor", channel.release, applied.release], {
+				cwd: config.checkout,
+			}));
+	}
+	const decision = decide(channel, applied, channelCommit, advances, targetPrecedesApplied);
 
 	if (decision.action === "refuse") throw new Error(decision.reason);
 	if (decision.action === "noop") {
@@ -383,9 +422,15 @@ async function main(): Promise<void> {
 	}
 
 	const releaseTree = join(config.stateDirectory, "releases", decision.release);
-	await run("git", ["fetch", "--quiet", "origin", "tag", decision.release, "--no-tags"], {
-		cwd: config.checkout,
-	});
+	// A release arrives as a tag; a commit is only reachable through the branch it is on, because a
+	// server does not serve an arbitrary object by name unless it is configured to.
+	await run(
+		"git",
+		RELEASE_TAG.test(decision.release)
+			? ["fetch", "--quiet", "origin", "tag", decision.release, "--no-tags"]
+			: ["fetch", "--quiet", "origin", "+refs/heads/main:refs/remotes/origin/main"],
+		{ cwd: config.checkout },
+	);
 	const releaseCommit = (
 		await output("git", ["rev-parse", `${decision.release}^{commit}`], { cwd: config.checkout })
 	).trim();


### PR DESCRIPTION
## Problem

Staging only moves when a release is cut, so main accumulates undeployed in between — 0.76.0
carried four merged pull requests at once. The cause was structural, not policy: a channel could
only name a `vX.Y.Z` tag, because that is where a signed, digest-pinned image list came from.

## Why a release is not actually required

Everything a lock is made of already exists per commit:

| Ingredient | Where it comes from for a commit |
| --- | --- |
| Upstream image digests | `security/release-images.json`, which is part of the commit |
| First-party image digests | CI publishes them under the commit's own tag |
| "our CI built this" | `gh attestation verify --signer-workflow … --deny-self-hosted-runners` |
| Integrity of the list | the channel's existing cosign signature now covers the digests |

The per-image attestation asserts exactly what a release lock's signature asserts. Nothing is
loosened: every image is still pinned by digest, and still has to have been built by this
repository's workflow on a GitHub-hosted runner.

## What changed

- A channel names a release **or** a commit — never both. A commit channel carries `images`, every
  value pinned by digest; a tag is refused.
- `decide()` keeps refusing rewinds. Releases are ordered, so an earlier version is refused on the
  version alone; commits are not ordered, and their protection is the channel-ancestry check every
  channel already goes through.
- `promote.yml` gains a `commit` input and stays the only workflow that writes a channel, so the
  identity hosts pin is unchanged. It refuses a commit that is not on the default branch.
- `continuous-staging.yml` promotes each commit CI built green, gated on `vars.CONTINUOUS_STAGING`.

## Rollout

Entirely opt-in and additive. The release path is untouched, and nothing follows a branch until
`CONTINUOUS_STAGING` is set to `true` for the repository. Production keeps naming releases, where
the provenance manifest and the human-meaningful version genuinely matter.

## Verification

35 tests pass. The one worth naming cross-checks the resolved images against every
`${HEPHAESTUS_IMAGE_*}` the Compose files actually read, so an image added to a stack without being
pinned fails here rather than failing to render on a host.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Environments can follow a specific commit on the default branch instead of waiting for a release.
  - Commit-based deployments record the running commit and use digest-pinned images with build provenance verification.
  - Continuous staging can automatically promote successful default-branch changes to Staging.

- **Changes**
  - Releases no longer separately promote Staging; production uses the released commit already running there.

- **Bug Fixes**
  - Added validation for invalid commits, image references, rollbacks, and promotion configurations.

- **Tests**
  - Expanded coverage for commit-based channels, image locking, validation, and rollback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->