### PR TITLE
ci: require every commit on a pull request to resolve to its author

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -66,6 +66,104 @@ jobs:
         if: steps.commitlint.outcome == 'failure'
         run: exit 1
 
+  # Squash-merge hides a commit's author on `main`, but a pull request's commit list keeps it
+  # forever, and that list is where reviewers and provenance readers look. `CONTRIBUTING.md`
+  # § Identity and Transparency asks for accountable identities; this is what holds them to it.
+  verify-commit-identity:
+    name: "Verify commit identity"
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    if: ${{ !github.event.pull_request.draft }}
+    permissions:
+      contents: read
+      pull-requests: write
+    # No checkout: the query and the rule live here, so nothing from the pull request is fetched.
+    steps:
+      - name: "Resolve the author of every commit"
+        id: identity
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        continue-on-error: true
+        with:
+          script: |
+            const { writeFile } = require("node:fs/promises");
+
+            // `authors(first:1)` is the primary author alone: a co-author after the first is a
+            // credit, not the identity the commit is attributed to.
+            const query = `query($owner:String!,$name:String!,$number:Int!,$after:String){
+              repository(owner:$owner,name:$name){ pullRequest(number:$number){
+                author{ __typename login }
+                commits(first:100,after:$after){ pageInfo{hasNextPage endCursor}
+                  nodes{ commit{ abbreviatedOid authors(first:1){ nodes{ email name user{ login } } } } } } } } }`;
+
+            const pull = context.payload.pull_request;
+            const nodes = [];
+            let author;
+            let after = null;
+            do {
+              const page = await github.graphql(query, {
+                owner: context.repo.owner,
+                name: context.repo.repo,
+                number: pull.number,
+                after,
+              });
+              const data = page.repository.pullRequest;
+              author = data.author;
+              nodes.push(...data.commits.nodes);
+              after = data.commits.pageInfo.hasNextPage ? data.commits.pageInfo.endCursor : null;
+            } while (after);
+
+            // A `Bot` author's login carries no suffix while the account its commits resolve to
+            // does: Renovate opens a pull request as `renovate` and signs its commits as
+            // `renovate[bot]`. Deriving the one from the other keeps bots under the same rule
+            // rather than exempting them.
+            const expected = author.__typename === "Bot" ? `${author.login}[bot]` : author.login;
+            const offenders = nodes.filter(
+              ({ commit }) =>
+                commit.authors.nodes[0]?.user?.login?.toLowerCase() !== expected.toLowerCase(),
+            );
+            if (offenders.length === 0) return;
+
+            const listed = offenders.map(({ commit }) => {
+              const [commitAuthor] = commit.authors.nodes;
+              const resolved = commitAuthor?.user ? `@${commitAuthor.user.login}` : "no GitHub account";
+              return `    ${commit.abbreviatedOid}  ${commitAuthor?.email ?? "no author email"}  ${resolved}`;
+            });
+            await writeFile(
+              `${process.env.RUNNER_TEMP}/identity-comment.md`,
+              [
+                "## Commit identity check failed",
+                "",
+                `Every commit here must be authored by @${expected}, the account that opened this`,
+                "pull request. These are not:",
+                "",
+                ...listed,
+                "",
+                "Point `git config user.email` at an address on that account, then re-author them:",
+                "",
+                `    git rebase -i --exec "git commit --amend --no-edit --reset-author" origin/${pull.base.ref}`,
+                "",
+              ].join("\n"),
+            );
+            core.setFailed(`${offenders.length} commit(s) do not resolve to @${expected}.`);
+
+      - name: "Comment on PR with the offending commits"
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
+        if: steps.identity.outcome == 'failure'
+        with:
+          header: pr-commit-identity-error
+          path: ${{ runner.temp }}/identity-comment.md
+
+      - name: "Remove error comment on success"
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
+        if: steps.identity.outcome == 'success'
+        with:
+          header: pr-commit-identity-error
+          delete: true
+
+      - name: "Fail workflow if a commit did not resolve"
+        if: steps.identity.outcome == 'failure'
+        run: exit 1
+
   assign-author:
     name: "Assign author"
     timeout-minutes: 5

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,8 @@ To ensure a transparent and trustworthy environment, we have established differe
 
 ### Compliance
 
+Every commit on a pull request must be authored by an email address that resolves to the GitHub account that opened it, so set `git config user.email` accordingly before you commit.
+
 Contributions that do not adhere to these guidelines will be rejected. We align with [GitHub Acceptable Use Policies](https://docs.github.com/en/site-policy/acceptable-use-policies).
 
 ## Contribution Process

--- a/docs/contributor/ci-cd.mdx
+++ b/docs/contributor/ci-cd.mdx
@@ -65,6 +65,7 @@ published.
 | Docker → Webapp, Agent: Pi, Postgres (pg_partman), Tag unchanged images | Dockerfile images; aliases for unchanged ones | — |
 | Supported-host boot smoke | `docker/self-host/setup.sh`, then PostgreSQL, NATS and the application server from this run's own images, waiting for the application to report healthy | — |
 | Actionlint, Zizmor | workflow lint with ShellCheck warnings; Zizmor at medium confidence | — |
+| PR → Verify commit identity | every commit's primary author resolves to a GitHub account, and that account is the pull request's author; a `Bot` author is matched against its `[bot]` account | — |
 
 The four quality legs are one matrix job, one entry per leg of the task graph. Each runs
 `vp run ci:<leg>`, then pipes `vp run --last-details` through `scripts/report-task-run.ts`: every
@@ -243,7 +244,7 @@ why the label is the authority, and which alternatives were priced and declined,
 | --- | --- | --- |
 | `cicd.yml` | PR, merge group, push to main, manual | Validates changes before merge and builds final-SHA images after merge; the release evidence gate runs over the images the run built on the Version PR's branch, and wherever the `release-preflight` dispatch input asks for it |
 | `review-policy.yml` | PR opened, reopened, synchronized, ready for review, edited | Approves a listed maintainer's pull request so the ruleset's required approval is met; does nothing for anyone else |
-| `pull-request.yml` | PR opened, edited, synchronized, reopened, ready for review | Validates the title with commitlint and assigns the author when the pull request opens |
+| `pull-request.yml` | PR opened, edited, synchronized, reopened, ready for review | Validates the title with commitlint, checks that every commit resolves to the pull request's author, and assigns the author when the pull request opens |
 | `ci-quality-gates.yml` | Called by cicd.yml | Formatting, lint, type checks, webapp unit and story tests: everything verifiable from source |
 | `ci-build.yml` | Called by cicd.yml | Packages the server reactor once, then runs the OpenAPI, schema, database and browser E2E gates and the application-server image against that artifact |
 | `ci-tests.yml` | Called by cicd.yml | The server unit, architecture and integration suites, compiled from source |

--- a/scripts/ci-contract.test.ts
+++ b/scripts/ci-contract.test.ts
@@ -1503,6 +1503,17 @@ void describe("CI contract", () => {
 		);
 	});
 
+	void test("resolves every commit's author without checking out the pull request", async () => {
+		const identity = job(
+			await readFile(".github/workflows/pull-request.yml", "utf8"),
+			"verify-commit-identity",
+		);
+		// The workflow's trigger is justified to Zizmor by the claim that it checks out and runs no
+		// pull-request code; a job that reads the pull request's own commits is where that slips.
+		assert.doesNotMatch(identity, /uses: actions\/checkout@/);
+		assert.match(identity, /uses: actions\/github-script@/);
+	});
+
 	void test("never invokes a repository-local action before checkout", async () => {
 		for (const [file, source] of await workflowSources()) {
 			for (const jobSource of source.split(/^ {2}(?=[A-Za-z][\w-]*:\s*$)/m).slice(1)) {


### PR DESCRIPTION
## What changed and why

Five pull requests merged recently carried commits whose author does not resolve to the pull request's author: three authored from `felix.dietrich@financial-health-initiative.org`, an address linked to no GitHub account, so the commit shows no user at all; and two from an address that resolves to a *different* account, `felixtjdietrich2`. `CONTRIBUTING.md` § Identity and Transparency asks for real, accountable identities and nothing enforced it. Squash-merge hides this on `main`, but a pull request's commit list keeps it forever, and that list is where reviewers and provenance readers look.

`pull-request.yml` gains a `verify-commit-identity` job in the same shape as `validate-title`: it resolves every commit's primary author through the GraphQL API, requires the resulting account to be the pull request's author, and on failure leaves a sticky comment naming each offending commit — short SHA, author email, and either the account it resolved to or "no GitHub account" — with the one-line rebase that fixes them. The comment is deleted when the check passes.

Bots are held to the same rule rather than exempted. A `Bot` author's login carries no suffix while the account its commits resolve to does — Renovate opens a pull request as `renovate` and signs its commits as `renovate[bot]` — so the expected login is derived by appending `[bot]` to a `Bot` author's login. This was checked against merged #1795 (Renovate) and #1797 (github-actions) before it was written, not assumed.

Only the primary author is checked; `authors(first:1)` leaves co-authors after the first alone.

## How to test

The rule was run as committed — extracted from the workflow YAML and driven against the live GraphQL API with a stubbed `github.graphql` — over the four cases that matter:

| PR | Author | Commit | Verdict |
| --- | --- | --- | --- |
| #1832 | `FelixTJDietrich` | `93675ba` `felixtj.dietrich@gmail.com` → `@felixtjdietrich2` | **fails**, as required |
| #1821 | `FelixTJDietrich` | `0a75d03` `felix.dietrich@financial-health-initiative.org` → no GitHub account | **fails**, as required |
| #1834 | `FelixTJDietrich` | `b88b51b` `felix_dietrich@gmx.de` → `@FelixTJDietrich` | **passes** |
| #1795 | `Bot` / `renovate` | `7e02f83` `29139614+renovate[bot]@users.noreply.github.com` → `@renovate[bot]` | **passes** |

The comment #1821 would receive:

```text
## Commit identity check failed

Every commit here must be authored by @FelixTJDietrich, the account that opened this
pull request. These are not:

    0a75d03  felix.dietrich@financial-health-initiative.org  no GitHub account

Point `git config user.email` at an address on that account, then re-author them:

    git rebase -i --exec "git commit --amend --no-edit --reset-author" origin/main
```

Commands:

- `pnpm exec vp run check` — exit 0 (41 tasks).
- `node --test scripts/ci-contract.test.ts` — 44 pass, 0 fail. The new assertion was confirmed to bite: adding an `actions/checkout` step to the job turns it red.
- `actionlint 1.7.7` on `.github/workflows/pull-request.yml` — exit 0.
- `zizmor 1.29.0 --min-confidence medium` on the same file — "No findings to report", with the workflow's existing `# zizmor: ignore[dangerous-triggers]` justification intact.

## Release impact

No changeset. Nothing under `server`, `webapp` or `docker` changes; this is repository tooling, workflow documentation and a contributor rule.

## Notes for reviewers

- **`pull_request_target` safety.** The job checks out nothing at all — the query and the rule are inline — which is what keeps the trigger's existing Zizmor justification honest. `scripts/ci-contract.test.ts` now asserts that property so a later edit cannot quietly add a checkout.
- **This pull request cannot demonstrate the gate on itself.** `pull_request_target` runs the workflow from the base branch, so the job does not exist for this run. The four results above are the proof.
- **Making it blocking is a ruleset change.** Like `validate-title`, this job is not a required status check; the required contexts live in the `main` ruleset and are the maintainer's to set. Worth adding `PR / Verify commit identity` there.
- **Hot lanes are clear.** Of the open pull requests, #1834 and #1824 touch no workflows, and #1830 writes `continuous-staging.yml`, `promote.yml` and `release.yml`. None writes `pull-request.yml` or `scripts/ci-contract.test.ts`.
- Docs: one row in the quality-gates table of `docs/contributor/ci-cd.mdx`, the `pull-request.yml` row in the workflows table brought up to date, and one sentence in `CONTRIBUTING.md` § Identity and Transparency.
