### PR TITLE
fix(config): point CODEOWNERS at a team that exists

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,32 +2,32 @@
 # Docs: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 # Default owners for everything in the repo
-* @ls1intum/hephaestus-maintainers
+* @hephaestus-build/maintainer
 
 # Release management and CI/CD
-.github/                         @ls1intum/hephaestus-maintainers
-.changeset/                      @ls1intum/hephaestus-maintainers
-CHANGELOG.md                     @ls1intum/hephaestus-maintainers
-commitlint.config.ts             @ls1intum/hephaestus-maintainers
-renovate.json                    @ls1intum/hephaestus-maintainers
+.github/                         @hephaestus-build/maintainer
+.changeset/                      @hephaestus-build/maintainer
+CHANGELOG.md                     @hephaestus-build/maintainer
+commitlint.config.ts             @hephaestus-build/maintainer
+renovate.json                    @hephaestus-build/maintainer
 
 # Application Server (Java/Spring)
-server/       @ls1intum/hephaestus-maintainers
+server/       @hephaestus-build/maintainer
 
 # Auth / identity (Account, IdentityLink, JWT issuance, oauth2Login) — see ADR 0017
-server/application/src/main/java/de/tum/cit/aet/hephaestus/core/auth/   @FelixTJDietrich @ls1intum/hephaestus-maintainers
+server/application/src/main/java/de/tum/cit/aet/hephaestus/core/auth/   @FelixTJDietrich @hephaestus-build/maintainer
 docs/decisions/0017-replace-keycloak-with-spring-native-auth.md   @FelixTJDietrich
 docs/auth-glossary.md            @FelixTJDietrich
 docs/auth-architecture.md        @FelixTJDietrich
 docs/runbooks/auth-cutover.md    @FelixTJDietrich
 
 # Webapp (React/TypeScript)
-webapp/                          @ls1intum/hephaestus-maintainers
+webapp/                          @hephaestus-build/maintainer
 
 # Documentation
-docs/                            @ls1intum/hephaestus-maintainers
+docs/                            @hephaestus-build/maintainer
 
 # Infrastructure
-docker/                          @ls1intum/hephaestus-maintainers
-**/Dockerfile                    @ls1intum/hephaestus-maintainers
-**/docker-compose*.yml           @ls1intum/hephaestus-maintainers
+docker/                          @hephaestus-build/maintainer
+**/Dockerfile                    @hephaestus-build/maintainer
+**/docker-compose*.yml           @hephaestus-build/maintainer


### PR DESCRIPTION
## What changed and why

Every rule in `.github/CODEOWNERS` owned to `@ls1intum/hephaestus-maintainers`, a team that does not
exist in this organization. GitHub resolved all 13 rules to nobody: automatic review assignment
silently assigned no reviewer, and the file itself carried an error banner. `gh api
repos/hephaestus-build/Hephaestus/codeowners/errors` on `main` returns 13 `Unknown owner` errors,
one per rule.

This organization's teams are exactly `maintainer` and `developer`
(`gh api orgs/hephaestus-build/teams`). `@hephaestus-build/maintainer` is the right owner: it is
visible (`privacy: closed`) and holds admin — so also write — on this repository
(`gh api orgs/hephaestus-build/teams/maintainer/repos`), which is what GitHub requires before it will
accept a team as a code owner.

Every `@ls1intum/hephaestus-maintainers` becomes `@hephaestus-build/maintainer`. Nothing else moves:
the ownership map, the rule order, the alignment and `@FelixTJDietrich`'s auth-path rules are
unchanged, so this is a rename of the owner and not a change to who owns what.

The `Default` ruleset has `require_code_owner_review: false`
(`gh api repos/hephaestus-build/Hephaestus/rulesets/1290597`), so ownership here is advisory: it
drives reviewer assignment and does not gate merging. Nothing was blocked by the broken file, and
nothing starts being blocked by the fixed one. Whether to make code-owner review required is a
ruleset decision that #1599 raises separately, and this PR does not take it.

Part of #1599.

## How to test

- All four `@FelixTJDietrich` paths still exist on `main`, so no rule was dropped:
  `docs/decisions/0017-replace-keycloak-with-spring-native-auth.md`, `docs/auth-glossary.md`,
  `docs/auth-architecture.md`, `docs/runbooks/auth-cutover.md`.
- `gh api "repos/hephaestus-build/Hephaestus/codeowners/errors?ref=fix/codeowners-team"` returns
  `{"errors":[]}`; the same call against `main` returns 13.
- `pnpm exec vp run check` — exit 0.

## Release impact

No changeset: this changes repository configuration only. Nothing ships, and no operator acts.

## Notes for reviewers

One follow-up this PR deliberately leaves alone, because it is a different concern and would change
who owns what: CODEOWNERS applies the *last* matching rule, so the `docs/` rule near the bottom
already overrides the three `docs/auth-*.md` and `docs/runbooks/auth-cutover.md` rules above it.
Those three lines were dead before this change and are dead after it, unchanged. Reordering them is
worth doing on its own.
