### PR TITLE
feat(ci): add Semgrep TLS policy checks

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -150,6 +150,7 @@ jobs:
               - '!server/**/CLAUDE.md'
             tooling:
               - 'scripts/**'
+              - 'security/semgrep/**'
               - 'docker/agents/**'
               # format:load:check and test:load:syntax run on this leg.
               - 'load-tests/**'

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,61 @@
+name: Semgrep
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  merge_group:
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  scan:
+    name: TLS policy
+    # GitHub's actions are glibc-based, so the musl scanner image runs as a container step rather
+    # than as the job's container.
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      security-events: write
+    env:
+      SEMGREP_IMAGE: semgrep/semgrep:1.176.1@sha256:34ab619bf1391a24bfda3f05debd0d8a6ce3093c2d5f9d39cfc00f83c1397823
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Test policy examples
+        run: >-
+          docker run --rm --network none -v "$GITHUB_WORKSPACE:/src:ro" -w /src
+          "$SEMGREP_IMAGE" semgrep scan --test --config security/semgrep security/semgrep --metrics=off --disable-version-check
+      - name: Scan tracked source
+        run: |
+          mkdir -p tmp
+          docker run --rm --network none -v "$GITHUB_WORKSPACE:/src:ro" -w /src \
+            -v "$GITHUB_WORKSPACE/tmp:/out" \
+            "$SEMGREP_IMAGE" semgrep scan --config security/semgrep --metrics=off --disable-version-check \
+            --disable-nosem --strict --error --sarif-output /out/semgrep.sarif \
+            --exclude security/semgrep .
+      # A fork pull request's token cannot hold security-events: write, so the upload would fail on
+      # a clean scan. The scan itself still reports the verdict.
+      - name: Upload code scanning results
+        if: >-
+          ${{ !cancelled() && hashFiles('tmp/semgrep.sarif') != ''
+          && (github.event_name != 'pull_request'
+          || github.event.pull_request.head.repo.full_name == github.repository) }}
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+        with:
+          sarif_file: tmp/semgrep.sarif
+          category: semgrep-tls
+      - name: Preserve scan evidence
+        if: ${{ !cancelled() && hashFiles('tmp/semgrep.sarif') != '' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: semgrep-${{ github.sha }}
+          path: tmp/semgrep.sarif
+          if-no-files-found: error
+          retention-days: 14

--- a/docs/contributor/ci-cd.mdx
+++ b/docs/contributor/ci-cd.mdx
@@ -120,6 +120,7 @@ changesets rather than adding one. [Release management](./release-management.mdx
 | CodeQL default setup | managed by GitHub | repository SAST policy | code scanning |
 | TruffleHog and GitHub push protection | pull requests and pushes | block verified secrets | Security workflow and repository protection |
 | Trivy filesystem scan | Security workflow | a scanner error blocks; findings of every severity are report-only | code scanning |
+| Semgrep TLS policy | pull requests, merge groups, and `main` pushes | fails on a rule violation or a scanner error | code scanning and a run artifact |
 | Image vulnerability policy | image build and release | blocks fixable high or critical findings | build summary and release evidence |
 | Weekly image rescans | `rescan-main-images.yml`, `rescan-release-images.yml` | the `main` rescan upserts one tracking issue; the release rescan fails and comments on the vulnerability response issue | issues and run artifacts |
 | OpenSSF Scorecard | `main` pushes, branch-protection changes, and weekly; never on pull requests | reports | code scanning and a run artifact |
@@ -155,6 +156,20 @@ provisions the Node it runs lockfile updates with from `engines`, so `engines.no
 ceiling and approval of an exception, for images and dependencies alike.
 [Release management](./release-management.mdx#supply-chain-evidence) owns artifact signing, provenance,
 SBOM, and release-verification guarantees.
+
+### Semgrep policy
+
+`security/semgrep/` holds this repository's own rule pack: syntax checks for disabled Node
+certificate verification and unconditional Java hostname verifiers, not comprehensive TLS analysis.
+CodeQL keeps the deep dataflow analysis, and the image-reference, `security.txt` and Liquibase guards
+in `ci-security-scan.yml` stay independent. Inline `nosemgrep` suppression is disabled, so an
+exception is a reviewed rule change, and every rule carries a positive and a negative fixture beside
+it.
+
+Semgrep reports; it is not a required check. The digest-pinned scanner runs without network access or
+credentials over a read-only checkout, and `.github/workflows/semgrep.yml` owns the commands that
+reproduce a run locally. A pull request from a fork gets the scan verdict but no code-scanning row,
+because GitHub caps a fork token's `security-events` access at read.
 
 ## Environments
 
@@ -259,6 +274,7 @@ why the label is the authority, and which alternatives were priced and declined,
 | `openapi-autocommit.yml` | `autocommit-openapi` label | Regenerates the OpenAPI spec and client and commits them to the pull request |
 | `security-mutation.yml` | PR touching the suite's inputs, manual | Runs the security mutation suite |
 | `scorecard.yml` | Push to main, branch-protection change, weekly | Publishes the OpenSSF Scorecard |
+| `semgrep.yml` | Pull request, push to main, merge group | Tests and scans the repository's own TLS rule pack |
 | `rescan-main-images.yml` | Weekly, manual | Rescans main's published images against the release vulnerability policy and keeps one tracking issue in step with the findings |
 | `rescan-release-images.yml` | Weekly, manual | Rescans the latest published release's images and reports drift on the vulnerability response issue |
 | `ci-profile.yml` | Weekly, manual | Profiles server integration tests and Spring contexts |

--- a/renovate.json
+++ b/renovate.json
@@ -220,6 +220,15 @@
 				"\"repository\": \"(?<depName>[^\"]+)\",\\s+\"tag\": \"(?<currentValue>[^\"]+)\",\\s+\"digest\": \"(?<currentDigest>sha256:[a-f0-9]{64})\""
 			],
 			"datasourceTemplate": "docker"
+		},
+		{
+			"description": "Track the isolated Semgrep scanner image",
+			"customType": "regex",
+			"managerFilePatterns": ["/^\\.github/workflows/semgrep\\.yml$/"],
+			"matchStrings": [
+				"SEMGREP_IMAGE: (?<depName>semgrep/semgrep):(?<currentValue>[0-9.]+)@(?<currentDigest>sha256:[a-f0-9]{64})"
+			],
+			"datasourceTemplate": "docker"
 		}
 	],
 	"vulnerabilityAlerts": {

--- a/scripts/ci-contract.test.ts
+++ b/scripts/ci-contract.test.ts
@@ -10,7 +10,7 @@ import { type Document, isMap, isScalar, isSeq, parseDocument, type YAMLMap } fr
 
 import { evaluate as evaluateVulnerabilityPolicy } from "./check-release-vulnerabilities.ts";
 import { versionBranch } from "./dispatch-version-pr-ci.ts";
-import { asRecord, isRecord } from "./lib/json.ts";
+import { asArray, asRecord, asString, isRecord } from "./lib/json.ts";
 import { commandsOf, loadTasks } from "./lib/task-graph.ts";
 import { planRelease, releaseOutputs } from "./plan-release.ts";
 import { planSubjects } from "./scan-main-images.ts";
@@ -1741,4 +1741,57 @@ void test("a change to the task graph or the hooks selects every quality leg", a
 			/'\.java-version'/,
 			`${name} must list .java-version`,
 		);
+});
+
+void test("Semgrep scans PRs, main and merge queues without a privileged trigger or mutable rules", async () => {
+	const source = await readFile(".github/workflows/semgrep.yml", "utf8");
+	const workflow = parseDocument(source);
+	for (const trigger of ["pull_request", "push", "merge_group"])
+		assert.ok(workflow.hasIn(["on", trigger]), `semgrep.yml must run on ${trigger}`);
+	assert.equal(workflow.hasIn(["on", "pull_request_target"]), false);
+	assert.match(
+		String(workflow.getIn(["jobs", "scan", "env", "SEMGREP_IMAGE"])),
+		/^semgrep\/semgrep:[\d.]+@sha256:[a-f0-9]{64}$/,
+	);
+	for (const [command] of source.matchAll(/docker run.*/g))
+		assert.match(command, /--network none/, "the scanner runs without a network");
+	assert.match(source, /--test --config security\/semgrep/);
+	assert.match(source, /--disable-nosem\b/);
+	assert.match(source, /--strict\b/);
+	assert.match(source, /--error\b/);
+	assert.match(source, /--sarif-output\b/);
+	assert.doesNotMatch(source, /continue-on-error|secrets\.|--config (auto|p\/)/);
+	const upload = namedStep(workflow, ["jobs", "scan"], "Upload code scanning results");
+	assert.equal(stepInputs(upload).get("category"), "semgrep-tls");
+	assert.match(
+		String(upload.get("if")),
+		/github\.event\.pull_request\.head\.repo\.full_name == github\.repository/,
+		"a fork pull request cannot upload SARIF and must skip the step",
+	);
+	assert.match(
+		pathFilter(await readFile(".github/workflows/cicd.yml", "utf8"), "tooling"),
+		/security\/semgrep\/\*\*/,
+	);
+});
+
+void test("every Semgrep rule ships a positive and a negative fixture", async () => {
+	const files = await posixGlob("security/semgrep/*");
+	const rulesets = files.filter((file) => file.endsWith(".yaml"));
+	assert.ok(rulesets.length > 0, "security/semgrep holds no ruleset");
+	const fixtures = (
+		await Promise.all(
+			files.filter((file) => !file.endsWith(".yaml")).map((file) => readFile(file, "utf8")),
+		)
+	).join("\n");
+	for (const file of rulesets) {
+		const ruleset = asRecord(parseDocument(await readFile(file, "utf8")).toJSON(), file);
+		const ids = asArray(ruleset.rules, `${file} rules`).map((rule) =>
+			asString(asRecord(rule, "rule").id, "rule.id"),
+		);
+		assert.ok(ids.length > 0, `${file} declares no rule`);
+		for (const id of ids) {
+			assert.match(fixtures, new RegExp(`ruleid: ${id}$`, "m"), `${id} has no violating example`);
+			assert.match(fixtures, new RegExp(`ok: ${id}$`, "m"), `${id} has no compliant example`);
+		}
+	}
 });

--- a/scripts/renovate-config.test.ts
+++ b/scripts/renovate-config.test.ts
@@ -167,6 +167,7 @@ void test("every custom manager reads every file it claims to read", async () =>
 			],
 		],
 		["Track release image tags and digests", ["security/release-images.json"]],
+		["Track the isolated Semgrep scanner image", [".github/workflows/semgrep.yml"]],
 	]);
 	assert.ok(Array.isArray(config.customManagers));
 	assert.ok(config.customManagers.every(isRecord));

--- a/security/semgrep/tls.java
+++ b/security/semgrep/tls.java
@@ -1,0 +1,16 @@
+class TlsExamples {
+    void configure() {
+        // ruleid: java-hostname-verification-disabled
+        connection.setHostnameVerifier((host, session) -> true);
+        // ruleid: java-hostname-verification-disabled
+        connection.setHostnameVerifier((host, session) -> { return true; });
+        // ruleid: java-hostname-verification-disabled
+        HttpsURLConnection.setDefaultHostnameVerifier((host, session) -> true);
+        // ruleid: java-hostname-verification-disabled
+        HttpsURLConnection.setDefaultHostnameVerifier((host, session) -> { return true; });
+        // ok: java-hostname-verification-disabled
+        connection.setHostnameVerifier(HttpsURLConnection.getDefaultHostnameVerifier());
+        // ok: java-hostname-verification-disabled
+        connection.setHostnameVerifier((host, session) -> verifier.verify(host, session));
+    }
+}

--- a/security/semgrep/tls.js
+++ b/security/semgrep/tls.js
@@ -1,0 +1,8 @@
+// ruleid: node-tls-verification-disabled
+const insecure = { rejectUnauthorized: false };
+// ok: node-tls-verification-disabled
+const secure = { rejectUnauthorized: true };
+// ruleid: node-tls-verification-disabled
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+// ok: node-tls-verification-disabled
+process.env.NODE_EXTRA_CA_CERTS = "/etc/ssl/private-ca.pem";

--- a/security/semgrep/tls.ts
+++ b/security/semgrep/tls.ts
@@ -1,0 +1,6 @@
+// ruleid: node-tls-verification-disabled
+const insecure = { rejectUnauthorized: false };
+// ok: node-tls-verification-disabled
+const secure = { rejectUnauthorized: true };
+// ok: node-tls-verification-disabled
+const defaults = { ca: trustedCa };

--- a/security/semgrep/tls.yaml
+++ b/security/semgrep/tls.yaml
@@ -1,0 +1,23 @@
+rules:
+  - id: node-tls-verification-disabled
+    languages: [javascript, typescript]
+    severity: ERROR
+    message: Keep TLS certificate verification enabled; configure a trusted CA instead.
+    metadata:
+      category: security
+      cwe: ["CWE-295: Improper Certificate Validation"]
+    pattern-either:
+      - pattern: "{..., rejectUnauthorized: false, ...}"
+      - pattern: process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0"
+  - id: java-hostname-verification-disabled
+    languages: [java]
+    severity: ERROR
+    message: Do not install an unconditional hostname verifier; use the default verifier.
+    metadata:
+      category: security
+      cwe: ["CWE-297: Improper Validation of Certificate with Host Mismatch"]
+    pattern-either:
+      - pattern: $CONNECTION.setHostnameVerifier(($HOST, $SESSION) -> true)
+      - pattern: $CONNECTION.setHostnameVerifier(($HOST, $SESSION) -> { return true; })
+      - pattern: $CONNECTION.setDefaultHostnameVerifier(($HOST, $SESSION) -> true)
+      - pattern: $CONNECTION.setDefaultHostnameVerifier(($HOST, $SESSION) -> { return true; })


### PR DESCRIPTION
## What changed and why

CodeQL carries this repository's deep dataflow analysis, but the repository owns no rule pack of its
own for the patterns it wants kept out of the tree.

This adds a Semgrep leg on pull requests, merge groups and pushes to `main`. `security/semgrep/`
holds two rules — disabled Node certificate verification, and an unconditional Java hostname
verifier — each with a violating and a compliant example beside it, and `semgrep scan --test` runs
those examples before the scan. The digest-pinned scanner runs with no network and no credentials
over a read-only checkout; findings, a scanner error and an unloadable rule each fail the job.
Results reach code scanning where the token allows it: a pull request from a fork gets the scan
verdict but no code-scanning row, because GitHub caps a fork token's `security-events` access at
read. Renovate moves the image's tag and digest together, and a rule edit selects the tooling
quality leg.

Semgrep reports; it is not a required check.

Part of [#1653](https://github.com/hephaestus-build/Hephaestus/issues/1653). The issue's other
deliverable, the Scorecard ratchet, is [#1873](https://github.com/hephaestus-build/Hephaestus/pull/1873);
the issue pre-authorised the split. This PR does not close #1653: three of its four *Done when*
bullets are verdicts observed after a merge rather than changes that ship, which the issue needs to
re-word under `CONTRIBUTING.md` § Issues.

## How to test

- `vp run format` and `vp run check` — green.
- `node --test scripts/ci-contract.test.ts scripts/renovate-config.test.ts` — 48 and 14 passing.
- The two commands the workflow runs, with the pinned image: the fixtures report
  `2/2: ✓ All tests passed`, and the repository scan reports `0 findings` and exits 0.
- Mutation-proved the new contract assertions: deleting the code-scanning upload step, dropping
  `--network none` from either `docker run`, dropping the fork guard, dropping `--disable-nosem`,
  `--strict` or `--error`, unpinning the image, adding a rule with no fixtures, removing a rule's
  examples, and dropping `security/semgrep/**` from the `tooling` path filter each turn the suite
  red; reordering `--strict` and `--error`, which changes no behaviour, does not.
- `actionlint` and `zizmor 1.29.0 --min-confidence medium` on `semgrep.yml` and `cicd.yml` — no
  findings.

## Release impact

CI, repository policy, tests and contributor documentation only. Nothing shipped changes, so there
is no changeset — `.changeset/README.md` scopes that requirement to `server/`, `webapp/` and
`docker/` — no migration and no operator action.

## Notes for reviewers

Start with `.github/workflows/semgrep.yml` and `security/semgrep/tls.yaml`.

The rules are syntax checks, not TLS analysis: they catch the object-literal and
`NODE_TLS_REJECT_UNAUTHORIZED` spellings on the Node side and unconditional lambda hostname
verifiers on the Java side, and they find nothing on `main` today. That is the intended first cut —
the pack is meant to grow, and `semgrep scan --test` plus the fixture contract test keep each rule
honest as it does. Inline `nosemgrep` suppression is disabled, so an exception is a reviewed rule
change. The existing image-reference, `security.txt` and Liquibase guards in `ci-security-scan.yml`
are untouched.

The scanner writes its SARIF to the ignored `tmp/`, so reproducing a run locally leaves no untracked
file behind.

This holds the `.github/workflows/**` lane and is meant to land first in it.
