### PR TITLE
ci: create automation commits through GitHub's API

### DIFF
--- a/.github/workflows/openapi-autocommit.yml
+++ b/.github/workflows/openapi-autocommit.yml
@@ -54,16 +54,19 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
-      contents: write # push generated files to the PR branch
+      contents: write # commit generated files to the PR branch
     outputs:
       changed: ${{ steps.commit.outputs.changed }}
     steps:
-      # Holds the write token: nothing from the checkout or artifact is executed here.
+      # Holds the write token: it installs no dependencies, and nothing from the artifact is run.
       - name: Checkout PR commit
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
+      - uses: ./.github/actions/setup-toolchain
+        with:
+          install: "none"
       - name: Remove checked-in client
         run: rm -rf webapp/src/api
       - name: Download generated files
@@ -71,25 +74,20 @@ jobs:
         with:
           name: generated-openapi-${{ github.run_id }}
           path: .
-      - name: Commit and push generated files
+      - name: Commit generated files
         id: commit
         env:
           GH_TOKEN: ${{ github.token }}
           HEAD_BRANCH: ${{ github.event.pull_request.head.ref }}
+          # Stale runs fail closed: a branch that moved since the label was applied rejects the
+          # commit rather than replacing whatever moved it.
+          EXPECTED_HEAD: ${{ github.event.pull_request.head.sha }}
         run: |
-          set -euo pipefail
-          git add -- server/openapi.yaml webapp/src/api
-          if git diff --cached --quiet; then
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          git config --local user.name "github-actions[bot]"
-          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git commit -m "chore: update API specs and client"
-          # Never force-push: stale runs must fail closed.
-          gh auth setup-git
-          git push origin "HEAD:$HEAD_BRANCH"
-          echo "changed=true" >> "$GITHUB_OUTPUT"
+          node scripts/commit-via-api.ts \
+            --branch "$HEAD_BRANCH" \
+            --expected-head "$EXPECTED_HEAD" \
+            --message "chore: update API specs and client" \
+            -- server/openapi.yaml webapp/src/api
 
   report:
     name: Report result

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -49,10 +49,21 @@ jobs:
       contents: write
       id-token: write
     steps:
+      # `deploy-state` carries channels and no code, so the tooling that writes it is checked out
+      # from the ref this workflow was dispatched on and the branch itself sits beside it.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: deploy-state
+          path: deploy-state
           persist-credentials: false
+
+      - uses: ./.github/actions/setup-toolchain
+        with:
+          install: "none"
 
       - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
@@ -77,6 +88,7 @@ jobs:
           echo "environment_url=https://${HOSTNAME}" >> "$GITHUB_OUTPUT"
 
       - name: Write and sign the channel
+        working-directory: deploy-state
         env:
           CHANNEL: ${{ inputs.environment }}
           RELEASE: ${{ steps.release.outputs.release }}
@@ -96,18 +108,17 @@ jobs:
           echo "CHANNEL_FILE=channels/${channel}.json" >> "$GITHUB_ENV"
 
       - name: Publish the channel
+        working-directory: deploy-state
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE: ${{ steps.release.outputs.release }}
         run: |
-          set -euo pipefail
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add channels
-          # An empty commit would read as a move forward to hosts that compare ancestry.
-          git diff --cached --quiet && { echo "Channel already at $RELEASE"; exit 0; }
-          git commit -m "chore(deploy): ${CHANNEL_FILE} -> ${RELEASE}"
-          git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}" HEAD:deploy-state
+          # An empty commit would read as a move forward to hosts that compare ancestry, so a channel
+          # already at this release produces none.
+          node ../scripts/commit-via-api.ts \
+            --branch deploy-state \
+            --message "chore(deploy): ${CHANNEL_FILE} -> ${RELEASE}" \
+            -- channels
 
       - name: Wait for the environment to converge
         if: ${{ !inputs.freeze }}

--- a/docs/contributor/ci-cd.mdx
+++ b/docs/contributor/ci-cd.mdx
@@ -268,6 +268,22 @@ why the label is the authority, and which alternatives were priced and declined,
 | `release-upgrade.yml` | Called by `release.yml`, weekly | Boots the previous stable release with seeded data, then the candidate against the same database |
 | `deploy-staging.yml`, `deploy-prod.yml` | Called by `release.yml` or manual dispatch | Deploy a verified release lock through `deploy-locked-compose.yml` |
 
+### Commits a workflow makes
+
+Actions holds no signing key, so a commit pushed with `git` from a workflow is unsigned and a
+required-signature rule rejects it. Every commit an automation makes here is created through
+GitHub's `createCommitOnBranch` mutation instead, which GitHub signs — the same path
+`changesets/action` lands the Version PR on and Renovate lands a dependency bump on.
+`scripts/commit-via-api.ts` is the one caller: `openapi-autocommit.yml` commits the regenerated spec
+and client to the pull request's branch through it, and `promote.yml` commits the channel to
+`deploy-state`. `scripts/ci-contract.test.ts` fails any workflow that pushes to a real ref.
+
+The mutation carries whole file contents rather than a diff, so the script enumerates every added,
+modified and deleted path from the work tree and sends each file entire; a rename is its source
+deleted and its destination added. It commits against the head the work tree was compared with, so a
+branch that moved in the meantime fails the run instead of overwriting whatever moved it. The
+credential is still `GITHUB_TOKEN`, so these commits start no further workflow run.
+
 ### Shared setup actions
 
 | Action | Contract |

--- a/scripts/ci-contract.test.ts
+++ b/scripts/ci-contract.test.ts
@@ -1486,6 +1486,24 @@ void describe("CI contract", () => {
 		assert.doesNotMatch(source, /pull_request\.title|github\.head_ref/);
 	});
 
+	void test("creates every automation commit through the API, so GitHub signs it", async () => {
+		// Actions holds no signing key, so a commit a workflow pushes with git is unsigned and a
+		// required-signature rule rejects it. `scripts/commit-via-api.ts` commits through
+		// `createCommitOnBranch`, which GitHub signs. A dry run is the one push that reaches no ref:
+		// the pre-push hook probe needs a push to prove the hook runs, and writes nothing.
+		const pushes: string[] = [];
+		for (const [file, source] of await workflowSources()) {
+			for (const [index, line] of source.split("\n").entries()) {
+				const statement = line.trim();
+				if (statement.startsWith("#")) continue;
+				const command = /\bgit push\b.*/.exec(statement)?.[0];
+				if (!command || /\s--dry-run(?:\s|$)/.test(command)) continue;
+				pushes.push(`${file}:${index + 1}: ${command}`);
+			}
+		}
+		assert.deepEqual(pushes, [], "A workflow commits through scripts/commit-via-api.ts");
+	});
+
 	void test("checks out no ref taken straight from a pull_request_target or workflow_run event", async () => {
 		// Scorecard's Dangerous-Workflow rule, checked here because Scorecard itself runs only after merge.
 		for (const [file, source] of await workflowSources()) {

--- a/scripts/commit-via-api.test.ts
+++ b/scripts/commit-via-api.test.ts
@@ -1,0 +1,109 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+
+import { changedPaths, commitInput } from "./commit-via-api.ts";
+
+/**
+ * Git hooks export GIT_DIR, GIT_INDEX_FILE and friends, which would point every command below at the
+ * repository being pushed instead of at the fixture. Strip them so the fixtures are self-contained
+ * however these tests are invoked.
+ */
+const cleanGitEnv = (): NodeJS.ProcessEnv =>
+	Object.fromEntries(Object.entries(process.env).filter(([key]) => !key.startsWith("GIT_")));
+
+type Git = (...args: string[]) => string;
+
+/** A throwaway repo holding one tracked file per shape of change these tests make. */
+function repoWithCommittedFiles(): { repo: string; git: Git; status: () => string } {
+	const repo = mkdtempSync(join(tmpdir(), "commit-via-api-"));
+	const git: Git = (...args) =>
+		execFileSync("git", args, {
+			cwd: repo,
+			encoding: "utf8",
+			stdio: ["ignore", "pipe", "pipe"],
+			env: cleanGitEnv(),
+		});
+	git("init", "--quiet", "--initial-branch=main");
+	git("config", "user.email", "test@example.invalid");
+	git("config", "user.name", "Test");
+	for (const path of ["kept.txt", "edited.txt", "removed.txt", "moved.txt"])
+		writeFileSync(join(repo, path), `${path}\n`);
+	git("add", "-A");
+	git("commit", "--quiet", "-m", "initial");
+	return {
+		repo,
+		git,
+		status: () => git("status", "--porcelain=v1", "-z", "--untracked-files=all"),
+	};
+}
+
+await test("enumerates every added, modified and deleted path in the work tree", (t) => {
+	const { repo, status } = repoWithCommittedFiles();
+	t.after(() => rmSync(repo, { recursive: true, force: true }));
+	writeFileSync(join(repo, "edited.txt"), "edited\n");
+	rmSync(join(repo, "removed.txt"));
+	mkdirSync(join(repo, "generated"));
+	writeFileSync(join(repo, "generated/added.txt"), "added\n");
+
+	// An untracked directory is enumerated file by file: the mutation commits contents, not trees.
+	assert.deepEqual(changedPaths(status()), {
+		additions: ["edited.txt", "generated/added.txt"],
+		deletions: ["removed.txt"],
+	});
+});
+
+await test("splits a rename into the source deleted and the destination added", (t) => {
+	const { repo, git, status } = repoWithCommittedFiles();
+	t.after(() => rmSync(repo, { recursive: true, force: true }));
+	git("mv", "moved.txt", "arrived.txt");
+
+	assert.deepEqual(changedPaths(status()), {
+		additions: ["arrived.txt"],
+		deletions: ["moved.txt"],
+	});
+});
+
+await test("has nothing to commit from a clean work tree", (t) => {
+	const { repo, status } = repoWithCommittedFiles();
+	t.after(() => rmSync(repo, { recursive: true, force: true }));
+
+	assert.deepEqual(changedPaths(status()), { additions: [], deletions: [] });
+});
+
+await test("refuses a work tree with a conflict in it", () => {
+	assert.throws(() => changedPaths("UU merged.txt\0"), /merged\.txt is unmerged/);
+});
+
+await test("builds the mutation input, with file contents base64-encoded", () => {
+	const input = commitInput(
+		{
+			repository: "hephaestus-build/Hephaestus",
+			branch: "deploy-state",
+			expectedHeadOid: "0f1e2d3c4b5a69788796a5b4c3d2e1f00f1e2d3c",
+			headline: "chore(deploy): channels/staging.json -> v1.2.3",
+		},
+		new Map([["channels/staging.json", Buffer.from('{"release":"v1.2.3"}\n')]]),
+		["channels/retired.json"],
+	);
+
+	assert.deepEqual(input, {
+		branch: {
+			repositoryNameWithOwner: "hephaestus-build/Hephaestus",
+			branchName: "deploy-state",
+		},
+		expectedHeadOid: "0f1e2d3c4b5a69788796a5b4c3d2e1f00f1e2d3c",
+		message: { headline: "chore(deploy): channels/staging.json -> v1.2.3" },
+		fileChanges: {
+			additions: [{ path: "channels/staging.json", contents: "eyJyZWxlYXNlIjoidjEuMi4zIn0K" }],
+			deletions: [{ path: "channels/retired.json" }],
+		},
+	});
+	assert.equal(
+		Buffer.from(input.fileChanges.additions[0]?.contents ?? "", "base64").toString("utf8"),
+		'{"release":"v1.2.3"}\n',
+	);
+});

--- a/scripts/commit-via-api.ts
+++ b/scripts/commit-via-api.ts
@@ -1,0 +1,182 @@
+/**
+ * Commits the work tree to a branch through GitHub's `createCommitOnBranch` mutation.
+ *
+ * A ruleset that requires signed commits rejects everything `git commit` produces inside a workflow:
+ * Actions holds no signing key and GitHub will not vouch for a commit it did not make. The mutation
+ * is the path GitHub signs — it is how `changesets/action` lands the Version PR and how Renovate
+ * lands a dependency bump, and both verify as `web-flow`. The credential is unchanged, so the
+ * documented consequence of committing with `GITHUB_TOKEN` is unchanged too: the resulting push
+ * starts no further workflow run.
+ *
+ * The mutation carries file contents rather than a diff, so every path the commit touches has to be
+ * named and every added or modified file sent whole. A rename has no representation of its own: it
+ * is the source path deleted and the destination path added.
+ *
+ * `expectedHeadOid` is what the shell path spelled as "never force-push". A branch that moved while
+ * the files were being produced rejects the commit instead of burying the move.
+ */
+import { appendFile, readFile } from "node:fs/promises";
+import { parseArgs } from "node:util";
+
+import { requiredEnv } from "./lib/env.ts";
+import { asRecord, asString, at, isRecord } from "./lib/json.ts";
+import { output } from "./lib/process.ts";
+
+/** Paths whose work-tree state one commit must carry, as `createCommitOnBranch` divides them. */
+export interface WorkTreeChanges {
+	readonly additions: readonly string[];
+	readonly deletions: readonly string[];
+}
+
+/** `CreateCommitOnBranchInput`, restricted to the fields a workflow commit uses. */
+export interface CommitInput {
+	readonly branch: { readonly repositoryNameWithOwner: string; readonly branchName: string };
+	readonly expectedHeadOid: string;
+	readonly message: { readonly headline: string };
+	readonly fileChanges: {
+		readonly additions: readonly { readonly path: string; readonly contents: string }[];
+		readonly deletions: readonly { readonly path: string }[];
+	};
+}
+
+export interface CommitTarget {
+	readonly repository: string;
+	readonly branch: string;
+	readonly expectedHeadOid: string;
+	readonly headline: string;
+}
+
+/** The two-letter codes `git status` uses for a path it cannot describe as one change. */
+const UNMERGED = new Set(["DD", "AU", "UD", "UA", "DU", "AA", "UU"]);
+
+/**
+ * Reads `git status --porcelain=v1 -z`, whose entries are NUL-terminated `XY path`, and whose rename
+ * and copy entries put the source path in a field of its own after the destination.
+ */
+export function changedPaths(porcelain: string): WorkTreeChanges {
+	const fields = porcelain.split("\0");
+	const additions: string[] = [];
+	const deletions: string[] = [];
+	for (let index = 0; index < fields.length; index += 1) {
+		const entry = fields[index];
+		// The last field after a trailing NUL is empty.
+		if (!entry) continue;
+		const codes = entry.slice(0, 2);
+		const path = entry.slice(3);
+		if (UNMERGED.has(codes))
+			throw new Error(`${path} is unmerged; a conflicted work tree is not a commit`);
+		if (codes.startsWith("R") || codes.startsWith("C")) {
+			index += 1;
+			const source = fields[index];
+			if (!source) throw new Error(`${path} is reported as a rename with no source path`);
+			// A copy leaves its source where it is; a rename does not.
+			if (codes.startsWith("R")) deletions.push(source);
+		}
+		// The work-tree column decides wherever it has an opinion: it holds the state to be committed,
+		// and the index column only says what the path looked like on the way there.
+		const state = codes[1] === " " ? codes[0] : codes[1];
+		(state === "D" ? deletions : additions).push(path);
+	}
+	return { additions: additions.toSorted(), deletions: deletions.toSorted() };
+}
+
+export function commitInput(
+	target: CommitTarget,
+	contents: ReadonlyMap<string, Uint8Array>,
+	deletions: readonly string[],
+): CommitInput {
+	return {
+		branch: { repositoryNameWithOwner: target.repository, branchName: target.branch },
+		expectedHeadOid: target.expectedHeadOid,
+		message: { headline: target.headline },
+		fileChanges: {
+			additions: [...contents].map(([path, bytes]) => ({
+				path,
+				contents: Buffer.from(bytes).toString("base64"),
+			})),
+			deletions: deletions.map((path) => ({ path })),
+		},
+	};
+}
+
+const COMMIT_MUTATION = `mutation ($input: CreateCommitOnBranchInput!) {
+  createCommitOnBranch(input: $input) {
+    commit {
+      oid
+      signature {
+        state
+        wasSignedByGitHub
+      }
+    }
+  }
+}`;
+
+/** The new commit's object name and what GitHub says about its signature. */
+async function createCommit(token: string, input: CommitInput): Promise<string> {
+	const response = await fetch(process.env.GITHUB_GRAPHQL_URL ?? "https://api.github.com/graphql", {
+		method: "POST",
+		headers: { authorization: `bearer ${token}`, "content-type": "application/json" },
+		body: JSON.stringify({ query: COMMIT_MUTATION, variables: { input } }),
+	});
+	const text = await response.text();
+	if (!response.ok) throw new Error(`GitHub answered ${response.status} ${response.statusText}`);
+	const body = asRecord(JSON.parse(text), "GraphQL response");
+	// A moved head, a deletion of a path the branch does not have, a branch that is not a branch:
+	// GitHub explains each of them here, and none of the explanations quote the credential.
+	if (body.errors) throw new Error(`createCommitOnBranch refused the commit: ${text}`);
+	const commit = asRecord(
+		at(body, ["data", "createCommitOnBranch", "commit"], "response"),
+		"commit",
+	);
+	const signature = isRecord(commit.signature) ? commit.signature : undefined;
+	const verification = signature
+		? `${asString(signature.state, "signature state")}, signed by GitHub: ${signature.wasSignedByGitHub === true}`
+		: "unsigned";
+	return `${asString(commit.oid, "commit oid")} (${verification})`;
+}
+
+if (import.meta.main) {
+	const { values, positionals } = parseArgs({
+		options: {
+			branch: { type: "string" },
+			message: { type: "string" },
+			"expected-head": { type: "string" },
+		},
+		allowPositionals: true,
+	});
+	const { branch, message } = values;
+	if (!branch || !message) throw new Error("--branch and --message are required");
+	const target: CommitTarget = {
+		repository: requiredEnv(process.env, "GITHUB_REPOSITORY"),
+		branch,
+		headline: message,
+		// The work tree was compared against this commit, so nothing else is a base the changes below
+		// describe.
+		expectedHeadOid: values["expected-head"] ?? (await output("git", ["rev-parse", "HEAD"])).trim(),
+	};
+	const changes = changedPaths(
+		await output("git", [
+			"status",
+			"--porcelain=v1",
+			"-z",
+			"--untracked-files=all",
+			...(positionals.length > 0 ? ["--", ...positionals] : []),
+		]),
+	);
+	const changed = changes.additions.length > 0 || changes.deletions.length > 0;
+	if (!changed) {
+		console.log("The work tree matches the branch; no commit was created.");
+	} else {
+		const contents = new Map(
+			await Promise.all(
+				changes.additions.map(async (path) => [path, await readFile(path)] as const),
+			),
+		);
+		const token = requiredEnv(process.env, "GH_TOKEN");
+		console.log(
+			`Committed ${await createCommit(token, commitInput(target, contents, changes.deletions))} on ${branch}.`,
+		);
+	}
+	if (process.env.GITHUB_OUTPUT)
+		await appendFile(process.env.GITHUB_OUTPUT, `changed=${changed}\n`);
+}


### PR DESCRIPTION
## What changed and why

The repository is about to require signed commits on every branch, and two workflows would be
rejected by that rule. `openapi-autocommit.yml` and `promote.yml` both build a commit with `git
commit` under a workflow token and push it; Actions holds no signing key, so those commits are
unsigned. Every other automation here already lands a signed commit — `changesets/action` on
`changeset-release/main` and Renovate on `main` both verify as `state=VALID`,
`wasSignedByGitHub=true`, signer `web-flow` — because both go through GitHub's GraphQL
`createCommitOnBranch` mutation, whose schema documentation says commits it creates "are
automatically signed by GitHub if supported and will be marked as verified".

Both workflows now take the same path, through one script.

**The mechanism.** `scripts/commit-via-api.ts` takes a branch, a message, an optional expected head
and optional pathspecs. It enumerates the work tree with `git status --porcelain=v1 -z
--untracked-files=all`, splits the entries into `fileChanges.additions` and `fileChanges.deletions`,
reads each addition whole and base64-encodes it, and posts one `createCommitOnBranch` mutation with
`branch { repositoryNameWithOwner, branchName }`, `expectedHeadOid` and `message { headline }`. It
prints the new commit's OID and GitHub's own verification state, writes `changed=<bool>` to
`$GITHUB_OUTPUT`, and creates no commit at all when nothing changed. The mutation commits file
contents rather than a diff, so a rename has no representation of its own: the source path is a
deletion and the destination an addition, which is how the enumeration reports it.

`expectedHeadOid` replaces the comment that used to say "never force-push: stale runs must fail
closed". A branch that moved while the files were being produced now rejects the commit at GitHub
rather than being overwritten.

`promote.yml` needed a second checkout: `deploy-state` carries channels and no code, so the
repository is checked out at the workspace root for the script and the toolchain, and the branch
itself beside it at `deploy-state/`. Nothing else about the promotion changes — the reconciler
verifies the cosign bundle and the commit's ancestry and never reads a commit's author or committer,
so who authors a channel commit is invisible to hosts.

**The size measurement.** GitHub documents node limits (`first`/`last` within 1–100, 500,000 nodes
per call) and rate limits for the GraphQL API, but documents no maximum request body size and no
limit on the number of entries in `fileChanges`; the `FileChanges` schema documentation constrains
only path uniqueness and RFC 4648 base64 encoding. So the worst case here was measured instead. A
full regeneration is `server/openapi.yaml` plus every file under `webapp/src/api/**`: **19 files,
1,301,014 raw bytes, 1,734,712 bytes once base64-encoded — 1.65 MiB.**

That was then sent for real. A throwaway branch was cut from `main`, all 19 files were modified, and
the script committed them in **one** mutation: commit `82a7414` landed with 19 files changed,
committer `GitHub`, `verified: true`, `reason: valid`, and the script reported `(VALID, signed by
GitHub: true)`. The branch was deleted afterwards. One mutation carries a full regeneration with
room to spare.

**Tokens and triggers.** `openapi-autocommit.yml`'s commit job already ran on `GH_TOKEN: ${{
github.token }}` with `permissions: contents: write`, and `promote.yml`'s job already ran on
`GH_TOKEN: ${{ github.token }}` with `contents: write` and `id-token: write` (the latter for cosign).
Both are the repository `GITHUB_TOKEN`, not an app or a PAT, and `contents: write` is exactly what
the mutation needs; no permission was widened or added. Because the credential is unchanged, the
documented consequence is unchanged too: "events triggered by the `GITHUB_TOKEN` will not create a
new workflow run", which was already true of the `git push` path, so neither workflow starts any run
it did not start before.

**The finding is now a gate.** `scripts/ci-contract.test.ts` fails any workflow that runs `git push`
without `--dry-run`. It matches the property rather than a file name: a dry run is the one push that
reaches no ref, which is what the pre-push hook probe in `ci-quality-gates.yml` needs.

## How to test

- `node --test scripts/commit-via-api.test.ts` — 5 pass. The enumeration tests build a throwaway
  repository and read real `git status` output for an addition, a modification, a deletion, an
  untracked subdirectory, a rename and a clean tree; the last test asserts the exact mutation input,
  including the base64 contents. Nothing calls GitHub.
- The gate was proven both ways. On `875a1fce5` (today's `main`) with only the new assertion applied,
  it fails naming both offenders:

  ```
  + [
  +   '.github/workflows/openapi-autocommit.yml:91: git push origin "HEAD:$HEAD_BRANCH"',
  +   '.github/workflows/promote.yml:110: git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}" HEAD:deploy-state'
  + ]
  - []
  ```

  On this branch it passes.
- `pnpm exec vp run check` exits 0.
- `actionlint` on both changed workflows reports the same two pre-existing shellcheck notes in
  `promote.yml` (SC2129, SC2153) that it reports on `main`, and nothing new. `zizmor` 1.29.0 at
  `--min-confidence medium`, the version and threshold CI pins, reports no findings on either file.

## Release impact

No changeset: this changes workflows and repository tooling, not shipped code. No operator action.

## Notes for reviewers

`scripts/commit-via-api.ts` is the whole mechanism and the best place to start; the two workflow
diffs are then just call sites.

The commit job in `openapi-autocommit.yml` gains `setup-toolchain` with `install: "none"` so it has
the pinned Node. Its comment moved with it: the job holds the write token, and what still holds is
that it installs no dependencies and runs nothing from the artifact.
