### PR TITLE
fix(ci): give a promotion an absolute path to its resolver

### DIFF
--- a/.changeset/promotion-finds-its-resolver.md
+++ b/.changeset/promotion-finds-its-resolver.md
@@ -1,0 +1,5 @@
+---
+---
+
+No release note: this only changes how a promotion locates its own tooling. Nothing an operator runs
+or an instance serves changes.

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -71,16 +71,23 @@ jobs:
 
       - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
-      # deploy-state carries channels, not code, so the image resolver comes from the default branch.
+      # The resolver is tooling: it comes from the default branch so that a commit older than it can
+      # still be promoted, which is exactly what rolling an environment back means.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # The commit being promoted, so the upstream pins and the resolver are the ones that
-          # commit carries. An empty ref is the default branch, which is what a release wants.
-          ref: ${{ inputs.commit }}
           path: .promotion-scripts
-          sparse-checkout: |
-            scripts
-            security
+          sparse-checkout: scripts
+          persist-credentials: false
+
+      # The pins are data about the commit being promoted, so they come from that commit. Reading
+      # them from the default branch instead would deploy one commit's code against another's
+      # upstream images.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        if: ${{ inputs.commit != '' }}
+        with:
+          ref: ${{ inputs.commit }}
+          path: .promotion-inventory
+          sparse-checkout: security
           persist-credentials: false
 
       - name: Resolve the release to promote
@@ -140,7 +147,9 @@ jobs:
             # A commit has no release to fetch a lock from, so the channel carries the digests
             # itself. They are covered by the signature below, which is the same authority that
             # stands behind a release lock.
-            node .promotion-scripts/scripts/commit-image-lock.ts "$RELEASE" "$OWNER" > images.json
+            node "$GITHUB_WORKSPACE/.promotion-scripts/scripts/commit-image-lock.ts" \
+              "$RELEASE" "$OWNER" "$GITHUB_WORKSPACE/.promotion-inventory/security/release-images.json" \
+              > images.json
             jq -n --arg commit "$RELEASE" --slurpfile images images.json \
               --argjson allowRollback "$ALLOW_ROLLBACK" --argjson freeze "$FREEZE" \
               '{commit: $commit, images: $images[0], allowRollback: $allowRollback, freeze: $freeze}' \

--- a/scripts/commit-image-lock.ts
+++ b/scripts/commit-image-lock.ts
@@ -146,9 +146,11 @@ async function resolveAndVerify(repository: string, commit: string): Promise<str
 }
 
 if (import.meta.main) {
-	const [commit, owner = "hephaestus-build"] = process.argv.slice(2);
-	if (!commit) throw new Error("usage: commit-image-lock <commit> [owner]");
-	const inventory = await readInventory("security/release-images.json");
+	const [commit, owner = "hephaestus-build", inventoryPath = "security/release-images.json"] =
+		process.argv.slice(2);
+	if (!commit) throw new Error("usage: commit-image-lock <commit> [owner] [inventory]");
+	// The inventory belongs to the commit being promoted; this file may be newer than it.
+	const inventory = await readInventory(inventoryPath);
 	const images = await resolveImages(inventory, commit, owner, resolveAndVerify);
 	process.stdout.write(`${JSON.stringify(images, null, 2)}\n`);
 }


### PR DESCRIPTION
## Why staging stopped updating

Continuous staging has fired correctly twice since it merged and failed both times, so staging has
sat on `v0.76.0` while merged fixes — including the HSTS one — went undeployed.

The channel is written with `working-directory: deploy-state`, and the resolver was invoked by a
relative path. It therefore resolved to `deploy-state/.promotion-scripts/…`, which does not exist:

```
Error: Cannot find module '…/Hephaestus/deploy-state/.promotion-scripts/scripts/commit-image-lock.ts'
```

The two failures printed the same message with different paths — the first was a commit that genuinely
predated the resolver, the second this collision — which made them easy to conflate.

## Also fixed: promoting an older commit

The resolver and the pins were both read from the promoted commit. That makes a **rollback**
impossible, because a commit older than the tooling does not contain it. They have different correct
sources:

| | Source | Why |
| --- | --- | --- |
| Resolver | default branch | tooling; must exist when promoting an older commit |
| `security/release-images.json` | the promoted commit | describes what *that* commit runs |

Taking both from the commit breaks rollback; taking both from the branch would deploy one commit's
code against another commit's upstream images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZzUtPvAhEnBHsxqWTaRHn