### PR TITLE
test(scripts): make Compose load runs reproducible

### DIFF
--- a/load-tests/README.md
+++ b/load-tests/README.md
@@ -1,6 +1,6 @@
 # Compose capacity qualification
 
-These [Grafana k6](https://grafana.com/docs/k6/latest/) scenarios qualify the supported single-host
+These [Grafana k6](https://grafana.com/docs/k6/latest/) scenarios measure the supported single-host
 Compose topology. They spend LLM budget and create durable rows; run them only on an isolated host.
 
 Webhook traffic uses a [constant arrival rate](https://grafana.com/docs/k6/latest/using-k6/scenarios/concepts/arrival-rate-vu-allocation/).
@@ -17,66 +17,96 @@ both service objectives and saturation, following Google's SLO guidance
 - Bind practice review and mentor to a deterministic OpenAI-compatible test provider. Record its
   response latency separately: provider time is not host capacity.
 - Use a short-lived workspace-admin token. Never commit it or the webhook secret.
-- Stop background sync and other tenants, then reset PostgreSQL and JetStream to the same snapshot
-  before every candidate. Run three times; publish the median and retain every raw result.
+- Disable background sync and unrelated traffic. Restore PostgreSQL and JetStream from the same
+  snapshot before every repetition at each candidate host and load step. Run three times; publish
+  the median and retain every raw result.
 
 ## Run
 
-Use the digest-pinned k6 image:
+The two load scenarios are uncached and manual. CI runs `test:load:syntax`, which inspects both
+scenarios and tests their contracts using the same digest-pinned k6 image, with networking disabled.
+`vp run check` runs the runner's own tests.
 
 ```bash
 vp run test:load:syntax
-```
-
-```bash
 export BASE_URL=https://hephaestus-load.example.test
+export LOAD_TEST_ACKNOWLEDGE=isolated-host
 export WEBHOOK_SECRET=...
-export K6_IMAGE=grafana/k6:1.2.3@sha256:4f82892217f3110cb233e2b2622bcc97fabc70f14bd241fbfbfe7305105c68aa
-mkdir -p load-results
-docker run --rm -i \
-  -e BASE_URL -e WEBHOOK_SECRET -e WEBHOOK_RATE=100 -e DURATION=2m \
-  -v "$PWD/load-tests:/tests:ro" -v "$PWD/load-results:/results" \
-  "$K6_IMAGE" \
-  run --summary-export=/results/webhook-summary.json /tests/webhook-burst.js
-```
+vp run test:load:webhook-burst
 
-The mixed scenario runs long-lived mentor HTTP responses while distinct practice reviews execute. It
-requires every review request and job to complete:
-
-```bash
-export API_BASE_URL=https://hephaestus-load.example.test/api
 export AUTH_TOKEN=... WORKSPACE_SLUG=capacity-test
 export ARTIFACT_IDS=101,102,103,104,105
-docker run --rm -i \
-  -e API_BASE_URL -e AUTH_TOKEN -e WORKSPACE_SLUG -e ARTIFACT_IDS \
-  -e MENTOR_VUS=5 -e REVIEW_VUS=2 -e REVIEW_REQUESTS=5 -e DURATION=10m \
-  -v "$PWD/load-tests:/tests:ro" -v "$PWD/load-results:/results" \
-  "$K6_IMAGE" \
-  run --summary-export=/results/mixed-summary.json /tests/detection-mentor.js
+export REVIEW_REQUESTS=5 MENTOR_VUS=5 REVIEW_VUS=2
+# Copy the actual deployed values from the isolated host; neither value changes that host.
+export SANDBOX_API_MAX_REQUEST_BYTES=4194304
+export SANDBOX_API_REQUESTS_PER_MINUTE=120
+vp run test:load:detection-mentor
 ```
+
+`BASE_URL` is the externally reachable application root (without `/api`); both scenarios use it.
+The gateway remains private, and only the detection+mentor workload crosses it, so only that
+scenario takes and records the gateway limits.
+Optional workload inputs are documented by the scenario's defaults.
+Keep mentor traffic running long enough to overlap practice reviews; the default mentor phase is
+10 minutes, while slow reviews can take longer. This is a finite concurrent-session workload,
+not an arrival-rate claim for mentor throughput ([open versus closed models](https://grafana.com/docs/k6/latest/using-k6/scenarios/concepts/open-vs-closed/)).
+
+Each invocation prints a fresh `load-results/<scenario>-<timestamp>` directory. Set `LOAD_RESULTS_DIR`
+to choose another **unused** directory. It contains `summary.json`, `run.json` (inputs, image,
+start time, effective scenarios/thresholds from `k6 inspect`, and exit status), the baseline template,
+and a `scripts/` snapshot. k6 inspects and runs that snapshot, not a mutable checkout. Keep the whole
+directory so defaults and workload code remain reproducible after the checkout changes.
+Secret values are not written to metadata or command arguments.
+Artifacts can still contain sensitive workspace identifiers: inspect them before publication.
+A failed k6 threshold preserves k6's nonzero exit status; keep failed runs, too.
+
+Generate the document from that directory, including failed runs:
+
+```bash
+vp run report:load:baseline load-results/<scenario>-<timestamp>
+```
+
+This renders the saved `baseline-template.md` to `<run-directory>/baseline.md`, reporting every
+threshold and metric without recomputing k6's verdict. It requires every threshold captured by
+`k6 inspect`, valid runner metadata, and the gateway limits the scenario records. A setup failure or
+interrupted export with missing evidence is rejected. Any digest-pinned run stays renderable, and
+the document names the k6 image the run used and whether the checkout has moved on since. A passing
+k6 result alone does not qualify a host: supply the companion operator evidence listed in the
+document. Do not commit tokens, environment files or unredacted Compose configuration.
 
 The pinned k6 client buffers each `text/event-stream` response. This scenario measures concurrent
 full-response completion, not time to first event or per-event latency.
 
-In separate terminals collect container and host samples. Docker defines the container fields and
-their semantics in [`docker stats`](https://docs.docker.com/reference/cli/docker/container/stats/);
-in particular, its Linux CLI memory figure subtracts cache, so retain the raw output rather than
-copying only a peak percentage:
+## Collect host evidence
+
+Webhook bursts land on the `webhook-server` container and detection+mentor traffic on
+`application-server`, so collect both containers and read the busy one against the scenario you ran.
+
+On the **Compose host**, create a fresh evidence directory for each run. From that directory, start
+these collectors in separate terminals before starting k6 on the load-generator host:
 
 ```bash
-(cd docker/self-host && \
-  docker compose --env-file .env --env-file release-lock.env stats --format json \
-    application-server webhook-server postgres nats-server) \
-  > load-results/container-stats.jsonl
+docker stats --format json > container-stats.jsonl
 ```
 
 ```bash
-vmstat 1 > load-results/host-vmstat.txt
+vmstat -y -t 1 > host-vmstat.txt
 ```
 
-Stop both collectors when k6 exits. Capture `df -h` before and after the run. Retain `docker compose
-ps`, `docker info`, the release lock, k6 summaries, provider latency, PostgreSQL size, JetStream state,
-and application metrics/logs. The increase in `webhook.publish{outcome="success"}` must equal accepted
+Collect all containers, including review sandboxes. Docker's Linux CLI memory figure subtracts
+cache; retain the raw samples rather than only a peak percentage
+([`docker stats` semantics](https://docs.docker.com/reference/cli/docker/container/stats/)).
+The [`vmstat` options](https://man7.org/linux/man-pages/man8/vmstat.8.html) timestamp samples and
+omit the since-boot report. Also configure your host monitor to record `MemAvailable` from
+`/proc/meminfo` throughout the run; `vmstat` reports free memory, not available memory. Retain
+timestamped samples so the qualification rule below can be checked.
+
+After load stops, keep the collectors running until the review queue drains or the five-minute
+drain deadline expires.
+Capture `df -h` before and after the run. Retain `docker compose ps`, `docker info`, the release lock,
+provider latency, PostgreSQL size, JetStream state, and application metrics/logs. Copy the evidence
+into its matching k6 run directory; never overwrite another repetition's samples.
+The increase in `webhook.publish{outcome="success"}` must equal accepted
 webhook iterations while the failure counter remains unchanged. Reject a run with a reconciliation
 mismatch, dropped iterations, provider throttling, a container restart/OOM, or swap activity.
 
@@ -91,4 +121,31 @@ The documented size qualifies only when all three repeated runs meet thresholds,
 the data filesystem has at least 20% free before and after, no swap/OOM/restart occurs, and the review
 queue drains within five minutes after load stops. Publish the first failing step as the ceiling.
 
-Copy `baseline-template.md` for every release. Record every repetition and link its raw artifacts.
+Generate a baseline for every repetition and link its raw artifacts. Publish measured minimum and
+recommended sizing and the JetStream durability throughput delta with the recorded baseline under
+the [release capacity gate](https://github.com/hephaestus-build/Hephaestus/issues/1377).
+Qualification must measure the release candidate, including its job-folder implementation.
+
+## What the thresholds prove (and do not prove)
+
+The scenario `options.thresholds` own the numerical budgets; generated baselines report them with
+k6's verdict. Do not maintain a second set of threshold values in documentation.
+
+- Webhook burst offers constant-arrival-rate ingress traffic and fails on dropped iterations.
+  Synthetic `capacity_test` events measure authenticated publication, **not** downstream sync of
+  real provider events. Acceptance requires `202` with `status: "ok"`; intentionally dropped events
+  also return `202` but must not count as published. Neither scenario follows redirects.
+- Only GitHub deliveries are measured. GitLab and Outline share the ingest path, so their capacity
+  is read from this scenario rather than measured separately; Slack is not measured, because its
+  publish gate and fast-path timeout make it a different workload that needs its own scenario.
+- The mixed scenario requires every requested review to finish successfully. Exact completion
+  counts catch interrupted iterations that never add a sample to a completion-rate metric.
+- Mentor HTTP failures and whole-turn success are independent of polling traffic. Streams must
+  contain a finish chunk and the terminal sentinel, without error/abort/tool-error chunks;
+  the server sends `[DONE]` on errors too.
+- These are workload budgets, not an isolated gateway latency SLO or time-to-first-token SLO.
+  Inspect gateway metrics for [the dedicated connector](https://github.com/hephaestus-build/Hephaestus/issues/1730)
+  and reject capacity qualification on `429`/`413` or provider throttling, including failures hidden
+  inside streamed responses. Do not raise the production limiter just to make a benchmark pass.
+- k6 cannot prove CPU, memory, disk, queue drain or ingest reconciliation from HTTP summaries.
+  The operator evidence and qualification rule above remain mandatory.

--- a/load-tests/baseline-template.md
+++ b/load-tests/baseline-template.md
@@ -1,35 +1,47 @@
-# Hephaestus capacity baseline template
+# Hephaestus capacity baseline
 
-## Reproduction identity
+Generated from the scenario's `handleSummary` JSON and its runner metadata. Do not hand-edit metrics
+or verdicts. One document describes one scenario on one host in one repetition.
 
-| Field | Value |
-| --- | --- |
-| Date / operator | |
-| Commit, release-lock path and digest | |
-| Release-lock signature verification result | |
-| Rendered Compose configuration digest | |
-| Host provider / machine / region | |
-| CPU model, vCPUs, RAM, storage | |
-| Linux, Docker, Compose, k6 versions | |
-| Application, webhook, Postgres, NATS image digests | |
-| Database snapshot / row counts / JetStream state | |
-| Test-provider model and latency distribution | |
+## Automated evidence
 
-## Results
+{{RUN}}
 
-| Host | Run | Scenario | Offered load | p50 / p95 / p99 | Error rate | CPU 60s max | Minimum available memory | Filesystem free | Drain time | Result |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| | 1 | Webhook burst | | | | | | | | |
-| | 2 | Webhook burst | | | | | | | | |
-| | 3 | Webhook burst | | | | | | | | |
-| | 1 | Detection + mentor | | | | | | | | |
-| | 2 | Detection + mentor | | | | | | | | |
-| | 3 | Detection + mentor | | | | | | | | |
+### Effective workload
 
-## Ceiling and conclusion
+{{SCENARIOS}}
 
-- First failing step and failure mode:
-- Minimum qualified host:
-- Recommended qualified host and measured headroom:
-- Limits outside the qualified envelope:
-- Links to k6 JSON, container stats, metrics and logs:
+### Thresholds
+
+| Metric | Objective | Result |
+| --- | --- | --- |
+| {{THRESHOLDS}} | | |
+
+### Measurements
+
+Trend durations are milliseconds; `med` is p50. Rates are fractions unless the metric is a counter's
+per-second `rate`. HTTP timings do not isolate gateway or provider time.
+
+| Metric | Statistic | Value |
+| --- | --- | --- |
+| {{METRICS}} | | |
+
+## Operator evidence required for qualification
+
+The summary cannot establish host sizing. Publish a companion record with all of the following;
+missing evidence means the host remains **unqualified**, even if every threshold passes:
+
+- Operator, commit, release-lock digest and signature verification, rendered Compose digest, all
+  application and sandbox image digests; Linux, Docker and Compose versions.
+- Host provider, region, CPU model, vCPUs, RAM and storage; load-generator host and utilization.
+- Snapshot identity, row counts and JetStream state; deterministic provider identity, model and
+  latency distribution. Any gateway limit recorded above must match the deployed configuration, not
+  an assumed default.
+- Raw container and host samples, busiest rolling 60-second CPU window, minimum available memory,
+  filesystem space before/after, swap, OOM/restarts and queue drain time.
+- Accepted webhook / publish-counter reconciliation; gateway throttling, request-size rejection and
+  provider error evidence. A throttled run measures the limiter, not stack capacity.
+- Every raw summary and run metadata file across three repetitions for each candidate host and
+  scenario, the median, first failing load step and failure mode.
+- Minimum qualified host, recommended qualified host with measured headroom, and limits outside
+  that envelope. Publish these in the admin installation guide with links to all evidence.

--- a/load-tests/detection-mentor.js
+++ b/load-tests/detection-mentor.js
@@ -1,8 +1,7 @@
 import { check, sleep } from "k6";
-import crypto from "k6/crypto";
 import exec from "k6/execution";
 import http from "k6/http";
-import { Rate, Trend } from "k6/metrics";
+import { Counter, Rate, Trend } from "k6/metrics";
 
 import {
 	apiBaseUrl,
@@ -13,11 +12,18 @@ import {
 	sharedThresholds,
 } from "./lib/config.js";
 
+import { mentorStreamCompleted } from "./lib/mentor.js";
+
+export { handleSummary } from "./lib/summary.js";
+
 const workspace = required("WORKSPACE_SLUG");
 const mentorVUs = integer("MENTOR_VUS", 5);
 const reviewVUs = integer("REVIEW_VUS", 2);
 const reviewRequests = integer("REVIEW_REQUESTS", reviewVUs);
+const reviewTimeoutSeconds = integer("REVIEW_TIMEOUT_SECONDS", 1200);
 const reviewJobDuration = new Trend("review_job_duration", true);
+const reviewJobsFinished = new Counter("review_jobs_finished");
+const mentorCompleted = new Rate("mentor_completed");
 const reviewJobsCompleted = new Rate("review_jobs_completed");
 const terminalStatuses = new Set(["COMPLETED", "FAILED", "TIMED_OUT", "CANCELLED"]);
 const api = apiBaseUrl();
@@ -25,12 +31,14 @@ const headers = authHeaders();
 
 export const options = {
 	discardResponseBodies: false,
+	maxRedirects: 0,
 	scenarios: {
 		mentor_sessions: {
 			exec: "mentor",
 			executor: "constant-vus",
 			vus: mentorVUs,
 			duration: __ENV.DURATION ?? "10m",
+			gracefulStop: "10m",
 		},
 		practice_detection: {
 			exec: "detection",
@@ -43,6 +51,11 @@ export const options = {
 	},
 	thresholds: {
 		...sharedThresholds,
+		dropped_iterations: ["count==0"],
+		review_jobs_finished: [`count==${reviewRequests}`],
+		mentor_completed: ["rate>0.99"],
+		"http_req_failed{operation:mentor_turn}": ["rate<0.01"],
+		"http_req_failed{operation:review_request}": ["rate==0"],
 		"checks{scenario:mentor_sessions}": ["rate>0.99"],
 		"checks{scenario:practice_detection}": ["rate==1"],
 		"http_req_duration{operation:mentor_turn}": ["p(95)<120000"],
@@ -58,28 +71,35 @@ export function setup() {
 		.map((value) => Number(value.trim()));
 	if (artifactIds.some((value) => !Number.isSafeInteger(value) || value < 1))
 		throw new Error("ARTIFACT_IDS must be comma-separated positive integers");
+	if (new Set(artifactIds).size !== artifactIds.length)
+		throw new Error("ARTIFACT_IDS must be distinct");
 	if (reviewRequests > artifactIds.length)
 		throw new Error("ARTIFACT_IDS must contain at least REVIEW_REQUESTS distinct ids");
 	return { artifactIds };
 }
 
+export function mentorTurn() {
+	return JSON.stringify({
+		message: {
+			id: crypto.randomUUID(),
+			role: "user",
+			parts: [{ type: "text", text: "Summarize my current practice priorities." }],
+		},
+	});
+}
+
 export function mentor() {
-	const messageId = crypto.randomUUID();
 	const response = http.post(
 		`${api}/workspaces/${encodeURIComponent(workspace)}/mentor/chat`,
-		JSON.stringify({
-			message: {
-				id: messageId,
-				role: "user",
-				parts: [{ type: "text", text: "Summarize my current practice priorities." }],
-			},
-		}),
+		mentorTurn(),
 		{ headers, tags: { operation: "mentor_turn" }, timeout: "10m" },
 	);
-	check(response, {
-		"mentor stream completed": (result) => result.status === 200,
-		"mentor emitted completion": (result) => result.body?.includes("[DONE]") === true,
-	});
+	mentorCompleted.add(
+		check(response, {
+			"mentor returned HTTP 200": (result) => result.status === 200,
+			"mentor stream completed without errors": (result) => mentorStreamCompleted(result.body),
+		}),
+	);
 }
 
 export function detection(data) {
@@ -99,7 +119,7 @@ export function detection(data) {
 		return;
 	}
 
-	const deadline = startedAt + integer("REVIEW_TIMEOUT_SECONDS", 1200) * 1000;
+	const deadline = startedAt + reviewTimeoutSeconds * 1000;
 	while (Date.now() < deadline) {
 		sleep(2);
 		const job = http.get(
@@ -111,6 +131,7 @@ export function detection(data) {
 		if (terminalStatuses.has(status)) {
 			reviewJobDuration.add(Date.now() - startedAt);
 			reviewJobsCompleted.add(status === "COMPLETED");
+			if (status === "COMPLETED") reviewJobsFinished.add(1);
 			check(job, { "review job completed": () => status === "COMPLETED" });
 			return;
 		}

--- a/load-tests/lib/config.js
+++ b/load-tests/lib/config.js
@@ -8,7 +8,8 @@ export function required(name) {
 
 export function integer(name, fallback) {
 	const raw = __ENV[name] ?? String(fallback);
-	if (!/^\d+$/.test(raw) || Number(raw) < 1) exec.test.abort(`${name} must be a positive integer`);
+	if (!/^\d+$/.test(raw) || !Number.isSafeInteger(Number(raw)) || Number(raw) < 1)
+		exec.test.abort(`${name} must be a positive integer`);
 	return Number(raw);
 }
 
@@ -17,7 +18,7 @@ export function baseUrl() {
 }
 
 export function apiBaseUrl() {
-	return required("API_BASE_URL").replace(/\/$/, "");
+	return `${baseUrl()}/api`;
 }
 
 export function authHeaders() {

--- a/load-tests/lib/mentor.js
+++ b/load-tests/lib/mentor.js
@@ -1,0 +1,30 @@
+/**
+ * A mentor turn succeeded only when its stream carries a non-error finish chunk before the `[DONE]`
+ * sentinel; the server sends `[DONE]` to terminate an error response too.
+ */
+export function mentorStreamCompleted(body) {
+	if (typeof body !== "string") return false;
+	let finished = false;
+	let done = false;
+	for (const line of body.split(/\r?\n/)) {
+		if (!line.startsWith("data:")) continue;
+		if (done) return false;
+		const data = line.slice(5).trim();
+		if (data === "[DONE]") {
+			done = true;
+			continue;
+		}
+		try {
+			const chunk = JSON.parse(data);
+			if (!chunk || typeof chunk.type !== "string") return false;
+			if (["error", "abort", "tool-output-error"].includes(chunk.type)) return false;
+			if (chunk.type === "finish") {
+				if (["error", "content-filter"].includes(chunk.finishReason)) return false;
+				finished = true;
+			}
+		} catch {
+			return false;
+		}
+	}
+	return finished && done;
+}

--- a/load-tests/lib/summary.js
+++ b/load-tests/lib/summary.js
@@ -1,0 +1,8 @@
+/**
+ * Writes the end-of-test summary k6 documents for `handleSummary` into the run directory the runner
+ * mounts at `/results`. Each key of the returned object is a file path; returning one at all replaces
+ * the summary k6 would otherwise print, which the generated baseline document reports in full.
+ */
+export function handleSummary(data) {
+	return { "/results/summary.json": JSON.stringify(data, null, 2) };
+}

--- a/load-tests/scenarios.test.js
+++ b/load-tests/scenarios.test.js
@@ -1,0 +1,88 @@
+import { check } from "k6";
+import { Counter } from "k6/metrics";
+import { mentorTurn, options as mixed, setup } from "./detection-mentor.js";
+import { integer } from "./lib/config.js";
+import { mentorStreamCompleted } from "./lib/mentor.js";
+import { signedDelivery, webhookAccepted } from "./webhook-burst.js";
+
+export { handleSummary } from "./lib/summary.js";
+
+const completed = new Counter("contract_tests_completed");
+const reviewJobsFinished = new Counter("review_jobs_finished");
+const unfinished = __ENV.TEST_CASE === "unfinished";
+export const options = {
+	vus: 1,
+	iterations: 1,
+	thresholds: unfinished
+		? { review_jobs_finished: mixed.thresholds.review_jobs_finished }
+		: { checks: ["rate==1"], contract_tests_completed: ["count==1"] },
+};
+
+function assert(condition, message) {
+	if (!check(condition, { [message]: (value) => value })) throw new Error(message);
+}
+
+function rejects(fn, message) {
+	try {
+		fn();
+	} catch {
+		return;
+	}
+	throw new Error(message);
+}
+
+export default function () {
+	if (unfinished) {
+		reviewJobsFinished.add(integer("REVIEW_REQUESTS", 2) - 1);
+		return;
+	}
+	for (const [status, body, expected] of [
+		[202, "ok", true],
+		[202, "dropped", false],
+		[200, "ok", false],
+		[302, "ok", false],
+		[503, "ok", false],
+	]) {
+		assert(
+			webhookAccepted({ status, json: () => body }) === expected,
+			`Webhook ${status}/${body} publication verdict`,
+		);
+	}
+	assert(
+		!webhookAccepted({
+			status: 202,
+			json: () => {
+				throw new Error("Invalid JSON");
+			},
+		}),
+		"Malformed webhook response fails",
+	);
+	const uuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+	const delivery = signedDelivery();
+	assert(uuid.test(delivery.id), "Webhook delivery carries a unique id");
+	assert(/^[0-9a-f]{64}$/.test(delivery.signature), "Webhook delivery carries an HMAC signature");
+	assert(uuid.test(JSON.parse(mentorTurn()).message.id), "Mentor turn carries a unique message id");
+	__ENV.ARTIFACT_IDS = "1,2";
+	assert(setup().artifactIds.length === 2, "Distinct artifacts must be accepted");
+	for (const ids of ["1,1", "1", "1,nope", "1,0", "1,9007199254740992"]) {
+		__ENV.ARTIFACT_IDS = ids;
+		rejects(setup, `Invalid artifacts accepted: ${ids}`);
+	}
+	assert(
+		mentorStreamCompleted('data: {"type":"finish","finishReason":"stop"}\r\n\r\ndata: [DONE]\r\n'),
+		"Completed mentor turn passes",
+	);
+	for (const body of [
+		null,
+		"[DONE]",
+		"data: [DONE]\n",
+		'data: {"type":"finish"}\n',
+		"data: invalid\ndata: [DONE]\n",
+		'data: {"type":"error","errorText":"provider failed"}\ndata: [DONE]\n',
+		'data: {"type":"finish","finishReason":"error"}\ndata: [DONE]\n',
+		'data: {"type":"tool-output-error"}\ndata: {"type":"finish"}\ndata: [DONE]\n',
+	]) {
+		assert(!mentorStreamCompleted(body), "Failed or incomplete mentor turn fails");
+	}
+	completed.add(1);
+}

--- a/load-tests/webhook-burst.js
+++ b/load-tests/webhook-burst.js
@@ -1,8 +1,11 @@
 import { check } from "k6";
-import crypto from "k6/crypto";
+// A default import of `k6/crypto` shadows the global WebCrypto that owns randomUUID.
+import { hmac } from "k6/crypto";
 import http from "k6/http";
 
-import { baseUrl, integer, required, sharedThresholds } from "./lib/config.js";
+import { baseUrl, integer, jsonField, required, sharedThresholds } from "./lib/config.js";
+
+export { handleSummary } from "./lib/summary.js";
 
 const rate = integer("WEBHOOK_RATE", 100);
 const duration = __ENV.DURATION ?? "2m";
@@ -13,6 +16,7 @@ const webhookSecret = required("WEBHOOK_SECRET");
 
 export const options = {
 	discardResponseBodies: true,
+	maxRedirects: 0,
 	scenarios: {
 		webhook_burst: {
 			executor: "constant-arrival-rate",
@@ -36,17 +40,28 @@ const payload = JSON.stringify({
 	padding: "x".repeat(integer("WEBHOOK_PADDING_BYTES", 4096)),
 });
 
+export function webhookAccepted(response) {
+	return response.status === 202 && jsonField(response, "status") === "ok";
+}
+
+export function signedDelivery() {
+	return {
+		id: crypto.randomUUID(),
+		signature: hmac("sha256", webhookSecret, payload, "hex"),
+	};
+}
+
 export default function webhookBurst() {
-	const delivery = crypto.randomUUID();
-	const signature = crypto.hmac("sha256", webhookSecret, payload, "hex");
+	const delivery = signedDelivery();
 	const response = http.post(target, payload, {
 		headers: {
 			"Content-Type": "application/json",
-			"X-GitHub-Delivery": delivery,
+			"X-GitHub-Delivery": delivery.id,
 			"X-GitHub-Event": event,
-			"X-Hub-Signature-256": `sha256=${signature}`,
+			"X-Hub-Signature-256": `sha256=${delivery.signature}`,
 		},
 		tags: { operation: "webhook_ingest" },
+		responseType: "text",
 	});
-	check(response, { "webhook accepted": (result) => result.status >= 200 && result.status < 300 });
+	check(response, { "webhook published": webhookAccepted });
 }

--- a/scripts/load-test.test.ts
+++ b/scripts/load-test.test.ts
@@ -1,0 +1,273 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { delimiter, resolve } from "node:path";
+import { test } from "node:test";
+
+import { asRecord, asStringArray } from "./lib/json.ts";
+import { loadTasks } from "./lib/task-graph.ts";
+
+import { configuration, k6Image, renderBaseline } from "./load-test.ts";
+
+const env = {
+	BASE_URL: "https://load.example.test",
+	WEBHOOK_SECRET: "do-not-record",
+	AUTH_TOKEN: "also-secret",
+	SANDBOX_API_MAX_REQUEST_BYTES: "1048576",
+	SANDBOX_API_REQUESTS_PER_MINUTE: "120",
+};
+const mentorEnv = { ...env, WORKSPACE_SLUG: "capacity-test", ARTIFACT_IDS: "1,2" };
+const template = await readFile(
+	new URL("../load-tests/baseline-template.md", import.meta.url),
+	"utf8",
+);
+const options = {
+	scenarios: { webhook_burst: { executor: "constant-arrival-rate", rate: 100, duration: "2m0s" } },
+	thresholds: { http_req_duration: ["p(95)<250"], http_req_failed: ["rate<0.01"] },
+};
+const metadata = {
+	...configuration("webhook-burst", env),
+	startedAt: "2026-09-05T00:00:00Z",
+	exitCode: 0,
+	options,
+};
+const mentorMetadata = { ...metadata, ...configuration("detection-mentor", mentorEnv) };
+const summary = {
+	metrics: {
+		http_req_duration: {
+			type: "trend",
+			contains: "time",
+			values: { med: 10, "p(95)": 20, "p(99)": 30 },
+			thresholds: { "p(95)<250": { ok: true } },
+		},
+		http_req_failed: {
+			type: "rate",
+			contains: "default",
+			values: { rate: 0, passes: 0, fails: 100 },
+			thresholds: { "rate<0.01": { ok: true } },
+		},
+	},
+};
+
+await test("runner records the inputs a scenario ran under and never records secrets", () => {
+	assert.ok(!JSON.stringify(mentorMetadata).includes("do-not-record"));
+	assert.ok(!JSON.stringify(mentorMetadata).includes("also-secret"));
+	assert.deepEqual(Object.keys(configuration("webhook-burst", env).inputs), ["BASE_URL"]);
+	assert.deepEqual(Object.keys(configuration("detection-mentor", mentorEnv).inputs).toSorted(), [
+		"ARTIFACT_IDS",
+		"BASE_URL",
+		"SANDBOX_API_MAX_REQUEST_BYTES",
+		"SANDBOX_API_REQUESTS_PER_MINUTE",
+		"WORKSPACE_SLUG",
+	]);
+	for (const key of ["BASE_URL", "WEBHOOK_SECRET"])
+		assert.throws(() => configuration("webhook-burst", { ...env, [key]: "" }), new RegExp(key));
+	for (const key of ["SANDBOX_API_MAX_REQUEST_BYTES", "SANDBOX_API_REQUESTS_PER_MINUTE"])
+		assert.throws(
+			() => configuration("detection-mentor", { ...mentorEnv, [key]: "" }),
+			new RegExp(key),
+		);
+	for (const BASE_URL of ["file:///tmp", "https://user:secret@host", "https://host?token=secret"])
+		assert.throws(() => configuration("webhook-burst", { ...env, BASE_URL }));
+	assert.throws(() => configuration("unknown", env));
+	assert.throws(() => configuration("detection-mentor", env), /WORKSPACE_SLUG/);
+	assert.throws(() =>
+		configuration("detection-mentor", { ...mentorEnv, SANDBOX_API_REQUESTS_PER_MINUTE: "0" }),
+	);
+});
+
+await test("renders k6 threshold verdicts without claiming host qualification", () => {
+	const report = renderBaseline(summary, metadata, template);
+	assert.match(report, /Automated result: PASS/);
+	assert.match(report, /qualification: PENDING/);
+	assert.match(report, /p\(99\) \| 30/);
+	assert.ok(!report.includes("{{"));
+	assert.ok(!report.includes("SANDBOX_API"));
+	assert.match(
+		renderBaseline(summary, mentorMetadata, template),
+		/SANDBOX_API_REQUESTS_PER_MINUTE \| 120/,
+	);
+	assert.match(
+		renderBaseline(summary, { ...metadata, exitCode: 99 }, template),
+		/Automated result: FAIL/,
+	);
+	assert.match(
+		renderBaseline(
+			{
+				metrics: {
+					...summary.metrics,
+					http_req_failed: {
+						...summary.metrics.http_req_failed,
+						thresholds: { "rate<0.01": { ok: false } },
+					},
+				},
+			},
+			metadata,
+			template,
+		),
+		/Automated result: FAIL/,
+	);
+});
+
+await test("renders a run recorded under another digest-pinned k6 image", () => {
+	const image = `grafana/k6:1.0.0@sha256:${"a".repeat(64)}`;
+	const report = renderBaseline(summary, { ...metadata, image }, template);
+	assert.match(report, new RegExp(`k6 image: ${image.replaceAll(".", "\\.")}`));
+	assert.match(report, /this checkout pins grafana\/k6:/);
+	assert.ok(!renderBaseline(summary, metadata, template).includes("this checkout pins"));
+	for (const unpinned of ["grafana/k6:1.2.3", `ghcr.io/grafana/k6:1.2.3@sha256:${"a".repeat(64)}`])
+		assert.throws(
+			() => renderBaseline(summary, { ...metadata, image: unpinned }, template),
+			/digest-pinned/,
+		);
+});
+
+await test("rejects incomplete threshold evidence, malformed values and invalid metadata", () => {
+	const failed = summary.metrics.http_req_failed;
+	assert.throws(
+		() =>
+			renderBaseline(
+				{ metrics: { http_req_failed: summary.metrics.http_req_failed } },
+				metadata,
+				template,
+			),
+		/http_req_duration/,
+	);
+	for (const [thresholds, message] of [
+		[{}, /threshold evidence/],
+		[{ "rate<0.01": { ok: "true" } }, /threshold verdict/],
+		[{ "rate<0.01": false }, /must be a JSON object/],
+	] as const)
+		assert.throws(
+			() =>
+				renderBaseline(
+					{ metrics: { ...summary.metrics, http_req_failed: { ...failed, thresholds } } },
+					metadata,
+					template,
+				),
+			message,
+		);
+	assert.throws(
+		() =>
+			renderBaseline(
+				{
+					metrics: { ...summary.metrics, http_req_failed: { ...failed, values: { rate: "bad" } } },
+				},
+				metadata,
+				template,
+			),
+		/Invalid metric/,
+	);
+	for (const change of [
+		{ scenario: "unknown" },
+		{ image: "unpinned" },
+		{ startedAt: "invalid" },
+		{ exitCode: "0" },
+		{ options: {} },
+		{ inputs: { ...metadata.inputs, AUTH_TOKEN: "must-not-render" } },
+		{ inputs: { ...metadata.inputs, SANDBOX_API_REQUESTS_PER_MINUTE: "120" } },
+	])
+		assert.throws(() => renderBaseline(summary, { ...metadata, ...change }, template));
+	for (const change of [
+		{ inputs: { ...mentorMetadata.inputs, SANDBOX_API_REQUESTS_PER_MINUTE: "9007199254740992" } },
+		{ inputs: { BASE_URL: env.BASE_URL } },
+	])
+		assert.throws(
+			() => renderBaseline(summary, { ...mentorMetadata, ...change }, template),
+			/gateway limit/,
+		);
+	assert.match(
+		renderBaseline(summary, { ...metadata, exitCode: null }, template),
+		/Automated result: FAIL/,
+	);
+});
+
+await test(
+	"CLI preserves failure evidence and refuses stale output",
+	{ skip: process.platform === "win32" },
+	async () => {
+		const root = await mkdtemp(resolve(tmpdir(), "load-test-"));
+		try {
+			const docker = resolve(root, "docker");
+			await writeFile(
+				docker,
+				`#!/usr/bin/env node
+import { writeFileSync } from 'node:fs';
+writeFileSync(process.env.ARGS_FILE, JSON.stringify(process.argv.slice(2)));
+if (process.argv.includes('inspect')) {
+ process.stdout.write(${JSON.stringify(JSON.stringify(options))});
+} else {
+ process.exit(99);
+}
+`,
+			);
+			await chmod(docker, 0o755);
+			const output = resolve(root, "results with spaces");
+			const argsFile = resolve(root, "args.json");
+			const invoke = (extra: NodeJS.ProcessEnv = {}) =>
+				spawnSync(process.execPath, ["scripts/load-test.ts", "webhook-burst"], {
+					encoding: "utf8",
+					maxBuffer: 2 * 1024 * 1024,
+					env: {
+						...process.env,
+						...env,
+						PATH: `${root}${delimiter}${process.env.PATH}`,
+						ARGS_FILE: argsFile,
+						LOAD_RESULTS_DIR: output,
+						LOAD_TEST_ACKNOWLEDGE: "isolated-host",
+						...extra,
+					},
+				});
+			assert.equal(invoke({ LOAD_TEST_ACKNOWLEDGE: "" }).status, 1);
+			assert.equal(invoke().status, 99);
+			const recorded = await readFile(resolve(output, "run.json"), "utf8");
+			assert.match(recorded, /"exitCode": 99/);
+			assert.ok(!recorded.includes(env.WEBHOOK_SECRET));
+			const args = await readFile(argsFile, "utf8");
+			assert.ok(args.includes(k6Image));
+			assert.ok(args.includes("--summary-trend-stats=avg,min,med,max,p(95),p(99)"));
+			assert.ok(args.includes("/tests/webhook-burst.js"));
+			assert.ok(!args.includes(env.WEBHOOK_SECRET));
+			assert.ok(args.includes(`${output}/scripts:/tests:ro`));
+			for (const file of ["webhook-burst.js", "lib/summary.js"])
+				assert.equal(
+					await readFile(resolve(output, "scripts", file), "utf8"),
+					await readFile(`load-tests/${file}`, "utf8"),
+				);
+			assert.equal(await readFile(resolve(output, "baseline-template.md"), "utf8"), template);
+			assert.equal(invoke().status, 1);
+			assert.equal(await readFile(resolve(output, "run.json"), "utf8"), recorded);
+			await writeFile(resolve(output, "summary.json"), JSON.stringify(summary));
+			const report = spawnSync(process.execPath, ["scripts/load-test.ts", "report", output], {
+				encoding: "utf8",
+				maxBuffer: 2 * 1024 * 1024,
+			});
+			assert.equal(report.status, 0, report.stderr);
+			assert.match(
+				await readFile(resolve(output, "baseline.md"), "utf8"),
+				/Automated result: FAIL/,
+			);
+		} finally {
+			await rm(root, { recursive: true, force: true });
+		}
+	},
+);
+
+await test("load tasks stay uncached and outside automatic quality and verification graphs", async () => {
+	const tasks = await loadTasks();
+	for (const name of [
+		"test:load:webhook-burst",
+		"test:load:detection-mentor",
+		"report:load:baseline",
+	]) {
+		assert.equal(asRecord(tasks[name], name).cache, false);
+		for (const task of Object.values(tasks)) {
+			const dependencies = asRecord(task, "task").dependsOn;
+			if (dependencies !== undefined)
+				assert.ok(!asStringArray(dependencies, "dependsOn").includes(name));
+		}
+	}
+	const gate = asRecord(tasks["gate:load-syntax"], "gate:load-syntax");
+	assert.deepEqual(asStringArray(gate.dependsOn, "dependsOn"), ["test:load:syntax"]);
+});

--- a/scripts/load-test.ts
+++ b/scripts/load-test.ts
@@ -1,0 +1,323 @@
+import { spawnSync } from "node:child_process";
+import { copyFile, glob, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { asRecord, asString, asStringArray, parseJson } from "./lib/json.ts";
+import { CAPTURE_LIMIT_BYTES } from "./lib/process.ts";
+
+export const k6Image =
+	"grafana/k6:1.2.3@sha256:4f82892217f3110cb233e2b2622bcc97fabc70f14bd241fbfbfe7305105c68aa";
+const dockerUser =
+	process.getuid && process.getgid ? ["--user", `${process.getuid()}:${process.getgid()}`] : [];
+const inputs = [
+	"BASE_URL",
+	"WEBHOOK_SECRET",
+	"AUTH_TOKEN",
+	"WORKSPACE_SLUG",
+	"ARTIFACT_IDS",
+	"WEBHOOK_RATE",
+	"DURATION",
+	"PRE_ALLOCATED_VUS",
+	"MAX_VUS",
+	"WEBHOOK_PADDING_BYTES",
+	"MENTOR_VUS",
+	"REVIEW_VUS",
+	"REVIEW_REQUESTS",
+	"REVIEW_MAX_DURATION",
+	"REVIEW_START_TIME",
+	"REVIEW_TIMEOUT_SECONDS",
+];
+const secrets = new Set(["WEBHOOK_SECRET", "AUTH_TOKEN"]);
+const limits = ["SANDBOX_API_MAX_REQUEST_BYTES", "SANDBOX_API_REQUESTS_PER_MINUTE"];
+
+// Only the detection+mentor workload reaches the sandbox gateway, so only its result depends on the
+// gateway's deployed limits.
+const gatewayLimits = (scenario: string) => (scenario === "detection-mentor" ? limits : []);
+
+export function configuration(scenario: string, env: NodeJS.ProcessEnv) {
+	if (scenario !== "webhook-burst" && scenario !== "detection-mentor")
+		throw new Error("Unknown load scenario");
+	const recorded = gatewayLimits(scenario);
+	const required = [
+		"BASE_URL",
+		...recorded,
+		...(scenario === "webhook-burst"
+			? ["WEBHOOK_SECRET"]
+			: ["AUTH_TOKEN", "WORKSPACE_SLUG", "ARTIFACT_IDS"]),
+	];
+	for (const name of required) if (!env[name]?.trim()) throw new Error(`${name} is required`);
+	const url = new URL(env.BASE_URL ?? "");
+	if (
+		!["http:", "https:"].includes(url.protocol) ||
+		url.username ||
+		url.password ||
+		url.search ||
+		url.hash
+	)
+		throw new Error("BASE_URL must be an HTTP(S) URL without credentials, query or fragment");
+	for (const name of recorded)
+		if (!/^[1-9]\d*$/.test(env[name] ?? "") || !Number.isSafeInteger(Number(env[name])))
+			throw new Error(`${name} must be a positive safe integer`);
+	return {
+		scenario,
+		image: k6Image,
+		inputs: Object.fromEntries(
+			[...inputs, ...recorded]
+				.filter((key) => !secrets.has(key) && env[key] !== undefined)
+				.map((key) => [key, env[key]]),
+		),
+	};
+}
+
+function docker(args: string[], capture = false) {
+	const result = spawnSync("docker", args, {
+		encoding: "utf8",
+		maxBuffer: CAPTURE_LIMIT_BYTES,
+		stdio: capture ? ["ignore", "pipe", "inherit"] : "inherit",
+	});
+	if (result.error) throw result.error;
+	return result;
+}
+
+async function checkScenarios(root: string) {
+	const directory = await mkdtemp(resolve(tmpdir(), "k6-contracts-"));
+	const container = [
+		"run",
+		"--rm",
+		"--network=none",
+		...dockerUser,
+		"-v",
+		`${root}/load-tests:/tests:ro`,
+		"-v",
+		`${directory}:/results`,
+		k6Image,
+	];
+	const env = [
+		"-e",
+		"BASE_URL=http://example.test",
+		"-e",
+		"WEBHOOK_SECRET=test",
+		"-e",
+		"AUTH_TOKEN=test",
+		"-e",
+		"WORKSPACE_SLUG=test",
+		"-e",
+		"ARTIFACT_IDS=1,2",
+	];
+	try {
+		for (const scenario of ["webhook-burst", "detection-mentor"]) {
+			if (docker([...container, "inspect", ...env, `/tests/${scenario}.js`], true).status !== 0)
+				throw new Error(`Cannot inspect ${scenario}`);
+		}
+		for (const [name, expected] of [
+			["contracts", 0],
+			["unfinished", 99],
+		] as const) {
+			const result = docker([
+				...container,
+				"run",
+				...env,
+				"-e",
+				`TEST_CASE=${name}`,
+				"/tests/scenarios.test.js",
+			]);
+			if (result.status !== expected)
+				throw new Error(`${name}: expected exit ${expected}, got ${result.status}`);
+			if (name !== "unfinished") continue;
+			const summary = asRecord(
+				parseJson(await readFile(resolve(directory, "summary.json"), "utf8")),
+				"summary",
+			);
+			const metrics = asRecord(summary.metrics, "metrics");
+			const metric = asRecord(metrics.review_jobs_finished, "review_jobs_finished");
+			const verdicts = Object.values(asRecord(metric.thresholds, "thresholds"));
+			if (
+				verdicts.length === 0 ||
+				verdicts.some((verdict) => asRecord(verdict, "threshold").ok !== false)
+			)
+				throw new Error("Unfinished review threshold did not fail in the k6 summary");
+		}
+	} finally {
+		await rm(directory, { recursive: true, force: true });
+	}
+}
+
+const cell = (value: string) => value.replaceAll("|", "\\|").replaceAll(/\r?\n/g, " ");
+
+export function renderBaseline(summary: unknown, metadata: unknown, template: string) {
+	const metrics = asRecord(asRecord(summary, "summary").metrics, "metrics");
+	const run = asRecord(metadata, "run");
+	const config = asRecord(run.inputs, "inputs");
+	if (run.scenario !== "webhook-burst" && run.scenario !== "detection-mentor")
+		throw new Error("Invalid run scenario");
+	// A recorded run stays renderable after the checkout moves its pin, so the image only has to prove
+	// it was digest-pinned; the document names the image the run actually used.
+	const image = asString(run.image, "image");
+	if (!/^grafana\/k6:[\w.-]+@sha256:[0-9a-f]{64}$/.test(image))
+		throw new Error("Run must record a digest-pinned k6 image");
+	const pinned = image === k6Image ? "" : ` (this checkout pins ${k6Image})`;
+	if (!Number.isFinite(Date.parse(asString(run.startedAt, "startedAt"))))
+		throw new Error("Invalid run timestamp");
+	if (
+		run.exitCode !== null &&
+		(!Number.isInteger(run.exitCode) || Number(run.exitCode) < 0 || Number(run.exitCode) > 255)
+	)
+		throw new Error("Invalid run exit code");
+	const options = asRecord(run.options, "options");
+	const expected = asRecord(options.thresholds, "options.thresholds");
+	const scenarios = asRecord(options.scenarios, "options.scenarios");
+	if (Object.keys(expected).length === 0 || Object.keys(scenarios).length === 0)
+		throw new Error("Missing effective k6 options");
+	for (const [name, expressions] of Object.entries(expected)) {
+		const metric = asRecord(metrics[name], `metrics.${name}`);
+		const actual = asRecord(metric.thresholds, `metrics.${name}.thresholds`);
+		const thresholds = asStringArray(expressions, `options.thresholds.${name}`);
+		if (
+			thresholds.length === 0 ||
+			thresholds.some((expression) => !(expression in actual)) ||
+			Object.keys(actual).length !== thresholds.length
+		)
+			throw new Error(`Missing or mismatched threshold evidence for ${name}`);
+	}
+	const recorded = gatewayLimits(run.scenario);
+	for (const [key, value] of Object.entries(config)) {
+		if (![...inputs, ...recorded].includes(key) || secrets.has(key) || typeof value !== "string")
+			throw new Error(`Invalid recorded input ${key}`);
+	}
+	for (const key of recorded)
+		if (
+			typeof config[key] !== "string" ||
+			!/^[1-9]\d*$/.test(config[key]) ||
+			!Number.isSafeInteger(Number(config[key]))
+		)
+			throw new Error(`Missing gateway limit ${key}`);
+	const rows: string[] = [];
+	let failed = run.exitCode !== 0;
+	for (const [name, value] of Object.entries(metrics).toSorted(([a], [b]) => a.localeCompare(b))) {
+		const metric = asRecord(value, name);
+		if (metric.thresholds === undefined) continue;
+		if (!(name in expected)) throw new Error(`Unexpected threshold metric ${name}`);
+		for (const [expression, verdict] of Object.entries(asRecord(metric.thresholds, "thresholds"))) {
+			const passed = asRecord(verdict, `metrics.${name}.thresholds.${expression}`).ok;
+			if (typeof passed !== "boolean") throw new Error("Expected a k6 threshold verdict");
+			failed ||= !passed;
+			rows.push(`| ${cell(name)} | ${cell(expression)} | ${passed ? "PASS" : "FAIL"} |`);
+		}
+	}
+	if (rows.length === 0) throw new Error("Summary has no threshold evidence");
+	const values = Object.entries(metrics)
+		.toSorted(([a], [b]) => a.localeCompare(b))
+		.flatMap(([name, value]) =>
+			Object.entries(asRecord(asRecord(value, name).values, `metrics.${name}.values`)).map(
+				([key, number]) => {
+					if (typeof number !== "number" || !Number.isFinite(number))
+						throw new Error(`Invalid metric ${name}.${key}`);
+					return `| ${cell(name)} | ${cell(key)} | ${number} |`;
+				},
+			),
+		);
+	const identity = Object.entries(config)
+		.map(([key, value]) => `| ${cell(key)} | ${cell(String(value))} |`)
+		.join("\n");
+	// A function replacement is the only form that does not read `$&` and friends in a metric value
+	// or a recorded input as a replacement pattern.
+	return template
+		.replace(
+			"{{RUN}}",
+			() =>
+				`Scenario: ${cell(String(run.scenario))}\n\nStarted: ${cell(String(run.startedAt))}\n\nk6 image: ${cell(image)}${cell(pinned)}\n\nProcess exit: ${cell(String(run.exitCode))}\n\n**Automated result: ${failed ? "FAIL" : "PASS"}. Host qualification: PENDING operator evidence.**\n\n| Input (omitted values use scenario defaults) | Value |\n| --- | --- |\n${identity}`,
+		)
+		.replace("{{SCENARIOS}}", () => `\`\`\`json\n${JSON.stringify(scenarios, null, 2)}\n\`\`\``)
+		.replace("| {{THRESHOLDS}} | | |", () => rows.join("\n"))
+		.replace("| {{METRICS}} | | |", () => values.join("\n"));
+}
+
+async function main() {
+	const [command, argument, ...extra] = process.argv.slice(2);
+	if (extra.length > 0 || (command !== "report" && argument !== undefined))
+		throw new Error("Unexpected load-test arguments");
+	const root = resolve(import.meta.dirname, "..");
+	if (command === "syntax") {
+		await checkScenarios(root);
+		return;
+	}
+	if (command === "report") {
+		if (!argument) throw new Error("Usage: report:load:baseline <run-directory>");
+		const directory = resolve(argument);
+		const document = renderBaseline(
+			parseJson(await readFile(resolve(directory, "summary.json"), "utf8")),
+			parseJson(await readFile(resolve(directory, "run.json"), "utf8")),
+			await readFile(resolve(directory, "baseline-template.md"), "utf8"),
+		);
+		await writeFile(resolve(directory, "baseline.md"), document);
+		return;
+	}
+	const config = configuration(command ?? "", process.env);
+	if (process.env.LOAD_TEST_ACKNOWLEDGE !== "isolated-host")
+		throw new Error("Set LOAD_TEST_ACKNOWLEDGE=isolated-host after reading load-tests/README.md");
+	const startedAt = new Date().toISOString();
+	const directory = resolve(
+		process.env.LOAD_RESULTS_DIR ??
+			`load-results/${config.scenario}-${startedAt.replaceAll(":", "-")}`,
+	);
+	await mkdir(resolve(directory, ".."), { recursive: true });
+	await mkdir(directory, { mode: 0o700 });
+	for (const file of await Array.fromAsync(glob("**/*.js", { cwd: resolve(root, "load-tests") }))) {
+		const target = resolve(directory, "scripts", file);
+		await mkdir(dirname(target), { recursive: true });
+		await copyFile(resolve(root, "load-tests", file), target);
+	}
+	await copyFile(
+		resolve(root, "load-tests/baseline-template.md"),
+		resolve(directory, "baseline-template.md"),
+	);
+	const metadata = { ...config, startedAt, exitCode: null };
+	await writeFile(resolve(directory, "run.json"), JSON.stringify(metadata, null, 2), {
+		flag: "wx",
+	});
+	const args = [
+		"run",
+		"--rm",
+		...dockerUser,
+		...inputs.filter((key) => process.env[key] !== undefined).flatMap((key) => ["-e", key]),
+		"-v",
+		`${directory}/scripts:/tests:ro`,
+		"-v",
+		`${directory}:/results`,
+		k6Image,
+	];
+	// `k6 inspect` defaults --include-system-env-vars to false where `k6 run` defaults it to true, so
+	// the container environment carrying the workload — and the secrets kept out of argv — needs it.
+	const inspected = docker(
+		[...args, "inspect", "--include-system-env-vars", `/tests/${config.scenario}.js`],
+		true,
+	);
+	if (inspected.status !== 0) throw new Error("k6 inspection failed before load started");
+	const inspectedOptions = asRecord(parseJson(inspected.stdout), "k6 options");
+	const options = {
+		scenarios: asRecord(inspectedOptions.scenarios, "scenarios"),
+		thresholds: asRecord(inspectedOptions.thresholds, "thresholds"),
+	};
+	await writeFile(
+		resolve(directory, "run.json"),
+		JSON.stringify({ ...metadata, options }, null, 2),
+	);
+	const result = docker([
+		...args,
+		"run",
+		// The scenarios' handleSummary writes /results/summary.json; these are the statistics it carries.
+		"--summary-trend-stats=avg,min,med,max,p(95),p(99)",
+		`/tests/${config.scenario}.js`,
+	]);
+	const exitCode = result.status ?? 1;
+	await writeFile(
+		resolve(directory, "run.json"),
+		JSON.stringify({ ...metadata, options, exitCode }, null, 2),
+	);
+	process.stdout.write(`Load evidence: ${directory}\n`);
+	process.exitCode = exitCode;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) await main();

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -102,8 +102,6 @@ const docsLintInputs = [
 ];
 
 const mvnw = "node scripts/run-mvnw.ts";
-const k6 =
-	"grafana/k6:1.2.3@sha256:4f82892217f3110cb233e2b2622bcc97fabc70f14bd241fbfbfe7305105c68aa";
 
 // The gates, by the tree they judge. `quality` runs all of them; each CI job runs one tree's set.
 const policyGates = [
@@ -313,9 +311,10 @@ export default defineConfig({
 			// Load tests
 			"gate:load-format": cached(`vp fmt --check ${loadSources}`),
 			"gate:load-syntax": group(["test:load:syntax"]),
-			"test:load:syntax": run(
-				`docker run --rm -v "${repoRoot}/load-tests:/tests:ro" ${k6} inspect -e BASE_URL=http://example.test -e WEBHOOK_SECRET=abcdefghijklmnopqrstuvwxyz123456 /tests/webhook-burst.js >/dev/null && docker run --rm -v "${repoRoot}/load-tests:/tests:ro" ${k6} inspect -e API_BASE_URL=http://example.test/api -e AUTH_TOKEN=test -e WORKSPACE_SLUG=test -e ARTIFACT_IDS=1,2 /tests/detection-mentor.js >/dev/null`,
-			),
+			"test:load:webhook-burst": run("node scripts/load-test.ts webhook-burst"),
+			"test:load:detection-mentor": run("node scripts/load-test.ts detection-mentor"),
+			"report:load:baseline": run("node scripts/load-test.ts report"),
+			"test:load:syntax": run("node scripts/load-test.ts syntax"),
 
 			// Docs
 			"gate:docs-format": cached(`vp fmt --check ${docsSources}`),


### PR DESCRIPTION
## What changed and why

Compose load qualification required hand-written Docker commands and a hand-filled baseline
document, and some of the scenarios' success checks passed on work that had failed.

- Add `vp run test:load:webhook-burst` and `vp run test:load:detection-mentor`, both targeting
  `BASE_URL` and requiring explicit acknowledgment of an isolated test host. Each run snapshots the
  scenario sources and the template, records the effective k6 workload and thresholds, and keeps its
  evidence in its own directory.
- Generate the baseline with `vp run report:load:baseline <run-directory>`. The scenarios write
  their summary through k6's documented `handleSummary`, so the report reads an explicit per
  threshold pass/fail rather than reverse-engineering the legacy `--summary-export` schema Grafana
  asks people not to build on. Any digest-pinned run stays renderable, and the document names the
  image the run used.
- Require successful webhook publication and completed reviews, and distinguish a successful mentor
  stream from an error response that also ends with `[DONE]`.
- Fix two defects that stopped a real run from meaning anything: `k6 inspect` does not inherit the
  system environment the way `k6 run` does, so a run aborted before it started; and a default import
  of `k6/crypto` shadowed the global WebCrypto that owns `randomUUID`, so every iteration threw
  before its check and the run still reported a pass. Both are now covered by the contract scenario
  CI already runs.

Part of #1602. Its first three open bullets are met — thresholds verified and completed on both
scenarios, one task per scenario driven by `BASE_URL`, and a generated baseline document that
carries the gateway limits the scenario ran against. The remaining bullet, minimum and recommended
host sizing in `docs/admin/`, belongs to the pull request that records the first run, so this PR
leaves `docs/admin/install.mdx` alone; the recorded baseline itself stays a gate on #1377. No live
load qualification was performed here and no measured capacity is claimed.

## How to test

```bash
vp run format
vp run check
vp run docs:lint
vp run test:load:syntax
```

`test:load:syntax` runs the k6 contract scenario with networking disabled. Its "unfinished" case
deliberately exits 99; the task succeeds only when it observes that exit status and the matching
failed threshold in the exported summary. The contract case asserts the webhook delivery id and HMAC
and the mentor message id, which is what catches the `randomUUID` class of defect.

Verified end to end against a throwaway target: the runner produced a real k6 summary and
`report:load:baseline` rendered a document reporting `FAIL` with the two crossed thresholds. For a
real run, follow the safety prerequisites in `load-tests/README.md`, use an isolated Compose host
and a deterministic test provider, then generate the baseline.

## Release impact

No application runtime, public API, database schema or deployment configuration changes, so no
changeset and no operator action. The mixed scenario now derives its API root from `BASE_URL`
instead of a separate `API_BASE_URL`.

## Notes for reviewers

- Start with the scenario success conditions, then the runner's snapshot and report-validation paths
  in `scripts/load-test.ts`.
- `vite.config.ts` is the hot lane shared with #1867. There is no textual conflict — the regions are
  disjoint — and the hunk here is deliberately minimal: move the k6 digest to the runner and replace
  one command with the four task entries. `scripts/ci-contract.test.ts` is not touched, so #1847 and
  #1846 are unaffected.
- `docs/admin/install.mdx` is intentionally not in this diff, which also removes the conflicts with
  #1851 and #1868. The honest "provisional starting point, not measured capacity" wording for the
  existing host sizes is worth keeping, but it is one sentence and belongs in the sizing pull
  request on top of #1851's organization sweep.
- The k6 digest pin is still unmanaged by Renovate, as it was before this change. A custom manager
  for it should follow #1846, which is rewriting `renovate.json` and its test right now.
- A passing k6 report is not host qualification. Resource headroom, gateway and provider throttling,
  webhook reconciliation and queue drain still need the operator evidence the generated document
  lists.
