### PR TITLE
ci: fail the contract when a job declares no timeout

### DIFF
--- a/scripts/ci-contract.test.ts
+++ b/scripts/ci-contract.test.ts
@@ -1516,6 +1516,24 @@ void describe("CI contract", () => {
 			}
 		}
 	});
+
+	void test("bounds every job that runs steps of its own", async () => {
+		// A job that declares no `timeout-minutes` inherits GitHub's six-hour default, so one hung
+		// step holds a runner for a working day and reports nothing until it is killed. A job that
+		// only `uses:` a reusable workflow runs no step here: its bound is on the callee's jobs.
+		const unbounded: string[] = [];
+		for (const [file, source] of await workflowSources()) {
+			const jobs = parseDocument(source).get("jobs");
+			if (!isMap(jobs)) continue;
+			for (const entry of jobs.items) {
+				const definition = entry.value;
+				if (!isMap(definition) || !isSeq(definition.get("steps"))) continue;
+				if (definition.get("timeout-minutes") === undefined)
+					unbounded.push(`${file}#${String(entry.key)}`);
+			}
+		}
+		assert.deepEqual(unbounded, [], "these jobs run steps without bounding how long they may run");
+	});
 });
 
 void test("the task graph keeps its cache posture", async () => {


### PR DESCRIPTION
## What changed and why

#1600 established that every step-running job in `.github/workflows/**` declares `timeout-minutes`,
and verified it by hand. Nothing asserts it, so the property survives only as long as everyone
remembers: a new job that omits it inherits GitHub's six-hour default, and one hung step then holds a
runner for most of a working day while reporting nothing.

This adds that assertion to `scripts/ci-contract.test.ts`, where the rest of the workflow contract
already lives. It parses every workflow with `yaml` — the same `parseDocument`/`isMap`/`isSeq` walk
its neighbours use rather than a regex over the text — and collects every job that has a `steps:`
sequence but no `timeout-minutes`. A job that only `uses:` a reusable workflow is exempt: it runs no
step of its own, and the callee's jobs carry the bound. That exemption is not a special case in the
code, it falls out of only looking at jobs that have steps.

Like its neighbours the test collects offenders and asserts the list is empty, so a failure names
every unbounded job at once instead of stopping at the first.

All 56 step-running jobs across the 24 workflows already declare a timeout and all 13 reusable-workflow
callers declare none, so the gate is green on `main` and this PR changes no workflow.

Part of #1608.

## How to test

- `node --test scripts/ci-contract.test.ts` — 43 tests pass.
- The gate fails on the defect it exists for. Deleting `timeout-minutes: 20` from `server-package`
  in `.github/workflows/ci-build.yml` and re-running gives:

  ```
  ✖ bounds every job that runs steps of its own
    AssertionError: these jobs run steps without bounding how long they may run
    + actual - expected
    + [ '.github/workflows/ci-build.yml#server-package' ]
    - []
  ```

  Restoring the line makes it green again. The workflow is unmodified in this PR.
- `pnpm exec vp run check` — exit 0.

## Release impact

No changeset: this adds a repository quality gate. Nothing ships, and no operator acts.

## Notes for reviewers

`scripts/ci-contract.test.ts` and `.github/workflows/**` are hot-file lanes. Of the two open pull
requests, #1824 is the release Version PR and touches neither; #1830 adds
`.github/workflows/continuous-staging.yml` and edits `promote.yml` and `release.yml`, but not this
test file, so there is no conflict. #1830's new `follow-main` job already declares
`timeout-minutes: 30` and passes this gate as written.
