### PR TITLE
fix(ci): make promotion and review decisions fail safely

### DIFF
--- a/.github/actions/setup-caches/action.yml
+++ b/.github/actions/setup-caches/action.yml
@@ -36,8 +36,7 @@ runs:
         fi
         echo "dependencies=$DEPENDENCY_HASH" >> "$GITHUB_OUTPUT"
         echo "generated-clients=$GENERATED_CLIENTS_HASH" >> "$GITHUB_OUTPUT"
-        # Only default-branch runs write caches: a cache saved on any other ref is invisible to every
-        # other ref, so a pull-request write would never be reused.
+        # Publish default-branch caches for reuse across PRs, rather than PR-scoped entries.
         if [[ "$GITHUB_REF" == "refs/heads/$DEFAULT_BRANCH" && "$GITHUB_EVENT_NAME" =~ ^(push|schedule|workflow_dispatch)$ ]]; then
           echo "save=true" >> "$GITHUB_OUTPUT"
         else

--- a/.github/actions/setup-toolchain/action.yml
+++ b/.github/actions/setup-toolchain/action.yml
@@ -12,12 +12,9 @@ runs:
       shell: bash
       run: |
         echo "version=$(jq -r '.devEngines.packageManager.version' package.json)" >> "$GITHUB_OUTPUT"
-        # On Windows this shell is Git Bash, whose $HOME is an MSYS path that the Windows PATH
-        # cannot resolve. os.homedir() is what both pnpm/setup and actions/cache's `~` expand to, so
-        # asking Node keeps the destination, the cache path and PATH the same directory everywhere.
+        # Use the native home directory, not Git Bash's MSYS path, on Windows.
         echo "dest=$(node -p 'require("node:path").join(require("node:os").homedir(), "setup-pnpm")')" >> "$GITHUB_OUTPUT"
-    # The path is pnpm/setup's own default destination, so the action does not restate it as `dest`;
-    # the version check below fails the job if that default ever moves.
+    # Cache pnpm/setup's default installation directory.
     - id: pnpm-cache
       uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
@@ -78,14 +75,12 @@ runs:
         cache-dependency-path: pnpm-lock.yaml
         install: false
         require-lockfile: true
-    # A cache key cannot be overwritten, so one truncated save would poison every job until the pin
-    # moves. Answering here proves the restored tree and the PATH it was reached through, and holds
-    # the freshly installed tree to the pin before it is offered to anyone else.
+    # Cache entries are immutable: validate the executable before publishing a new entry.
     - shell: bash
       env:
         PNPM_VERSION: ${{ steps.pnpm.outputs.version }}
       run: test "$(pnpm --version)" = "$PNPM_VERSION"
-    # A cache saved on any ref other than the default branch is invisible to every other ref.
+    # Default-branch caches are reusable across PRs; merge-ref caches are scoped to that PR.
     - if: steps.pnpm-cache.outputs.cache-hit != 'true' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
       uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:

--- a/.github/workflows/continuous-staging.yml
+++ b/.github/workflows/continuous-staging.yml
@@ -1,13 +1,4 @@
-# Moves the environment that follows the default branch to every commit CI has built.
-#
-# Releases are how production is promoted: they carry a version, a provenance manifest and a signed
-# lock, and a person decides when one is cut. Staging exists to be the branch as it stands, so it
-# follows commits instead — the promotion workflow is still the only thing that writes a channel, so
-# the identity a host pins does not change.
-#
-# There is no switch for this. An environment that sometimes follows the branch and sometimes runs a
-# release is two environments wearing one name, and the channel already has the only hold that
-# matters: `freeze`, which is signed and travels with the channel rather than sitting beside it.
+# Promotes successful main builds through the environment-protected promotion workflow.
 name: Continuous staging
 
 on:
@@ -19,14 +10,12 @@ on:
 permissions: {}
 
 concurrency:
-  # Not cancel-in-progress: a superseded promotion has already written its channel, and the next one
-  # supersedes it on the host anyway.
+  # Let the current run finish observing the promotion it dispatched.
   group: continuous-staging
   cancel-in-progress: false
 
 jobs:
   follow-main:
-    # A red build is not something to deploy, and a run that was cancelled decided nothing.
     if: >-
       ${{ github.event.workflow_run.conclusion == 'success'
         && github.event.workflow_run.event == 'push' }}
@@ -34,7 +23,6 @@ jobs:
     timeout-minutes: 30
     permissions:
       actions: write # dispatch the promotion workflow
-      contents: read # read the channel to honour a freeze
     steps:
       - name: Follow this commit on staging
         env:
@@ -42,26 +30,8 @@ jobs:
           COMMIT: ${{ github.event.workflow_run.head_sha }}
         run: |
           set -euo pipefail
-          # A hold has to survive the next green build, or it is advice rather than a hold. The
-          # channel is the record of it, so it is what gets asked.
-          frozen=$(gh api "repos/$GITHUB_REPOSITORY/contents/channels/staging.json?ref=deploy-state" \
-            --jq '.content' 2>/dev/null | base64 -d 2>/dev/null | jq -r '.freeze // false' || echo false)
-          if [ "$frozen" = true ]; then
-            echo "::notice::staging is frozen; leaving it where it is"
-            exit 0
-          fi
-
-          since=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-          gh workflow run promote.yml --repo "$GITHUB_REPOSITORY" \
-            -f environment=Staging -f commit="$COMMIT"
-          # The dispatch returns before the run exists, and taking the newest run blindly could
-          # watch someone else's promotion, so the run is matched on being newer than the request.
-          for _ in $(seq 1 30); do
-            run=$(gh run list --repo "$GITHUB_REPOSITORY" --workflow promote.yml --limit 10 \
-              --json databaseId,createdAt \
-              --jq "[.[] | select(.createdAt > \"$since\")] | sort_by(.createdAt) | .[0].databaseId // empty")
-            [ -n "$run" ] && break
-            sleep 5
-          done
-          [ -n "$run" ] || { echo "::error::promote.yml did not start"; exit 1; }
+          run=$(gh api --method POST "repos/$GITHUB_REPOSITORY/actions/workflows/promote.yml/dispatches" \
+            -f ref=main -f 'inputs[environment]=Staging' -f "inputs[commit]=$COMMIT" \
+            -f 'inputs[automatic]=true' -F return_run_details=true --jq '.workflow_run_id')
+          [[ "$run" =~ ^[1-9][0-9]*$ ]] || { echo "::error::Dispatch returned no run ID"; exit 1; }
           gh run watch "$run" --repo "$GITHUB_REPOSITORY" --exit-status

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -1,12 +1,7 @@
-# Moves an environment to a release by writing its channel on `deploy-state`, which the hosts poll.
-#
-# The hosts pin this workflow's identity, and a GitHub environment gates it, so a signature carrying
-# that identity is proof its reviewers approved. That holds only while this workflow stays
-# non-reusable: a `workflow_call` trigger would let any caller mint the same identity. The release
-# reaches staging by dispatching this workflow, not by triggering on its completion, so no run here
-# inherits a context it did not ask for.
+# Hosts trust this workflow's signing identity. Keep signing behind the environment gate;
+# making this workflow reusable would let callers share that identity.
 name: Promote
-run-name: Promote ${{ inputs.release }} to ${{ inputs.environment }}
+run-name: Promote ${{ inputs.release || inputs.commit }} to ${{ inputs.environment }}
 
 on:
   workflow_dispatch:
@@ -24,6 +19,10 @@ on:
         description: Commit to run, as a full SHA. Only for an environment that follows main.
         type: string
         required: false
+      automatic:
+        description: Follow main only if the channel is not frozen or ahead of this build
+        type: boolean
+        default: false
       allow-rollback:
         description: Permit moving this environment backwards
         type: boolean
@@ -39,22 +38,49 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  automatic:
+    if: ${{ inputs.automatic }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      apply: ${{ steps.policy.outputs.apply }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: deploy-state
+          path: deploy-state
+          persist-credentials: false
+      - uses: ./.github/actions/setup-toolchain
+        with:
+          install: "none"
+      # The workflow lock covers this read through publication, including manually requested holds.
+      - name: Check automatic promotion
+        id: policy
+        env:
+          GH_TOKEN: ${{ github.token }}
+          COMMIT: ${{ inputs.commit }}
+          CHANNEL: ${{ inputs.environment }}
+        run: node scripts/automatic-promotion.ts
+
   promote:
+    needs: automatic
+    if: ${{ !cancelled() && !failure() && (!inputs.automatic || needs.automatic.outputs.apply == 'true') }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     environment:
       name: ${{ inputs.environment }}
-      # GitHub records this as the deployment's environment_url, on the status it writes when the
-      # job ends. A status posted from inside the job would be superseded by that one, so the URL
-      # has to come from here rather than from a step. It is a step output because APP_HOSTNAME is
-      # scoped to the environment being resolved.
+      # APP_HOSTNAME is environment-scoped, so resolve it after the job starts.
       url: ${{ steps.release.outputs.environment_url }}
     permissions:
       contents: write
       id-token: write
     steps:
-      # `deploy-state` carries channels and no code, so the tooling that writes it is checked out
-      # from the ref this workflow was dispatched on and the branch itself sits beside it.
+      # Tooling comes from the dispatched workflow ref, not from the deployment target.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
@@ -71,17 +97,7 @@ jobs:
 
       - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
-      # The resolver is tooling: it comes from the default branch so that a commit older than it can
-      # still be promoted, which is exactly what rolling an environment back means.
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          path: .promotion-scripts
-          sparse-checkout: scripts
-          persist-credentials: false
-
-      # The pins are data about the commit being promoted, so they come from that commit. Reading
-      # them from the default branch instead would deploy one commit's code against another's
-      # upstream images.
+      # Unlike tooling, upstream image pins must come from the deployment target.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         if: ${{ inputs.commit != '' }}
         with:
@@ -106,8 +122,7 @@ jobs:
               echo "::error::Name a release or a commit, not both"; exit 1; }
             [[ "$COMMIT" =~ ^[0-9a-f]{40}$ ]] || {
               echo "::error::Follow a full commit SHA, not '$COMMIT'"; exit 1; }
-            # Only what is already on the default branch may be followed: a commit that is not an
-            # ancestor of main has not been through review, whoever is able to dispatch this.
+            # Dispatch permission must not authorize commits outside main.
             gh api "repos/$GITHUB_REPOSITORY/compare/$COMMIT...main" --jq .status |
               grep -qE '^(identical|ahead)$' || {
                 echo "::error::$COMMIT is not on the default branch"; exit 1; }
@@ -120,9 +135,7 @@ jobs:
           release="$REQUESTED"
           [[ "$release" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]] || {
             echo "::error::Promote an immutable vX.Y.Z release, not '$release'"; exit 1; }
-          # GitHub tag immutability is not a gate here: the host takes the source commit and every
-          # image digest from the cosign-signed release lock, so a moved tag changes nothing that is
-          # deployed. Requiring it would refuse the older releases a rollback exists to reach.
+          # The host binds the tag's source tree to the signed release lock before applying it.
           [ "$(gh release view "$release" --repo "$GITHUB_REPOSITORY" --json isDraft --jq .isDraft)" = false ] || {
             echo "::error::$release is still a draft"; exit 1; }
           echo "release=$release" >> "$GITHUB_OUTPUT"
@@ -144,10 +157,8 @@ jobs:
           channel=$(echo "$CHANNEL" | tr '[:upper:]' '[:lower:]')
           mkdir -p channels
           if [ "$FOLLOWS" = commit ]; then
-            # A commit has no release to fetch a lock from, so the channel carries the digests
-            # itself. They are covered by the signature below, which is the same authority that
-            # stands behind a release lock.
-            node "$GITHUB_WORKSPACE/.promotion-scripts/scripts/commit-image-lock.ts" \
+            # Commit deployments carry verified image digests in the signed channel.
+            node "$GITHUB_WORKSPACE/scripts/commit-image-lock.ts" \
               "$RELEASE" "$OWNER" "$GITHUB_WORKSPACE/.promotion-inventory/security/release-images.json" \
               > images.json
             jq -n --arg commit "$RELEASE" --slurpfile images images.json \
@@ -172,8 +183,6 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           RELEASE: ${{ steps.release.outputs.release }}
         run: |
-          # An empty commit would read as a move forward to hosts that compare ancestry, so a channel
-          # already at this release produces none.
           node ../scripts/commit-via-api.ts \
             --branch deploy-state \
             --message "chore(deploy): ${CHANNEL_FILE} -> ${RELEASE}" \
@@ -186,8 +195,7 @@ jobs:
           HOSTNAME: ${{ vars.APP_HOSTNAME }}
         run: |
           set -euo pipefail
-          # Nothing here can push the hosts, so the deploy is observed: the webapp publishes the
-          # version it runs, which makes convergence visible without any access to the host.
+          # Observe the public webapp version; host metrics report stack readiness separately.
           deadline=$(( SECONDS + 900 ))
           while [ "$SECONDS" -lt "$deadline" ]; do
             config=$(curl -fsS --max-time 20 "https://${HOSTNAME}/" |

--- a/.github/workflows/review-policy.yml
+++ b/.github/workflows/review-policy.yml
@@ -1,29 +1,19 @@
 name: Review policy
 
 on:
-  pull_request_target: # zizmor: ignore[dangerous-triggers] API reads only; no pull-request code is executed.
+  pull_request_target: # zizmor: ignore[dangerous-triggers] Trusted policy only; no pull-request code is executed.
     types: [opened, reopened, synchronize, ready_for_review, edited]
 
 permissions: {}
 
 concurrency:
-  # Never cancel: runs in a group are serialised, so the newest event's decision is the one that
-  # lands, and a cancelled run leaves an approval unsubmitted rather than half-written.
+  # Serialize writes without interrupting an approval; each run re-reads the current head.
   group: review-policy-${{ github.event.pull_request.number }}
   cancel-in-progress: false
 
 jobs:
-  # This job is *not* a required status check, and must never become one. The `main` ruleset requires
-  # one native approving review; all this job does is supply that approval for the authors listed in
-  # `REVIEW_POLICY_MAINTAINERS`. A pull request by anyone else gets no approval here and sits in
-  # GitHub's own "Review required" state, which blocks merging, merge-queue entry and auto-merge.
-  #
-  # `synchronize` is load-bearing: the ruleset dismisses stale approvals on push, so every push has
-  # to earn a fresh one. `edited` is load-bearing for stacked pull requests: merging a lower layer
-  # retargets the upper one onto `main`, which fires no other event here — without it the layer
-  # arrives at the queue unapproved and cannot enter. For the same reason there is no `branches:`
-  # filter: a layer must already hold its approval when it is retargeted, and an approval on a pull
-  # request targeting anything but `main` satisfies no rule and is inert.
+  # Not a required check: GitHub's native review requirement owns merge eligibility.
+  # No base filter: stacked layers need approval before retargeting. Pushes dismiss stale reviews.
   approve:
     name: Approve a maintainer's pull request
     runs-on: ubuntu-latest
@@ -32,8 +22,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      # The default branch, never `github.sha` or the pull request's head: the base branch's copy of
-      # the policy is the authoritative one, and nothing from the pull request is fetched or run.
+      # Execute only the default branch's policy, never the pull request's code.
       - name: Load the trusted policy evaluator
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -41,9 +30,7 @@ jobs:
           persist-credentials: false
           sparse-checkout: scripts
 
-      # The review is attributed to `github-actions[bot]`, which counts toward the ruleset's
-      # `required_approving_review_count`. That needs the organisation's "Allow GitHub Actions to
-      # create and approve pull requests" setting left on.
+      # Requires the organisation's "Allow GitHub Actions to create and approve pull requests" setting.
       - name: Approve when the author is a listed maintainer
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:

--- a/docs/admin/pull-based-deployment.mdx
+++ b/docs/admin/pull-based-deployment.mdx
@@ -1,30 +1,24 @@
 ---
 id: pull-based-deployment
 title: Pull-Based Deployment
-description: Let a host keep itself on the release its channel names, verifying the signature itself, with nothing dialing in.
+description: Reconcile a host to a signed release or commit channel without inbound deployment access.
 ---
 
-A host can upgrade itself. It polls a **channel** — one file naming a release — verifies the
-signatures, and applies the release's digest-pinned Compose stacks. Nothing connects *to* the host,
-so no deployment credential exists anywhere off it.
-
-This is the same verification the manual upgrade in [Install](./install.mdx#upgrades) performs, on a
-timer.
+A host polls a **channel** naming a release or commit, verifies its signature, and applies
+digest-pinned Compose stacks. Deployment needs no inbound administration connection to the host.
 
 ## What the host trusts
 
-Two signatures, both checked on the host:
+For a release deployment, the host verifies two signatures:
 
 | Artifact | Signed by | Answers |
 | --- | --- | --- |
 | The channel (`channels/<env>.json`) | the promotion workflow | *may this host move, and who said so* |
 | The release lock (`release-<version>.json`) | the release workflow | *which source commit and image digests are this release* |
 
-A signature proves who wrote something, never that it is the newest thing they wrote — a valid old
-channel replayed verifies perfectly. Freshness therefore comes from the commit graph: the channel
-lives on the `deploy-state` branch, and each accepted commit must descend from the last one. A lower
-release version also requires `allowRollback`; a deliberate rollback is a new channel commit, never
-permission to replay an old one.
+The host rejects a new channel commit that does not descend from its last accepted channel commit.
+It also rejects lower release versions and older commits unless `allowRollback` is set. These checks
+do not order manual transitions between releases and commits; choose those targets deliberately.
 
 ## The channel
 
@@ -34,24 +28,40 @@ permission to replay an old one.
 
 | Field | Effect |
 | --- | --- |
-| `release` | the immutable `vX.Y.Z` release this environment runs |
+| `release` | the `vX.Y.Z` release to apply when not frozen |
 | `allowRollback` | permits one deliberate move backwards |
 | `freeze` | holds the environment where it is, for an incident |
 
+Staging can follow successful builds of `main` instead of releases. Its channel names a full
+`commit` SHA instead of `release`, plus an `images` map of digest-pinned references. The promotion
+workflow verifies first-party image provenance against that source commit before signing the channel.
+Upstream image pins come from that commit's inventory.
+
+Automatic promotions check the latest channel while holding the promotion lock. A frozen channel,
+an already-promoted commit, or an older completed build leaves the channel unchanged, including
+when switching from a release to a commit. An unreadable channel or failed history comparison stops
+promotion rather than clearing a hold. Establish the initial channel with a manual promotion before
+enabling continuous staging.
+
 ## Requirements
 
-On the host: Docker Engine with Compose v2, `git`, `cosign`, and Node.js at the version in
-`package.json#devEngines.runtime`. Outbound HTTPS to `github.com` and `ghcr.io` is the only network
-access needed — nothing has to reach the host, which is the point.
+Install Docker Engine with Compose v2, `git`, `cosign`, and the Node.js version pinned in
+`package.json#devEngines.runtime`. Verify downloaded tools against their published checksums.
 
-Pin what you install. `cosign` verifies the release, so fetch it by checksum from its own release
-page rather than from a convenience script.
+Allow outbound HTTPS to GitHub and its release-asset download hosts, Sigstore trust services, and
+the image registries in the lock, including GHCR and Docker Hub. Registry authentication and download
+redirects may use additional hosts; an allowlist limited to `github.com` and `ghcr.io` is insufficient.
 
 ## Install
 
-1. Clone the `main` branch to `/var/lib/hephaestus/checkout`. This is the trusted, host-owned copy of
-   the reconciler and release verifier; release contents never replace it. Update it separately when
-   you intentionally adopt reconciler changes.
+1. Install the trusted reconciler checkout. Update it separately from application releases.
+
+   ```bash
+   sudo install -d -m 0750 /var/lib/hephaestus
+   sudo git clone --branch main --single-branch \
+     https://github.com/hephaestus-build/Hephaestus.git /var/lib/hephaestus/checkout
+   ```
+
 2. Copy `docker/self-host/systemd/reconcile.env.example` to `/etc/hephaestus/reconcile.env`
    (`root:root`, `0600`) and set the channel, the stacks this host owns, and the promotion identity.
 3. Put one `<stack>.env` per stack in `/etc/hephaestus`, `0600`. These hold the deployment secrets
@@ -59,9 +69,6 @@ page rather than from a convenience script.
 4. Install the units:
 
    ```bash
-   sudo install -d -m 0750 /var/lib/hephaestus
-   sudo git clone --branch main --single-branch \
-     https://github.com/hephaestus-build/Hephaestus.git /var/lib/hephaestus/checkout
    sudo install -m 644 \
      /var/lib/hephaestus/checkout/docker/self-host/systemd/hephaestus-reconcile.service \
      /var/lib/hephaestus/checkout/docker/self-host/systemd/hephaestus-reconcile.timer \
@@ -72,31 +79,34 @@ page rather than from a convenience script.
 
 5. Watch the first run: `journalctl -fu hephaestus-reconcile.service`.
 
-`HEPHAESTUS_STACKS` is what a host owns. A host whose edge belongs to something else — a shared
-proxy, or a PaaS serving preview environments beside it — omits `proxy` and keeps `core app`.
+`HEPHAESTUS_STACKS` selects the Compose projects this host manages. If another proxy provides its
+ingress, omit `proxy` and use `core app`.
 
 ## Operating it
 
 | You want to | Do this |
 | --- | --- |
-| Move an environment | Run the **Promote** workflow: pick the environment and release |
+| Move an environment | Run the **Promote** workflow: pick the environment and release or commit |
 | Roll back | Promote the older release with **allow-rollback** |
 | Hold an environment | Promote with **freeze** |
-| Put a hand-patched host back on its release | Promote the release it already runs |
-| Stop the host reconciling, right now | `sudo systemctl disable --now hephaestus-reconcile.timer` |
+| Resume a held environment | Manually promote the desired release or commit with **freeze** cleared |
+| Reapply Compose configuration | Promote the release or commit the host already runs |
+| Prevent new reconciliation runs | `sudo systemctl disable --now hephaestus-reconcile.timer` |
 | See what a host runs | `cat /var/lib/hephaestus/applied.json` |
 
-:::warning Disable the timer before hand-patching a host
-A reconciler reapplies its channel. Manual changes to a stack it owns are reverted the next time the
-channel moves — including a promotion of the release the host already runs, which is how you put a
-drifted host back. During an incident that is the last thing you want, so disable the timer first,
-and re-enable it when the fix has landed in a release.
+:::warning Pause reconciliation before manual changes
+Disable the timer and confirm the service is no longer running with
+`systemctl status hephaestus-reconcile.service` before editing.
+Disabling the timer does not stop an active reconciliation. Re-enable the timer after recovery.
+
+Re-promoting reapplies Compose configuration; it does not restore arbitrary container-file changes.
+The reconciler refuses a release checkout with modified tracked files.
 :::
 
 ## Watching it
 
 Set `HEPHAESTUS_METRICS_FILE` to a `.prom` file in an existing node_exporter textfile collector
-directory. Each run then writes:
+directory. After a deployment has succeeded, the metrics include:
 
 ```text
 hephaestus_deploy_info{channel="staging",release="v1.2.3",channel_commit="…"} 1
@@ -105,23 +115,21 @@ hephaestus_deploy_reconcile_timestamp_seconds …
 hephaestus_deploy_last_success_timestamp_seconds …
 ```
 
-**Alert on staleness.** A host that stops reconciling is silent, not loud — that is the one real cost
-of pulling instead of being pushed to. Alert when
-`time() - hephaestus_deploy_last_success_timestamp_seconds` exceeds ten minutes, or when
-`hephaestus_deploy_reconcile_success` is `0`. Without that alert, a host can sit on an old release
-indefinitely and nothing will say so.
+Alert when `time() - hephaestus_deploy_reconcile_timestamp_seconds` exceeds ten minutes, when
+`hephaestus_deploy_reconcile_success` is `0`, or when the host's reconciliation metrics are absent.
+`hephaestus_deploy_last_success_timestamp_seconds` records the last successful **apply**; unchanged
+and frozen channels do not advance it, so its age is not a reconciliation-liveness check.
 
-The promotion workflow also waits for the environment to report the new version before it goes
-green, so an unconverged deploy fails in Actions as well.
+A promotion without **freeze** waits for the public webapp to report the requested version. This
+checks the webapp version, not the readiness of every service; use host metrics and logs for the
+Compose result. A promotion with **freeze** records the hold without waiting for a version change.
+Skipped automatic promotions do not start an environment deployment.
 
 ## What it will not do
 
-**It does not roll back a failed deploy.** A failed apply stops and publishes a failure metric when
-the textfile collector is configured. Schema changes here are forward-only, so putting the previous
-images back would leave old code on a migrated database — the failure the rollback was meant to
-prevent. Recover by promoting a release that fixes the problem, or by restoring from a backup if the
-database itself is wrong; see
-[Backup & Restore](./backup-restore.mdx).
+**It does not roll back a failed deploy.** A failed apply may leave some services updated. Schema
+migrations are forward-only; older images may be incompatible with the migrated database. Promote a
+fix, or follow [Backup & Restore](./backup-restore.mdx) if database recovery is needed.
 
 **It does not manage anything it does not own.** The reconciler touches only the Compose projects
 named in `HEPHAESTUS_STACKS`. Containers belonging to anything else on the host are left alone.

--- a/docs/contributor/ci-cd.mdx
+++ b/docs/contributor/ci-cd.mdx
@@ -90,15 +90,18 @@ to nobody.
 
 Review is a native ruleset requirement with stale approvals dismissed on every push. Authors listed
 in `REVIEW_POLICY_MAINTAINERS` receive an automated approval; every other author needs a human with
-write access. Repository administrators own that allow-list. Remove the automation when independent
-maintainer review is available. The workflow minimizes superseded automatic reviews after approving
-the current commit, so only its current automatic approval remains expanded.
+write access, including Renovate. Green checks and Dependency Dashboard approval do not satisfy this
+review requirement. Renovate includes that reminder in each pull request's body. Repository
+administrators own the allow-list; do not add dependency bots to it. Remove the automation when
+independent maintainer review is available. After approving the current commit, the workflow attempts
+to minimize superseded automatic reviews. A minimization failure is a warning, not a failed approval.
 
-The approval workflow runs on `pull_request_target` with `pull-requests: write`, so it checks out only
-`scripts/` from the default branch, reads the author login and nothing else, and executes no
-pull-request code. An empty allow-list approves nobody. It has no `branches:` filter: a stacked
-layer is approved while it still targets the layer below, because retargeting to `main` after the
-lower layer merges fires no event.
+The approval workflow runs on `pull_request_target` with `pull-requests: write`. It loads the evaluator
+from `scripts/` on the default branch, reads current pull-request metadata and reviews from GitHub,
+and executes no pull-request code. An empty allow-list approves nobody. It has no `branches:` filter:
+a stacked layer is approved while it still targets the layer below, because retargeting to `main` after the
+lower layer merges must not depend on receiving a subsequent event. The `edited` trigger also
+re-evaluates explicit base changes.
 
 The Version PR carries checks like any other pull request. Its updates are pushed with
 `GITHUB_TOKEN`, which starts no workflow run, so `version-pr.yml` dispatches CI/CD on the Version

--- a/docs/contributor/local-verification.mdx
+++ b/docs/contributor/local-verification.mdx
@@ -6,8 +6,8 @@ title: Local verification
 
 | Command | What success proves | Excludes |
 |---|---|---|
-| `vp run check:affected` | Static and policy checks selected for the branch and working tree passed | Tests, builds, unaffected scopes, and CI-only checks |
-| `vp run check` | Every gate the `quality` task in `vite.config.ts` runs passed | Builds, browser and live-service tests, images, mutation analysis, and release security |
+| `vp run check:affected` | Selected gates passed, including any tests they contain | Unselected scopes, verification-only suites and builds, and CI-only checks |
+| `vp run check` | Every gate the `quality` task in `vite.config.ts` runs passed | Distributable builds, browser and live-service tests, images, mutation analysis, and release security |
 | `vp run verify` | The complete credential-free local CI inventory passed | Live-service integration and E2E tests, images, mutation analysis, and release security |
 
 Run `check:affected` while working, `check` before pushing, and `verify` before requesting review.
@@ -33,8 +33,11 @@ rename are evaluated. Git documents the underlying change statuses in
 
 ## Pre-push hook
 
-`vp install` enables the Vite+ hook dispatcher, which runs the project hooks in `.vite-hooks/`. The
-pre-push hook runs `vp run check`; `git push --no-verify` skips it.
+`vp install` configures the Vite+ hook dispatcher, which runs the project hooks in `.vite-hooks/`.
+It preserves a custom `core.hooksPath` and the local preference set by `vp hooks disable`;
+`vp hooks enable` re-enables the dispatcher. `vp hooks status` shows which hooks are active.
+The pre-push hook runs `vp run check`; `git push --no-verify` skips it. With custom hooks, run
+`vp run check` yourself before pushing.
 
 ## Complete local verification
 
@@ -43,8 +46,8 @@ pre-push hook runs `vp run check`; `git push --no-verify` skips it.
 `routeTree.gen.ts` comparison that restores the committed file before exiting, the Storybook build,
 and the docs build.
 
-Checks that need browsers as a service, images, release infrastructure or credentials run only in
-CI: [CI/CD](./ci-cd.mdx).
+Full-application E2E, live-service integration, image builds, mutation analysis and release security
+are outside `verify`; see [CI/CD](./ci-cd.mdx).
 
 ## Vite+ task cache
 

--- a/docs/contributor/vulnerability-remediation.mdx
+++ b/docs/contributor/vulnerability-remediation.mdx
@@ -7,19 +7,15 @@ description: What blocks a build or a release, why unfixable findings do not, an
 
 # Vulnerability remediation
 
-The policy is executable: `scripts/check-release-vulnerabilities.ts` evaluates a Trivy report against
-`security/vulnerability-policy.json`. This page states it in prose.
-
-Disclosure — how to report a vulnerability privately — is `SECURITY.md`; this page is remediation
-only.
+`scripts/check-release-vulnerabilities.ts` evaluates Trivy image reports against
+`security/vulnerability-policy.json`. For private disclosure, see `SECURITY.md`.
 
 ## What blocks
 
 A finding blocks when it is **HIGH or CRITICAL and upstream has published a fix** — Trivy reports a
 non-empty `FixedVersion`. MEDIUM and below never block, at any scan.
 
-An unfixable HIGH is not an exception and does not need one. It remains recorded, but without a
-patched version there is no upgrade for the gate to require.
+An unfixable HIGH or CRITICAL remains recorded and needs no exception.
 
 Unfixable findings stay in an image scan report and in the `highCritical` list of the `.policy.json`
 attached to the release; that filter is in the evaluator, not a `--ignore-unfixed` flag. The
@@ -35,58 +31,46 @@ beside it still records what the gate filtered out.
 | The Version PR, and any CI/CD dispatch with `release-preflight` (`cicd.yml`) | both platforms of every first-party and upstream image, over the images that run built | fails the run |
 | Release evidence (`release.yml`) | both platforms of every first-party and upstream image | no release is created |
 | Weekly (`rescan-main-images.yml`) | the `linux/amd64` image behind each `:main` tag, and both platforms of each pinned upstream digest | opens or updates a tracking issue |
-| Weekly (`rescan-release-images.yml`) | every subject in the latest published release | fails and comments on [the vulnerability response issue](https://github.com/ls1intum/Hephaestus/issues/1369) |
+| Weekly (`rescan-release-images.yml`) | every subject in the latest published release | fails and comments on [the vulnerability response issue](https://github.com/hephaestus-build/Hephaestus/issues/1369) |
 
-All six evaluate `security/vulnerability-policy.json` through `scripts/check-release-vulnerabilities.ts`;
-the release, the preflight and the rescans reach it through `verify-release-evidence.ts`,
-`scan-main-images.ts` and `scan-upstream-images.ts`, and `scripts/ci-contract.test.ts` asserts there
-is one policy file. That test also asserts the scans before the release cover exactly the subject set
-the release gate covers, both derived from `security/release-images.json`: the upstream images are
-shipped by digest and never built here, so nothing scanned them until the release gate did, and
-v0.75.0 failed on a finding that had been in the pinned alpine digest for days. The preflight row is
-the whole gate rather than this one check — it evaluates the policy as part of verifying a real
-evidence bundle, so `release-management.mdx` § Nothing may fail for the first time at a release, not
-this table, is where its coverage is reasoned about. The scheduled rescans do not fail a commit
-status: a finding published after a clean merge has no commit to revert. A scanner failure is never
-treated as no findings.
+All six evaluate `security/vulnerability-policy.json` through `scripts/check-release-vulnerabilities.ts`.
+The release, preflight and rescans use the same evaluator. The CI contract checks that scans before
+release cover the subject set derived from `security/release-images.json`.
 
-A pinned upstream image cannot be patched by rebuilding anything here. Its remedy is a digest bump in
-`security/release-images.json` — which Renovate proposes, and which the pull request proposing it now
-scans — and until upstream republishes the tag there may be no digest to bump to.
+The Version PR preflight verifies the complete evidence bundle, not just vulnerability policy;
+see [Release management](release-management.mdx). Scheduled rescans report newly disclosed
+vulnerabilities without changing a previously passed commit status.
 
-That is also why the upstream scan covers both platforms while the scans of images we build cover
-`linux/amd64` only. An exception matches on `image | platform | vulnerability | package |
-installedVersion`, so a single-platform scan can only ever half-check a subject. For an image we
-build, the other half costs little to leave to the release: a finding on either architecture is
-fixed by the same rebuild, and the Version PR preflight scans both before the release is cut. For a
-pinned upstream digest there is no rebuild, the fix is a digest bump nobody can make until upstream
-publishes one, and the bump arrives in a pull request — so an arm64-only finding has to fail that
-pull request rather than the release.
+A scanner failure or malformed report never means no vulnerabilities. The evaluator accepts only
+[Trivy's severity vocabulary](https://github.com/aquasecurity/trivy-db/blob/main/pkg/types/types.go),
+including `UNKNOWN`; an unrecognized severity fails validation rather than silently passing the
+HIGH/CRITICAL filter.
+
+Pinned upstream images are not built here. Update their digests in `security/release-images.json`
+when a fixed upstream image is available; Renovate proposes these updates.
 
 ## Image exceptions
 
 An exception lets one fixable finding through for at most 90 days. It is an entry in
-`security/vulnerability-policy.json`, and `security/` has no CODEOWNERS rule of its own, so the default
-one applies: a member of the @ls1intum/hephaestus-maintainers team has to approve it.
+`security/vulnerability-policy.json`. Review ownership follows `.github/CODEOWNERS`; approval
+requirements are defined in [Merge policy](ci-cd.mdx#merge-policy).
 
 - `image`, `platform`, `vulnerability`, `package`, `installedVersion` — the match key. All five bind
   exactly, and `installedVersion` is what makes an exception die when the package moves.
-- `digest` — recorded so the exception names the artefact it was reviewed against, but deliberately
-  **not** matched on. A release digest does not exist until the images are tagged, so a digest-keyed
-  exception could only ever be written after the gate had already failed a release.
+- `digest` — the reviewed artefact, **not** part of the match key. An exception survives a rebuild
+  only while the matching fields remain unchanged.
 - `owner` — who is accountable for retiring it.
 - `status` — `affected` or `not_affected`, plus a `justification` in prose.
 - `evidence` — an HTTPS URL: the upstream advisory, the tracking issue, or the analysis the claim rests
-  on. A link a reviewer can follow, not a sentence.
+  on.
 - `expires` — `YYYY-MM-DDTHH:MM:SSZ`, in the future, at most 90 days out; when it lapses the gate
   fails again.
 
 ### `not_affected` justifications
 
-A `not_affected` exception also carries a `justificationCategory`, one of the five in CISA's *Minimum
-Requirements for Vulnerability Exploitability eXchange (VEX)*. Naming one forces the claim to say which
-way the finding does not apply, so prose like "not reachable" cannot stand in for an analysis nobody
-did.
+A `not_affected` exception requires a `justificationCategory` from CISA's *Minimum Requirements for
+Vulnerability Exploitability eXchange (VEX)*. The policy uses this vocabulary, not the VEX document
+format; `evidence` and `justification` must support the selected category.
 
 | Value | Means |
 | --- | --- |
@@ -96,16 +80,14 @@ did.
 | `vulnerable_code_cannot_be_controlled_by_adversary` | it is called, but never with attacker-controlled input |
 | `inline_mitigations_already_exist` | it is reachable and controllable, but a compensating control blocks exploitation |
 
-A value outside those five is a malformed policy and throws. An `affected` exception carries no
-category — it defers a risk we concede applies, and claiming non-exploitability at the same time is a
-contradiction.
+Other values fail validation. An `affected` exception accepts a risk and must not carry a
+`justificationCategory`.
 
 ## Dependency exceptions
 
 The dependency gate in `ci-security-scan.yml` reads `security/trivy-dependency-ignore.yaml`, Trivy's
-YAML ignore format, and it is the only place a dependency finding is excepted — dependency review
-holds no verdict to except. An entry carries the same ceiling and accountability as an image
-exception:
+YAML ignore format. Dependency exceptions belong here, not in the informational dependency-review
+check. Each entry requires:
 
 - `id` — the vulnerability the exception is for.
 - `purls` — the package URLs it applies to, so it dies when the dependency moves.
@@ -114,9 +96,7 @@ exception:
   lapses.
 - `statement` — why the risk is accepted, in prose a reviewer can weigh.
 
-The file sits under `security/`, so the same default CODEOWNERS rule applies, and the security path
-filter in `.github/workflows/cicd.yml` names it, so the pull request that adds a suppression re-runs
-the gate it suppresses.
+Changes to this file select the security gate through `.github/workflows/cicd.yml`.
 
 To reproduce a finding, run the gate over a clean checkout:
 

--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,9 @@
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
 	"extends": ["config:best-practices", ":semanticCommitTypeAll(chore)"],
 	"labels": ["dependencies"],
+	"prBodyNotes": [
+		"**Human review required:** Passing CI checks does not approve this dependency update. A maintainer with write access must approve it before it can enter the merge queue; Renovate is not auto-approved. See the [review policy](https://docs.hephaestus.build/contributor/ci-cd#merge-policy)."
+	],
 	"assigneesFromCodeOwners": true,
 	"timezone": "Europe/Berlin",
 	"schedule": ["before 7am every weekday"],

--- a/scripts/automatic-promotion.test.ts
+++ b/scripts/automatic-promotion.test.ts
@@ -1,0 +1,131 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { automaticPromotion } from "./automatic-promotion.ts";
+import { parseChannel } from "./reconcile-deployment.ts";
+
+const current = "a".repeat(40);
+const next = "b".repeat(40);
+const channel = parseChannel({
+	commit: current,
+	images: { HEPHAESTUS_IMAGE_WEBAPP: `ghcr.io/example/webapp@sha256:${"c".repeat(64)}` },
+});
+
+await test("automatic promotion preserves a hold without consulting commit history", async () => {
+	assert.equal(
+		await automaticPromotion({ ...channel, freeze: true }, next, () => {
+			throw new Error("a frozen channel must not query history");
+		}),
+		false,
+	);
+});
+
+await test("automatic promotion advances but never replays or rewinds a completed build", async () => {
+	for (const [status, expected] of [
+		["ahead", true],
+		["identical", false],
+		["behind", false],
+	] as const) {
+		assert.equal(
+			await automaticPromotion(channel, next, (base, head) => {
+				assert.equal(base, current);
+				assert.equal(head, next);
+				return Promise.resolve(status);
+			}),
+			expected,
+		);
+	}
+});
+
+await test("unknown history and API failures cannot authorize promotion", async () => {
+	for (const status of ["diverged", "unexpected"])
+		await assert.rejects(
+			automaticPromotion(channel, next, () => Promise.resolve(status)),
+			/history/,
+		);
+	await assert.rejects(
+		automaticPromotion(channel, next, () => Promise.reject(new Error("unavailable"))),
+		/unavailable/,
+	);
+	await assert.rejects(
+		automaticPromotion(channel, "main", () => Promise.resolve("ahead")),
+		/full commit SHA/,
+	);
+});
+
+await test("switching from a release to main cannot replay or rewind the release's source", async () => {
+	const release = parseChannel({ release: "v1.2.3" });
+	for (const [status, expected] of [
+		["ahead", true],
+		["identical", false],
+		["behind", false],
+	] as const) {
+		assert.equal(
+			await automaticPromotion(release, next, (base, head) => {
+				assert.equal(base, "v1.2.3");
+				assert.equal(head, next);
+				return Promise.resolve(status);
+			}),
+			expected,
+		);
+	}
+	await assert.rejects(
+		automaticPromotion(release, next, () => Promise.reject(new Error("unknown release"))),
+		/unknown release/,
+	);
+});
+
+await test("the CLI fails closed for invalid channels but honors a valid hold without network access", (t) => {
+	const directory = mkdtempSync(join(tmpdir(), "automatic-promotion-"));
+	t.after(() => rmSync(directory, { recursive: true, force: true }));
+	mkdirSync(join(directory, "deploy-state/channels"), { recursive: true });
+	const outputFile = join(directory, "output");
+	for (const contents of [undefined, "{", JSON.stringify({ release: "v1.2.3", freeze: "true" })]) {
+		if (contents !== undefined)
+			writeFileSync(join(directory, "deploy-state/channels/staging.json"), contents);
+		const result = spawnSync(
+			process.execPath,
+			[fileURLToPath(new URL("./automatic-promotion.ts", import.meta.url))],
+			{
+				cwd: directory,
+				encoding: "utf8",
+				env: {
+					...process.env,
+					CHANNEL: "Staging",
+					COMMIT: next,
+					GITHUB_REPOSITORY: "example/repo",
+					GITHUB_OUTPUT: outputFile,
+				},
+			},
+		);
+		assert.notEqual(result.status, 0, result.stderr);
+		assert.equal(existsSync(outputFile), false);
+	}
+	writeFileSync(
+		join(directory, "deploy-state/channels/staging.json"),
+		JSON.stringify({ release: "v1.2.3", freeze: true }),
+	);
+	const held = spawnSync(
+		process.execPath,
+		[fileURLToPath(new URL("./automatic-promotion.ts", import.meta.url))],
+		{
+			cwd: directory,
+			encoding: "utf8",
+			env: {
+				...process.env,
+				PATH: "",
+				CHANNEL: "Staging",
+				COMMIT: next,
+				GITHUB_REPOSITORY: "example/repo",
+				GITHUB_OUTPUT: outputFile,
+			},
+		},
+	);
+	assert.equal(held.status, 0, held.stderr);
+	assert.equal(readFileSync(outputFile, "utf8"), "apply=false\n");
+});

--- a/scripts/automatic-promotion.ts
+++ b/scripts/automatic-promotion.ts
@@ -1,0 +1,46 @@
+import { appendFile, readFile } from "node:fs/promises";
+
+import { requiredEnv } from "./lib/env.ts";
+import { asRecord, asString, parseJson } from "./lib/json.ts";
+import { output } from "./lib/process.ts";
+import { parseChannel, type Channel } from "./reconcile-deployment.ts";
+
+/** Called under the promotion concurrency lock, against its freshly checked-out channel. */
+export async function automaticPromotion(
+	channel: Channel,
+	commit: string,
+	compare: (base: string, head: string) => Promise<string>,
+): Promise<boolean> {
+	if (!/^[0-9a-f]{40}$/.test(commit))
+		throw new Error("automatic promotion requires a full commit SHA");
+	if (channel.freeze) return false;
+	const status = await compare(channel.release, commit);
+	if (status === "ahead") return true;
+	if (status === "behind" || status === "identical") return false;
+	throw new Error(`cannot automatically promote divergent or unknown history: ${status}`);
+}
+
+if (import.meta.main) {
+	const channel = requiredEnv(process.env, "CHANNEL");
+	if (channel !== "Staging") throw new Error("automatic promotion is only supported for Staging");
+	const commit = requiredEnv(process.env, "COMMIT");
+	const repository = requiredEnv(process.env, "GITHUB_REPOSITORY");
+	const current = parseChannel(
+		parseJson(await readFile("deploy-state/channels/staging.json", "utf8")),
+	);
+	const apply = await automaticPromotion(current, commit, async (base, head) =>
+		asString(
+			asRecord(
+				parseJson(await output("gh", ["api", `repos/${repository}/compare/${base}...${head}`])),
+				"comparison",
+			).status,
+			"comparison status",
+		),
+	);
+	console.log(
+		apply
+			? `Promoting ${commit}`
+			: "Automatic promotion skipped: channel is frozen or already at a newer build.",
+	);
+	await appendFile(requiredEnv(process.env, "GITHUB_OUTPUT"), `apply=${apply}\n`);
+}

--- a/scripts/check-release-vulnerabilities.test.ts
+++ b/scripts/check-release-vulnerabilities.test.ts
@@ -174,7 +174,7 @@ await test("rejects expired and malformed exceptions", () => {
 	assert.throws(() => evaluate("server", {}, policy), /malformed Trivy report/);
 	assert.throws(
 		() => evaluate("server", { Results: [{ Vulnerabilities: [{ Severity: "HIGH" }] }] }, policy),
-		/missing InstalledVersion/,
+		/InstalledVersion must be a string/,
 	);
 	assert.match(
 		evaluate("server", report, {
@@ -289,4 +289,51 @@ await test("names the rejected findings in the run summary", () => {
 	);
 	assert.match(clean, /server \(linux\/amd64\): pass/);
 	assert.doesNotMatch(clean, /\| Vulnerability \|/);
+});
+
+await test("rejects malformed severities rather than treating them as below HIGH", () => {
+	for (const severity of ["high", "CRITCAL", " ", 4, null]) {
+		assert.throws(
+			() =>
+				evaluate(
+					"server",
+					{ Results: [{ Vulnerabilities: [{ ...finding, Severity: severity }] }] },
+					policy,
+				),
+			/Severity/,
+		);
+	}
+	for (const severity of ["UNKNOWN", "LOW", "MEDIUM", "HIGH", "CRITICAL"]) {
+		const result = evaluate(
+			"server",
+			{ Results: [{ Vulnerabilities: [{ ...finding, Severity: severity }] }] },
+			policy,
+		);
+		assert.equal(result.rejected.length, ["HIGH", "CRITICAL"].includes(severity) ? 1 : 0);
+	}
+});
+
+await test("rejects an exception expiry that JavaScript rolls into another month", () => {
+	const exception = {
+		digest,
+		evidence: "https://github.com/example/project/issues/1",
+		expires: "2026-02-30T00:00:00Z",
+		image: "server",
+		installedVersion: "1",
+		justification: "risk accepted pending an upgrade",
+		owner: "@security",
+		package: "lib",
+		platform: "linux/amd64",
+		status: "affected",
+		vulnerability: "CVE-1",
+	};
+	assert.match(
+		evaluate(
+			"server",
+			report,
+			{ ...policy, exceptions: [exception] },
+			new Date("2026-02-01T00:00:00Z"),
+		).errors.join("\n"),
+		/invalid or expired exception/,
+	);
 });

--- a/scripts/check-release-vulnerabilities.ts
+++ b/scripts/check-release-vulnerabilities.ts
@@ -1,20 +1,16 @@
 import { appendFileSync, readFileSync, writeFileSync } from "node:fs";
 
+import { asString, isRecord as record } from "./lib/json.ts";
+
 type Finding = {
 	FixedVersion?: string;
-	InstalledVersion?: string;
-	PkgName?: string;
-	Severity?: string;
-	VulnerabilityID?: string;
+	InstalledVersion: string;
+	PkgName: string;
+	Severity: string;
+	VulnerabilityID: string;
 };
 
-/**
- * The five `not_affected` justifications from CISA's *Minimum Requirements for Vulnerability
- * Exploitability eXchange (VEX)*. They are taken as a vocabulary only: a claim that a finding does
- * not apply has to name which of the five ways it does not apply, so prose like "not reachable"
- * cannot stand in for an analysis nobody did. VEX itself is not adopted — see
- * `docs/contributor/vulnerability-remediation.mdx`.
- */
+// CISA VEX justification vocabulary; policy: docs/contributor/vulnerability-remediation.mdx.
 const JUSTIFICATION_CATEGORIES = [
 	"component_not_present",
 	"vulnerable_code_not_present",
@@ -28,11 +24,7 @@ export type JustificationCategory = (typeof JUSTIFICATION_CATEGORIES)[number];
 const isJustificationCategory = (value: unknown): value is JustificationCategory =>
 	JUSTIFICATION_CATEGORIES.some((category) => category === value);
 
-// `digest` is recorded so an exception names the artefact it was reviewed against, but it is
-// deliberately not part of the match key: the release digest does not exist until `tag-images`
-// runs, so a digest-keyed exception could only ever be authored after the gate had already
-// failed a release, and would die on the next rebuild. `installedVersion` already gives the
-// "this exception expires when the package moves" property that digest matching was there for.
+// Match package versions, not build digests: exceptions must be authorable before release signing.
 type Exception = {
 	digest: string;
 	evidence: string;
@@ -49,9 +41,6 @@ type Exception = {
 	vulnerability: string;
 };
 type Policy = { exceptions: Exception[]; schemaVersion: 2 };
-
-const record = (value: unknown): value is Record<string, unknown> =>
-	typeof value === "object" && value !== null && !Array.isArray(value);
 
 const isException = (value: unknown): value is Exception =>
 	record(value) &&
@@ -130,9 +119,6 @@ export function evaluate(
 			errors.push(`malformed exception digest: ${exception.digest}`);
 		if (!/^linux\/(?:amd64|arm64)$/.test(exception.platform))
 			errors.push(`unsupported exception platform: ${exception.platform}`);
-		// An unrecognised category is already a malformed policy; what is left to check is that the
-		// category and the status agree. `affected` defers a risk we accept, and saying why the
-		// finding does not apply while conceding that it does is a contradiction, not a detail.
 		if (exception.status === "not_affected" && exception.justificationCategory === undefined)
 			errors.push(
 				`not_affected exception must name a justification category: ${exception.vulnerability}`,
@@ -151,9 +137,12 @@ export function evaluate(
 		if (
 			!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/.test(exception.expires) ||
 			Number.isNaN(expiry.valueOf()) ||
+			expiry.toISOString() !== exception.expires.replace("Z", ".000Z") ||
 			expiry <= now
 		)
-			errors.push(`exception expired: ${exception.vulnerability} (${exception.expires})`);
+			errors.push(
+				`invalid or expired exception: ${exception.vulnerability} (${exception.expires})`,
+			);
 		else if (expiry.valueOf() - now.valueOf() > 90 * 24 * 60 * 60 * 1000)
 			errors.push(
 				`exception exceeds 90-day limit: ${exception.vulnerability} (${exception.expires})`,
@@ -168,21 +157,28 @@ export function evaluate(
 			throw new Error("malformed Trivy result");
 		for (const value of result.Vulnerabilities ?? []) {
 			if (!record(value)) throw new Error("malformed Trivy vulnerability");
-			for (const field of ["InstalledVersion", "PkgName", "Severity", "VulnerabilityID"])
-				if (typeof value[field] !== "string" || value[field].length === 0)
-					throw new Error(`malformed Trivy vulnerability: missing ${field}`);
-			// Trivy omits FixedVersion entirely when upstream has published no fix, so its
-			// absence is data rather than corruption; only a non-string is malformed.
-			if (value.FixedVersion !== undefined && typeof value.FixedVersion !== "string")
-				throw new Error("malformed Trivy vulnerability: FixedVersion must be a string");
+			const required = (field: string) => {
+				const text = asString(value[field], `Trivy vulnerability ${field}`);
+				if (!text.trim()) throw new Error(`malformed Trivy vulnerability: empty ${field}`);
+				return text;
+			};
+			const installedVersion = required("InstalledVersion");
+			const packageName = required("PkgName");
+			const severity = required("Severity");
+			const vulnerability = required("VulnerabilityID");
+			if (!["UNKNOWN", "LOW", "MEDIUM", "HIGH", "CRITICAL"].includes(severity))
+				throw new Error(`malformed Trivy vulnerability: unsupported Severity ${severity}`);
+			// Trivy omits FixedVersion when upstream has published no fix.
+			const fixedVersion =
+				value.FixedVersion === undefined
+					? undefined
+					: asString(value.FixedVersion, "Trivy vulnerability FixedVersion");
 			findings.push({
-				FixedVersion: typeof value.FixedVersion === "string" ? value.FixedVersion : undefined,
-				InstalledVersion:
-					typeof value.InstalledVersion === "string" ? value.InstalledVersion : undefined,
-				PkgName: typeof value.PkgName === "string" ? value.PkgName : undefined,
-				Severity: typeof value.Severity === "string" ? value.Severity : undefined,
-				VulnerabilityID:
-					typeof value.VulnerabilityID === "string" ? value.VulnerabilityID : undefined,
+				FixedVersion: fixedVersion,
+				InstalledVersion: installedVersion,
+				PkgName: packageName,
+				Severity: severity,
+				VulnerabilityID: vulnerability,
 			});
 		}
 	}
@@ -190,11 +186,7 @@ export function evaluate(
 		(finding) => finding.Severity === "HIGH" || finding.Severity === "CRITICAL",
 	);
 	const subjectPlatform = subject?.platform;
-	// Only a finding upstream has published a fix for can block: the upstream images in
-	// security/release-images.json cannot be patched at all, so failing on an unfixable
-	// finding removes no risk and leaves nobody an action. The filter lives here rather than
-	// on Trivy's command line (`--ignore-unfixed`) so unfixable findings stay counted in
-	// `highCritical` and visible in the signed evidence bundle.
+	// Keep unfixable vulnerabilities in the evidence; only published fixes block release.
 	const rejected = highCritical.filter((finding) => {
 		if (!finding.FixedVersion?.trim()) return false;
 		return !policy.exceptions.some(
@@ -216,11 +208,6 @@ export function evaluate(
 
 export type Evaluation = ReturnType<typeof evaluate>;
 
-/**
- * A run summary naming what was rejected. The gate used to fail with nothing but
- * `<image> does not satisfy vulnerability policy`, so diagnosing it meant rebuilding and
- * rescanning the base image by hand.
- */
 export function renderSummary(
 	subject: { digest: string; image: string; platform: string },
 	result: Evaluation,

--- a/scripts/commit-image-lock.test.ts
+++ b/scripts/commit-image-lock.test.ts
@@ -15,9 +15,6 @@ const digest = `sha256:${"1".repeat(64)}`;
 const resolver = () => Promise.resolve(digest);
 
 await test("a commit channel pins every image the stacks actually read", async () => {
-	// The point of the lock is that nothing renders from a floating tag. If the stacks grow an
-	// image this does not resolve, Compose would fail to render on the host rather than here.
-	// fileURLToPath, not .pathname: on Windows that yields "/C:/..." and no file opens there.
 	const inventory = await readInventory(
 		fileURLToPath(new URL("../security/release-images.json", import.meta.url)),
 	);

--- a/scripts/commit-image-lock.ts
+++ b/scripts/commit-image-lock.ts
@@ -1,17 +1,7 @@
-/**
- * Builds the images a commit channel pins, so an environment can follow the default branch.
- *
- * A release ships a signed lock listing every image by digest. A commit has no release, but it has
- * everything the lock is made of: the upstream images are pinned in `security/release-images.json`,
- * which is part of the commit, and the first-party images are published by CI under the commit's
- * own tag. Resolving those tags to digests here produces the same pinning without a release.
- *
- * Provenance comes from GitHub's artifact attestations rather than from a signature over the list:
- * `gh attestation verify` fails unless this repository's build workflow signed that exact digest on
- * a GitHub-hosted runner, which is the claim a release lock's signature makes as well.
- */
+/** Resolve commit-tagged images and verify their build provenance before channel signing. */
 import { readFile } from "node:fs/promises";
 
+import { asArray, asRecord, asString, asStringArray, parseJson } from "./lib/json.ts";
 import { CAPTURE_LIMIT_BYTES } from "./lib/process.ts";
 
 export interface ImageInventory {
@@ -23,56 +13,28 @@ export interface ImageInventory {
 	}[];
 }
 
-export interface ResolvedImage {
-	readonly key: string;
-	readonly reference: string;
-}
-
 const COMMIT_SHA = /^[0-9a-f]{40}$/;
 const DIGEST = /^sha256:[0-9a-f]{64}$/;
 
-/** `application-server` is read from the environment as HEPHAESTUS_IMAGE_APPLICATION_SERVER. */
 export function environmentKey(image: string): string {
 	return `HEPHAESTUS_IMAGE_${image.toUpperCase().replaceAll("-", "_")}`;
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-	return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function stringField(source: Record<string, unknown>, field: string, label: string): string {
-	const value = source[field];
-	if (typeof value !== "string") throw new Error(`${label} has no ${field}`);
-	return value;
-}
-
 export function parseInventory(value: unknown): ImageInventory {
-	if (!isRecord(value)) throw new Error("image inventory is not an object");
-	const { images, upstream } = value;
-	if (!Array.isArray(images) || !images.every((image) => typeof image === "string"))
-		throw new Error("image inventory lists no first-party images");
-	if (!Array.isArray(upstream)) throw new Error("image inventory lists no upstream images");
+	const record = asRecord(value, "image inventory");
 	return {
-		images,
-		upstream: upstream.map((entry, index) => {
+		images: asStringArray(record.images, "image inventory.images"),
+		upstream: asArray(record.upstream, "image inventory.upstream").map((candidate, index) => {
 			const label = `upstream[${index}]`;
-			if (!isRecord(entry)) throw new Error(`${label} is not an object`);
-			const digest = stringField(entry, "digest", label);
-			if (!DIGEST.test(digest))
-				throw new Error(`upstream ${stringField(entry, "name", label)} is not pinned by digest`);
-			return {
-				name: stringField(entry, "name", label),
-				repository: stringField(entry, "repository", label),
-				digest,
-			};
+			const entry = asRecord(candidate, label);
+			const name = asString(entry.name, `${label}.name`);
+			const digest = asString(entry.digest, `${label}.digest`);
+			if (!DIGEST.test(digest)) throw new Error(`upstream ${name} is not pinned by digest`);
+			return { name, repository: asString(entry.repository, `${label}.repository`), digest };
 		}),
 	};
 }
 
-/**
- * Every image the Compose files read, pinned by digest: the upstream ones as the commit pins them,
- * and the first-party ones as the registry answers for this commit's tag.
- */
 export async function resolveImages(
 	inventory: ImageInventory,
 	commit: string,
@@ -93,14 +55,9 @@ export async function resolveImages(
 }
 
 export async function readInventory(path: string): Promise<ImageInventory> {
-	return parseInventory(JSON.parse(await readFile(path, "utf8")));
+	return parseInventory(parseJson(await readFile(path, "utf8")));
 }
 
-/**
- * Resolves a first-party image and refuses it unless GitHub attests that this repository's build
- * workflow produced that exact digest on a hosted runner. That attestation is what stands in for a
- * release lock's signature: both say "our CI built this", and this one is checked per image.
- */
 async function resolveAndVerify(repository: string, commit: string): Promise<string> {
 	const { execFileSync } = await import("node:child_process");
 	const ghRepository = process.env.GITHUB_REPOSITORY;
@@ -129,12 +86,8 @@ async function resolveAndVerify(repository: string, commit: string): Promise<str
 			ghRepository,
 			"--signer-workflow",
 			`${ghRepository}/.github/workflows/reusable-docker-build.yml`,
-			// The runner is part of what the signature attests to, and no self-hosted runner is in
-			// this repository's build path.
 			"--deny-self-hosted-runners",
-			// Without this the check proves only that this workflow attested this digest at some
-			// point, so an older image retagged onto the commit would pass. This binds the
-			// attestation to the source revision being deployed.
+			// Reject an older attested image retagged onto the requested commit.
 			"--source-digest",
 			commit,
 			"--predicate-type",

--- a/scripts/commit-via-api.test.ts
+++ b/scripts/commit-via-api.test.ts
@@ -1,33 +1,38 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { devNull, tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "node:test";
 
-import { changedPaths, commitInput } from "./commit-via-api.ts";
+import { stageChanges, commitInput } from "./commit-via-api.ts";
 
-/**
- * Git hooks export GIT_DIR, GIT_INDEX_FILE and friends, which would point every command below at the
- * repository being pushed instead of at the fixture. Strip them so the fixtures are self-contained
- * however these tests are invoked.
- */
-const cleanGitEnv = (): NodeJS.ProcessEnv =>
-	Object.fromEntries(Object.entries(process.env).filter(([key]) => !key.startsWith("GIT_")));
+// Unset inherited Git hook variables as process helpers merge overrides with the environment.
+const cleanGitEnv = (): NodeJS.ProcessEnv => ({
+	...Object.fromEntries(
+		Object.keys(process.env)
+			.filter((key) => key.startsWith("GIT_"))
+			.map((key) => [key, undefined]),
+	),
+	GIT_CONFIG_GLOBAL: devNull,
+	GIT_CONFIG_NOSYSTEM: "1",
+});
 
 type Git = (...args: string[]) => string;
 
-/** A throwaway repo holding one tracked file per shape of change these tests make. */
-function repoWithCommittedFiles(): { repo: string; git: Git; status: () => string } {
+function repoWithCommittedFiles() {
 	const repo = mkdtempSync(join(tmpdir(), "commit-via-api-"));
+	const env = { ...process.env, ...cleanGitEnv() };
 	const git: Git = (...args) =>
 		execFileSync("git", args, {
 			cwd: repo,
 			encoding: "utf8",
 			stdio: ["ignore", "pipe", "pipe"],
-			env: cleanGitEnv(),
+			env,
 		});
 	git("init", "--quiet", "--initial-branch=main");
+	git("config", "commit.gpgsign", "false");
+	git("config", "core.hooksPath", devNull);
 	git("config", "user.email", "test@example.invalid");
 	git("config", "user.name", "Test");
 	for (const path of ["kept.txt", "edited.txt", "removed.txt", "moved.txt"])
@@ -37,45 +42,60 @@ function repoWithCommittedFiles(): { repo: string; git: Git; status: () => strin
 	return {
 		repo,
 		git,
-		status: () => git("status", "--porcelain=v1", "-z", "--untracked-files=all"),
+		changes: (...paths: string[]) => stageChanges(paths, { cwd: repo, env }),
 	};
 }
 
-await test("enumerates every added, modified and deleted path in the work tree", (t) => {
-	const { repo, status } = repoWithCommittedFiles();
+await test("enumerates every added, modified and deleted path in the work tree", async (t) => {
+	const { repo, changes } = repoWithCommittedFiles();
 	t.after(() => rmSync(repo, { recursive: true, force: true }));
 	writeFileSync(join(repo, "edited.txt"), "edited\n");
 	rmSync(join(repo, "removed.txt"));
 	mkdirSync(join(repo, "generated"));
 	writeFileSync(join(repo, "generated/added.txt"), "added\n");
 
-	// An untracked directory is enumerated file by file: the mutation commits contents, not trees.
-	assert.deepEqual(changedPaths(status()), {
+	assert.deepEqual(await changes(), {
 		additions: ["edited.txt", "generated/added.txt"],
 		deletions: ["removed.txt"],
 	});
 });
 
-await test("splits a rename into the source deleted and the destination added", (t) => {
-	const { repo, git, status } = repoWithCommittedFiles();
+await test("splits a rename into the source deleted and the destination added", async (t) => {
+	const { repo, git, changes } = repoWithCommittedFiles();
 	t.after(() => rmSync(repo, { recursive: true, force: true }));
 	git("mv", "moved.txt", "arrived.txt");
 
-	assert.deepEqual(changedPaths(status()), {
+	assert.deepEqual(await changes(), {
 		additions: ["arrived.txt"],
 		deletions: ["moved.txt"],
 	});
 });
 
-await test("has nothing to commit from a clean work tree", (t) => {
-	const { repo, status } = repoWithCommittedFiles();
+await test("has nothing to commit from a clean work tree", async (t) => {
+	const { repo, changes } = repoWithCommittedFiles();
 	t.after(() => rmSync(repo, { recursive: true, force: true }));
 
-	assert.deepEqual(changedPaths(status()), { additions: [], deletions: [] });
+	assert.deepEqual(await changes(), { additions: [], deletions: [] });
 });
 
-await test("refuses a work tree with a conflict in it", () => {
-	assert.throws(() => changedPaths("UU merged.txt\0"), /merged\.txt is unmerged/);
+await test("refuses scoped conflicts without staging them", async (t) => {
+	const { repo, git, changes } = repoWithCommittedFiles();
+	t.after(() => rmSync(repo, { recursive: true, force: true }));
+	git("checkout", "-qb", "other");
+	writeFileSync(join(repo, "edited.txt"), "other\n");
+	git("commit", "-qam", "other");
+	git("checkout", "-q", "main");
+	writeFileSync(join(repo, "edited.txt"), "main\n");
+	git("commit", "-qam", "main");
+	assert.throws(() => git("merge", "other"));
+	await assert.rejects(changes("edited.txt"), /unmerged/);
+	assert.equal(git("diff", "--name-only", "--diff-filter=U"), "edited.txt\n");
+	mkdirSync(join(repo, "generated"));
+	writeFileSync(join(repo, "generated/added.txt"), "added\n");
+	assert.deepEqual(await changes("generated"), {
+		additions: ["generated/added.txt"],
+		deletions: [],
+	});
 });
 
 await test("builds the mutation input, with file contents base64-encoded", () => {
@@ -106,4 +126,66 @@ await test("builds the mutation input, with file contents base64-encoded", () =>
 		Buffer.from(input.fileChanges.additions[0]?.contents ?? "", "base64").toString("utf8"),
 		'{"release":"v1.2.3"}\n',
 	);
+});
+
+await test("a staged new file removed before committing is not a deletion on the branch", async (t) => {
+	const { repo, git, changes } = repoWithCommittedFiles();
+	t.after(() => rmSync(repo, { recursive: true, force: true }));
+	writeFileSync(join(repo, "temporary.txt"), "temporary\n");
+	git("add", "temporary.txt");
+	rmSync(join(repo, "temporary.txt"));
+	assert.deepEqual(await changes(), { additions: [], deletions: [] });
+});
+
+await test("a renamed file removed before committing deletes only its original path", async (t) => {
+	const { repo, git, changes } = repoWithCommittedFiles();
+	t.after(() => rmSync(repo, { recursive: true, force: true }));
+	git("mv", "moved.txt", "arrived.txt");
+	rmSync(join(repo, "arrived.txt"));
+	assert.deepEqual(await changes(), { additions: [], deletions: ["moved.txt"] });
+});
+
+await test("recreating a staged deletion or rename replaces the original contents", async (t) => {
+	const { repo, git, changes } = repoWithCommittedFiles();
+	t.after(() => rmSync(repo, { recursive: true, force: true }));
+	git("rm", "removed.txt");
+	git("mv", "moved.txt", "arrived.txt");
+	writeFileSync(join(repo, "removed.txt"), "replacement\n");
+	writeFileSync(join(repo, "moved.txt"), "replacement\n");
+	assert.deepEqual(await changes(), {
+		additions: ["arrived.txt", "moved.txt", "removed.txt"],
+		deletions: [],
+	});
+});
+
+await test("staged edits reverted in the work tree produce no commit", async (t) => {
+	const { repo, git, changes } = repoWithCommittedFiles();
+	t.after(() => rmSync(repo, { recursive: true, force: true }));
+	writeFileSync(join(repo, "edited.txt"), "staged\n");
+	git("add", "edited.txt");
+	writeFileSync(join(repo, "edited.txt"), "edited.txt\n");
+	assert.deepEqual(await changes(), { additions: [], deletions: [] });
+});
+
+await test("commits only selected generated paths, excluding staged and unstaged unrelated edits", async (t) => {
+	const { repo, git, changes } = repoWithCommittedFiles();
+	t.after(() => rmSync(repo, { recursive: true, force: true }));
+	writeFileSync(join(repo, "edited.txt"), "staged\n");
+	git("add", "edited.txt");
+	writeFileSync(join(repo, "kept.txt"), "unstaged\n");
+	mkdirSync(join(repo, "generated"));
+	writeFileSync(join(repo, "generated/added.txt"), "added\n");
+	assert.deepEqual(await changes("generated"), {
+		additions: ["generated/added.txt"],
+		deletions: [],
+	});
+	assert.equal(git("diff", "--name-only"), "kept.txt\n");
+});
+
+await test("preserves filenames that require Git's NUL-delimited output", async (t) => {
+	const { repo, changes } = repoWithCommittedFiles();
+	t.after(() => rmSync(repo, { recursive: true, force: true }));
+	const paths = ["space name.txt", ...(process.platform === "win32" ? [] : ["line\nbreak.txt"])];
+	for (const path of paths) writeFileSync(join(repo, path), "added\n");
+	assert.deepEqual(await changes(), { additions: paths.toSorted(), deletions: [] });
 });

--- a/scripts/commit-via-api.test.ts
+++ b/scripts/commit-via-api.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
-import { devNull, tmpdir } from "node:os";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "node:test";
 
@@ -14,7 +14,6 @@ const cleanGitEnv = (): NodeJS.ProcessEnv => ({
 			.filter((key) => key.startsWith("GIT_"))
 			.map((key) => [key, undefined]),
 	),
-	GIT_CONFIG_GLOBAL: devNull,
 	GIT_CONFIG_NOSYSTEM: "1",
 });
 
@@ -22,7 +21,10 @@ type Git = (...args: string[]) => string;
 
 function repoWithCommittedFiles() {
 	const repo = mkdtempSync(join(tmpdir(), "commit-via-api-"));
-	const env = { ...process.env, ...cleanGitEnv() };
+	mkdirSync(join(repo, ".git"));
+	const globalConfig = join(repo, ".git", "test-global-config");
+	writeFileSync(globalConfig, "");
+	const env = { ...process.env, ...cleanGitEnv(), GIT_CONFIG_GLOBAL: globalConfig };
 	const git: Git = (...args) =>
 		execFileSync("git", args, {
 			cwd: repo,
@@ -32,7 +34,7 @@ function repoWithCommittedFiles() {
 		});
 	git("init", "--quiet", "--initial-branch=main");
 	git("config", "commit.gpgsign", "false");
-	git("config", "core.hooksPath", devNull);
+	git("config", "core.hooksPath", join(repo, ".git", "disabled-hooks"));
 	git("config", "user.email", "test@example.invalid");
 	git("config", "user.name", "Test");
 	for (const path of ["kept.txt", "edited.txt", "removed.txt", "moved.txt"])

--- a/scripts/commit-via-api.ts
+++ b/scripts/commit-via-api.ts
@@ -1,28 +1,11 @@
-/**
- * Commits the work tree to a branch through GitHub's `createCommitOnBranch` mutation.
- *
- * A ruleset that requires signed commits rejects everything `git commit` produces inside a workflow:
- * Actions holds no signing key and GitHub will not vouch for a commit it did not make. The mutation
- * is the path GitHub signs — it is how `changesets/action` lands the Version PR and how Renovate
- * lands a dependency bump, and both verify as `web-flow`. The credential is unchanged, so the
- * documented consequence of committing with `GITHUB_TOKEN` is unchanged too: the resulting push
- * starts no further workflow run.
- *
- * The mutation carries file contents rather than a diff, so every path the commit touches has to be
- * named and every added or modified file sent whole. A rename has no representation of its own: it
- * is the source path deleted and the destination path added.
- *
- * `expectedHeadOid` is what the shell path spelled as "never force-push". A branch that moved while
- * the files were being produced rejects the commit instead of burying the move.
- */
+/** GitHub signs API-created commits; expectedHeadOid rejects a concurrently moved branch. */
 import { appendFile, readFile } from "node:fs/promises";
 import { parseArgs } from "node:util";
 
 import { requiredEnv } from "./lib/env.ts";
 import { asRecord, asString, at, isRecord } from "./lib/json.ts";
-import { output } from "./lib/process.ts";
+import { output, type RunOptions } from "./lib/process.ts";
 
-/** Paths whose work-tree state one commit must carry, as `createCommitOnBranch` divides them. */
 export interface WorkTreeChanges {
 	readonly additions: readonly string[];
 	readonly deletions: readonly string[];
@@ -46,38 +29,41 @@ export interface CommitTarget {
 	readonly headline: string;
 }
 
-/** The two-letter codes `git status` uses for a path it cannot describe as one change. */
-const UNMERGED = new Set(["DD", "AU", "UD", "UA", "DU", "AA", "UU"]);
-
-/**
- * Reads `git status --porcelain=v1 -z`, whose entries are NUL-terminated `XY path`, and whose rename
- * and copy entries put the source path in a field of its own after the destination.
- */
-export function changedPaths(porcelain: string): WorkTreeChanges {
-	const fields = porcelain.split("\0");
-	const additions: string[] = [];
-	const deletions: string[] = [];
-	for (let index = 0; index < fields.length; index += 1) {
-		const entry = fields[index];
-		// The last field after a trailing NUL is empty.
-		if (!entry) continue;
-		const codes = entry.slice(0, 2);
-		const path = entry.slice(3);
-		if (UNMERGED.has(codes))
-			throw new Error(`${path} is unmerged; a conflicted work tree is not a commit`);
-		if (codes.startsWith("R") || codes.startsWith("C")) {
-			index += 1;
-			const source = fields[index];
-			if (!source) throw new Error(`${path} is reported as a rename with no source path`);
-			// A copy leaves its source where it is; a rename does not.
-			if (codes.startsWith("R")) deletions.push(source);
-		}
-		// The work-tree column decides wherever it has an opinion: it holds the state to be committed,
-		// and the index column only says what the path looked like on the way there.
-		const state = codes[1] === " " ? codes[0] : codes[1];
-		(state === "D" ? deletions : additions).push(path);
-	}
-	return { additions: additions.toSorted(), deletions: deletions.toSorted() };
+/** Stages the selected work-tree paths; automation callers use disposable checkouts. */
+export async function stageChanges(
+	paths: readonly string[] = [],
+	options: RunOptions = {},
+): Promise<WorkTreeChanges> {
+	const conflicts = await output(
+		"git",
+		["diff", "--name-only", "--diff-filter=U", "-z", "--", ...paths],
+		options,
+	);
+	if (conflicts)
+		throw new Error("Selected paths are unmerged; resolve conflicts before committing");
+	await output("git", ["add", "-A", "--", ...paths], options);
+	const changed = async (filter: string) =>
+		(
+			await output(
+				"git",
+				[
+					"diff",
+					"--cached",
+					"HEAD",
+					"--no-renames",
+					"--name-only",
+					"-z",
+					`--diff-filter=${filter}`,
+					"--",
+					...paths,
+				],
+				options,
+			)
+		)
+			.split("\0")
+			.filter(Boolean);
+	const [additions, deletions] = await Promise.all([changed("AMT"), changed("D")]);
+	return { additions, deletions };
 }
 
 export function commitInput(
@@ -111,7 +97,6 @@ const COMMIT_MUTATION = `mutation ($input: CreateCommitOnBranchInput!) {
   }
 }`;
 
-/** The new commit's object name and what GitHub says about its signature. */
 async function createCommit(token: string, input: CommitInput): Promise<string> {
 	const response = await fetch(process.env.GITHUB_GRAPHQL_URL ?? "https://api.github.com/graphql", {
 		method: "POST",
@@ -121,8 +106,6 @@ async function createCommit(token: string, input: CommitInput): Promise<string> 
 	const text = await response.text();
 	if (!response.ok) throw new Error(`GitHub answered ${response.status} ${response.statusText}`);
 	const body = asRecord(JSON.parse(text), "GraphQL response");
-	// A moved head, a deletion of a path the branch does not have, a branch that is not a branch:
-	// GitHub explains each of them here, and none of the explanations quote the credential.
 	if (body.errors) throw new Error(`createCommitOnBranch refused the commit: ${text}`);
 	const commit = asRecord(
 		at(body, ["data", "createCommitOnBranch", "commit"], "response"),
@@ -150,22 +133,12 @@ if (import.meta.main) {
 		repository: requiredEnv(process.env, "GITHUB_REPOSITORY"),
 		branch,
 		headline: message,
-		// The work tree was compared against this commit, so nothing else is a base the changes below
-		// describe.
 		expectedHeadOid: values["expected-head"] ?? (await output("git", ["rev-parse", "HEAD"])).trim(),
 	};
-	const changes = changedPaths(
-		await output("git", [
-			"status",
-			"--porcelain=v1",
-			"-z",
-			"--untracked-files=all",
-			...(positionals.length > 0 ? ["--", ...positionals] : []),
-		]),
-	);
+	const changes = await stageChanges(positionals);
 	const changed = changes.additions.length > 0 || changes.deletions.length > 0;
 	if (!changed) {
-		console.log("The work tree matches the branch; no commit was created.");
+		console.log("Selected paths match HEAD; no commit was created.");
 	} else {
 		const contents = new Map(
 			await Promise.all(

--- a/scripts/enable-hooks.test.ts
+++ b/scripts/enable-hooks.test.ts
@@ -11,7 +11,6 @@ const REPO_ROOT = resolve(import.meta.dirname, "..");
 const SCRIPT = join(REPO_ROOT, "scripts", "enable-hooks.ts");
 const temporaries: string[] = [];
 
-/** A global Git config holding exactly these lines, so the machine's own cannot decide a test. */
 function globalConfig(contents = ""): string {
 	const directory = mkdtempSync(join(tmpdir(), "enable-hooks-config-"));
 	temporaries.push(directory);
@@ -22,14 +21,7 @@ function globalConfig(contents = ""): string {
 
 const EMPTY_GLOBAL_CONFIG = globalConfig();
 
-/**
- * Git exports `GIT_DIR` and its siblings to every hook process, and they outrank a child's `cwd`.
- * Inherited, they would point both the script under test and the assertions at the repository the
- * hook is running in rather than at the clone made below. The global and system configs are then
- * replaced rather than dropped, and `CI` is removed, because what a developer's own config says
- * about commit signing and whether this suite is running on a runner are exactly what these tests
- * decide.
- */
+// Git hook variables override cwd; keep each subprocess inside its isolated fixture.
 function hookFreeEnv(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
 	const inherited = Object.fromEntries(
 		Object.entries(process.env).filter(([key]) => !key.startsWith("GIT_") && key !== "CI"),
@@ -46,7 +38,6 @@ after(() => {
 	for (const temporary of temporaries) rmSync(temporary, { recursive: true, force: true });
 });
 
-/** A clone with the project hooks whose Git still points at an earlier hook manager's directory. */
 function clone(): { repository: string; git: (...args: string[]) => string } {
 	const repository = mkdtempSync(join(tmpdir(), "enable-hooks-"));
 	temporaries.push(repository);
@@ -58,12 +49,11 @@ function clone(): { repository: string; git: (...args: string[]) => string } {
 			env: hookFreeEnv(),
 		}).trim();
 	git("init", "--quiet");
-	git("config", "core.hooksPath", ".husky/_");
 	cpSync(join(REPO_ROOT, ".vite-hooks"), join(repository, ".vite-hooks"), { recursive: true });
 	return { repository, git };
 }
 
-void test("an install moves Git from an earlier hooks directory to the dispatcher", () => {
+void test("an install enables the dispatcher and is idempotent", () => {
 	const { repository, git } = clone();
 	const result = spawnSync("node", [SCRIPT], {
 		cwd: repository,
@@ -82,25 +72,48 @@ void test("an install moves Git from an earlier hooks directory to the dispatche
 	assert.equal(git("config", "core.hooksPath"), ".vite-hooks/_");
 });
 
-// Git exports `GIT_DIR` to a hook only when the push runs from a linked worktree, so no CI push can
-// reach this state; setting it here is the whole reproduction.
-void test("an install under a hook's GIT_DIR configures the clone it runs in", () => {
-	const decoy = clone();
+void test("an install preserves disabled hooks until explicitly re-enabled", () => {
 	const { repository, git } = clone();
-	process.env.GIT_DIR = join(decoy.repository, ".git");
-	try {
-		const result = spawnSync("node", [SCRIPT], {
-			cwd: repository,
-			encoding: "utf8",
-			maxBuffer: CAPTURE_LIMIT_BYTES,
-			env: hookFreeEnv(),
-		});
+	const run = (...args: string[]) => {
+		const result = spawnSync("vp", args, { cwd: repository, encoding: "utf8", env: hookFreeEnv() });
 		assert.equal(result.status, 0, `${result.stdout}${result.stderr}`);
-	} finally {
-		delete process.env.GIT_DIR;
-	}
+	};
+	run("hooks", "enable");
+	run("hooks", "disable");
+	const install = spawnSync("node", [SCRIPT], {
+		cwd: repository,
+		encoding: "utf8",
+		env: hookFreeEnv(),
+	});
+	assert.equal(install.status, 0, `${install.stdout}${install.stderr}`);
+	assert.equal(git("config", "--type=bool", "vp.hooks.disabled"), "true");
+	assert.ok(!git("config", "--local", "--list").includes("core.hookspath="));
+	run("hooks", "enable");
 	assert.equal(git("config", "core.hooksPath"), ".vite-hooks/_");
-	assert.equal(decoy.git("config", "core.hooksPath"), ".husky/_");
+});
+
+void test("an install leaves a contributor's custom hooks directory intact", () => {
+	const { repository, git } = clone();
+	git("config", "core.hooksPath", ".custom-hooks");
+	const result = spawnSync("node", [SCRIPT], {
+		cwd: repository,
+		encoding: "utf8",
+		env: hookFreeEnv(),
+	});
+	assert.equal(result.status, 0, `${result.stdout}${result.stderr}`);
+	assert.equal(git("config", "core.hooksPath"), ".custom-hooks");
+});
+
+void test("a source archive installs without Git configuration or signing advice", () => {
+	const directory = mkdtempSync(join(tmpdir(), "enable-hooks-archive-"));
+	temporaries.push(directory);
+	const result = spawnSync("node", [SCRIPT], {
+		cwd: directory,
+		encoding: "utf8",
+		env: hookFreeEnv(),
+	});
+	assert.equal(result.status, 0, `${result.stdout}${result.stderr}`);
+	assert.equal(result.stderr, "");
 });
 
 void test("an install without commit signing configured warns and still succeeds", () => {

--- a/scripts/enable-hooks.ts
+++ b/scripts/enable-hooks.ts
@@ -1,20 +1,10 @@
-/**
- * Points Git at the Vite+ hook dispatcher in `.vite-hooks/`, which `package.json#scripts.prepare`
- * runs on every install. `vp hooks enable` keeps whatever `core.hooksPath` a clone already has, so
- * a checkout made before the dispatcher moved would keep the old path and run none of the project
- * hooks; clearing it first is what makes the install repair such a clone rather than pass over it.
- */
+/** Configure the Vite+ dispatcher during install without changing local hook preferences. */
 import { execFileSync, spawnSync } from "node:child_process";
 
 import { CAPTURE_LIMIT_BYTES } from "./lib/process.ts";
 
 const HOOKS_DIR = ".vite-hooks";
 
-/**
- * The repository refuses a push whose commits are unsigned, and an install is the last moment a
- * contributor is in front of the machine that has to sign. It is a warning rather than a failure:
- * a clone with no signing key still has to be able to build.
- */
 const SIGNING_WARNING = `
 warning: commits pushed to a branch in this repository must be signed, and this checkout is not
 configured to sign. Sign with the SSH key you already push with:
@@ -43,18 +33,13 @@ function git(...args: string[]): string {
 
 // An image build or a source tarball has no work tree, and no hooks to enable.
 if (git("rev-parse", "--is-inside-work-tree") === "true") {
-	const current = git("config", "--local", "core.hooksPath");
-	if (current !== "" && current !== `${HOOKS_DIR}/_`)
-		git("config", "--local", "--unset", "core.hooksPath");
-	const enabled = spawnSync("vp", ["hooks", "enable", "--hooks-dir", HOOKS_DIR], {
+	const enabled = spawnSync("vp", ["config", "--no-agent", "--hooks-dir", HOOKS_DIR], {
 		stdio: "inherit",
 	});
 	process.exitCode = enabled.status ?? 1;
 
-	// The hint is for a person at their keyboard; in a job log it is only noise. GitHub Actions, like
-	// every runner, sets `CI`.
+	// Signing remains a warning so a checkout without a key can still build.
 	if (process.env.CI !== "true") {
-		// `--type=bool` so `1`, `yes` and `on` count as configured; every `gpg.format` signs.
 		const signs =
 			git("config", "--get", "--type=bool", "commit.gpgsign") === "true" &&
 			git("config", "--get", "user.signingkey") !== "";

--- a/scripts/release-deployment-policy.test.ts
+++ b/scripts/release-deployment-policy.test.ts
@@ -2,6 +2,8 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { test } from "node:test";
 
+import { parseDocument } from "yaml";
+
 import { releaseSignerIdentity, releaseSignerRepository } from "./lib/release-signer.ts";
 import { SMOKE_HOSTNAME } from "./prepare-host-smoke-env.ts";
 import { parseStacks } from "./reconcile-deployment.ts";
@@ -130,14 +132,13 @@ await test("verification identity is the release's own: run context now, the map
 
 await test("promotion refuses a draft but reaches any published release, and the host verifies", () => {
 	assert.match(promotion, /--json isDraft --jq \.isDraft/);
-	// Releases published before GitHub offered tag immutability are the ones a rollback reaches, and
-	// the signed lock names the source commit and every digest, so tag mutability changes nothing.
+	// Rollback must support releases predating immutable tags; the signed lock binds their digests.
 	assert.doesNotMatch(promotion, /isImmutable/);
 	assert.match(reconciler, /join\(config\.checkout, "scripts\/prepare-release-lock\.ts"\)/);
 	assert.doesNotMatch(reconciler, /join\(releaseTree, "scripts\/prepare-release-lock\.ts"\)/);
 });
 
-await test("derived signer identity matches today's literals in the canonical repository", () => {
+await test("derives the canonical signer identity and refuses missing CI identity", () => {
 	const canonicalRun = {
 		CI: "true",
 		GITHUB_SERVER_URL: "https://github.com",
@@ -177,5 +178,22 @@ await test("the release smoke reaches the installation by the name the installer
 	assert.ok(
 		release.includes(`https://${SMOKE_HOSTNAME}/`),
 		`release.yml must request the installation at ${SMOKE_HOSTNAME}`,
+	);
+});
+
+await test("automatic promotion gates the environment job under one workflow lock", () => {
+	const workflow = parseDocument(promotion);
+	assert.equal(workflow.getIn(["concurrency", "group"]), `promote-\${{ inputs.environment }}`);
+	assert.equal(workflow.getIn(["concurrency", "cancel-in-progress"]), false);
+	assert.equal(workflow.getIn(["jobs", "automatic", "environment"]), undefined);
+	assert.equal(workflow.getIn(["jobs", "automatic", "permissions", "contents"]), "read");
+	assert.equal(
+		workflow.getIn(["jobs", "automatic", "outputs", "apply"]),
+		`\${{ steps.policy.outputs.apply }}`,
+	);
+	assert.equal(workflow.getIn(["jobs", "promote", "needs"]), "automatic");
+	assert.equal(
+		workflow.getIn(["jobs", "promote", "if"]),
+		`\${{ !cancelled() && !failure() && (!inputs.automatic || needs.automatic.outputs.apply == 'true') }}`,
 	);
 });

--- a/scripts/renovate-config.test.ts
+++ b/scripts/renovate-config.test.ts
@@ -47,6 +47,18 @@ void test("Renovate creates bounded update PRs without a manual dispatch queue",
 	}
 });
 
+void test("dependency pull requests explain the human-review requirement", () => {
+	assert.ok(Array.isArray(config.prBodyNotes));
+	assert.ok(
+		config.prBodyNotes.some(
+			(note) =>
+				typeof note === "string" &&
+				note.includes("Human review required") &&
+				note.includes("https://docs.hephaestus.build/contributor/ci-cd#merge-policy"),
+		),
+	);
+});
+
 void test("every pin of one toolchain version moves in a single pull request", () => {
 	assert.ok(Array.isArray(config.packageRules));
 	const rules = config.packageRules.filter(isRecord);

--- a/scripts/review-policy.test.ts
+++ b/scripts/review-policy.test.ts
@@ -2,6 +2,10 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { afterEach, beforeEach, describe, it } from "node:test";
 
+import { parse as parseYaml } from "yaml";
+
+import { asRecord } from "./lib/json.ts";
+
 import {
 	APPROVAL_MARKER,
 	approvalBody,
@@ -21,7 +25,6 @@ const originalEnvironment = { ...process.env };
 const HEAD = "0123456789abcdef0123456789abcdef01234567";
 const OTHER = "fedcba9876543210fedcba9876543210fedcba98";
 
-/** A review this module submitted: it carries the marker. */
 const ours = (over: Partial<Review> & Pick<Review, "id">): Review => ({
 	node_id: `review-${over.id}`,
 	state: "APPROVED",
@@ -31,7 +34,6 @@ const ours = (over: Partial<Review> & Pick<Review, "id">): Review => ({
 	...over,
 });
 
-/** A review somebody else submitted: no marker. */
 const theirs = (over: Partial<Review> & Pick<Review, "id">): Review => ({
 	node_id: `review-${over.id}`,
 	state: "APPROVED",
@@ -100,7 +102,6 @@ const makeGitHub = (options: GitHubOptions = {}) => {
 	return { minimized, submitted, github };
 };
 
-/** The single review a run under test is expected to have submitted. */
 const onlyReview = (submitted: readonly CreateReviewRequest[]): CreateReviewRequest => {
 	assert.equal(submitted.length, 1);
 	const [review] = submitted;
@@ -140,12 +141,13 @@ void describe("review policy", () => {
 		});
 
 		void it("ignores an approval recorded against an earlier commit", () => {
-			// `dismiss_stale_reviews_on_push` and the `synchronize` event race; pinning on the commit
-			// settles it without waiting for the dismissal to land.
 			assert.equal(approvalStands([ours({ id: 1, commit_id: OTHER })], HEAD), false);
 		});
 
-		void it("ignores an approval this module did not submit", () => {
+		void it("does not recognize copied markers as its own approval", () => {
+			for (const user of [{ login: "reviewer" }, null]) {
+				assert.equal(approvalStands([ours({ id: 1, user })], HEAD), false);
+			}
 			assert.equal(approvalStands([theirs({ id: 1 })], HEAD), false);
 		});
 
@@ -164,8 +166,26 @@ void describe("review policy", () => {
 			assert.equal(approvalStands(reviews, HEAD), true);
 		});
 
+		void it("uses the bot's latest decisive position even without the policy marker", () => {
+			for (const state of ["CHANGES_REQUESTED", "DISMISSED", "APPROVED"]) {
+				assert.equal(
+					approvalStands([ours({ id: 1 }), ours({ id: 2, state, body: "Another workflow" })], HEAD),
+					false,
+				);
+			}
+			assert.equal(
+				approvalStands(
+					[ours({ id: 1 }), ours({ id: 2, state: "COMMENTED", body: "Another workflow" })],
+					HEAD,
+				),
+				true,
+			);
+		});
+
 		void it("survives a review with no body at all", () => {
-			assert.equal(approvalStands([theirs({ id: 1, body: null })], HEAD), false);
+			for (const body of [null, undefined]) {
+				assert.equal(approvalStands([ours({ id: 1, body })], HEAD), false);
+			}
 		});
 
 		void it("finds no approval in an empty review list", () => {
@@ -197,7 +217,6 @@ void describe("review policy", () => {
 		});
 
 		void it("approves nobody when the allow-list is empty", () => {
-			// The fail-safe direction: with nothing listed, every pull request needs a human.
 			assert.equal(decide({ ...base, maintainers: new Set() }).kind, "skip");
 		});
 
@@ -220,28 +239,12 @@ void describe("review policy", () => {
 		});
 
 		void it("ignores a stranger's approval when deciding whether to approve", () => {
-			// A read-access approval does not count toward the ruleset, so it must not talk this
-			// module out of supplying one that does.
 			const decision = decide({
 				...base,
 				maintainers: new Set(["maintainer"]),
 				reviews: [theirs({ id: 1 })],
 			});
 			assert.equal(decision.kind, "approve");
-		});
-
-		void it("approves a stacked pull request that targets another branch", () => {
-			// A layer must already hold its approval when merging the layer below retargets it onto
-			// main: that retarget fires no event that could earn one, so declining here would strand
-			// the stack at the merge queue.
-			assert.equal(decide({ ...base, maintainers: new Set(["maintainer"]) }).kind, "approve");
-		});
-	});
-
-	void describe("approvalBody", () => {
-		void it("carries the marker approvalStands looks for", () => {
-			assert.ok(approvalBody("Maintainer").includes(APPROVAL_MARKER));
-			assert.equal(approvalStands([ours({ id: 1, body: approvalBody("Maintainer") })], HEAD), true);
 		});
 	});
 
@@ -261,7 +264,11 @@ void describe("review policy", () => {
 
 		void it("minimizes earlier automatic approvals after submitting their replacement", async () => {
 			const { minimized, github, submitted } = makeGitHub({
-				reviews: [ours({ id: 1, commit_id: OTHER }), ours({ id: 2, commit_id: OTHER })],
+				reviews: [
+					ours({ id: 1, commit_id: OTHER }),
+					ours({ id: 2, commit_id: OTHER }),
+					ours({ id: 3, user: { login: "reviewer" } }),
+				],
 			});
 			await enforce({ github, context, core: makeCore() });
 
@@ -282,7 +289,11 @@ void describe("review policy", () => {
 
 		void it("keeps the standing approval visible and minimizes its predecessors", async () => {
 			const { minimized, submitted, github } = makeGitHub({
-				reviews: [ours({ id: 1, commit_id: OTHER }), ours({ id: 2 })],
+				reviews: [
+					ours({ id: 1, commit_id: OTHER }),
+					ours({ id: 2 }),
+					ours({ id: 3, state: "COMMENTED" }),
+				],
 			});
 			await enforce({ github, context, core: makeCore() });
 
@@ -304,14 +315,6 @@ void describe("review policy", () => {
 			assert.deepEqual(core.failures, []);
 		});
 
-		void it("approves a stacked pull request, so it survives being retargeted onto main", async () => {
-			const { submitted, github } = makeGitHub();
-			await enforce({ github, context, core: makeCore() });
-
-			assert.equal(submitted.length, 1);
-			assert.equal(submitted[0]?.event, "APPROVE");
-		});
-
 		void it("warns, and approves nobody, when the allow-list is unset", async () => {
 			delete process.env.MAINTAINERS;
 			const { submitted, github } = makeGitHub();
@@ -322,20 +325,6 @@ void describe("review policy", () => {
 			assert.equal(core.warnings.length, 1);
 			assert.match(String(core.warnings[0]), /REVIEW_POLICY_MAINTAINERS/);
 			assert.deepEqual(core.failures, []);
-		});
-
-		void it("reads the author from the API rather than from the webhook payload", async () => {
-			// The payload is attacker-adjacent under `pull_request_target`; the API is not.
-			const { submitted, github } = makeGitHub({
-				resolvedPull: { ...pull, user: { login: "Contributor" } },
-			});
-			await enforce({
-				github,
-				core: makeCore(),
-				context: { ...context, payload: { pull_request: { number: 7 } } },
-			});
-
-			assert.deepEqual(submitted, []);
 		});
 
 		void it("fails the job when the pull request cannot be read", async () => {
@@ -371,29 +360,31 @@ void describe("review policy", () => {
 		});
 	});
 
-	// The workflow half of the contract. It runs under `pull_request_target` with
-	// `pull-requests: write`, so the hardening below is the security boundary, not a preference.
 	void describe("the workflow that applies it", () => {
 		const workflow = readFileSync(
 			new URL("../.github/workflows/review-policy.yml", import.meta.url),
 			"utf8",
 		);
 
-		void it("keeps the checkout on the base branch's copy of the policy", () => {
+		const configuration = asRecord(parseYaml(workflow), "review-policy workflow");
+		const jobs = asRecord(configuration.jobs, "jobs");
+		const approvalJob = asRecord(jobs.approve, "approve");
+
+		void it("keeps the checkout on the default branch's copy of the policy", () => {
 			assert.match(workflow, /ref: \$\{\{ github\.event\.repository\.default_branch \}\}/);
 			assert.doesNotMatch(workflow, /ref: \$\{\{ github\.sha \}\}/);
 			assert.doesNotMatch(workflow, /github\.event\.pull_request\.head/);
 		});
 
-		void it("checks out no more than the policy, and keeps no credentials", () => {
+		void it("uses sparse checkout and keeps no credentials", () => {
 			assert.match(workflow, /persist-credentials: false/);
 			assert.match(workflow, /sparse-checkout: scripts/);
 		});
 
 		void it("asks for write access to pull requests and nothing else", () => {
-			assert.match(workflow, /^permissions: \{\}$/m);
-			assert.match(workflow, /pull-requests: write/);
-			assert.doesNotMatch(workflow, /contents: write/);
+			assert.deepEqual(configuration.permissions, {});
+			assert.deepEqual(Object.keys(jobs), ["approve"]);
+			assert.deepEqual(approvalJob.permissions, { contents: "read", "pull-requests": "write" });
 		});
 
 		void it("re-runs on every push, because the ruleset dismisses stale approvals", () => {
@@ -401,13 +392,10 @@ void describe("review policy", () => {
 		});
 
 		void it("runs for a stacked pull request, whatever branch it targets", () => {
-			// A `branches:` filter would strand every stack: the retarget onto main that follows the
-			// lower layer's merge fires only `edited`, and only on a workflow that runs off main.
 			assert.doesNotMatch(workflow, /^\s+branches:/m);
 		});
 
-		void it("publishes no check run, now that the ruleset requires a native approval", () => {
-			// A required context nothing reports blocks every pull request, including the fix.
+		void it("does not create custom check runs or run for merge groups", () => {
 			assert.doesNotMatch(workflow, /checks\.create|checks: write/);
 			assert.doesNotMatch(workflow, /merge_group/);
 		});

--- a/scripts/review-policy.ts
+++ b/scripts/review-policy.ts
@@ -1,27 +1,7 @@
 /**
- * The review policy, expressed as a review rather than as a check run.
- *
- * The `main` ruleset now requires one native approval. This module supplies it for the authors the
- * repository has decided need no second reader — the logins listed in `REVIEW_POLICY_MAINTAINERS` —
- * by submitting an approving review with `GITHUB_TOKEN`, which GitHub attributes to
- * `github-actions[bot]` and counts toward `required_approving_review_count`. Every other author gets
- * nothing from this module, so their pull request sits in GitHub's own "Review required" state until
- * a human with write access approves it.
- *
- * Two properties this replaces the old custom check run for. A pull request awaiting review now
- * reads as *awaiting review* in the merge box instead of carrying a permanently yellow required
- * context, and the checks list on a healthy pull request goes fully green. The enforcement is
- * GitHub's, not ours: the count is evaluated at merge and at merge-queue entry, and an armed
- * auto-merge will not fire while it is unmet.
- *
- * The policy this encodes — "a maintainer may merge their own work" — exists only because the
- * repository has a single write-access collaborator, so there is nobody else to ask. The moment a
- * second reviewer holds write access, delete this workflow and the allow-list with it and let the
- * native requirement stand on its own.
- *
- * The decision reads the author login and nothing else. It never reads the diff, the title, the body
- * or any other pull-request-controlled content, which is what makes it safe to run under
- * `pull_request_target` with `pull-requests: write`.
+ * Supplies the maintainer exception to GitHub's native review requirement.
+ * Policy: docs/contributor/ci-cd.mdx#merge-policy.
+ * Only the default branch's copy runs under pull_request_target; no pull-request code is executed.
  */
 
 type ApiMethod<T> = (params: Record<string, unknown>) => Promise<{ data: T }>;
@@ -41,7 +21,6 @@ export interface PullRequest {
 	readonly user: { readonly login: string };
 }
 
-/** The subset of the review-creation request this module ever sends. */
 export interface CreateReviewRequest {
 	readonly owner: string;
 	readonly repo: string;
@@ -88,20 +67,7 @@ export interface EnforceInput {
 	readonly core: ActionsCore;
 }
 
-/**
- * The branch whose ruleset requires the approval this module supplies. Nothing here filters on it:
- * an approval on a pull request targeting any other branch satisfies no rule and is inert, whereas
- * filtering strands every stacked pull request — the lower layer merges, GitHub retargets the upper
- * one onto `main`, and a base-filtered policy has already declined to approve it.
- */
-export const POLICY_BASE_REF = "main";
-
-/**
- * Marks the reviews this module submitted, so a re-run recognises its own standing approval and adds
- * no second one. Matching on the marker rather than on the reviewer login keeps a human approval —
- * which may or may not carry write access, and so may or may not count — out of the decision: the
- * only approval this module reasons about is the one it is responsible for.
- */
+// Match the author as well as this marker: anyone can copy a review body.
 export const APPROVAL_MARKER = "<!-- review-policy: maintainer auto-approval -->";
 
 /** Review states that replace a reviewer's previous position. `COMMENTED` leaves it standing. */
@@ -117,24 +83,25 @@ export const parseMaintainers = (raw: string | undefined): Set<string> =>
 			.filter(Boolean),
 	);
 
-/**
- * Whether this module's own approval still covers `headSha`.
- *
- * The ruleset sets `dismiss_stale_reviews_on_push`, so a push both invalidates the previous approval
- * and fires `synchronize`. Pinning on `commit_id` rather than on the dismissal state settles that
- * race in the safe direction: an approval recorded against an earlier commit does not count here
- * either way, so a re-approval is submitted whether or not GitHub has finished dismissing it yet.
- */
-const ourReviews = (reviews: readonly Review[]): Review[] =>
+const decisiveBotReviews = (reviews: readonly Review[]): Review[] =>
 	reviews
-		.filter((entry) => (entry.body ?? "").includes(APPROVAL_MARKER))
+		.filter(
+			(entry) => entry.user?.login === "github-actions[bot]" && DECISIVE_STATES.has(entry.state),
+		)
 		.toSorted((left, right) => left.id - right.id);
 
-export const approvalStands = (reviews: readonly Review[], headSha: string): boolean => {
-	const ours = ourReviews(reviews).filter((entry) => DECISIVE_STATES.has(entry.state));
+const ourReviews = (reviews: readonly Review[]): Review[] =>
+	decisiveBotReviews(reviews).filter((entry) => (entry.body ?? "").includes(APPROVAL_MARKER));
 
-	const latest = ours.at(-1);
-	return latest !== undefined && latest.state === "APPROVED" && latest.commit_id === headSha;
+export const approvalStands = (reviews: readonly Review[], headSha: string): boolean => {
+	// A synchronize event can arrive before GitHub dismisses the old review.
+	const latest = decisiveBotReviews(reviews).at(-1);
+	return (
+		latest !== undefined &&
+		(latest.body ?? "").includes(APPROVAL_MARKER) &&
+		latest.state === "APPROVED" &&
+		latest.commit_id === headSha
+	);
 };
 
 const minimizeReview = `mutation MinimizeReview($subjectId: ID!) {
@@ -174,10 +141,6 @@ export interface DecisionInput {
 	readonly reviews: readonly Review[];
 }
 
-/**
- * What this module should do about one pull request. Purely a function of the author login, the head
- * commit and the approvals already on record — never of anything the author wrote.
- */
 export const decide = (input: DecisionInput): Decision => {
 	if (!input.maintainers.has(input.author.toLowerCase())) {
 		return {
@@ -199,24 +162,16 @@ export const decide = (input: DecisionInput): Decision => {
 		kind: "approve",
 		reason:
 			`@${input.author} is listed in REVIEW_POLICY_MAINTAINERS, so ${shortSha(input.headSha)} ` +
-			"is approved on the policy's behalf.",
+			"qualifies for automatic approval.",
 	};
 };
 
-/** The body of the review this module submits, marker included. */
 export const approvalBody = (author: string): string =>
 	`${APPROVAL_MARKER}\nApproved automatically: @${author} is listed in the ` +
 	"`REVIEW_POLICY_MAINTAINERS` repository variable, which the repository treats as satisfying the " +
-	"review requirement. See the review policy in `docs/contributor/ci-cd.mdx`.";
+	"review requirement. See the [review policy](https://docs.hephaestus.build/contributor/ci-cd#merge-policy).";
 
-/**
- * Applies the review policy to one pull request event.
- *
- * The pull request is re-read from the API rather than trusted from the webhook payload, so the
- * author login and head commit come from GitHub rather than from the event that woke the workflow.
- * A failure here fails the job: nothing is approved, and the native requirement leaves the pull
- * request blocked, which is the safe direction.
- */
+// Re-read the head: queued events may describe a commit that has already been replaced.
 export const enforce = async ({ github, context, core }: EnforceInput): Promise<void> => {
 	const eventPullRequest = context.payload.pull_request;
 	if (!eventPullRequest) {
@@ -232,10 +187,6 @@ export const enforce = async ({ github, context, core }: EnforceInput): Promise<
 
 		const maintainers = parseMaintainers(process.env.MAINTAINERS);
 		if (maintainers.size === 0) {
-			// Fail-safe, and quietly so: with nobody allow-listed every pull request simply needs a
-			// human approval, which is what the native requirement asks for anyway. It is worth saying
-			// out loud because a maintainer whose own pull request stopped self-approving would
-			// otherwise have to guess why.
 			core.warning(
 				"REVIEW_POLICY_MAINTAINERS is empty or unset, so no pull request is auto-approved. " +
 					"Every pull request now needs an approval from someone with write access.",
@@ -261,10 +212,7 @@ export const enforce = async ({ github, context, core }: EnforceInput): Promise<
 			return;
 		}
 
-		// `commit_id` pins the approval to the commit the decision was made against. If a push landed
-		// between the read and this call, the approval attaches to the commit that was evaluated and
-		// the ruleset treats it as stale for the new head — and the push's own `synchronize` event
-		// produces a fresh one.
+		// Pin the approval to the evaluated head even if a push races this request.
 		await github.rest.pulls.createReview({
 			...context.repo,
 			pull_number: pull.number,


### PR DESCRIPTION
## What changed and why

Recent CI changes left gaps in deployment ordering, review ownership, and generated commits. This PR fixes those paths, replaces custom Git-state handling with native Git commands, and corrects operational guidance that overstated what the checks prove.

- **Promotions:** check the current channel before starting an environment deployment. Frozen, identical, or older targets are skipped, including release-to-commit transitions; unreadable channels and failed comparisons cannot authorize promotion. Continuous staging watches the exact run returned by GitHub instead of guessing from timestamps.
- **Reviews:** recognize automatic reviews by both author and marker, respect the bot's latest decisive review, and leave human reviews untouched. Renovate explains its human-review requirement using its native PR-body configuration.
- **Repository tooling:** use scoped Git staging and diffs for API commits, avoiding no-op commits and incorrect rename/deletion payloads. Configure Vite+ hooks without overriding a contributor's explicit disable preference or custom hook path.
- **Validation and documentation:** reject malformed vulnerability severities and impossible exception dates. Correct monitoring, freeze, recovery, and verification guidance; remove redundant comments and tests with overstated coverage.

Fixes #1826.

## How to test

- `vp run format` and `vp run check` — passed locally. The tooling suite covers promotion decisions, real Git staging edge cases, hook installation, review ownership, and vulnerability validation.
- `node --test scripts/automatic-promotion.test.ts scripts/commit-via-api.test.ts scripts/enable-hooks.test.ts scripts/review-policy.test.ts scripts/check-release-vulnerabilities.test.ts` — focused regression coverage.
- Actionlint 1.7.12 with CI-equivalent ShellCheck severity and Zizmor 1.29.0 — passed locally, with no new suppressions.
- The documentation lint covers 120 files. Review the **Operating it** and **Watching it** sections of `docs/admin/pull-based-deployment.mdx`: reconciliation freshness is distinct from the last successful application.

Live promotion, signing, and host convergence were not exercised locally. A deployment smoke test should confirm that a frozen or superseded automatic request creates no environment deployment, and that a newer approved target converges. After merge, inspect a Renovate PR for the human-review explanation.

## Release impact

No application release, database migration, API regeneration, or changeset is required: the changes are limited to repository workflows, tooling, configuration, and documentation. Existing application installations require no upgrade action. Operators using the documented monitoring guidance should alert on reconciliation freshness rather than the age of the last successful application.

## Notes for reviewers

Start with `automatic-promotion.ts` and the two promotion workflows, then `commit-via-api.ts` and its real-Git tests. Review-policy changes preserve the existing maintainer exception; dependency bots are not auto-approved.

**Existing limitation:** GitHub's default concurrency behavior can replace a pending manual promotion when another request arrives. Native `queue: max` is not enabled because the current actionlint rejects it ([upstream issue #657](https://github.com/rhysd/actionlint/issues/657)). This PR protects applied holds and promotion ordering; it does not claim to preserve every pending operator request or introduce a custom queue.
