### PR TITLE
fix(scm): hide GitHub App setup when the installation URL is blank

### DIFF
--- a/.changeset/blank-github-installation-url.md
+++ b/.changeset/blank-github-installation-url.md
@@ -1,0 +1,5 @@
+---
+"hephaestus": patch
+---
+
+The workspace wizard no longer offers GitHub App setup when its installation URL is blank.

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/github/GitHubProperties.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/github/GitHubProperties.java
@@ -76,7 +76,14 @@ public record GitHubProperties(@Valid App app, @Valid Meta meta) {
 
             @Nullable Resource privateKeyLocation,
             @Nullable String privateKey,
-            @Nullable String installationUrl) {}
+            @Nullable String installationUrl) {
+        // application.yml binds `${GH_APP_INSTALLATION_URL:}`, so an install that configured no URL
+        // arrives as "" rather than null — treat blank as absent, or GitHubWorkspaceProviderAvailability
+        // offers a wizard option whose link is the empty string.
+        public App {
+            installationUrl = installationUrl == null || installationUrl.isBlank() ? null : installationUrl;
+        }
+    }
 
     /**
      * GitHub metadata API configuration.

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/scm/github/GitHubPropertiesEnvBindingTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/scm/github/GitHubPropertiesEnvBindingTest.java
@@ -1,0 +1,108 @@
+package de.tum.cit.aet.hephaestus.integration.scm.github;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import de.tum.cit.aet.hephaestus.integration.scm.github.workspace.GitHubWorkspaceProviderAvailability;
+import java.io.IOException;
+import java.util.Map;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.boot.env.YamlPropertySourceLoader;
+import org.springframework.core.env.StandardEnvironment;
+import org.springframework.core.env.SystemEnvironmentPropertySource;
+import org.springframework.core.io.ClassPathResource;
+
+/**
+ * Compose forwards {@code GH_APP_INSTALLATION_URL} unconditionally, so an install that configured
+ * no URL still reaches the container with the variable set to the empty string. Availability has to
+ * agree with the operator that they configured nothing, or the workspace wizard offers a GitHub
+ * option whose link goes nowhere.
+ *
+ * <p>These bind through a real {@link SystemEnvironmentPropertySource} and the shipped
+ * {@code application.yml}, because the defect only exists on that path: the variable reaches the
+ * {@code hephaestus.integration.github} prefix through a placeholder with an empty default, which a
+ * direct constructor call would never exercise.
+ */
+@Tag("unit")
+class GitHubPropertiesEnvBindingTest {
+
+    private static final String INSTALLATION_URL = "https://github.com/apps/hephaestus/installations/new";
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", " "})
+    void shouldHideGitHubAppWhenInstallationUrlIsBlank(String url) throws IOException {
+        var properties = bindWith(Map.of("GH_APP_ID", "123456", "GH_APP_INSTALLATION_URL", url));
+
+        assertThat(properties.app().id()).isEqualTo(123456);
+        assertThat(properties.app().installationUrl()).isNull();
+        assertThat(new GitHubWorkspaceProviderAvailability(properties).hintUrl())
+                .isEmpty();
+    }
+
+    @Test
+    void shouldHideGitHubAppWhenInstallationUrlIsMissing() throws IOException {
+        var properties = bindWith(Map.of("GH_APP_ID", "123456"));
+
+        assertThat(properties.app().installationUrl()).isNull();
+        assertThat(new GitHubWorkspaceProviderAvailability(properties).hintUrl())
+                .isEmpty();
+    }
+
+    @Test
+    void shouldHideGitHubAppWhenNothingIsConfigured() throws IOException {
+        var properties = bindWith(Map.of());
+
+        assertThat(properties.app().id()).isZero();
+        assertThat(properties.app().installationUrl()).isNull();
+        assertThat(new GitHubWorkspaceProviderAvailability(properties).hintUrl())
+                .isEmpty();
+    }
+
+    @Test
+    void shouldHideGitHubAppWhenAppIdIsMissing() throws IOException {
+        var properties = bindWith(Map.of("GH_APP_INSTALLATION_URL", INSTALLATION_URL));
+
+        assertThat(properties.app().id()).isZero();
+        assertThat(properties.app().installationUrl()).isEqualTo(INSTALLATION_URL);
+        assertThat(new GitHubWorkspaceProviderAvailability(properties).hintUrl())
+                .isEmpty();
+    }
+
+    @Test
+    void shouldHideGitHubAppWhenAppIdIsDisabled() throws IOException {
+        var properties = bindWith(Map.of("GH_APP_ID", "0", "GH_APP_INSTALLATION_URL", INSTALLATION_URL));
+
+        assertThat(new GitHubWorkspaceProviderAvailability(properties).hintUrl())
+                .isEmpty();
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {INSTALLATION_URL, "https://github.example.com/apps/hephaestus/installations/new?target_id=42"})
+    void shouldExposeUnchangedInstallationUrlWhenGitHubAppIsConfigured(String url) throws IOException {
+        var properties = bindWith(Map.of("GH_APP_ID", "123456", "GH_APP_INSTALLATION_URL", url));
+        var availability = new GitHubWorkspaceProviderAvailability(properties);
+
+        assertThat(properties.app().installationUrl()).isEqualTo(url);
+        assertThat(availability.hintUrl()).contains(url);
+    }
+
+    private static GitHubProperties bindWith(Map<String, Object> environmentVariables) throws IOException {
+        var environment = new StandardEnvironment();
+        environment
+                .getPropertySources()
+                .replace(
+                        StandardEnvironment.SYSTEM_ENVIRONMENT_PROPERTY_SOURCE_NAME,
+                        new SystemEnvironmentPropertySource(
+                                StandardEnvironment.SYSTEM_ENVIRONMENT_PROPERTY_SOURCE_NAME, environmentVariables));
+        // GH_APP_* reach the configuration prefix through application.yml placeholders. Only the
+        // first document is profile-independent; the rest activate on a profile no test selects.
+        var yaml = new YamlPropertySourceLoader().load("application.yml", new ClassPathResource("application.yml"));
+        environment.getPropertySources().addLast(yaml.getFirst());
+
+        return Binder.get(environment).bindOrCreate("hephaestus.integration.github", GitHubProperties.class);
+    }
+}

--- a/webapp/src/routes/_authenticated/workspaces/new/-provider-availability-route.test.tsx
+++ b/webapp/src/routes/_authenticated/workspaces/new/-provider-availability-route.test.tsx
@@ -1,0 +1,84 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { describe, expect, it, vi } from "vitest";
+
+import type { WorkspaceProviders } from "@/api/types.gen";
+import { server } from "@/mocks/server";
+import { renderRouteAt, ROUTE_RENDER_WAIT } from "@/test/router-harness";
+
+// Mounting the real route pulls in the whole authenticated tree, and the last case mounts two
+// routes; the timeout is a deadlock backstop, not a budget these renders were meant to fit inside.
+vi.setConfig({ testTimeout: 20_000 });
+
+function serveProviders(providers: WorkspaceProviders) {
+	server.use(http.get("*/workspaces/providers", () => HttpResponse.json(providers)));
+}
+
+describe("workspace provider availability", () => {
+	it("shows the empty state without a GitHub setup link when no provider is configured", async () => {
+		serveProviders({ creationPolicy: "SELF_SERVICE" });
+		renderRouteAt("/workspaces/new");
+
+		await screen.findByText(
+			"No providers are currently available. Contact your administrator.",
+			{},
+			ROUTE_RENDER_WAIT,
+		);
+		expect(screen.queryByRole("link", { name: "Set up workspace with GitHub" })).toBeNull();
+	});
+
+	it("hides GitHub setup when the installation URL arrives blank", async () => {
+		serveProviders({ creationPolicy: "SELF_SERVICE", github: { appInstallationUrl: "" } });
+		renderRouteAt("/workspaces/new");
+
+		await screen.findByText(
+			"No providers are currently available. Contact your administrator.",
+			{},
+			ROUTE_RENDER_WAIT,
+		);
+		expect(screen.queryByRole("link", { name: "Set up workspace with GitHub" })).toBeNull();
+	});
+
+	it("keeps GitLab available when GitHub is not configured", async () => {
+		serveProviders({
+			creationPolicy: "SELF_SERVICE",
+			gitlab: { defaultServerUrl: "https://gitlab.com" },
+		});
+		renderRouteAt("/workspaces/new");
+
+		expect(
+			(
+				await screen.findByRole("link", { name: "Set up workspace with GitLab" }, ROUTE_RENDER_WAIT)
+			).getAttribute("href"),
+		).toBe("/workspaces/new/gitlab");
+		expect(screen.queryByRole("link", { name: "Set up workspace with GitHub" })).toBeNull();
+	});
+
+	it("explains unavailable GitHub setup when visiting its route directly", async () => {
+		serveProviders({ creationPolicy: "SELF_SERVICE" });
+		renderRouteAt("/workspaces/new/github");
+
+		await screen.findByText("GitHub App not configured", {}, ROUTE_RENDER_WAIT);
+		expect(screen.queryByRole("link", { name: /Install GitHub App/ })).toBeNull();
+	});
+
+	it("opens setup with the configured GitHub App installation link", async () => {
+		const user = userEvent.setup();
+		const installationUrl = "https://github.com/apps/hephaestus/installations/new";
+		serveProviders({
+			creationPolicy: "SELF_SERVICE",
+			github: { appInstallationUrl: installationUrl },
+		});
+		renderRouteAt("/workspaces/new");
+
+		await user.click(
+			await screen.findByRole("link", { name: "Set up workspace with GitHub" }, ROUTE_RENDER_WAIT),
+		);
+		expect(
+			(
+				await screen.findByRole("link", { name: /Install GitHub App/ }, ROUTE_RENDER_WAIT)
+			).getAttribute("href"),
+		).toBe(installationUrl);
+	});
+});

--- a/webapp/src/routes/_authenticated/workspaces/new/index.tsx
+++ b/webapp/src/routes/_authenticated/workspaces/new/index.tsx
@@ -42,7 +42,9 @@ function ProviderSelectionPage() {
 	const blockedForNonAdmin = adminOnly && !isAppAdmin;
 
 	const providers: Provider[] = [];
-	if (workspaceProviders?.github) {
+	// The GitHub card leads to a page whose only action is the installation link, so a provider
+	// without a usable URL is a dead end rather than a choice.
+	if (workspaceProviders?.github?.appInstallationUrl) {
 		providers.push({
 			id: "github",
 			name: "GitHub",


### PR DESCRIPTION
## What changed and why

A deployment that sets a GitHub App ID but leaves the installation URL blank still saw the workspace
wizard offer GitHub setup, and the setup page it led to dead-ended on "GitHub App not configured".
Compose forwards `GH_APP_INSTALLATION_URL` whether or not the operator set it, and `application.yml`
binds it through a placeholder with an empty default, so an unconfigured install arrives as `""` —
which the availability check read as a configured URL.

`GitHubProperties.App` now normalizes a blank installation URL to `null` in its compact constructor,
the same treatment NATS and security credentials already get at their binding boundary, so every
caller of the property agrees with the operator that nothing is configured. The wizard's provider
list now requires an installation URL before it offers the GitHub card, so a blank value reaching the
SPA from any source stops producing an option whose link is empty.

Fixes #1759.

## How to test

- Configuration binding, from `server/`:
  ```sh
  MANAGEMENT_PORT=0 SERVER_PORT=0 ./mvnw -f application/pom.xml \
    -Dtest=GitHubPropertiesEnvBindingTest,GitHubPropertiesTest test --batch-mode
  ```
  Binds the documented environment variables through the shipped `application.yml` and asserts
  `GitHubWorkspaceProviderAvailability` alongside them. Reverting the compact constructor turns the
  blank-URL case red.
- Wizard routes: `pnpm exec vp run test:webapp`. The blank-URL case asserts the wizard shows its
  empty state and no GitHub link; it fails against `main`'s provider list, which offers the card.
- Repository quality gate: `pnpm exec vp run check:affected`.

## Release impact

[Patch changeset](https://github.com/hephaestus-build/Hephaestus/blob/fix/scm-blank-github-installation-url/.changeset/blank-github-installation-url.md):
the workspace wizard no longer offers GitHub App setup when its installation URL is blank. No
operator action is required and no new variable ships.

## Notes for reviewers

- **Integrations.** GitLab is unaffected: Compose forwards `GITLAB_DEFAULT_SERVER_URL` with a
  non-empty default, so `GitLabProperties.defaultServerUrl` never binds `""` the way the GitHub
  variable does. Slack and Outline expose no workspace-creation provider.
- **UI states.** The unavailable state is covered by a route test rather than a story: both branches
  live inline in the wizard routes, and a wire contract is owned by the route test that drives the
  query, not by a story mock (`webapp/AGENTS.md`).
- **Wire contract.** Unchanged — `WorkspaceProviders.github` and `GitHubProvider.appInstallationUrl`
  are already optional, so this changes which value the existing contract carries, not its shape. No
  schema, channel or admin-console surface is touched.
- `GitHubProperties.java` is also rewritten by #1851; the two changes are independent and taking both
  sides is a one-hunk rebase for whichever lands second.

## Visual evidence

No new visual state ships: with a blank URL the wizard renders its existing "No providers are
currently available" message instead of a card whose link was empty. The route test pins both that
state and the configured one.
