### PR TITLE
docs: require every issue to ship a change

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -28,7 +28,7 @@ body:
     id: criteria
     attributes:
       label: Acceptance criteria
-      description: List observable behavior that would show the problem is solved.
+      description: Observable behavior that shows the problem is solved. Each bullet is a change that ships; a measurement alone is not one (CONTRIBUTING.md § Issues).
       placeholder: |
         - [ ] A workspace admin can add a repository by entering owner/name.
         - [ ] A clear error explains when the repository cannot be accessed.

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -34,7 +34,7 @@ body:
     id: done
     attributes:
       label: Done when
-      description: List observable, independently verifiable acceptance criteria.
+      description: Changes a reviewer can find in the repository — code, a test, a gate, a document. A measurement or a verdict alone is not a criterion (CONTRIBUTING.md § Issues).
       placeholder: |
         - [ ] Retryable responses are retried with the provider-requested delay.
         - [ ] Non-retryable responses fail without another request.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -261,7 +261,8 @@ directories the `.gitignore` names are the only place for them. Durable architec
 and decisions go into the `docs/` document that owns them, or an ADR under `docs/decisions/`, and
 get updated when the product changes so the next reader finds facts rather than abandoned
 intentions. A merged PR is the implementation record; do not keep a second checklist in the
-repository.
+repository. An issue you file follows `CONTRIBUTING.md` § Issues: every *Done when* bullet is a
+change that ships, never a measurement or a verdict alone.
 
 ## Taste
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,20 @@ To ensure a transparent and trustworthy environment, we have established differe
 
 Contributions that do not adhere to these guidelines will be rejected. We align with [GitHub Acceptable Use Policies](https://docs.github.com/en/site-policy/acceptable-use-policies).
 
+## Issues
+
+An issue ships something. Its *Done when* names changes a reviewer can find in the repository — code,
+a test, a gate, a document — never a number, a measurement or a verdict on its own. A measurement is a
+step toward one of those bullets, or it comes out of a harness the issue ships; the run itself is an
+operations action recorded where it happens, such as a release plan, not an issue that waits for it.
+"Verify" and "audit" are not outcomes: do the verification while writing the issue and file what it
+found as bullets, or make the check a gate that ships. Research is held to the same bar — the artifact
+in the tree is the outcome. What one review unit cannot ship becomes a follow-up issue linked with
+`Part of`.
+
+The [issue forms](.github/ISSUE_TEMPLATE) carry the shape. In a pull request, `Fixes #n` means every
+bullet of that issue is met; `Part of #n` means the issue stays open and says what remains.
+
 ## Contribution Process
 
 Run `vp install` after a pull that changes the lockfile; the [local verification guide](https://docs.hephaestus.build/contributor/local-verification) has what it does to your Git hooks. Use


### PR DESCRIPTION
## What changed and why

An issue could close on a number or a verdict. This week three v1.0.0 issues were waiting on a throughput measurement nobody had a host to run (#1602, and #1731 and #1730 through it), one was waiting for a cron job to go green (#1668), and #1600 and #1601 were "verify" and "audit" checklists with no change behind them. The project board showed all of them as in progress while nothing was in flight.

`CONTRIBUTING.md` gains an *Issues* section that states the rule once: every *Done when* bullet is a change a reviewer can find in the repository — code, a test, a gate, a document. A measurement is a step toward one of those, or it comes out of a harness the issue ships; the run itself is an operations action recorded where it happens, such as a release plan. "Verify" and "audit" are done while writing the issue and filed as bullets, or become a gate that ships. Research is held to the same bar. The section also fixes the meaning of `Fixes #n` and `Part of #n` in a pull request.

The task and feature issue forms and `AGENTS.md` § Plans and work artifacts each carry one sentence pointing at it, so agents filing issues through `gh` see the rule too.

The issues named above were reframed under this rule today: #1602 now ships the load task and a generated baseline document, #1731 and #1668 closed on their implementations, #1730 lost its measurement bullet, #1600 closed with every item ticked or struck, and #1601 became fixes plus a gate. The capacity run moved to the v1.0.0 release plan (#1377) as a gate.

## How to test

- `vp run check:affected` — passes; `gate:instructions` covers `AGENTS.md`.
- Open a new issue from either form and read the *Done when* / *Acceptance criteria* hint.

## Release impact

No changeset: contribution guidance and issue forms are not shipped code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated feature and task issue templates with clearer requirements for observable, shippable completion criteria.
  * Clarified that measurements, verification, and audit results are not sufficient outcomes on their own.
  * Added contribution guidance describing acceptable issue deliverables and the meanings of `Fixes `#n`` and `Part of `#n`` in pull requests.
  * Updated planning guidance to align “Done when” statements with shipped, reviewable changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->