### PR TITLE
chore(scripts): keep the signing hint out of CI logs

### DIFF
--- a/scripts/enable-hooks.test.ts
+++ b/scripts/enable-hooks.test.ts
@@ -26,14 +26,19 @@ const EMPTY_GLOBAL_CONFIG = globalConfig();
  * Git exports `GIT_DIR` and its siblings to every hook process, and they outrank a child's `cwd`.
  * Inherited, they would point both the script under test and the assertions at the repository the
  * hook is running in rather than at the clone made below. The global and system configs are then
- * replaced rather than dropped, because what a developer's own config says about commit signing is
- * exactly what these tests decide.
+ * replaced rather than dropped, and `CI` is removed, because what a developer's own config says
+ * about commit signing and whether this suite is running on a runner are exactly what these tests
+ * decide.
  */
-function hookFreeEnv(configPath: string = EMPTY_GLOBAL_CONFIG): NodeJS.ProcessEnv {
+function hookFreeEnv(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+	const inherited = Object.fromEntries(
+		Object.entries(process.env).filter(([key]) => !key.startsWith("GIT_") && key !== "CI"),
+	);
 	return {
-		...Object.fromEntries(Object.entries(process.env).filter(([key]) => !key.startsWith("GIT_"))),
-		GIT_CONFIG_GLOBAL: configPath,
+		...inherited,
+		GIT_CONFIG_GLOBAL: EMPTY_GLOBAL_CONFIG,
 		GIT_CONFIG_NOSYSTEM: "1",
+		...overrides,
 	};
 }
 
@@ -120,8 +125,21 @@ void test("an install with commit signing configured says nothing about it", () 
 		cwd: repository,
 		encoding: "utf8",
 		maxBuffer: CAPTURE_LIMIT_BYTES,
-		env: hookFreeEnv(signing),
+		env: hookFreeEnv({ GIT_CONFIG_GLOBAL: signing }),
 	});
 	assert.equal(result.status, 0, `${result.stdout}${result.stderr}`);
+	assert.doesNotMatch(result.stderr, /commit\.gpgsign/);
+});
+
+void test("an install on a runner stays silent even with no commit signing configured", () => {
+	const { repository, git } = clone();
+	const result = spawnSync("node", [SCRIPT], {
+		cwd: repository,
+		encoding: "utf8",
+		maxBuffer: CAPTURE_LIMIT_BYTES,
+		env: hookFreeEnv({ CI: "true" }),
+	});
+	assert.equal(result.status, 0, `${result.stdout}${result.stderr}`);
+	assert.equal(git("config", "core.hooksPath"), ".vite-hooks/_");
 	assert.doesNotMatch(result.stderr, /commit\.gpgsign/);
 });

--- a/scripts/enable-hooks.ts
+++ b/scripts/enable-hooks.ts
@@ -51,9 +51,13 @@ if (git("rev-parse", "--is-inside-work-tree") === "true") {
 	});
 	process.exitCode = enabled.status ?? 1;
 
-	// `--type=bool` so `1`, `yes` and `on` count as configured; every `gpg.format` signs.
-	const signs =
-		git("config", "--get", "--type=bool", "commit.gpgsign") === "true" &&
-		git("config", "--get", "user.signingkey") !== "";
-	if (!signs) process.stderr.write(SIGNING_WARNING);
+	// The hint is for a person at their keyboard; in a job log it is only noise. GitHub Actions, like
+	// every runner, sets `CI`.
+	if (process.env.CI !== "true") {
+		// `--type=bool` so `1`, `yes` and `on` count as configured; every `gpg.format` signs.
+		const signs =
+			git("config", "--get", "--type=bool", "commit.gpgsign") === "true" &&
+			git("config", "--get", "user.signingkey") !== "";
+		if (!signs) process.stderr.write(SIGNING_WARNING);
+	}
 }


### PR DESCRIPTION
## What changed and why

#1836 added an install-time hint telling a contributor how to configure commit signing. It is
addressed to a person at their keyboard, and CI is not one. Quality gate jobs install with
`--ignore-scripts` so `prepare` never runs there, but the toolchain job runs
`vp install --frozen-lockfile` on purpose, to prove an ordinary install sets `core.hooksPath` — and
that job's log picked the hint up.

`scripts/enable-hooks.ts` now skips the signing check when `CI` is set, matching how `scripts/` reads
that variable elsewhere (`scripts/db-utils.ts`). Enabling the hooks is untouched: the guard wraps
only the two `git config` reads and the warning.

## How to test

- `node --test scripts/enable-hooks.test.ts` — 5 pass. The new case runs the script with `CI=true`
  and no signing configured, and asserts both that nothing is printed and that `core.hooksPath` is
  still set. It fails when the guard is removed.
- The suite no longer depends on the machine it runs on: `hookFreeEnv` drops `CI` along with `GIT_*`,
  so "warns when unsigned" is not silently satisfied by the runner the tests happen to be on.
- `pnpm exec vp run check` exits 0.

## Release impact

No changeset. Repository tooling only; nothing under `server/`, `webapp/` or `docker/` changes.

## Notes for reviewers

Part of #1836's follow-through, not a new concern.
