### PR TITLE
fix(ci): avoid unnecessary toolchain downloads

### DIFF
--- a/.github/actions/setup-toolchain/action.yml
+++ b/.github/actions/setup-toolchain/action.yml
@@ -1,25 +1,34 @@
 name: "Setup toolchain"
-description: "The Node.js, pnpm and Vite+ versions package.json pins, with the pinned pnpm executable and, for a frozen install, the pnpm store cached; install is none or frozen."
+description: "The Node.js version package.json pins and, for a frozen install, its pnpm and Vite+ pins with the pnpm executable and the pnpm store cached; install is none or frozen."
 inputs:
   install:
-    description: "none, or frozen: pnpm install --frozen-lockfile --ignore-scripts. No lifecycle script runs in CI, so pnpm-workspace.yaml#allowBuilds is exercised only by a contributor's install."
+    description: "none: the Node.js runtime alone, for a job that runs node scripts/… or shell; frozen: pnpm and Vite+ as well, then pnpm install --frozen-lockfile --ignore-scripts. No lifecycle script runs in CI, so pnpm-workspace.yaml#allowBuilds is exercised only by a contributor's install."
     required: false
     default: "none"
 runs:
   using: "composite"
   steps:
+    - if: inputs.install != 'none' && inputs.install != 'frozen'
+      shell: bash
+      run: |
+        echo "::error::setup-toolchain: install must be none or frozen"
+        exit 1
     - id: pnpm
+      if: inputs.install == 'frozen'
       shell: bash
       run: |
         echo "version=$(jq -r '.devEngines.packageManager.version' package.json)" >> "$GITHUB_OUTPUT"
         # Use the native home directory, not Git Bash's MSYS path, on Windows.
         echo "dest=$(node -p 'require("node:path").join(require("node:os").homedir(), "setup-pnpm")')" >> "$GITHUB_OUTPUT"
-    # Cache pnpm/setup's default installation directory.
+    # Only the executable: pnpm/setup installs a Node runtime beside it, and setup-node owns Node.
     - id: pnpm-cache
+      if: inputs.install == 'frozen'
       uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
-        path: ~/setup-pnpm
-        key: pnpm-bin-${{ runner.os }}-${{ runner.arch }}-${{ steps.pnpm.outputs.version }}
+        path: |
+          ~/setup-pnpm/pnpm
+          ~/setup-pnpm/pnpm.exe
+        key: pnpm-bin-v2-${{ runner.os }}-${{ runner.arch }}-${{ steps.pnpm.outputs.version }}
     # A hit skips pnpm/setup, so it has to reproduce what that action exports: PNPM_HOME, and both
     # the destination and its bin directory on PATH.
     - if: steps.pnpm-cache.outputs.cache-hit == 'true'
@@ -27,29 +36,20 @@ runs:
       env:
         PNPM_DEST: ${{ steps.pnpm.outputs.dest }}
       run: |
+        mkdir -p "$PNPM_DEST/bin"
         echo "PNPM_HOME=$PNPM_DEST" >> "$GITHUB_ENV"
-        echo "$PNPM_DEST/bin" >> "$GITHUB_PATH"
         echo "$PNPM_DEST" >> "$GITHUB_PATH"
-    - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-      with:
-        node-version-file: package.json
-        cache: ${{ steps.pnpm-cache.outputs.cache-hit == 'true' && inputs.install == 'frozen' && 'pnpm' || '' }}
-        cache-dependency-path: pnpm-lock.yaml
-    - if: inputs.install != 'none' && inputs.install != 'frozen'
-      shell: bash
-      run: |
-        echo "::error::setup-toolchain: install must be none or frozen"
-        exit 1
+        echo "$PNPM_DEST/bin" >> "$GITHUB_PATH"
     # GitHub Actions has no retry for a `uses:` step and pnpm/setup has no retry input, so the
     # attempts are written out; a loop would mean re-implementing the installer and giving up npm's
     # signature verification of the executable. pnpm/setup does not separate a registry blip from a
     # bad pin, so a deterministic failure also costs all three attempts.
     - id: pnpm-setup-1
-      if: steps.pnpm-cache.outputs.cache-hit != 'true'
+      if: inputs.install == 'frozen' && steps.pnpm-cache.outputs.cache-hit != 'true'
       continue-on-error: true
       uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
       with:
-        cache: ${{ inputs.install == 'frozen' }}
+        cache: false
         cache-dependency-path: pnpm-lock.yaml
         install: false
         require-lockfile: true
@@ -61,7 +61,7 @@ runs:
       continue-on-error: true
       uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
       with:
-        cache: ${{ inputs.install == 'frozen' }}
+        cache: false
         cache-dependency-path: pnpm-lock.yaml
         install: false
         require-lockfile: true
@@ -71,22 +71,33 @@ runs:
     - if: steps.pnpm-setup-2.outcome == 'failure'
       uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
       with:
-        cache: ${{ inputs.install == 'frozen' }}
+        cache: false
         cache-dependency-path: pnpm-lock.yaml
         install: false
         require-lockfile: true
     # Cache entries are immutable: validate the executable before publishing a new entry.
-    - shell: bash
+    - if: inputs.install == 'frozen'
+      shell: bash
       env:
         PNPM_VERSION: ${{ steps.pnpm.outputs.version }}
       run: test "$(pnpm --version)" = "$PNPM_VERSION"
     # Default-branch caches are reusable across PRs; merge-ref caches are scoped to that PR.
-    - if: steps.pnpm-cache.outputs.cache-hit != 'true' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+    - if: inputs.install == 'frozen' && steps.pnpm-cache.outputs.cache-hit != 'true' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
       uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
-        path: ~/setup-pnpm
-        key: pnpm-bin-${{ runner.os }}-${{ runner.arch }}-${{ steps.pnpm.outputs.version }}
-    - uses: voidzero-dev/setup-vp@1b32467adbe183473499fd9d5d372c3ed9641754 # v1.18.0
+        path: |
+          ~/setup-pnpm/pnpm
+          ~/setup-pnpm/pnpm.exe
+        key: pnpm-bin-v2-${{ runner.os }}-${{ runner.arch }}-${{ steps.pnpm.outputs.version }}
+    # Both modes end here: pnpm/setup installs a Node runtime of its own, so the pinned one is
+    # selected last to win on PATH. setup-node reads `pnpm store path`, which needs pnpm installed.
+    - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      with:
+        node-version-file: package.json
+        cache: ${{ inputs.install == 'frozen' && 'pnpm' || '' }}
+        cache-dependency-path: pnpm-lock.yaml
+    - if: inputs.install == 'frozen'
+      uses: voidzero-dev/setup-vp@1b32467adbe183473499fd9d5d372c3ed9641754 # v1.18.0
       with:
         node-manager: false
         cache: false

--- a/.github/workflows/cleanup-preview.yml
+++ b/.github/workflows/cleanup-preview.yml
@@ -48,8 +48,6 @@ jobs:
           sparse-checkout: |
             .github/actions/setup-toolchain
             package.json
-            pnpm-lock.yaml
-            pnpm-workspace.yaml
             scripts
       - uses: ./.github/actions/setup-toolchain
         with:

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -43,8 +43,6 @@ jobs:
           sparse-checkout: |
             .github/actions/setup-toolchain
             package.json
-            pnpm-lock.yaml
-            pnpm-workspace.yaml
             scripts
       - uses: ./.github/actions/setup-toolchain
         with:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -26,44 +26,92 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - name: "Checkout repository"
+      - name: Load trusted title policy
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: ./.github/actions/setup-toolchain
         with:
-          install: "frozen"
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+          # package.json is what makes the policy module load as ESM; without it Node parses it as
+          # CommonJS first and warns on the reparse.
+          sparse-checkout: |
+            commitlint.config.ts
+            package.json
+          sparse-checkout-cone-mode: false
 
-      - name: "Validate PR title with commitlint"
-        id: commitlint
+      - name: Read title policy and validate header limits
+        id: policy
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          retries: 2
+          script: |
+            const { pathToFileURL } = await import("node:url");
+            const { pullRequestTitlePolicy: policy } = await import(pathToFileURL(`${process.env.GITHUB_WORKSPACE}/commitlint.config.ts`).href);
+            for (const [name, value] of Object.entries(policy)) core.setOutput(name, value);
+            // A rerun keeps its original payload even after the title has been edited.
+            const { data: { title } } = await github.rest.pulls.get({
+              ...context.repo, pull_number: context.payload.pull_request.number,
+            });
+            // The action below reads a header pattern and a subject pattern; what those cannot
+            // express is checked here, against the same policy the commit-msg hook enforces.
+            const problem = title.length > policy.headerMaxLength
+              ? `The title is ${title.length} characters long; the limit is ${policy.headerMaxLength}.`
+              : /[\r\n]/.test(title)
+                ? 'The title must be a single line.'
+                : new RegExp(policy.breakingMarkerPattern).test(title)
+                  ? 'A breaking change is carried by a changeset, so the title takes no ! marker.'
+                  : '';
+            if (problem) {
+              core.setOutput('error_message', problem);
+              core.setFailed(problem);
+            }
+
+      - name: Validate PR title
+        id: title
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+        continue-on-error: true
         env:
-          PR_TITLE: ${{ github.event.pull_request.title }}
-        run: |
-          printf '%s\n' "$PR_TITLE" | vp exec commitlint 2>&1 | tee "$RUNNER_TEMP/commitlint-output.txt"
-          exit_code=${PIPESTATUS[1]}
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          types: ${{ steps.policy.outputs.types }}
+          scopes: ${{ steps.policy.outputs.scopes }}
+          headerPattern: ${{ steps.policy.outputs.headerPattern }}
+          headerPatternCorrespondence: type, scope, subject
+          subjectPattern: ${{ steps.policy.outputs.subjectPattern }}
 
+      # Through the environment and a file: the message quotes the title, which is the author's text.
+      - name: Explain the validation failure
+        id: explain
+        if: ${{ !cancelled() && (steps.policy.outputs.error_message != '' || steps.title.outputs.error_message != '') }}
+        env:
+          POLICY_ERROR: ${{ steps.policy.outputs.error_message }}
+          TITLE_ERROR: ${{ steps.title.outputs.error_message }}
+          GUIDANCE: >-
+            Use `type(scope): description`, at most ${{ steps.policy.outputs.headerMaxLength }}
+            characters, with no final period and no breaking-change `!` marker. The allowed types and
+            scopes are in [the contribution guidelines](${{ steps.policy.outputs.helpUrl }}).
+        run: |
           {
             printf '## PR title validation failed\n\n'
-            sed 's/^/    /' "$RUNNER_TEMP/commitlint-output.txt"
-          } > "$RUNNER_TEMP/commitlint-comment.md"
+            printf '%s\n\n' "${POLICY_ERROR:-$TITLE_ERROR}"
+            printf '%s\n' "$GUIDANCE"
+          } > "$RUNNER_TEMP/title-error.md"
 
-          exit "$exit_code"
-        continue-on-error: true
-
-      - name: "Comment on PR with validation error"
+      - name: Comment on PR with validation error
         uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
-        if: steps.commitlint.outcome == 'failure'
+        if: ${{ !cancelled() && steps.explain.outcome == 'success' }}
         with:
           header: pr-title-lint-error
-          path: ${{ runner.temp }}/commitlint-comment.md
+          path: ${{ runner.temp }}/title-error.md
 
-      - name: "Remove error comment on success"
+      - name: Remove error comment on success
         uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
-        if: steps.commitlint.outcome == 'success'
+        if: steps.title.outcome == 'success'
         with:
           header: pr-title-lint-error
           delete: true
 
-      - name: "Fail workflow if commitlint failed"
-        if: steps.commitlint.outcome == 'failure'
+      - name: Fail workflow if title validation failed
+        if: steps.title.outcome == 'failure'
         run: exit 1
 
   # Squash-merge hides a commit's author on `main`, but a pull request's commit list keeps it

--- a/.github/workflows/reconcile-previews.yml
+++ b/.github/workflows/reconcile-previews.yml
@@ -29,14 +29,8 @@ jobs:
           ref: ${{ github.sha }}
           persist-credentials: false
           sparse-checkout: |
-            .github/actions/setup-toolchain
             package.json
-            pnpm-lock.yaml
-            pnpm-workspace.yaml
             scripts
-      - uses: ./.github/actions/setup-toolchain
-        with:
-          install: "none"
 
       - name: Find the previews that still hold a slot
         id: candidates
@@ -78,8 +72,6 @@ jobs:
           sparse-checkout: |
             .github/actions/setup-toolchain
             package.json
-            pnpm-lock.yaml
-            pnpm-workspace.yaml
             scripts
       - uses: ./.github/actions/setup-toolchain
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,7 +101,8 @@ are not awaited, and removing the label tears it down.
 
 ## Pull Request Title Guidelines
 
-`pull-request.yml` validates the title with commitlint (`commitlint.config.ts`). Titles follow the [Conventional Commits](https://www.conventionalcommits.org/) specification.
+PR titles follow the [Conventional Commits](https://www.conventionalcommits.org/) specification.
+`commitlint.config.ts` defines the allowed types and scopes shared by CI and local commit hooks.
 
 ### Format
 

--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -1,54 +1,40 @@
-/**
- * Commitlint Configuration
- *
- * This config validates commit messages and PR titles against Conventional Commits.
- * Primary use case: CI validation of PR titles (which become commit messages after squash merge).
- *
- * @see https://commitlint.js.org
- * @see CONTRIBUTING.md for guidelines
- */
+// Keep this module dependency-free: PR validation imports it without a workspace install.
 
 // Allowed commit types. Types categorize history for readers only — versioning
 // and changelog entries come from changesets (.changeset/*.md), not commit types.
 const TYPES = [
-	"feat", // New feature
-	"fix", // Bug fix
-	"docs", // Documentation only
-	"style", // Code style (formatting, semicolons, etc.)
-	"refactor", // Code refactoring (no feature/fix)
-	"perf", // Performance improvement
-	"test", // Test changes
-	"build", // Build system or dependencies
-	"ci", // CI/CD changes
-	"chore", // Maintenance tasks
-	"revert", // Revert previous commit
+	"feat",
+	"fix",
+	"docs",
+	"style",
+	"refactor",
+	"perf",
+	"test",
+	"build",
+	"ci",
+	"chore",
+	"revert",
 ];
 
-// Allowed scopes (aligned with pull-request.yml)
 const SCOPES = [
-	// === SERVICE SCOPES (where the code lives) ===
-	"webapp", // React frontend, webapp Dockerfile
-	"server", // Java backend (includes in-process Pi mentor agent + webhook receiver), server Dockerfile
-	"docs", // Documentation site
+	"webapp",
+	"server",
+	"docs",
 
-	// === INFRASTRUCTURE SCOPES (affect runtime) ===
-	"deps", // Production dependencies (security patches, bug fixes)
-	"security", // Security fixes (CRITICAL - must release)
-	"db", // Database migrations (affect runtime)
-	"docker", // Dockerfiles, production compose (affect deployed containers)
+	"deps",
+	"security",
+	"db",
+	"docker",
 
-	// === INFRASTRUCTURE SCOPES (tooling and process) ===
-	"ci", // GitHub Actions, CI workflows only
-	"config", // Developer tooling configuration
-	//          NOT for: application.yml (use 'server'), Dockerfiles (use service scope)
-	"deps-dev", // Dev dependencies only (test libs, linters)
-	"scripts", // Build/dev helper scripts
-	"release", // Release engineering (also used by the automated Version PR)
+	"ci",
+	"config", //  NOT for: application.yml (use 'server'), Dockerfiles (use service scope)
+	"deps-dev",
+	"scripts",
+	"release",
 
-	// === FEATURE SCOPES (domain-specific) ===
-	"auth", // Authentication / identity (Account, IdentityLink, JWT, oauth2Login)
-	"integration", // Cross-cutting integration framework (webhook, oauth, registry, SPI)
-	"scm", // Source-control management (GitHub, GitLab) — formerly 'gitprovider'
+	"auth",
+	"integration",
+	"scm",
 	"leaderboard",
 	"mentor",
 	"notifications",
@@ -57,16 +43,21 @@ const SCOPES = [
 	"workspace",
 ];
 
-/** The slice of commitlint's parsed header these two rules read. */
+// A breaking change is carried by a changeset, which is what sets the next version; a marker in the
+// title only says so where nothing reads it.
+const BREAKING_MARKER = /^[^:]*!:/;
+const SUBJECT_SHAPE = /^(?!.*\.$).*\S$/;
+const HELP_URL = "https://github.com/hephaestus-build/Hephaestus/blob/main/CONTRIBUTING.md";
+
 interface ParsedCommit {
 	readonly type?: string | null;
 	readonly scope?: string | null;
+	readonly subject?: string | null;
+	readonly header?: string | null;
 }
 
-/** What a commitlint rule answers: whether the header passes, and what to say when it does not. */
 type RuleOutcome = [valid: boolean, message?: string];
 
-// Custom plugin to provide helpful error messages
 const helpfulErrorsPlugin = {
 	rules: {
 		"type-enum-helpful": (parsed: ParsedCommit): RuleOutcome => {
@@ -86,7 +77,7 @@ const helpfulErrorsPlugin = {
 		},
 		"scope-enum-helpful": (parsed: ParsedCommit): RuleOutcome => {
 			const { scope } = parsed;
-			if (!scope) return [true]; // Scope is optional
+			if (!scope) return [true];
 			const valid = SCOPES.includes(scope);
 			return [
 				valid,
@@ -94,47 +85,55 @@ const helpfulErrorsPlugin = {
 					? ""
 					: `scope "${scope}" is not allowed.\n\n` +
 						`Allowed scopes:\n` +
-						`  Services:  webapp, server, docs\n` +
-						`  Infra:     deps, security, db, docker, ci, config, deps-dev, scripts, release\n` +
-						`  Features:  auth, integration, scm, leaderboard, mentor, notifications, profile, teams, workspace\n\n` +
+						`  ${SCOPES.join(", ")}\n\n` +
 						`⚠️  'config' is for developer tooling\n` +
 						`    For runtime config use 'server', for Dockerfiles use service scope\n\n` +
 						`Format: <type>(<scope>): <description>\n` +
-						`Example: fix(server): resolve null pointer exception\n` +
-						`         feat(auth): wire oauth2Login against gitlab.lrz.de`,
+						`Example: fix(server): reject invalid requests`,
 			];
 		},
+		"subject-shape": (parsed: ParsedCommit): RuleOutcome => [
+			SUBJECT_SHAPE.test(parsed.subject ?? ""),
+			"description must not be empty or end with a period",
+		],
+		"breaking-marker-absent": (parsed: ParsedCommit): RuleOutcome => [
+			!BREAKING_MARKER.test(parsed.header ?? ""),
+			"drop the ! marker and describe the breaking change in a changeset",
+		],
 	},
+};
+
+// The one home for what CI enforces on a pull request title: it reads this object from the default
+// branch without a workspace install, and the rules below hold a commit message to the same shapes.
+export const pullRequestTitlePolicy = {
+	types: TYPES.join("\n"),
+	scopes: SCOPES.join("\n"),
+	headerMaxLength: 100,
+	headerPattern: String.raw`^(\w+)(?:\(([\w-]+)\))?: (.+)$`,
+	subjectPattern: SUBJECT_SHAPE.source,
+	breakingMarkerPattern: BREAKING_MARKER.source,
+	helpUrl: HELP_URL,
 };
 
 const configuration = {
 	extends: ["@commitlint/config-conventional"],
 	plugins: [helpfulErrorsPlugin],
-	helpUrl: "https://github.com/hephaestus-build/Hephaestus/blob/main/CONTRIBUTING.md",
+	helpUrl: HELP_URL,
 	rules: {
-		// Use custom rules for helpful error messages
 		"type-enum-helpful": [2, "always"],
 		"scope-enum-helpful": [2, "always"],
-		// Disable default enum rules (replaced by helpful versions)
+		"subject-shape": [2, "always"],
+		"breaking-marker-absent": [2, "always"],
 		"type-enum": [0],
 		"scope-enum": [0],
-		// Allow empty scope (scope is optional per CONTRIBUTING.md)
 		"scope-empty": [0],
-		// Disable subject-case: lower-case is too strict for technical terms
-		// (API, URL, GraphQL, OAuth, class names, env vars like APPLICATION_HOST_URL).
-		// Angular convention says "don't capitalize first letter" which we enforce
-		// via convention/review, not tooling. This avoids false positives.
+		// Preserve technical names such as GraphQL and OAuth.
 		"subject-case": [0],
-		// No period at end of subject
-		"subject-full-stop": [2, "never", "."],
-		// Subject shouldn't be empty
-		"subject-empty": [2, "never"],
-		// Type shouldn't be empty
+		"subject-full-stop": [0],
+		"subject-empty": [0],
 		"type-empty": [2, "never"],
-		// Type must be lowercase
 		"type-case": [2, "always", "lower-case"],
-		// Header (full first line) max length
-		"header-max-length": [2, "always", 100],
+		"header-max-length": [2, "always", pullRequestTitlePolicy.headerMaxLength],
 	},
 };
 

--- a/docs/contributor/ci-cd.mdx
+++ b/docs/contributor/ci-cd.mdx
@@ -247,7 +247,7 @@ why the label is the authority, and which alternatives were priced and declined,
 | --- | --- | --- |
 | `cicd.yml` | PR, merge group, push to main, manual | Validates changes before merge and builds final-SHA images after merge; the release evidence gate runs over the images the run built on the Version PR's branch, and wherever the `release-preflight` dispatch input asks for it |
 | `review-policy.yml` | PR opened, reopened, synchronized, ready for review, edited | Approves a listed maintainer's pull request so the ruleset's required approval is met; does nothing for anyone else |
-| `pull-request.yml` | PR opened, edited, synchronized, reopened, ready for review | Validates the title with commitlint, checks that every commit resolves to the pull request's author, and assigns the author when the pull request opens |
+| `pull-request.yml` | PR opened, edited, synchronized, reopened, ready for review | Validates the title against the policy `commitlint.config.ts` exports, without installing the workspace, checks that every commit resolves to the pull request's author, and assigns the author when the pull request opens |
 | `ci-quality-gates.yml` | Called by cicd.yml | Formatting, lint, type checks, webapp unit and story tests: everything verifiable from source |
 | `ci-build.yml` | Called by cicd.yml | Packages the server reactor once, then runs the OpenAPI, schema, database and browser E2E gates and the application-server image against that artifact |
 | `ci-tests.yml` | Called by cicd.yml | The server unit, architecture and integration suites, compiled from source |
@@ -292,7 +292,7 @@ credential is still `GITHUB_TOKEN`, so these commits start no further workflow r
 
 | Action | Contract |
 | --- | --- |
-| `setup-toolchain` | Installs the Node.js and pnpm versions pinned in `package.json`, caching the pnpm executable by runner platform and pinned version and retrying its download twice on a miss, restores the pnpm store cache, and installs the launcher through the SHA-pinned `setup-vp` with `node-manager: false`, which then runs the lockfile's `vite-plus`; `install` is `none` or `frozen` |
+| `setup-toolchain` | Installs the Node.js version pinned in `package.json`, and nothing else when `install` is `none`, so a job that only runs `node scripts/…` reaches no package registry; `frozen` adds the pinned pnpm — caching its executable by runner platform and pinned version and retrying the download twice on a miss — restores the pnpm store cache, and installs the launcher through the SHA-pinned `setup-vp` with `node-manager: false`, which then runs the lockfile's `vite-plus` |
 | `setup-caches` | Sets up the JDK from `.java-version` and restores the Maven dependency cache with a prefix fallback; `application-server-reactor` also restores the generated-client build cache and is the only type that writes caches, on default-branch push, schedule and dispatch runs |
 | `restore-server-build` | Downloads the packaged reactor and installs its generated-clients JAR and parent pom so single-module Maven goals resolve them; outputs the executable JAR path |
 | `setup-browsers` | Restores the exact Playwright browser version and installs Chromium system dependencies |

--- a/scripts/check-toolchain.ts
+++ b/scripts/check-toolchain.ts
@@ -233,12 +233,15 @@ if (withOf(setupStep(usesAction("actions/setup-node")))["node-version-file"] !==
 // Every expression below is derived from the id of the step it reads, so renaming a step is not a
 // drift; changing what a step does is.
 const steps = setupSteps.filter(isRecord);
+const frozenOnly = "inputs.install == 'frozen'";
 const idOf = (step: Record<string, unknown>): string => {
 	if (typeof step.id !== "string") throw new Error("setup-toolchain step must carry an id");
 	return step.id;
 };
 const pnpmPin = setupStep((step) => String(step.run).includes("devEngines.packageManager.version"));
 const versionOutput = `steps.${idOf(pnpmPin)}.outputs.version`;
+if (pnpmPin.if !== frozenOnly)
+	throw new Error("setup-toolchain must read the pnpm pin only when it installs pnpm");
 // Git Bash gives Windows an MSYS $HOME that the Windows PATH cannot resolve, so the destination has
 // to be resolved the way pnpm/setup and actions/cache resolve it.
 if (!String(pnpmPin.run).includes("dest=$(node "))
@@ -247,18 +250,29 @@ const destOutput = `\${{ steps.${idOf(pnpmPin)}.outputs.dest }}`;
 const pnpmCache = setupStep(usesAction("actions/cache/restore"));
 const cacheHit = `steps.${idOf(pnpmCache)}.outputs.cache-hit`;
 if (
-	withOf(pnpmCache).path !== "~/setup-pnpm" ||
+	!isDeepStrictEqual(String(withOf(pnpmCache).path).trim().split(/\s+/).toSorted(), [
+		"~/setup-pnpm/pnpm",
+		"~/setup-pnpm/pnpm.exe",
+	]) ||
+	"restore-keys" in withOf(pnpmCache) ||
 	!["runner.os", "runner.arch", versionOutput].every((part) =>
 		String(withOf(pnpmCache).key).includes(part),
 	)
 )
 	throw new Error("setup-toolchain must cache the platform-specific pinned pnpm binary");
+if (pnpmCache.if !== frozenOnly)
+	throw new Error("setup-toolchain must restore the pnpm binary only when it installs pnpm");
 // Without PNPM_HOME and PATH the hit path leaves the job no pnpm at all, and setup-node's store
-// cache fails looking for it.
+// cache fails looking for it. pnpm/setup creates its bin directory upfront and prepends the
+// destination ahead of it, so a restored install has to arrive in the same shape.
 const restored = steps.find((step) => step.if === `${cacheHit} == 'true'`) ?? {};
+const restoredPath = String(restored.run)
+	.split("\n")
+	.flatMap((line) => /^\s*echo "(\$PNPM_DEST[^"]*)" >> "\$GITHUB_PATH"$/.exec(line)?.[1] ?? []);
 if (
 	!String(restored.run).includes("PNPM_HOME=") ||
-	!String(restored.run).includes('>> "$GITHUB_PATH"')
+	!String(restored.run).includes('mkdir -p "$PNPM_DEST/bin"') ||
+	!isDeepStrictEqual(restoredPath, ["$PNPM_DEST", "$PNPM_DEST/bin"])
 )
 	throw new Error("setup-toolchain must put the restored pnpm on PATH and in PNPM_HOME");
 if (
@@ -275,7 +289,7 @@ if (pnpmSetupOrder.length !== 3)
 	throw new Error("setup-toolchain must retry pnpm setup twice before failing");
 const pnpmSetups = pnpmSetupOrder.map((index) => steps[index] ?? {});
 const firstAttempt = pnpmSetups[0] ?? {};
-if (firstAttempt.if !== `${cacheHit} != 'true'`)
+if (firstAttempt.if !== `${frozenOnly} && ${cacheHit} != 'true'`)
 	throw new Error("setup-toolchain must skip pnpm setup entirely when the binary cache hits");
 for (const [attempt, index] of pnpmSetupOrder.slice(1).entries()) {
 	const previous = pnpmSetups[attempt] ?? {};
@@ -300,7 +314,11 @@ for (const step of pnpmSetups)
 		throw new Error("setup-toolchain must retry the same pnpm setup operation");
 // A cache key cannot be overwritten, so an unproven tree saved once is served to every job.
 const proof = steps.find((step) => String(step.run).includes("pnpm --version")) ?? {};
-if ("if" in proof || !isRecord(proof.env) || proof.env.PNPM_VERSION !== `\${{ ${versionOutput} }}`)
+if (
+	proof.if !== frozenOnly ||
+	!isRecord(proof.env) ||
+	proof.env.PNPM_VERSION !== `\${{ ${versionOutput} }}`
+)
 	throw new Error("setup-toolchain must prove the pinned pnpm answers on both setup paths");
 const pnpmCacheSave = setupStep(usesAction("actions/cache/save"));
 if (steps.indexOf(proof) > steps.indexOf(pnpmCacheSave))
@@ -309,26 +327,40 @@ if (!isDeepStrictEqual(withOf(pnpmCacheSave), withOf(pnpmCache)))
 	throw new Error("setup-toolchain must save the pnpm binary under its exact restore identity");
 if (
 	pnpmCacheSave.if !==
-	`${cacheHit} != 'true' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)`
+	`${frozenOnly} && ${cacheHit} != 'true' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)`
 )
 	throw new Error("setup-toolchain must write the pnpm binary cache only from the default branch");
-const nodeSetup = withOf(setupStep(usesAction("actions/setup-node")));
+const nodeSetupStep = setupStep(usesAction("actions/setup-node"));
+const nodeSetup = withOf(nodeSetupStep);
+// One cache scheme for the pnpm store: pnpm/setup's would key on a different digest, and which of
+// the two ran would then depend on the binary cache's outcome.
 if (
-	nodeSetup.cache !== `\${{ ${cacheHit} == 'true' && inputs.install == 'frozen' && 'pnpm' || '' }}`
+	pnpmSetup.cache !== false ||
+	nodeSetup.cache !== `\${{ ${frozenOnly} && 'pnpm' || '' }}` ||
+	nodeSetup["cache-dependency-path"] !== "pnpm-lock.yaml"
 )
-	throw new Error(
-		"setup-toolchain must cache the pnpm store through setup-node exactly when pnpm/setup did not",
-	);
-const vpSetup = withOf(setupStep(usesAction("voidzero-dev/setup-vp")));
+	throw new Error("setup-node must own the pnpm store cache on both setup paths");
+if ("if" in nodeSetupStep)
+	throw new Error("setup-toolchain must select the pinned Node version in either install mode");
+const vpSetupStep = setupStep(usesAction("voidzero-dev/setup-vp"));
+const vpSetup = withOf(vpSetupStep);
 if (vpSetup["node-manager"] !== false || vpSetup["run-install"] !== false)
 	throw new Error("setup-toolchain must let setup-vp neither manage Node nor install");
+if (vpSetupStep.if !== frozenOnly)
+	throw new Error("setup-toolchain must install Vite+ only for a job that runs it");
 const frozenInstall = setupStep(
 	(step) => step.run === "pnpm install --frozen-lockfile --ignore-scripts",
 );
-if (frozenInstall.if !== "inputs.install == 'frozen'")
+if (frozenInstall.if !== frozenOnly)
 	throw new Error(
 		"setup-toolchain must install from the lockfile without scripts, only when asked",
 	);
+// pnpm/setup installs a runtime of its own, and the frozen install must run under the pinned one.
+if (
+	steps.indexOf(nodeSetupStep) <= Math.max(...pnpmSetupOrder) ||
+	steps.indexOf(nodeSetupStep) > steps.indexOf(frozenInstall)
+)
+	throw new Error("setup-toolchain must select Node after pnpm/setup and before it installs");
 setupStep((step) => step.if === "inputs.install != 'none' && inputs.install != 'frozen'");
 for (const step of setupSteps.filter(isRecord)) {
 	const inputs = isRecord(step.with) ? step.with : {};

--- a/scripts/pull-request-workflows.test.ts
+++ b/scripts/pull-request-workflows.test.ts
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { copyFile, mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { test } from "node:test";
+
+import { isMap, isSeq, parseDocument, type YAMLMap } from "yaml";
+
+async function stepsIn(file: string, location: string[]): Promise<YAMLMap[]> {
+	const document = parseDocument(await readFile(file, "utf8"));
+	const steps = document.getIn(location);
+	assert.ok(isSeq(steps));
+	return steps.items.map((step) => {
+		assert.ok(isMap(step));
+		return step;
+	});
+}
+
+void test("title preflight loads without dependencies and validates the current title on reruns", async (t) => {
+	const steps = await stepsIn(".github/workflows/pull-request.yml", [
+		"jobs",
+		"validate-title",
+		"steps",
+	]);
+	assert.ok(steps.every((step) => !/setup-toolchain|setup-node/.test(String(step.get("uses")))));
+	const checkout = steps.find((step) => String(step.get("uses")).startsWith("actions/checkout@"));
+	assert.ok(checkout);
+	assert.equal(checkout.getIn(["with", "persist-credentials"]), false);
+	assert.equal(checkout.getIn(["with", "ref"]), `\${{ github.event.repository.default_branch }}`);
+
+	// The workspace the script runs in is the sparse checkout, and nothing else: a file the workflow
+	// stops fetching has to break this test rather than the pull request that reruns without it.
+	const workspace = await mkdtemp(join(tmpdir(), "title-policy-"));
+	t.after(() => rm(workspace, { recursive: true, force: true }));
+	for (const path of String(checkout.getIn(["with", "sparse-checkout"]))
+		.trim()
+		.split("\n")) {
+		const file = path.trim();
+		await mkdir(join(workspace, dirname(file)), { recursive: true });
+		await copyFile(file, join(workspace, file));
+	}
+
+	const policy = steps.find((step) => step.get("id") === "policy");
+	const script = policy?.getIn(["with", "script"]);
+	assert.equal(typeof script, "string");
+	const cases = [
+		["fix(ci): recover from a registry blip", true],
+		["fix: document !: syntax", true],
+		[`fix: ${"a".repeat(95)}`, true],
+		[`fix: ${"a".repeat(96)}`, false],
+		["fix!: breaking change", false],
+		["fix(ci)!: breaking change", false],
+		["fix: first line\nsecond line", false],
+		["fix: first line\rsecond line", false],
+	] as const;
+	for (const [title, valid] of cases) {
+		const result = spawnSync(
+			process.execPath,
+			[
+				"--input-type=module",
+				"-e",
+				`
+			const context = { repo: { owner: "owner", repo: "repo" }, payload: { pull_request: { number: 7, title: ${JSON.stringify(valid ? "fix!: stale invalid title" : "fix: stale valid title")} } } };
+			const github = { rest: { pulls: { get: async () => ({ data: { title: ${JSON.stringify(title)} } }) } } };
+			const core = { setOutput() {}, setFailed() { process.exitCode = 1; } };
+			${String(script)}
+		`,
+			],
+			{ encoding: "utf8", env: { ...process.env, GITHUB_WORKSPACE: workspace } },
+		);
+		assert.equal(result.status, valid ? 0 : 1, `${title}: ${result.stderr}`);
+		assert.equal(result.stderr, "", title);
+	}
+
+	const validator = steps.find((step) => step.get("id") === "title");
+	assert.ok(validator);
+	assert.match(
+		String(validator.get("uses")),
+		/^amannn\/action-semantic-pull-request@[a-f0-9]{40}$/,
+	);
+	for (const input of ["types", "scopes", "headerPattern", "subjectPattern"]) {
+		assert.equal(validator.getIn(["with", input]), `\${{ steps.policy.outputs.${input} }}`);
+	}
+	// The comment carries the validator's own message; a link to the run is not the reason.
+	const explanation = steps.find((step) => step.get("id") === "explain");
+	assert.ok(explanation);
+	assert.equal(
+		explanation.getIn(["env", "TITLE_ERROR"]),
+		`\${{ steps.title.outputs.error_message }}`,
+	);
+	const comment = steps.find((step) => step.getIn(["with", "path"]) !== undefined);
+	assert.ok(comment);
+	assert.equal(comment.getIn(["with", "header"]), "pr-title-lint-error");
+	assert.match(String(explanation.get("run")), /> "\$RUNNER_TEMP\/title-error\.md"/);
+	assert.equal(comment.getIn(["with", "path"]), `\${{ runner.temp }}/title-error.md`);
+});


### PR DESCRIPTION
## What changed and why

A job that only runs `node scripts/…` installed pnpm and Vite+ first. That put the npm registry on
the critical path of about twenty jobs that never use a workspace dependency, and a single blip
there failed one — the failure #1807 reports, which evicts a pull request from the merge queue
silently.

`setup-toolchain` now has a real dependency-free mode. `install: none` provisions the Node.js
version `package.json` pins and stops; `install: frozen` is unchanged and still installs pnpm, Vite+
and the locked dependencies. No call site changes, so every existing `install: none` job stops
reaching the registry, and the pinned `actions/setup-node` digest keeps its one home in the
composite action.

Title validation was the last job installing the workspace for a one-line check. `commitlint.config.ts`
now exports the policy — types, scopes, header limit, subject shape and the breaking-change marker —
and the workflow reads that module from the default branch through a sparse checkout, with no
install at all. The same constants back the commitlint rules the local `commit-msg` hook runs, so
the hook and CI now agree on `feat!:`, which they did not before.

The two pnpm store-cache schemes become one: `pnpm/setup` no longer caches, `actions/setup-node`
owns the store on both setup paths, and it runs after `pnpm/setup` so the pinned runtime wins on
`PATH` rather than the runtime `pnpm/setup` installs beside pnpm. The binary cache holds the pnpm
executable alone, which is why its key is namespaced afresh.

Fixes #1807.

## How to test

- `vp run format`, then `vp run check` — the full local quality gate, run by hand (the pre-push hook
  was not used).
- `node --test scripts/pull-request-workflows.test.ts scripts/ci-contract.test.ts`
- `node scripts/check-toolchain.ts` — the gate that holds the action's shape, including the setup
  order and the restored `PATH` emulation.
- `actionlint` 1.7.12 and `zizmor` 1.29.0 `--min-confidence medium` over every changed workflow.
- After merge: a cold and a warm setup on Linux and Windows. A binary-cache hit skips `pnpm/setup`;
  both paths select the pinned Node version and share one pnpm-store cache.
- On a disposable pull request: an invalid title comments the validator's own message, correcting
  the title removes the comment, and a rerun judges the current title rather than the payload's.

## Release impact

CI, repository tooling and contributor documentation only. No shipped application change, so no
changeset and no operator action.

## Notes for reviewers

Start with `.github/actions/setup-toolchain/action.yml` and diff it against `main`: every mechanism
#1815 landed is preserved, including the three signature-verifying `pnpm/setup` attempts with their
backoff, the version proof before the cache write, and the default-branch-only save. The comments
explaining them are preserved too.

Two things this cannot prove before it lands. The new binary-cache key needs one successful
default-branch run per runner platform to warm, so bullet 2 of #1807 holds again only after that.
And `pull_request_target` always runs the default branch's copy of a workflow, so the rewritten
title job first executes on the pull request after this one.

`pnpm/setup` also gives up its lockfile-verification cache when `cache: false`; the frozen install
that follows reads the same lockfile, so the cost is one restore, not a correctness change.

Two pieces of the earlier revision were cut as separate concerns: a rewrite of merge-queue eviction
reporting, and a `CONTRIBUTING.md` scope description that belongs to the guide-consistency pass.
