### PR TITLE
fix(docker): a host runs the tooling of the release it applied

### DIFF
--- a/.changeset/host-tooling-stays-current.md
+++ b/.changeset/host-tooling-stays-current.md
@@ -1,0 +1,11 @@
+---
+"hephaestus": patch
+---
+
+Once a host that pulls its own releases applies a release that carries this change, it runs that
+release's deployment tooling and keeps its two systemd units matching it, so applying a release
+also brings the tooling forward — a host whose tooling had fallen behind previously failed every run
+until an operator logged in and updated it by hand. The tooling an operator installs or upgrades by
+hand, and releases older than this change, are the exceptions: the host keeps the tooling it has
+while running one. A host installed before this release needs the one-time upgrade steps in the
+pull-based deployment guide.

--- a/docker/self-host/systemd/hephaestus-reconcile.service
+++ b/docker/self-host/systemd/hephaestus-reconcile.service
@@ -10,7 +10,13 @@ Type=oneshot
 EnvironmentFile=/etc/hephaestus/reconcile.env
 StateDirectory=hephaestus
 StateDirectoryMode=0750
-ExecStart=/usr/bin/env node /var/lib/hephaestus/checkout/scripts/reconcile-deployment.ts
+# The reconciler runs the tooling of the release this host last applied: `tooling` is a link the
+# reconciler moves only after it has verified and applied a release, so a release never supplies
+# its own verifier. The tooling this host runs is what a signed channel named, except for what an
+# operator installed or upgraded by hand until the first apply after it, and except that a release
+# older than this link keeps the tooling the host has. The reconciler also keeps this unit and its
+# timer in /etc/systemd/system at that release and reloads systemd itself.
+ExecStart=/usr/bin/env node /var/lib/hephaestus/tooling/scripts/reconcile-deployment.ts
 TimeoutStartSec=30min
 
 NoNewPrivileges=yes
@@ -18,6 +24,7 @@ ProtectSystem=strict
 ProtectHome=yes
 PrivateTmp=yes
 ReadWritePaths=-/var/lib/node_exporter
+ReadWritePaths=/etc/systemd/system
 # The Docker socket is reached over AF_UNIX; omitting it here breaks connect(2). Read-only
 # directory protections do not block Unix sockets, so ProtectSystem=strict leaves it reachable.
 RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6

--- a/docs/admin/pull-based-deployment.mdx
+++ b/docs/admin/pull-based-deployment.mdx
@@ -54,12 +54,16 @@ redirects may use additional hosts; an allowlist limited to `github.com` and `gh
 
 ## Install
 
-1. Install the trusted reconciler checkout. Update it separately from application releases.
+1. Install the trusted reconciler checkout. This clone is the first tooling the host runs: from the
+   first release it applies onward, the host runs the reconciler and verifier of the release it
+   applied, reached through the `/var/lib/hephaestus/tooling` link that the reconciler moves only
+   after it has verified and applied a release. A release never replaces the tooling that verifies it.
 
    ```bash
    sudo install -d -m 0750 /var/lib/hephaestus
    sudo git clone --branch main --single-branch \
      https://github.com/hephaestus-build/Hephaestus.git /var/lib/hephaestus/checkout
+   sudo ln -sfn /var/lib/hephaestus/checkout /var/lib/hephaestus/tooling
    ```
 
 2. Copy `docker/self-host/systemd/reconcile.env.example` to `/etc/hephaestus/reconcile.env`
@@ -77,7 +81,48 @@ redirects may use additional hosts; an allowlist limited to `github.com` and `gh
    sudo systemctl enable --now hephaestus-reconcile.timer
    ```
 
+   The units are copies, because systemd needs them on the root filesystem at boot. The reconciler
+   keeps both at the release the host runs and reloads systemd when it rewrites one, so this is the
+   last time they are installed by hand.
+
 5. Watch the first run: `journalctl -fu hephaestus-reconcile.service`.
+
+### Upgrading a host installed before the tooling link
+
+A host set up before `/var/lib/hephaestus/tooling` existed runs the reconciler straight from its
+checkout, and that checkout is exactly what stood still. Bring it forward once by hand; from then
+on the reconciler maintains the link and the units.
+
+```bash
+sudo systemctl stop hephaestus-reconcile.timer
+while [ "$(systemctl show --property=ActiveState --value hephaestus-reconcile.service)" = activating ]; do sleep 5; done
+sudo git -C /var/lib/hephaestus/checkout fetch --quiet origin main
+sudo git -C /var/lib/hephaestus/checkout reset --quiet --hard origin/main
+sudo ln -sfn /var/lib/hephaestus/checkout /var/lib/hephaestus/tooling
+sudo install -m 0644 \
+  /var/lib/hephaestus/checkout/docker/self-host/systemd/hephaestus-reconcile.service \
+  /var/lib/hephaestus/checkout/docker/self-host/systemd/hephaestus-reconcile.timer \
+  /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl start hephaestus-reconcile.service
+sudo systemctl start hephaestus-reconcile.timer
+sudo readlink /var/lib/hephaestus/tooling
+```
+
+Then run the **Promote** workflow for the release the host already runs. A record written before
+the release commit was kept is never completed from what is on disk — nothing there tells the tree
+the host accepted from one a failed promotion left behind — so the host keeps the tooling from the
+checkout, reports `hephaestus_deploy_tooling_pending 1`, and only the next apply records the commit
+and adopts that release's tooling.
+
+The timer is stopped first and a tick already running is waited out — a oneshot service is
+`activating` while it runs, and stopping its timer does not stop it — because nothing may change the
+checkout underneath a tick. The last line names the worktree of the release the host runs once a
+tick has adopted it. The service starts only through that link: if it is ever missing or points at
+a directory that is gone, recreate it with the `ln` line above. A recorded release whose worktree
+under `releases/` has been deleted is rebuilt before anything else, at the commit the host accepted
+for it rather than wherever its tag points now; if that cannot be done, because the checkout
+has lost that commit, say, the tick stops with the reason.
 
 `HEPHAESTUS_STACKS` selects the Compose projects this host manages. If another proxy provides its
 ingress, omit `proxy` and use `core app`.
@@ -106,12 +151,14 @@ The reconciler refuses a release checkout with modified tracked files.
 ## Watching it
 
 Set `HEPHAESTUS_METRICS_FILE` to a `.prom` file in an existing node_exporter textfile collector
-directory. After a deployment has succeeded, the metrics include:
+directory. After a deployment has succeeded, every run writes these, except one that only adopted
+the tooling of the applied release, which leaves them as they were:
 
 ```text
 hephaestus_deploy_info{channel="staging",release="v1.2.3",channel_commit="…"} 1
 hephaestus_deploy_reconcile_success 1
 hephaestus_deploy_reconcile_timestamp_seconds …
+hephaestus_deploy_tooling_pending 0
 hephaestus_deploy_last_success_timestamp_seconds …
 ```
 
@@ -119,6 +166,8 @@ Alert when `time() - hephaestus_deploy_reconcile_timestamp_seconds` exceeds ten 
 `hephaestus_deploy_reconcile_success` is `0`, or when the host's reconciliation metrics are absent.
 `hephaestus_deploy_last_success_timestamp_seconds` records the last successful **apply**; unchanged
 and frozen channels do not advance it, so its age is not a reconciliation-liveness check.
+Alert as well when `hephaestus_deploy_tooling_pending` stays `1`: the host runs tooling no apply has
+recorded yet, and a promotion of the release it runs ends that.
 
 A promotion without **freeze** waits for the public webapp to report the requested version. This
 checks the webapp version, not the readiness of every service; use host metrics and logs for the

--- a/docs/decisions/0042-hosts-pull-their-own-releases.md
+++ b/docs/decisions/0042-hosts-pull-their-own-releases.md
@@ -68,6 +68,21 @@ been running that commit since it merged, which is a longer and more honest rehe
 minutes a pre-production promotion bought. Holding an environment still is what the channel's
 `freeze` is for, signed and carried with the channel rather than configured beside it.
 
+**The host runs the tooling of the release it applied.** The reconciler and the verifier run from
+the host's own tooling directory, never from the release being verified: the tick that verifies a
+channel runs the tooling of the last release this host accepted, and only once the next release is
+verified and applied does the host move its tooling to that release's tree and bring the two systemd
+units in `/etc/systemd/system` to the same tree, reloading systemd itself. So a release cannot
+supply its own verifier, and the host runs no tooling a signed channel did not name, with two
+exceptions: the tooling an operator installs or upgrades by hand runs until the first apply after
+it, and a release that predates the tooling link is never adopted, so a host rolled back to one
+keeps the tooling it has, while a rollback to a release that carries the link moves the tooling back
+with it. That makes a rule for the promoter:
+a change to what `promote.yml` writes must stay readable by the tooling of every release a rollback
+can still reach, and nothing checks this for it. Standing still is not safe either: a host stranded
+on old tooling fails every tick until someone logs in, which is the silent failure this design exists
+to avoid.
+
 **A failed apply stops.** It does not roll back. Schema changes are forward-only here, so restoring
 the previous images would leave old code on a migrated database. Host monitoring reads the failure
 and staleness metrics instead.

--- a/scripts/prepare-release-lock.ts
+++ b/scripts/prepare-release-lock.ts
@@ -2,6 +2,9 @@ import { mkdtemp, rename, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { basename, dirname, join } from "node:path";
 
+/** A stalled download must not hold a host's reconcile tick until its unit gives up. */
+const DOWNLOAD_TIMEOUT_MS = 5 * 60_000;
+
 import { run } from "./lib/process.ts";
 import { releaseCertificateIdentity, releaseRepository } from "./lib/release-identities.ts";
 import { isRelease } from "./release-image-lock.ts";
@@ -18,7 +21,7 @@ async function downloadReleaseAsset(
 	into: string,
 ): Promise<void> {
 	const url = `https://github.com/${repository}/releases/download/${tag}/${name}`;
-	const response = await fetch(url);
+	const response = await fetch(url, { signal: AbortSignal.timeout(DOWNLOAD_TIMEOUT_MS) });
 	if (!response.ok) throw new Error(`GET ${url} returned ${response.status}`);
 	await writeFile(join(into, name), Buffer.from(await response.arrayBuffer()));
 }

--- a/scripts/reconcile-deployment.test.ts
+++ b/scripts/reconcile-deployment.test.ts
@@ -1,11 +1,16 @@
 import assert from "node:assert/strict";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { execFileSync } from "node:child_process";
+import { mkdir, mkdtemp, readFile, readlink, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "node:test";
 
 import {
+	adoptTooling,
+	appliedCommit,
+	carriesToolingLink,
 	commitLockEnvironment,
+	ensureReleaseTree,
 	decide,
 	isTarget,
 	lockedReleaseCommit,
@@ -13,6 +18,7 @@ import {
 	parseStacks,
 	readApplied,
 	renderMetrics,
+	syncUnits,
 	unlockedImages,
 } from "./reconcile-deployment.ts";
 
@@ -103,6 +109,16 @@ await test("only a missing applied-state file means first run", async () => {
 			}),
 		);
 		await assert.rejects(readApplied(corrupt), /ISO timestamp/);
+
+		// The commit is kept from the first record that carried it, and an older record has none.
+		const withCommit = join(directory, "with-commit.json");
+		await writeFile(withCommit, JSON.stringify({ ...applied, commit: "c".repeat(40) }));
+		assert.deepEqual(await readApplied(withCommit), { ...applied, commit: "c".repeat(40) });
+		const legacy = join(directory, "legacy.json");
+		await writeFile(legacy, JSON.stringify(applied));
+		assert.deepEqual(await readApplied(legacy), applied);
+		await writeFile(corrupt, JSON.stringify({ ...applied, commit: "v1.2.3" }));
+		await assert.rejects(readApplied(corrupt), /applied\.commit must be a Git commit/);
 	} finally {
 		await rm(directory, { recursive: true, force: true });
 	}
@@ -130,6 +146,13 @@ await test("the version rides in labels so a dashboard can group by it", () => {
 	);
 	assert.match(metrics, /hephaestus_deploy_reconcile_success 1/);
 	assert.match(metrics, /hephaestus_deploy_last_success_timestamp_seconds 1788469200/);
+	// The heartbeat every run that inspects the channel writes, and what the last-success series means.
+	assert.match(metrics, /hephaestus_deploy_reconcile_timestamp_seconds 1788469200\n/);
+	assert.match(metrics, /hephaestus_deploy_tooling_pending 0\n/);
+	assert.match(
+		metrics,
+		/# HELP hephaestus_deploy_last_success_timestamp_seconds When the release this host runs was applied\./,
+	);
 	assert.ok(metrics.endsWith("\n"));
 });
 
@@ -143,6 +166,8 @@ await test("a failed run still publishes a series, or silence and failure look a
 	});
 	assert.match(metrics, /hephaestus_deploy_reconcile_success 0/);
 	assert.doesNotMatch(metrics, /last_success/);
+	assert.match(metrics, /hephaestus_deploy_reconcile_timestamp_seconds 1788469200\n/);
+	assert.match(metrics, /hephaestus_deploy_tooling_pending 0\n/);
 });
 
 await test("an image the release lock does not cover is refused", () => {
@@ -261,4 +286,165 @@ await test("a host remembers a commit it applied, not only a release", () => {
 	assert.ok(isTarget("c".repeat(40)));
 	assert.ok(!isTarget("main"));
 	assert.ok(!isTarget("v1.2"));
+});
+
+await test("the tooling link moves to the applied tree in one step", async () => {
+	const directory = await mkdtemp(join(tmpdir(), "reconcile-tooling-"));
+	try {
+		const link = join(directory, "tooling");
+		await symlink(join(directory, "checkout"), link);
+		assert.equal(await adoptTooling(link, join(directory, "releases/v1.0.0")), true);
+		assert.equal(await readlink(link), join(directory, "releases/v1.0.0"));
+		assert.equal(await adoptTooling(link, join(directory, "releases/v1.0.1")), true);
+		assert.equal(await readlink(link), join(directory, "releases/v1.0.1"));
+		assert.equal(await adoptTooling(link, join(directory, "releases/v1.0.1")), false);
+		assert.equal(await readlink(link), join(directory, "releases/v1.0.1"));
+	} finally {
+		await rm(directory, { recursive: true, force: true });
+	}
+});
+
+await test("installed units follow the applied tree, and a link left by an earlier install is replaced", async () => {
+	const directory = await mkdtemp(join(tmpdir(), "reconcile-units-"));
+	try {
+		const tree = join(directory, "tree");
+		const source = join(tree, "docker/self-host/systemd");
+		const units = join(directory, "units");
+		await mkdir(source, { recursive: true });
+		await mkdir(units);
+		await writeFile(join(source, "hephaestus-reconcile.service"), "[Service]\nExecStart=new\n");
+		await writeFile(join(source, "hephaestus-reconcile.timer"), "[Timer]\nOnUnitActiveSec=1min\n");
+		await writeFile(join(units, "hephaestus-reconcile.service"), "[Service]\nExecStart=old\n");
+		await symlink(
+			join(source, "hephaestus-reconcile.timer"),
+			join(units, "hephaestus-reconcile.timer"),
+		);
+
+		assert.deepEqual(await syncUnits(tree, units), [
+			"hephaestus-reconcile.service",
+			"hephaestus-reconcile.timer",
+		]);
+		assert.equal(
+			await readFile(join(units, "hephaestus-reconcile.service"), "utf8"),
+			"[Service]\nExecStart=new\n",
+		);
+		await assert.rejects(readlink(join(units, "hephaestus-reconcile.timer")), { code: "EINVAL" });
+		assert.deepEqual(await syncUnits(tree, units), []);
+
+		await writeFile(join(source, "hephaestus-reconcile.timer"), "[Timer]\nOnUnitActiveSec=2min\n");
+		assert.deepEqual(await syncUnits(tree, units), ["hephaestus-reconcile.timer"]);
+		assert.equal(
+			await readFile(join(units, "hephaestus-reconcile.timer"), "utf8"),
+			"[Timer]\nOnUnitActiveSec=2min\n",
+		);
+	} finally {
+		await rm(directory, { recursive: true, force: true });
+	}
+});
+
+await test("a tree is adopted as tooling only when its own unit runs through the tooling link", async () => {
+	const directory = await mkdtemp(join(tmpdir(), "reconcile-floor-"));
+	try {
+		const units = join(directory, "docker/self-host/systemd");
+		await mkdir(units, { recursive: true });
+		assert.equal(await carriesToolingLink(directory), false);
+		await writeFile(
+			join(units, "hephaestus-reconcile.service"),
+			"# not /var/lib/hephaestus/tooling/\nExecStart=/usr/bin/env node /var/lib/hephaestus/checkout/scripts/reconcile-deployment.ts\n",
+		);
+		assert.equal(await carriesToolingLink(directory), false);
+		await writeFile(
+			join(units, "hephaestus-reconcile.service"),
+			"ExecStart=/usr/bin/env node /var/lib/hephaestus/tooling/scripts/reconcile-deployment.ts\n",
+		);
+		assert.equal(await carriesToolingLink(directory), true);
+	} finally {
+		await rm(directory, { recursive: true, force: true });
+	}
+});
+
+await test("a release's worktree is rebuilt at the accepted commit and checked before it is used", async () => {
+	const directory = await mkdtemp(join(tmpdir(), "reconcile-tree-"));
+	const git = (cwd: string, ...args: string[]): string =>
+		execFileSync("git", args, {
+			cwd,
+			encoding: "utf8",
+			env: { ...process.env, GIT_CONFIG_GLOBAL: "/dev/null", GIT_CONFIG_SYSTEM: "/dev/null" },
+		}).trim();
+	try {
+		const checkout = join(directory, "checkout");
+		await mkdir(checkout);
+		git(checkout, "init", "--quiet", "--initial-branch=main");
+		git(checkout, "config", "user.email", "host@example.invalid");
+		git(checkout, "config", "user.name", "host");
+		// Windows git would otherwise check the file out with CRLF and the content comparison fail.
+		git(checkout, "config", "core.autocrlf", "false");
+		await writeFile(join(checkout, "compose.yaml"), "services: {}\n");
+		git(checkout, "add", "compose.yaml");
+		git(checkout, "commit", "--quiet", "-m", "release");
+		git(checkout, "tag", "v1.0.0");
+		const accepted = git(checkout, "rev-parse", "HEAD");
+		const releases = join(directory, "releases");
+
+		const first = await ensureReleaseTree(checkout, releases, "v1.0.0", accepted);
+		assert.deepEqual(first, { tree: join(releases, "v1.0.0"), commit: accepted });
+		assert.equal(await readFile(join(first.tree, "compose.yaml"), "utf8"), "services: {}\n");
+
+		// The tag moves after acceptance, and the tree is deleted by hand while git still has the
+		// path registered: what comes back is the accepted commit, not where the tag points now.
+		await writeFile(join(checkout, "compose.yaml"), "services: {later: {}}\n");
+		git(checkout, "commit", "--quiet", "-am", "later");
+		git(checkout, "tag", "--force", "v1.0.0");
+		await rm(first.tree, { recursive: true, force: true });
+		assert.deepEqual(await ensureReleaseTree(checkout, releases, "v1.0.0", accepted), first);
+		assert.equal(await readFile(join(first.tree, "compose.yaml"), "utf8"), "services: {}\n");
+
+		// A clean tree at a different commit is refused, as is a tampered one.
+		await assert.rejects(
+			ensureReleaseTree(checkout, releases, "v1.0.0", git(checkout, "rev-parse", "HEAD")),
+			/is at .* not the .* accepted for v1\.0\.0/,
+		);
+		await writeFile(join(first.tree, "compose.yaml"), "services: {tampered: {}}\n");
+		await assert.rejects(
+			ensureReleaseTree(checkout, releases, "v1.0.0", accepted),
+			/differs from v1\.0\.0/,
+		);
+
+		await assert.rejects(
+			ensureReleaseTree(checkout, releases, "v9.9.9", "0".repeat(40)),
+			/git exited with code/,
+		);
+	} finally {
+		await rm(directory, { recursive: true, force: true });
+	}
+});
+
+await test("only a record that kept its commit, or names one, says what tooling to run", () => {
+	assert.equal(appliedCommit(applied), undefined);
+	assert.equal(appliedCommit({ ...applied, commit: "c".repeat(40) }), "c".repeat(40));
+	assert.equal(appliedCommit({ ...applied, release: "f".repeat(40) }), "f".repeat(40));
+	assert.match(
+		renderMetrics({
+			channel: "staging",
+			release: "v0.75.2",
+			commit: "abc",
+			success: true,
+			now: new Date("2026-09-03T21:00:00.000Z"),
+			lastSuccessAt: new Date("2026-09-03T21:00:00.000Z"),
+			toolingPending: true,
+		}),
+		/hephaestus_deploy_tooling_pending 1\n/,
+	);
+	// A failed run reports the same fact, so it cannot read as the apply that ends it.
+	assert.match(
+		renderMetrics({
+			channel: "staging",
+			release: "v0.75.2",
+			commit: "abc",
+			success: false,
+			now: new Date("2026-09-03T21:00:00.000Z"),
+			toolingPending: true,
+		}),
+		/hephaestus_deploy_tooling_pending 1\n/,
+	);
 });

--- a/scripts/reconcile-deployment.ts
+++ b/scripts/reconcile-deployment.ts
@@ -1,5 +1,14 @@
-import { existsSync } from "node:fs";
-import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import {
+	lstat,
+	mkdir,
+	readFile,
+	readlink,
+	rename,
+	rm,
+	stat,
+	symlink,
+	writeFile,
+} from "node:fs/promises";
 import { join } from "node:path";
 
 import { asRecord, asString, parseJson } from "./lib/json.ts";
@@ -23,6 +32,16 @@ const FOUNDATION: Partial<Record<Stack, readonly string[]>> = {
 	core: ["nats-server"],
 };
 
+/**
+ * A black-holed connection must not hold a tick until the unit's start timeout; the next tick
+ * retries, and the failure metric says why this one did not.
+ */
+const FETCH_TIMEOUT_MS = 5 * 60_000;
+
+/** The units this host runs, kept at the applied release by `syncUnits`. */
+const UNIT_FILES = ["hephaestus-reconcile.service", "hephaestus-reconcile.timer"] as const;
+const SYSTEMD_UNITS = "/etc/systemd/system";
+
 export interface Channel {
 	/** What this channel asks the host to run: a release tag, or the commit a build came from. */
 	release: string;
@@ -36,6 +55,8 @@ export interface AppliedState {
 	release: string;
 	channelCommit: string;
 	appliedAt: string;
+	/** The release's source commit as the signed lock named it; absent in records written earlier. */
+	commit?: string;
 }
 
 export type Decision =
@@ -184,6 +205,8 @@ export function renderMetrics(state: {
 	success: boolean;
 	now: Date;
 	lastSuccessAt?: Date;
+	/** The applied record predates the kept commit, so the tooling waits for the next apply. */
+	toolingPending?: boolean;
 }): string {
 	const seconds = (date: Date) => Math.floor(date.getTime() / 1000);
 	const lines = [
@@ -196,10 +219,13 @@ export function renderMetrics(state: {
 		"# HELP hephaestus_deploy_reconcile_timestamp_seconds When the last reconcile attempt ran.",
 		"# TYPE hephaestus_deploy_reconcile_timestamp_seconds gauge",
 		`hephaestus_deploy_reconcile_timestamp_seconds ${seconds(state.now)}`,
+		"# HELP hephaestus_deploy_tooling_pending Whether the host still waits for an apply to record the tooling it should run.",
+		"# TYPE hephaestus_deploy_tooling_pending gauge",
+		`hephaestus_deploy_tooling_pending ${state.toolingPending ? 1 : 0}`,
 	];
 	if (state.lastSuccessAt) {
 		lines.push(
-			"# HELP hephaestus_deploy_last_success_timestamp_seconds When this host last converged.",
+			"# HELP hephaestus_deploy_last_success_timestamp_seconds When the release this host runs was applied.",
 			"# TYPE hephaestus_deploy_last_success_timestamp_seconds gauge",
 			`hephaestus_deploy_last_success_timestamp_seconds ${seconds(state.lastSuccessAt)}`,
 		);
@@ -247,6 +273,8 @@ interface HostConfig {
 	channel: string;
 	stacks: Stack[];
 	checkout: string;
+	/** A link to the tree whose tooling this host runs: the checkout until the first apply. */
+	tooling: string;
 	stateDirectory: string;
 	secretsDirectory: string;
 	metricsFile?: string;
@@ -271,6 +299,7 @@ function hostConfig(environment: NodeJS.ProcessEnv): HostConfig {
 		channel,
 		stacks: parseStacks(environment.HEPHAESTUS_STACKS),
 		checkout: join(stateDirectory, "checkout"),
+		tooling: join(stateDirectory, "tooling"),
 		stateDirectory,
 		secretsDirectory: environment.HEPHAESTUS_SECRETS ?? "/etc/hephaestus",
 		metricsFile: environment.HEPHAESTUS_METRICS_FILE,
@@ -286,11 +315,14 @@ export async function readApplied(file: string): Promise<AppliedState | undefine
 			release: asString(record.release, "applied.release"),
 			channelCommit: asString(record.channelCommit, "applied.channelCommit"),
 			appliedAt: asString(record.appliedAt, "applied.appliedAt"),
+			...(record.commit === undefined ? {} : { commit: asString(record.commit, "applied.commit") }),
 		};
 		if (!isTarget(applied.release))
 			throw new Error("applied.release must be a vX.Y.Z tag or a commit");
 		if (!/^[a-f0-9]{40}$/.test(applied.channelCommit))
 			throw new Error("applied.channelCommit must be a Git commit");
+		if (applied.commit !== undefined && !COMMIT_SHA.test(applied.commit))
+			throw new Error("applied.commit must be a Git commit");
 		if (
 			!Number.isFinite(Date.parse(applied.appliedAt)) ||
 			new Date(applied.appliedAt).toISOString() !== applied.appliedAt
@@ -311,6 +343,10 @@ async function writeAtomic(file: string, contents: string): Promise<void> {
 	await rename(temporary, file);
 }
 
+function fetchOptions(config: HostConfig): { cwd: string; signal: AbortSignal } {
+	return { cwd: config.checkout, signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) };
+}
+
 async function main(): Promise<void> {
 	const config = hostConfig(process.env);
 	const appliedFile = join(config.stateDirectory, "applied.json");
@@ -318,13 +354,39 @@ async function main(): Promise<void> {
 	const startedAt = new Date();
 
 	await mkdir(config.stateDirectory, { recursive: true });
+	// Before anything else, and in particular before the channel is parsed: a tick that stopped between
+	// recording a release and adopting its tooling would otherwise read the next channel with the
+	// tooling that release replaced. The recorded release's tree is rebuilt at the commit the signed
+	// lock named if it is gone and checked either way, so what is adopted is that release and nothing
+	// that happens to sit at its path. Node keeps running the module it loaded, so when the link
+	// moved, this tick ends here and the next one runs the adopted tooling.
+	if (applied) {
+		const commit = appliedCommit(applied);
+		if (commit === undefined) {
+			// Nothing on disk tells an accepted tree from one a failed re-promotion staged, so a record
+			// from before the commit was kept is never completed from a tree or a lock: the next apply
+			// records the commit, and until then the host reports the tooling as pending.
+			console.log(
+				`${applied.release} was recorded before its commit was kept; keeping the current tooling until the next apply`,
+			);
+		} else {
+			const { tree } = await ensureReleaseTree(
+				config.checkout,
+				releasesDirectory(config),
+				applied.release,
+				commit,
+			);
+			if (await followTooling(config, tree)) {
+				console.log(`Adopted the tooling of ${applied.release}; the next run uses it`);
+				return;
+			}
+		}
+	}
 
 	await run(
 		"git",
 		["fetch", "--quiet", "origin", "+refs/heads/deploy-state:refs/remotes/origin/deploy-state"],
-		{
-			cwd: config.checkout,
-		},
+		fetchOptions(config),
 	);
 	// Trimmed because the SHA is compared and interpolated; the blobs below are not, since the
 	// channel must reach cosign byte for byte as it was signed.
@@ -378,9 +440,11 @@ async function main(): Promise<void> {
 	// as "not behind", which is the wrong way for this check to be wrong.
 	let targetPrecedesApplied = false;
 	if (applied && !RELEASE_TAG.test(channel.release) && !RELEASE_TAG.test(applied.release)) {
-		await run("git", ["fetch", "--quiet", "origin", "+refs/heads/main:refs/remotes/origin/main"], {
-			cwd: config.checkout,
-		});
+		await run(
+			"git",
+			["fetch", "--quiet", "origin", "+refs/heads/main:refs/remotes/origin/main"],
+			fetchOptions(config),
+		);
 		for (const commit of [channel.release, applied.release])
 			if (
 				!(await succeeds("git", ["cat-file", "-e", `${commit}^{commit}`], { cwd: config.checkout }))
@@ -415,13 +479,13 @@ async function main(): Promise<void> {
 					success: true,
 					now: startedAt,
 					lastSuccessAt: new Date(applied.appliedAt),
+					toolingPending: appliedCommit(applied) === undefined,
 				}),
 			);
 		}
 		return;
 	}
 
-	const releaseTree = join(config.stateDirectory, "releases", decision.release);
 	// A release arrives as a tag; a commit is only reachable through the branch it is on, because a
 	// server does not serve an arbitrary object by name unless it is configured to.
 	await run(
@@ -429,34 +493,17 @@ async function main(): Promise<void> {
 		RELEASE_TAG.test(decision.release)
 			? ["fetch", "--quiet", "origin", "tag", decision.release, "--no-tags"]
 			: ["fetch", "--quiet", "origin", "+refs/heads/main:refs/remotes/origin/main"],
-		{ cwd: config.checkout },
+		fetchOptions(config),
 	);
 	const releaseCommit = (
 		await output("git", ["rev-parse", `${decision.release}^{commit}`], { cwd: config.checkout })
 	).trim();
-	if (existsSync(releaseTree)) {
-		const worktreeCommit = (
-			await output("git", ["rev-parse", "HEAD"], { cwd: releaseTree })
-		).trim();
-		if (worktreeCommit !== releaseCommit)
-			throw new Error(`${releaseTree} is not the worktree for ${decision.release}`);
-	} else {
-		await run("git", ["worktree", "add", "--detach", "--quiet", releaseTree, decision.release], {
-			cwd: config.checkout,
-		});
-	}
-	// Tracked content only: Compose writes into the worktree it renders from — the proxy stack's ACME
-	// store is `docker/letsencrypt/` — so counting untracked files would turn every retry after a
-	// partial apply into a permanent refusal. An untracked file cannot alter a tracked Compose file,
-	// and anyone who can write here already has the Docker socket.
-	const worktreeChanges = await output(
-		"git",
-		["status", "--porcelain=v1", "--untracked-files=no"],
-		{
-			cwd: releaseTree,
-		},
+	const { tree: releaseTree } = await ensureReleaseTree(
+		config.checkout,
+		releasesDirectory(config),
+		decision.release,
+		releaseCommit,
 	);
-	if (worktreeChanges) throw new Error(`${releaseTree} differs from ${decision.release}`);
 
 	const lockDirectory = join(config.stateDirectory, "release-locks");
 	await mkdir(lockDirectory, { recursive: true });
@@ -469,10 +516,10 @@ async function main(): Promise<void> {
 			mode: 0o600,
 		});
 	} else {
-		// A release must not supply the code that decides whether that same release is trusted.
+		// The verifier is the tooling this tick runs, never the release's own copy of it.
 		await run(
 			process.execPath,
-			[join(config.checkout, "scripts/prepare-release-lock.ts"), decision.release, lockFile],
+			[join(import.meta.dirname, "prepare-release-lock.ts"), decision.release, lockFile],
 			{ cwd: releaseTree },
 		);
 	}
@@ -551,7 +598,7 @@ async function main(): Promise<void> {
 	const finishedAt = new Date();
 	await writeAtomic(
 		appliedFile,
-		`${JSON.stringify({ release: decision.release, channelCommit, appliedAt: finishedAt.toISOString() }, null, "\t")}\n`,
+		`${JSON.stringify({ release: decision.release, channelCommit, appliedAt: finishedAt.toISOString(), commit: releaseCommit }, null, "\t")}\n`,
 	);
 	if (config.metricsFile)
 		await writeAtomic(
@@ -566,6 +613,134 @@ async function main(): Promise<void> {
 			}),
 		);
 	console.log(`Applied ${decision.release} to ${config.stacks.join(", ")}`);
+	// Only now, with the release verified and running, does the host run that release's tooling.
+	await followTooling(config, releaseTree);
+}
+
+/**
+ * The host runs the tooling of the tree it applied: its reconciler through the `tooling` link and its
+ * units in systemd. A tree that predates the link is never adopted — its unit would run the checkout
+ * and its reconciler could not read a current channel — so a rollback to one keeps the tooling the
+ * host has. Every step is idempotent, because a tick can stop between any two of them.
+ */
+async function followTooling(config: HostConfig, tree: string): Promise<boolean> {
+	if (!(await carriesToolingLink(tree))) {
+		console.log(`Keeping the current tooling: ${tree} predates the tooling link`);
+		return false;
+	}
+	const moved = await adoptTooling(config.tooling, tree);
+	const changed = await syncUnits(tree, SYSTEMD_UNITS);
+	if (changed.length > 0) console.log(`Updated ${changed.join(", ")}`);
+	// systemd itself knows whether the units it loaded match the files, so a tick that stopped
+	// between writing a unit and reloading is finished by the next one.
+	const stale = await output("systemctl", [
+		"show",
+		"--property=NeedDaemonReload",
+		"--value",
+		...UNIT_FILES,
+	]);
+	if (stale.split("\n").includes("yes")) await run("systemctl", ["daemon-reload"]);
+	return moved;
+}
+
+function releasesDirectory(config: HostConfig): string {
+	return join(config.stateDirectory, "releases");
+}
+
+/** The accepted source commit a record names: kept since it was recorded, or the release itself. */
+export function appliedCommit(applied: AppliedState): string | undefined {
+	return applied.commit ?? (COMMIT_SHA.test(applied.release) ? applied.release : undefined);
+}
+
+/**
+ * The worktree for `release` under `releases`, created at `commit` when it is missing and checked
+ * either way: its HEAD is that commit and no tracked file differs. The commit is what was accepted,
+ * never re-read from a tag, so a moved tag changes nothing. `--force` twice lets git recreate a path
+ * it still has registered — even locked — after someone deleted the directory.
+ */
+export async function ensureReleaseTree(
+	checkout: string,
+	releases: string,
+	release: string,
+	commit: string,
+): Promise<{ tree: string; commit: string }> {
+	const tree = join(releases, release);
+	if (await isDirectory(tree)) {
+		const head = (await output("git", ["rev-parse", "HEAD"], { cwd: tree })).trim();
+		if (head !== commit)
+			throw new Error(`${tree} is at ${head}, not the ${commit} accepted for ${release}`);
+	} else {
+		await run(
+			"git",
+			["worktree", "add", "--detach", "--force", "--force", "--quiet", tree, commit],
+			{
+				cwd: checkout,
+			},
+		);
+	}
+	// Tracked content only: Compose writes into the worktree it renders from — the proxy stack's ACME
+	// store is `docker/letsencrypt/` — so counting untracked files would turn every retry after a
+	// partial apply into a permanent refusal. An untracked file cannot alter a tracked Compose file,
+	// and anyone who can write here already has the Docker socket.
+	const changes = await output("git", ["status", "--porcelain=v1", "--untracked-files=no"], {
+		cwd: tree,
+	});
+	if (changes) throw new Error(`${tree} differs from ${release}`);
+	return { tree, commit };
+}
+
+/** Unlike `existsSync`, this reports a lookup that failed for any reason other than absence. */
+async function isDirectory(path: string): Promise<boolean> {
+	try {
+		return (await stat(path)).isDirectory();
+	} catch (error) {
+		if (error instanceof Error && "code" in error && error.code === "ENOENT") return false;
+		throw error;
+	}
+}
+
+/** Whether a tree's own unit starts the reconciler through the tooling link, i.e. carries this model. */
+export async function carriesToolingLink(tree: string): Promise<boolean> {
+	let unit: string;
+	try {
+		unit = await readFile(join(tree, "docker/self-host/systemd", UNIT_FILES[0]), "utf8");
+	} catch (error) {
+		if (error instanceof Error && "code" in error && error.code === "ENOENT") return false;
+		throw error;
+	}
+	return /^ExecStart=.*\/var\/lib\/hephaestus\/tooling\//m.test(unit);
+}
+
+/**
+ * Moves the tooling link to `tree` in one rename, so a failure leaves the current tooling in place,
+ * and reports whether it moved.
+ */
+export async function adoptTooling(link: string, tree: string): Promise<boolean> {
+	if ((await readlink(link).catch(() => undefined)) === tree) return false;
+	const staged = `${link}.next`;
+	await rm(staged, { force: true });
+	await symlink(tree, staged);
+	await rename(staged, link);
+	return true;
+}
+
+/**
+ * Brings the units systemd reads to the copies in `tree` and returns the names it rewrote. They are
+ * copies rather than links because systemd needs them on the root filesystem at boot, and each is
+ * replaced by one rename, which also retires a link an earlier install may have left.
+ */
+export async function syncUnits(tree: string, unitsDirectory: string): Promise<string[]> {
+	const changed: string[] = [];
+	for (const name of UNIT_FILES) {
+		const wanted = await readFile(join(tree, "docker/self-host/systemd", name), "utf8");
+		const unit = join(unitsDirectory, name);
+		const installed = await lstat(unit).catch(() => undefined);
+		if (installed && !installed.isSymbolicLink() && (await readFile(unit, "utf8")) === wanted)
+			continue;
+		await writeAtomic(unit, wanted);
+		changed.push(name);
+	}
+	return changed;
 }
 
 /** Without a series on failure, a broken reconcile is indistinguishable from a host running none. */
@@ -585,11 +760,15 @@ async function reportFailure(): Promise<void> {
 			success: false,
 			now: new Date(),
 			lastSuccessAt: applied ? new Date(applied.appliedAt) : undefined,
+			// Pending is a fact about the record, so a failed run must not read as the apply that ends it.
+			toolingPending: applied !== undefined && appliedCommit(applied) === undefined,
 		}),
 	);
 }
 
-if (process.argv[1] === import.meta.filename) {
+// The unit runs this file through the tooling link, and `process.argv[1]` keeps that path while
+// `import.meta.filename` is the resolved one; only `import.meta.main` compares nothing.
+if (import.meta.main) {
 	try {
 		await main();
 	} catch (error) {

--- a/scripts/release-deployment-policy.test.ts
+++ b/scripts/release-deployment-policy.test.ts
@@ -134,8 +134,12 @@ await test("promotion refuses a draft but reaches any published release, and the
 	assert.match(promotion, /--json isDraft --jq \.isDraft/);
 	// Rollback must support releases predating immutable tags; the signed lock binds their digests.
 	assert.doesNotMatch(promotion, /isImmutable/);
-	assert.match(reconciler, /join\(config\.checkout, "scripts\/prepare-release-lock\.ts"\)/);
+	// The verifier is the tooling this tick runs — resolved from the running script, which Node pins
+	// to the tree it loaded — never the release under review.
+	assert.match(reconciler, /join\(import\.meta\.dirname, "prepare-release-lock\.ts"\)/);
 	assert.doesNotMatch(reconciler, /join\(releaseTree, "scripts\/prepare-release-lock\.ts"\)/);
+	// Run through the tooling link, argv[1] and import.meta.filename differ; only import.meta.main holds.
+	assert.match(reconciler, /^if \(import\.meta\.main\) \{/m);
 });
 
 await test("derives the canonical signer identity and refuses missing CI identity", () => {


### PR DESCRIPTION
## Problem

A host's reconciler ran from a checkout in `/var/lib/hephaestus` that nothing updated. When a promotion started writing commit channels, staging's tooling could not parse them and failed every tick until an operator reset the checkout by hand. Standing still was a silent failure, which is exactly what pull-based deployment exists to avoid.

## Fix

The host now runs the tooling of the release it applied. `/var/lib/hephaestus/tooling` is a link the reconciler moves, in one rename, to the release's worktree only after that release has been verified and applied. The tick that verifies a channel therefore runs the tooling of the last release the host accepted, never the release under review and never a moving branch. The reconciler also keeps `hephaestus-reconcile.{service,timer}` in `/etc/systemd/system` at the same tree, replacing a stale copy or a link with one rename and reloading systemd itself, and every `git fetch` is bounded so a stalled connection cannot hold a tick until the unit's start timeout.

ADR 0042 and the admin install steps describe the model, including its price: a channel must stay readable by the tooling of the release before it.

## Verification

- `node --test scripts/reconcile-deployment.test.ts`: 25 pass, including the new link swap and unit sync tests.
- oxlint, oxfmt and `tsc -p scripts/tsconfig.json` clean; markdownlint clean on the touched docs.
- On staging, the two commands the previous revision proposed ran cleanly as the service user, and the unit changes here will be applied there after merge, together with the one-time `tooling` link.

## Follow-ups

- #1862 moves the ACME store out of the worktrees so old trees can be pruned; #1842 leaves them alone on purpose.
- #1863 proves the startup orchestration with subprocess tests instead of source matching.
