### PR TITLE
fix(webapp): send the home route to the transparency notice

### DIFF
--- a/.changeset/consent-notice-meets-you-where-you-are.md
+++ b/.changeset/consent-notice-meets-you-where-you-are.md
@@ -1,0 +1,14 @@
+---
+"hephaestus": patch
+---
+
+Signing in for the first time works again. A new account was shown "Something went wrong" instead of
+the transparency notice: the server withholds everything until the notice is answered, and the page
+you land on after signing in asked for your workspaces before asking for the notice. That page now
+sends you to the notice like every other page already did, and the address bar stays on the page you
+were opening, so the notice reads as that page pausing rather than a detour.
+
+The notice itself is easier to answer: a short summary you can scroll, the required acceptance and
+the optional research choice clearly separated, and a way to sign out if you would rather not accept.
+The sign-in page is shorter, while still saying — before you sign in — that doing so shares your
+provider identity.

--- a/webapp/src/components/auth/ConsentDialog.stories.tsx
+++ b/webapp/src/components/auth/ConsentDialog.stories.tsx
@@ -1,0 +1,101 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, fn, userEvent, within } from "storybook/test";
+
+import { ConsentDialog } from "./ConsentDialog";
+
+const notice = {
+	completed: false,
+	noticeVersion: "2026-09-01",
+	participateInResearch: false,
+	noticeText: [
+		"Hephaestus reads the work you already do in GitHub, GitLab, Slack and Outline, and reviews it against the practices your team has chosen.",
+		"It stores the work it reviewed, the observations it recorded, and the feedback it wrote for you. Nobody outside your workspace sees any of it.",
+		"You can export or delete everything from your settings at any time.",
+	].join("\n\n"),
+};
+
+const meta = {
+	component: ConsentDialog,
+	args: { notice, onSubmit: fn(), onSignOut: fn(), onRetry: fn() },
+	parameters: { layout: "fullscreen" },
+} satisfies Meta<typeof ConsentDialog>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+/** Nothing can be submitted until the required acceptance is given. */
+export const RequiresAcceptance: Story = {
+	play: async ({ canvas, args }) => {
+		const dialog = within(await canvas.findByRole("dialog"));
+		const submit = dialog.getByRole("button", { name: "Continue" });
+		await expect(submit).toBeDisabled();
+
+		await userEvent.click(dialog.getByRole("checkbox", { name: /terms of use/i }));
+		await expect(submit).toBeEnabled();
+		await userEvent.click(submit);
+		await expect(args.onSubmit).toHaveBeenCalledWith({
+			noticeVersion: "2026-09-01",
+			termsAccepted: true,
+			participateInResearch: false,
+		});
+	},
+};
+
+/** The optional choice is off until it is chosen, and never gates the button. */
+export const ResearchIsOptional: Story = {
+	play: async ({ canvas, args }) => {
+		const dialog = within(await canvas.findByRole("dialog"));
+		await expect(dialog.getByRole("checkbox", { name: /research/i })).not.toBeChecked();
+
+		await userEvent.click(dialog.getByRole("checkbox", { name: /terms of use/i }));
+		await userEvent.click(dialog.getByRole("checkbox", { name: /research/i }));
+		await userEvent.click(dialog.getByRole("button", { name: "Continue" }));
+		await expect(args.onSubmit).toHaveBeenCalledWith(
+			expect.objectContaining({ participateInResearch: true }),
+		);
+	},
+};
+
+export const Submitting: Story = { args: { submitting: true } };
+
+/** The choice reached the server and was refused; the reader is told and can retry. */
+export const SubmitFailed: Story = {
+	args: { failedToSubmit: true },
+	play: async ({ canvas }) => {
+		const dialog = within(await canvas.findByRole("dialog"));
+		await expect(dialog.getByRole("alert")).toHaveTextContent(/wasn't saved/i);
+	},
+};
+
+/** Still open while the notice loads, so the application never paints behind it first. */
+export const Loading: Story = { args: { notice: undefined } };
+
+/** The notice could not be fetched. The reader stays blocked, because the choice is still required. */
+export const FailedToLoad: Story = {
+	args: { notice: undefined, failedToLoad: true },
+	play: async ({ canvas }) => {
+		const dialog = within(await canvas.findByRole("dialog"));
+		await expect(dialog.getByRole("alert")).toHaveTextContent(/couldn't load/i);
+	},
+};
+
+/** A mandatory dialog still needs a way out: declining is an answer, not a dead end. */
+export const CanDeclineAndSignOut: Story = {
+	play: async ({ canvas, args }) => {
+		const dialog = within(await canvas.findByRole("dialog"));
+		await userEvent.click(dialog.getByRole("button", { name: /sign out/i }));
+		await expect(args.onSignOut).toHaveBeenCalled();
+	},
+};
+
+/** The load failure offers a retry rather than stranding the reader on a reload instruction. */
+export const FailedToLoadCanRetry: Story = {
+	args: { notice: undefined, failedToLoad: true },
+	play: async ({ canvas, args }) => {
+		const dialog = within(await canvas.findByRole("dialog"));
+		await userEvent.click(dialog.getByRole("button", { name: /try again/i }));
+		await expect(args.onRetry).toHaveBeenCalled();
+	},
+};

--- a/webapp/src/components/auth/ConsentDialog.stories.tsx
+++ b/webapp/src/components/auth/ConsentDialog.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { expect, fn, userEvent, within } from "storybook/test";
+import { expect, fn, screen, userEvent, within } from "storybook/test";
 
 import { ConsentDialog } from "./ConsentDialog";
 
@@ -27,8 +27,8 @@ export const Default: Story = {};
 
 /** Nothing can be submitted until the required acceptance is given. */
 export const RequiresAcceptance: Story = {
-	play: async ({ canvas, args }) => {
-		const dialog = within(await canvas.findByRole("dialog"));
+	play: async ({ args }) => {
+		const dialog = within(await screen.findByRole("dialog"));
 		const submit = dialog.getByRole("button", { name: "Continue" });
 		await expect(submit).toBeDisabled();
 
@@ -45,8 +45,8 @@ export const RequiresAcceptance: Story = {
 
 /** The optional choice is off until it is chosen, and never gates the button. */
 export const ResearchIsOptional: Story = {
-	play: async ({ canvas, args }) => {
-		const dialog = within(await canvas.findByRole("dialog"));
+	play: async ({ args }) => {
+		const dialog = within(await screen.findByRole("dialog"));
 		await expect(dialog.getByRole("checkbox", { name: /research/i })).not.toBeChecked();
 
 		await userEvent.click(dialog.getByRole("checkbox", { name: /terms of use/i }));
@@ -63,8 +63,8 @@ export const Submitting: Story = { args: { submitting: true } };
 /** The choice reached the server and was refused; the reader is told and can retry. */
 export const SubmitFailed: Story = {
 	args: { failedToSubmit: true },
-	play: async ({ canvas }) => {
-		const dialog = within(await canvas.findByRole("dialog"));
+	play: async () => {
+		const dialog = within(await screen.findByRole("dialog"));
 		await expect(dialog.getByRole("alert")).toHaveTextContent(/wasn't saved/i);
 	},
 };
@@ -75,16 +75,16 @@ export const Loading: Story = { args: { notice: undefined } };
 /** The notice could not be fetched. The reader stays blocked, because the choice is still required. */
 export const FailedToLoad: Story = {
 	args: { notice: undefined, failedToLoad: true },
-	play: async ({ canvas }) => {
-		const dialog = within(await canvas.findByRole("dialog"));
+	play: async () => {
+		const dialog = within(await screen.findByRole("dialog"));
 		await expect(dialog.getByRole("alert")).toHaveTextContent(/couldn't load/i);
 	},
 };
 
 /** A mandatory dialog still needs a way out: declining is an answer, not a dead end. */
 export const CanDeclineAndSignOut: Story = {
-	play: async ({ canvas, args }) => {
-		const dialog = within(await canvas.findByRole("dialog"));
+	play: async ({ args }) => {
+		const dialog = within(await screen.findByRole("dialog"));
 		await userEvent.click(dialog.getByRole("button", { name: /sign out/i }));
 		await expect(args.onSignOut).toHaveBeenCalled();
 	},
@@ -93,8 +93,8 @@ export const CanDeclineAndSignOut: Story = {
 /** The load failure offers a retry rather than stranding the reader on a reload instruction. */
 export const FailedToLoadCanRetry: Story = {
 	args: { notice: undefined, failedToLoad: true },
-	play: async ({ canvas, args }) => {
-		const dialog = within(await canvas.findByRole("dialog"));
+	play: async ({ args }) => {
+		const dialog = within(await screen.findByRole("dialog"));
 		await userEvent.click(dialog.getByRole("button", { name: /try again/i }));
 		await expect(args.onRetry).toHaveBeenCalled();
 	},

--- a/webapp/src/components/auth/ConsentDialog.tsx
+++ b/webapp/src/components/auth/ConsentDialog.tsx
@@ -1,0 +1,172 @@
+import { ExternalLinkIcon } from "lucide-react";
+import { useId, useState } from "react";
+
+import type { ConsentStatus } from "@/api/types.gen";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+	Dialog,
+	DialogBody,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+import { Field, FieldContent, FieldDescription, FieldLabel } from "@/components/ui/field";
+import { Spinner } from "@/components/ui/spinner";
+
+export interface ConsentChoice {
+	noticeVersion: string;
+	termsAccepted: boolean;
+	participateInResearch: boolean;
+}
+
+interface ConsentDialogProps {
+	/** The notice to show. While it is loading the dialog is already open, so the app never flashes. */
+	notice: ConsentStatus | undefined;
+	/** The notice could not be loaded; the app stays blocked because the choice is still required. */
+	failedToLoad?: boolean;
+	onSubmit: (choice: ConsentChoice) => void;
+	/** Declining is an answer too: without a way out, the only exit from a trapped surface is the tab. */
+	onSignOut: () => void;
+	/** Retry loading the notice, so a failed fetch is not a dead end. */
+	onRetry: () => void;
+	submitting?: boolean;
+	/** The choice reached the server and was not stored. */
+	failedToSubmit?: boolean;
+}
+
+/**
+ * The transparency notice, asked where the reader already is.
+ *
+ * It is a dialog rather than a page because nothing about it is a destination: there is no url worth
+ * sharing, no back button worth pressing, and the work behind it is the work the reader asked for.
+ * It cannot be dismissed, because the server refuses every other call until the choice is recorded —
+ * a closeable dialog would only produce an application that answers nothing.
+ */
+export function ConsentDialog({
+	notice,
+	failedToLoad = false,
+	onSubmit,
+	onSignOut,
+	onRetry,
+	submitting = false,
+	failedToSubmit = false,
+}: ConsentDialogProps) {
+	const [termsAccepted, setTermsAccepted] = useState(false);
+	const [research, setResearch] = useState(false);
+	const termsId = useId();
+	const researchId = useId();
+
+	return (
+		// Held open: a request to close is ignored rather than unsupported, because the server refuses
+		// every other call until the choice is recorded and a closeable dialog would leave an
+		// application that answers nothing.
+		<Dialog open modal onOpenChange={() => undefined}>
+			<DialogContent showCloseButton={false} className="sm:max-w-xl" aria-describedby={undefined}>
+				<DialogHeader>
+					<DialogTitle>How Hephaestus uses your data</DialogTitle>
+					<DialogDescription>
+						{notice
+							? `A short summary, then two choices. Notice version ${notice.noticeVersion}.`
+							: "A short summary, then two choices."}
+					</DialogDescription>
+				</DialogHeader>
+
+				{failedToLoad ? (
+					<>
+						<DialogBody>
+							<p role="alert" className="text-muted-foreground">
+								We couldn't load the notice just now. Reload the page to try again — this choice is
+								needed before Hephaestus can show you anything.
+							</p>
+						</DialogBody>
+						<DialogFooter className="flex-col items-stretch gap-3 sm:flex-col sm:items-stretch">
+							<Button type="button" onClick={onRetry}>
+								Try again
+							</Button>
+							<Button type="button" variant="ghost" onClick={onSignOut}>
+								Sign out instead
+							</Button>
+						</DialogFooter>
+					</>
+				) : notice ? (
+					<>
+						<DialogBody className="space-y-4 leading-6">
+							{notice.noticeText.split("\n\n").map((paragraph) => (
+								<p key={paragraph} className="text-muted-foreground">
+									{paragraph}
+								</p>
+							))}
+							<a
+								href="/privacy"
+								target="_blank"
+								rel="noreferrer"
+								className="text-foreground inline-flex items-center gap-1 font-medium underline underline-offset-4"
+							>
+								Read the full privacy notice
+								<ExternalLinkIcon className="size-3.5" aria-hidden />
+							</a>
+						</DialogBody>
+
+						<form
+							className="contents"
+							onSubmit={(event) => {
+								event.preventDefault();
+								onSubmit({
+									noticeVersion: notice.noticeVersion,
+									termsAccepted,
+									participateInResearch: research,
+								});
+							}}
+						>
+							<DialogFooter className="flex-col items-stretch gap-3 sm:flex-col sm:items-stretch">
+								<Field orientation="horizontal">
+									<Checkbox
+										id={termsId}
+										checked={termsAccepted}
+										onCheckedChange={setTermsAccepted}
+									/>
+									<FieldContent>
+										<FieldLabel htmlFor={termsId}>I accept the terms of use</FieldLabel>
+										<FieldDescription>Required to use Hephaestus.</FieldDescription>
+									</FieldContent>
+								</Field>
+
+								<Field orientation="horizontal" className="bg-muted/40 rounded-lg border p-3">
+									<Checkbox id={researchId} checked={research} onCheckedChange={setResearch} />
+									<FieldContent>
+										<FieldLabel htmlFor={researchId}>Help improve Hephaestus research</FieldLabel>
+										<FieldDescription>
+											Optional. Declining changes nothing about your access, and you can change this
+											later in settings.
+										</FieldDescription>
+									</FieldContent>
+								</Field>
+
+								{failedToSubmit && (
+									<p role="alert" className="text-destructive">
+										Your choice wasn't saved. Try again.
+									</p>
+								)}
+
+								<Button type="submit" disabled={!termsAccepted || submitting}>
+									{submitting && <Spinner />}
+									{submitting ? "Saving" : "Continue"}
+								</Button>
+								<Button type="button" variant="ghost" onClick={onSignOut} disabled={submitting}>
+									Sign out instead
+								</Button>
+							</DialogFooter>
+						</form>
+					</>
+				) : (
+					<DialogBody className="flex justify-center py-8">
+						<Spinner className="size-6" aria-label="Loading the transparency notice" />
+					</DialogBody>
+				)}
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/webapp/src/components/auth/ConsentDialog.tsx
+++ b/webapp/src/components/auth/ConsentDialog.tsx
@@ -1,4 +1,4 @@
-import { ExternalLinkIcon } from "lucide-react";
+import { ExternalLinkIcon, GraduationCapIcon } from "lucide-react";
 import { useId, useState } from "react";
 
 import type { ConsentStatus } from "@/api/types.gen";
@@ -58,6 +58,7 @@ export function ConsentDialog({
 	const [research, setResearch] = useState(false);
 	const termsId = useId();
 	const researchId = useId();
+	const researchHeadingId = useId();
 
 	return (
 		// Held open: a request to close is ignored rather than unsupported, because the server refuses
@@ -93,21 +94,57 @@ export function ConsentDialog({
 					</>
 				) : notice ? (
 					<>
-						<DialogBody className="space-y-4 leading-6">
-							{notice.noticeText.split("\n\n").map((paragraph) => (
-								<p key={paragraph} className="text-muted-foreground">
-									{paragraph}
-								</p>
-							))}
-							<a
-								href="/privacy"
-								target="_blank"
-								rel="noreferrer"
-								className="text-foreground inline-flex items-center gap-1 font-medium underline underline-offset-4"
+						<DialogBody className="space-y-6 leading-6">
+							<div className="space-y-4">
+								{notice.noticeText.split("\n\n").map((paragraph) => (
+									<p key={paragraph} className="text-muted-foreground">
+										{paragraph}
+									</p>
+								))}
+								<a
+									href="/privacy"
+									target="_blank"
+									rel="noreferrer"
+									className="text-foreground inline-flex items-center gap-1 font-medium underline underline-offset-4"
+								>
+									Read the full privacy notice
+									<ExternalLinkIcon className="size-3.5" aria-hidden />
+								</a>
+							</div>
+
+							{/* The research invitation stands on its own, as a thing worth doing, rather than as a
+							    second checkbox under the legal one. It stays unticked: consent has to be an act
+							    the reader takes, and a pre-ticked box is not one. */}
+							<section
+								aria-labelledby={researchHeadingId}
+								className="bg-primary/5 ring-primary/20 space-y-3 rounded-lg p-4 ring-1"
 							>
-								Read the full privacy notice
-								<ExternalLinkIcon className="size-3.5" aria-hidden />
-							</a>
+								<div className="flex items-start gap-3">
+									<GraduationCapIcon className="text-primary mt-0.5 size-5 shrink-0" aria-hidden />
+									<div className="space-y-1">
+										<h3 id={researchHeadingId} className="text-foreground font-semibold">
+											Help TUM understand how developers grow
+										</h3>
+										<p className="text-muted-foreground">
+											Hephaestus is built by TUM's Applied Education Technologies group. If you take
+											part, how you use Hephaestus and how you respond to its feedback informs that
+											research — only for as long as you say so.
+										</p>
+									</div>
+								</div>
+								<Field orientation="horizontal" className="pl-8">
+									<Checkbox id={researchId} checked={research} onCheckedChange={setResearch} />
+									<FieldContent>
+										<FieldLabel htmlFor={researchId} className="font-medium">
+											Yes, I'll take part in the research
+										</FieldLabel>
+										<FieldDescription>
+											Optional. It never changes the feedback you get, and you can withdraw any time
+											in settings.
+										</FieldDescription>
+									</FieldContent>
+								</Field>
+							</section>
 						</DialogBody>
 
 						<form
@@ -131,17 +168,6 @@ export function ConsentDialog({
 									<FieldContent>
 										<FieldLabel htmlFor={termsId}>I accept the terms of use</FieldLabel>
 										<FieldDescription>Required to use Hephaestus.</FieldDescription>
-									</FieldContent>
-								</Field>
-
-								<Field orientation="horizontal" className="bg-muted/40 rounded-lg border p-3">
-									<Checkbox id={researchId} checked={research} onCheckedChange={setResearch} />
-									<FieldContent>
-										<FieldLabel htmlFor={researchId}>Help improve Hephaestus research</FieldLabel>
-										<FieldDescription>
-											Optional. Declining changes nothing about your access, and you can change this
-											later in settings.
-										</FieldDescription>
 									</FieldContent>
 								</Field>
 

--- a/webapp/src/integrations/auth/guard.ts
+++ b/webapp/src/integrations/auth/guard.ts
@@ -1,6 +1,7 @@
 import type { QueryClient } from "@tanstack/react-query";
 
 import {
+	getConsentStatusOptions,
 	getCurrentUserMembershipOptions,
 	getCurrentUserOptions,
 } from "@/api/@tanstack/react-query.gen";
@@ -144,4 +145,28 @@ export function safeReturnTo(value: string | undefined): string {
 	// Validation ran on the fully-decoded value; return the ORIGINAL so legitimate encoded
 	// segments (e.g. a `%26` in a query string) are preserved exactly as the caller intended.
 	return value;
+}
+
+/**
+ * Whether the reader still owes the transparency notice.
+ *
+ * The server answers every gated call with 428 until the choice is recorded, so a route that runs a
+ * gated query first would throw before anything could ask for the choice. Routes ask this instead
+ * and skip the work; the notice is then put to the reader in place, over the page they were opening.
+ */
+export async function consentIsPending(queryClient: QueryClient): Promise<boolean> {
+	// Only a signed-in reader can owe it. Asking on a public page would spend a request that can only
+	// answer 401, on the landing page's critical path, for every anonymous visitor.
+	if (!(await resolveCurrentUser(queryClient))) return false;
+	try {
+		const status = await queryClient.query(getConsentStatusOptions({}));
+		return !status.completed;
+	} catch {
+		// Only an explicit "not answered" blocks the application. Treating an unanswerable question as
+		// outstanding would put an undismissable notice in front of every reader whenever this one
+		// call failed, with no way out but a reload — and it would not even be protective, because the
+		// server refuses the gated calls itself. A reader who does owe the notice still meets that
+		// refusal; a reader who does not keeps working.
+		return false;
+	}
 }

--- a/webapp/src/routes/-consent-gate.test.tsx
+++ b/webapp/src/routes/-consent-gate.test.tsx
@@ -1,0 +1,50 @@
+import { QueryClient } from "@tanstack/react-query";
+import { describe, expect, it, vi } from "vitest";
+
+import { consentIsPending } from "@/integrations/auth/guard";
+
+/**
+ * The gate the root route consults before anything below it loads. Everything else about the notice
+ * is covered by the dialog's stories; what matters here is which way the gate errs, because the
+ * server refuses every gated call until the notice is answered.
+ */
+/** The generated query keys carry the operation name, which is what tells the two apart. */
+function asksAboutConsent(options: unknown): boolean {
+	return JSON.stringify(options).toLowerCase().includes("consent");
+}
+
+describe("consent gate", () => {
+	/** A signed-in reader: the current-user query resolves first, then the consent status. */
+	function clientAnswering(status: { completed: boolean }) {
+		const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+		vi.spyOn(client, "query").mockImplementation((options) =>
+			asksAboutConsent(options) ? Promise.resolve(status) : Promise.resolve({ id: 1 }),
+		);
+		return client;
+	}
+
+	it("lets the application load once the notice has been answered", async () => {
+		await expect(consentIsPending(clientAnswering({ completed: true }))).resolves.toBe(false);
+	});
+
+	it("holds the application back while the notice is outstanding", async () => {
+		await expect(consentIsPending(clientAnswering({ completed: false }))).resolves.toBe(true);
+	});
+
+	it("never asks on behalf of a signed-out visitor", async () => {
+		// The landing page waits on this, and the only answer it could get is 401.
+		const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+		const query = vi.spyOn(client, "query").mockResolvedValue(undefined);
+		await expect(consentIsPending(client)).resolves.toBe(false);
+		for (const [options] of query.mock.calls) expect(asksAboutConsent(options)).toBe(false);
+	});
+
+	it("lets the application load when it cannot tell, rather than blocking everyone", async () => {
+		// Blocking here would put an undismissable notice in front of every reader whenever this one
+		// call failed, with no way out but a reload — and it would not be protective either, because
+		// the server refuses the gated calls itself. A reader who owes the notice still meets that.
+		const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+		vi.spyOn(client, "query").mockRejectedValue(new Error("unreachable"));
+		await expect(consentIsPending(client)).resolves.toBe(false);
+	});
+});

--- a/webapp/src/routes/-consent-route.test.tsx
+++ b/webapp/src/routes/-consent-route.test.tsx
@@ -32,17 +32,11 @@ describe("first-login consent route", () => {
 		});
 		renderRouteAtWithRouter("/consent");
 
-		await screen.findByRole(
-			"heading",
-			{ name: "How Hephaestus uses your data" },
-			ROUTE_RENDER_WAIT,
-		);
+		await screen.findByRole("dialog", undefined, ROUTE_RENDER_WAIT);
 		const continueButton = screen.getByRole("button", { name: "Continue" });
 		expect(continueButton.hasAttribute("disabled")).toBe(true);
 
-		await userEvent.click(
-			screen.getByRole("checkbox", { name: "I accept the Hephaestus terms of use" }),
-		);
+		await userEvent.click(screen.getByRole("checkbox", { name: /terms of use/i }));
 		fireEvent.click(continueButton);
 
 		await waitFor(() =>
@@ -61,17 +55,9 @@ describe("first-login consent route", () => {
 		});
 		renderRouteAtWithRouter("/consent");
 
-		await screen.findByRole(
-			"heading",
-			{ name: "How Hephaestus uses your data" },
-			ROUTE_RENDER_WAIT,
-		);
-		await userEvent.click(
-			screen.getByRole("checkbox", { name: "I accept the Hephaestus terms of use" }),
-		);
-		await userEvent.click(
-			screen.getByRole("checkbox", { name: "I consent to academic research participation" }),
-		);
+		await screen.findByRole("dialog", undefined, ROUTE_RENDER_WAIT);
+		await userEvent.click(screen.getByRole("checkbox", { name: /terms of use/i }));
+		await userEvent.click(screen.getByRole("checkbox", { name: /research/i }));
 		fireEvent.click(screen.getByRole("button", { name: "Continue" }));
 
 		await waitFor(() =>

--- a/webapp/src/routes/consent.tsx
+++ b/webapp/src/routes/consent.tsx
@@ -1,22 +1,27 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { createFileRoute, Link, redirect, useNavigate } from "@tanstack/react-router";
-import { useState } from "react";
+import { createFileRoute, redirect, useNavigate } from "@tanstack/react-router";
 
 import {
 	completeFirstLoginConsentMutation,
 	getConsentStatusOptions,
 	getConsentStatusQueryKey,
 } from "@/api/@tanstack/react-query.gen";
-import { Button } from "@/components/ui/button";
-import { Checkbox } from "@/components/ui/checkbox";
-import { Field, FieldContent, FieldDescription, FieldLabel } from "@/components/ui/field";
-import { Spinner } from "@/components/ui/spinner";
+import { ConsentDialog } from "@/components/auth/ConsentDialog";
+import { useAuth } from "@/integrations/auth/AuthContext";
 import { resolveCurrentUser, safeReturnTo } from "@/integrations/auth/guard";
 
 interface ConsentSearch {
 	returnTo?: string;
 }
 
+/**
+ * The transparency notice.
+ *
+ * It is a route because only aborting the match stops the pages below from loading, and they fetch
+ * from endpoints the server refuses until the notice is answered — suppressing what renders would
+ * leave those requests running. The routes that send a reader here mask the address bar to the page
+ * they asked for, so what a reader sees is that page interrupted, not a trip somewhere else.
+ */
 export const Route = createFileRoute("/consent")({
 	staticData: { surface: "auth" },
 	validateSearch: (search): ConsentSearch => ({
@@ -36,9 +41,13 @@ function ConsentPage() {
 	const { returnTo } = Route.useSearch();
 	const navigate = useNavigate();
 	const queryClient = useQueryClient();
-	const [termsAccepted, setTermsAccepted] = useState(false);
-	const [research, setResearch] = useState(false);
-	const { data, isPending, isError } = useQuery(getConsentStatusOptions({}));
+	const { logout } = useAuth();
+	const { data, isError, refetch } = useQuery({
+		...getConsentStatusOptions({}),
+		// The guard above has just resolved this; refetching immediately would only risk replacing a
+		// usable notice with an error state.
+		staleTime: 30_000,
+	});
 	const mutation = useMutation({
 		...completeFirstLoginConsentMutation(),
 		onSuccess: (status) => {
@@ -47,89 +56,15 @@ function ConsentPage() {
 		},
 	});
 
-	if (isPending) return <Spinner className="size-8" aria-label="Loading transparency notice" />;
-	if (isError) {
-		return (
-			<p role="alert">We couldn't load the transparency notice. Please reload and try again.</p>
-		);
-	}
-
 	return (
-		<div className="mx-auto flex min-h-[100dvh] w-full max-w-2xl items-center px-4 py-10">
-			<section
-				className="w-full space-y-8 rounded-xl border bg-card p-6 shadow-sm sm:p-10"
-				aria-labelledby="consent-heading"
-			>
-				<header className="space-y-2">
-					<p className="text-sm font-medium text-primary">Before you continue</p>
-					<h1 id="consent-heading" className="text-3xl font-semibold tracking-tight">
-						How Hephaestus uses your data
-					</h1>
-					<p className="text-sm text-muted-foreground">Notice version {data.noticeVersion}</p>
-				</header>
-				<div className="space-y-4 text-sm leading-6">
-					{data.noticeText.split("\n\n").map((paragraph) => (
-						<p key={paragraph}>{paragraph}</p>
-					))}
-					<Link
-						to="/privacy"
-						target="_blank"
-						className="font-medium text-primary underline underline-offset-4"
-					>
-						Read the full privacy notice
-					</Link>
-				</div>
-				<form
-					className="space-y-6 border-t pt-6"
-					onSubmit={(event) => {
-						event.preventDefault();
-						mutation.mutate({
-							body: {
-								noticeVersion: data.noticeVersion,
-								termsAccepted,
-								participateInResearch: research,
-							},
-						});
-					}}
-				>
-					<Field orientation="horizontal">
-						<Checkbox
-							id="accept-terms"
-							checked={termsAccepted}
-							onCheckedChange={setTermsAccepted}
-						/>
-						<FieldContent>
-							<FieldLabel htmlFor="accept-terms">I accept the Hephaestus terms of use</FieldLabel>
-							<FieldDescription>
-								Terms acceptance is separate from the optional research choice.
-							</FieldDescription>
-						</FieldContent>
-					</Field>
-					<Field orientation="horizontal" className="rounded-lg border p-4">
-						<Checkbox id="research-opt-in" checked={research} onCheckedChange={setResearch} />
-						<FieldContent>
-							<FieldLabel htmlFor="research-opt-in">
-								I consent to academic research participation
-							</FieldLabel>
-							<FieldDescription>
-								Optional and unchecked by default. Declining does not change your access.
-							</FieldDescription>
-						</FieldContent>
-					</Field>
-					<p className="text-sm text-muted-foreground">
-						Continuing records that you received the privacy notice. This acknowledgement is not
-						consent.
-					</p>
-					<Button type="submit" className="w-full" disabled={!termsAccepted || mutation.isPending}>
-						{mutation.isPending ? "Saving…" : "Continue"}
-					</Button>
-					{mutation.isError && (
-						<p role="alert" className="text-sm text-destructive">
-							Your choice wasn't saved. Review the current notice and try again.
-						</p>
-					)}
-				</form>
-			</section>
-		</div>
+		<ConsentDialog
+			notice={data}
+			failedToLoad={isError}
+			submitting={mutation.isPending}
+			failedToSubmit={mutation.isError}
+			onSubmit={(choice) => mutation.mutate({ body: choice })}
+			onRetry={() => void refetch()}
+			onSignOut={() => void logout()}
+		/>
 	);
 }

--- a/webapp/src/routes/index.tsx
+++ b/webapp/src/routes/index.tsx
@@ -5,7 +5,7 @@ import { StandardPageSurface } from "@/components/core/StandardPageSurface";
 import { LandingPage } from "@/components/info/landing/LandingPage";
 import { NoWorkspace } from "@/components/workspace/NoWorkspace";
 import { useAuth } from "@/integrations/auth/AuthContext";
-import { resolveCurrentUser } from "@/integrations/auth/guard";
+import { consentIsPending, resolveCurrentUser } from "@/integrations/auth/guard";
 
 /**
  * Public home route. Signed-out visitors see the marketing landing page; signed-in visitors are
@@ -19,6 +19,21 @@ export const Route = createFileRoute("/")({
 	beforeLoad: async ({ context }) => {
 		const user = await resolveCurrentUser(context.queryClient);
 		if (!user) return;
+		// Every gated call is refused until the transparency notice is answered, and "/" is the page a
+		// reader lands on after signing in — so without this the first thing a new account meets is
+		// the error boundary. `_authenticated` has always done this; only this route was missing it.
+		//
+		// A redirect rather than a flag: suppressing what renders would not stop the routes below from
+		// running their own guards, which fetch too. Aborting the match is what actually stops them.
+		// The mask keeps the address bar on the page the reader asked for, so the notice reads as an
+		// interruption of that page rather than a trip to somewhere else.
+		if (await consentIsPending(context.queryClient)) {
+			throw redirect({
+				to: "/consent",
+				search: { returnTo: "/" },
+				mask: { to: "/" },
+			});
+		}
 		// A list that cannot be fetched is not an empty one: let the error surface rather than tell a
 		// member of workspaces that they are in none.
 		const workspaces = await context.queryClient.query(listWorkspacesOptions());

--- a/webapp/src/routes/login.tsx
+++ b/webapp/src/routes/login.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute, Link, redirect } from "@tanstack/react-router";
+import { createFileRoute, redirect } from "@tanstack/react-router";
 import { useEffect } from "react";
 import { toast } from "sonner";
 
@@ -59,19 +59,15 @@ function LoginPage() {
 	return (
 		<LoginCard
 			title="Welcome to Hephaestus"
+			// Two sentences, not five: the detail belongs in the transparency notice. But the fact that
+			// signing in shares a provider identity has to be here, because it is the decision being
+			// made on this page — a notice shown afterwards cannot inform it.
 			description={
 				<span className="space-y-2">
 					<span className="block">Your AI mentor for growing as a software engineer.</span>
-					<span className="block text-left">
-						TUM's Applied Education Technologies group operates Hephaestus. Signing in shares your
-						provider identity with us. Hephaestus analyzes connected GitHub, GitLab, Slack, and
-						Outline activity against your team's practices to provide feedback. Research use is
-						optional and off by default. You can exercise your data-protection rights as described
-						in the{" "}
-						<Link to="/privacy" target="_blank" className="underline underline-offset-4">
-							privacy notice
-						</Link>
-						.
+					<span className="block">
+						Signing in shares your provider identity with TUM. What happens with it is explained
+						next, before anything is analysed.
 					</span>
 				</span>
 			}


### PR DESCRIPTION
## The bug

Signing in as a new account on staging produced **"Something went wrong"**. From the console:

```
GET /api/workspaces 428 (Precondition Required)
{detail: "Complete the current transparency notice first", instance: "/workspaces"}
```

`ConsentGateInterceptor` refuses every call except `GET /user`, `GET`/`PUT /user/consent`, logout and
refresh until the first-login notice is answered — and `consent_decision` on staging has zero rows,
so this is every new account on every instance, not a staging quirk.

`_authenticated` has always redirected to the notice. But `/` is **not** under `_authenticated`: it is
the public home route that forwards a signed-in reader to their workspace, and its `beforeLoad` asked
for workspaces with no consent check. `/` is exactly where you land after signing in, so the first
page a new account ever sees was the error boundary. Every other route behaved correctly.

## The fix

`/` now does what `_authenticated` does. The redirect masks to the page that was asked for, so the
address bar does not move.

A redirect, not a flag the shell reads: suppressing what renders does **not** stop the routes below
from running. Their guards fetch too —
[`w/$workspaceSlug/route.tsx:11`](../blob/main/webapp/src/routes/_authenticated/w/%24workspaceSlug/route.tsx)
calls `listWorkspaces`, and the admin guard resolves membership — so a reader with a pending notice
would still fire gated calls and be redirected away from the URL they asked for. Aborting the match
is what stops them.

## The notice

Now a dialog rather than a page of prose: the summary scrolls so a long notice never pushes the
button off-screen, the required acceptance and the optional research choice are visually separated,
and it offers **"Sign out instead"** — a mandatory surface with a focus trap and no exit left closing
the tab as the only way to decline. A failed load offers a retry rather than telling you to reload.

The sign-in page loses four sentences of legal prose but keeps the one disclosure that must precede
the decision: that signing in shares your provider identity. A notice shown afterwards cannot inform
that choice.

## Verification

| | Clean `main` | This branch |
| --- | --- | --- |
| Test files failed | 16 | **15** |
| Tests failed | 88 | **85** |

Three fixed, none introduced — measured by stashing this work and re-running, because the suite has
85 pre-existing failures that are unrelated to this change and would otherwise obscure the signal.
Lint and typecheck clean; `gate:components`, `gate:stories`, `gate:story-sort` pass. Nine stories
cover the dialog's states, including that declining is possible and that a failed load can be retried.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZzUtPvAhEnBHsxqWTaRHn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a consent notice for first-time sign-in, including required terms acceptance and optional research participation.
  - Added retry, error, loading, and sign-out options to the consent experience.
  - Added a scrollable notice summary to make consent easier to review.

- **Bug Fixes**
  - Prevented first-time sign-in errors by redirecting users to the consent notice before workspace loading.
  - Preserved the original page address during consent completion.

- **Updates**
  - Simplified sign-in messaging while clarifying identity sharing with the provider and TUM.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->