### PR TITLE
fix(server): hold live reviews while work is marked deleted

### DIFF
--- a/.changeset/hold-live-reviews-of-swept-work.md
+++ b/.changeset/hold-live-reviews-of-swept-work.md
@@ -1,0 +1,5 @@
+---
+"hephaestus": patch
+---
+
+Live GitHub and GitLab events no longer start practice reviews while the work is marked as deleted upstream. The occasion stays visible as pending and can be retried if an ordinary sync restores the work, within the existing retry deadline.

--- a/docs/contributor/practice-review-glossary.mdx
+++ b/docs/contributor/practice-review-glossary.mdx
@@ -126,12 +126,11 @@ it resolves to, so the enum itself is the list. What the enum cannot say is whic
 reason is retryable exactly when the condition it names can clear on its own — an operator action, a budget
 refill, or an ordinary sync — without the work occurring again.
 
-Two values are easy to confuse. `ARTIFACT_GONE` is for work that is not there or cannot be reviewed at all,
-and it is terminal. `ARTIFACT_NOT_VISIBLE` is for work the mirror has tombstoned, which the next ordinary
-sync can clear
-([ADR 0024](https://github.com/ls1intum/Hephaestus/blob/main/docs/decisions/0024-integration-sync-lifecycle-and-two-deletion-semantics.md)),
-so it is retryable: the occasion is held and re-offered rather than retired, and a reconciliation sweep
-that guessed wrong costs a delay instead of a review.
+`ARTIFACT_GONE` is terminal: the work is missing or unreviewable, or a person requested a review while
+it was tombstoned. `ARTIFACT_NOT_VISIBLE` holds automatic occasions for a reversible mirror tombstone,
+including live events and pending retries. Ordinary sync can restore the row
+([ADR 0024](https://github.com/ls1intum/Hephaestus/blob/main/docs/decisions/0024-integration-sync-lifecycle-and-two-deletion-semantics.md)).
+A manual request is not retried after restoration; the person can request another review.
 
 ## Practice autonomy
 

--- a/docs/contributor/practice-review-pipeline.mdx
+++ b/docs/contributor/practice-review-pipeline.mdx
@@ -79,6 +79,12 @@ reason to reach for, and the two that are easy to confuse, are in
 labels are in [How a review was occasioned](./practice-review-glossary.mdx#how-a-review-was-occasioned).
 Operator remediation is in [When a workspace goes quiet](/admin/practice-review#when-a-workspace-goes-quiet).
 
+A live GitHub or GitLab event whose work is tombstoned holds its occasion with
+`ARTIFACT_NOT_VISIBLE` (`PENDING`) instead of starting a review, so the pending-signal reaper
+re-offers it and an ordinary sync can restore reviewability without another webhook. The check reads
+committed mirror state at admission; work deleted during capture or delivery belongs to that stage's
+refusal policy.
+
 The occurrence ledger has no pruning job; capacity planning must treat it as append-only. Retry and lapse
 thresholds are documented in the admin guide.
 

--- a/docs/decisions/0024-integration-sync-lifecycle-and-two-deletion-semantics.md
+++ b/docs/decisions/0024-integration-sync-lifecycle-and-two-deletion-semantics.md
@@ -265,3 +265,19 @@ adding one inherits this question.
 
 **Revisit trigger.** The live-event submission paths need the same distinction; an artifact kind
 other than `scm.pull_request` / `scm.issue` needs it; or Outline gains a resubmitter.
+
+## Update — 2026-09-05 (issue #1825): live occasions share the reversible hold
+
+Supersedes the live-event gap and that part of the revisit trigger in the 2026-09-04 update.
+Live GitHub and GitLab occasions are held rather than dropped while their work is tombstoned.
+The listeners record the occasion before admission, so the signal ledger provides both the recorded
+outcome and the retry mechanism.
+
+The automatic submission boundary owns the check: a global ORM filter would hide reversible absence,
+while a shared practice gate would have to distinguish an automatic hold from an explicit request's
+terminal refusal. The [glossary](../contributor/practice-review-glossary.mdx#signal-state-reasons) owns
+that distinction; the [pipeline](../contributor/practice-review-pipeline.mdx#occasion) owns eligibility
+and retry behavior.
+
+This does not serialize admission with later deletion, query upstream synchronously, or cancel
+in-flight reviews. Slack's irreversible deletion and Outline's lack of a resubmitter remain unchanged.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -62,7 +62,7 @@ do, its home is the Admin Guide (`docs/admin/`) and the runbook links to it.
 | [0021](0021-observations-feedback-synthesis-seam.md) | Findings vs feedback — evidence and delivered feedback are separate records | Accepted (amended 2026-07-31 #1423, 2026-08-16 #1430) |
 | [0022](0022-observation-presence-assessment-and-schema-cleanup.md) | Observation = presence × assessment (drop `Practice.kind`); reaction anchors on feedback; ruthless column cleanup | Accepted |
 | [0023](0023-outline-documentation-integration.md) | Outline documentation integration — a content source, not a detection surface | Accepted |
-| [0024](0024-integration-sync-lifecycle-and-two-deletion-semantics.md) | Integration sync lifecycle — drift tombstones and mirror erasure are two different operations | Accepted (amended 2026-09-03 #1404 — which reads honour a drift tombstone; 2026-09-04 #1806 — a re-offered signal is held, not retired) |
+| [0024](0024-integration-sync-lifecycle-and-two-deletion-semantics.md) | Integration sync lifecycle — drift tombstones and mirror erasure are two different operations | Accepted (amended 2026-09-03 #1404 — which reads honour a drift tombstone; 2026-09-04 #1806 — a re-offered signal is held, not retired; 2026-09-05 #1825 — live occasions share the reversible hold) |
 | [0025](0025-agent-job-queue-on-postgresql.md) | Agent job queue moves off NATS onto PostgreSQL | Accepted |
 | [0026](0026-per-purpose-agent-bindings-and-llm-governance.md) | Per-purpose agent bindings and governed OpenAI-compatible LLM catalog | Accepted (amended 2026-07-26 — named-agent-config model deleted) |
 | [0027](0027-dialog-lifetime-and-where-a-write-outcome-lands.md) | Dialog lifetime, and where a write's outcome lands when the dialog is gone | Accepted |

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobEventListener.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobEventListener.java
@@ -173,6 +173,13 @@ public class AgentJobEventListener {
                 return;
             }
 
+            // A tombstone the next ordinary sync can lift, so the occasion is held rather than retired:
+            // the reaper re-offers it, and a sweep that guessed wrong costs a delay instead of a review.
+            if (pr.getDeletedAt() != null) {
+                signalRecorder.markRefused(key, SignalStateReason.ARTIFACT_NOT_VISIBLE);
+                return;
+            }
+
             // A merged PR keeps its stored refs, so this holds post-merge too: without them there is
             // nothing to clone or diff against. Left RECORDED rather than refused on purpose: no
             // decision was reached, so a later delivery of the same occurrence can still claim it once

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/job/IssueAgentJobEventListener.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/job/IssueAgentJobEventListener.java
@@ -154,6 +154,13 @@ public class IssueAgentJobEventListener {
                 return;
             }
 
+            // A tombstone the next ordinary sync can lift, so the occasion is held rather than retired:
+            // the reaper re-offers it, and a sweep that guessed wrong costs a delay instead of a review.
+            if (issue.getDeletedAt() != null) {
+                signalRecorder.markRefused(key, SignalStateReason.ARTIFACT_NOT_VISIBLE);
+                return;
+            }
+
             switch (practiceReviewDetectionGate.evaluateIssue(issue, key.signalName(), TriggerMode.AUTO)) {
                 case GateDecision.Skip skip -> {
                     log.debug(

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobEventListenerTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobEventListenerTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import de.tum.cit.aet.hephaestus.agent.AgentJobType;
@@ -51,6 +52,8 @@ import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import tools.jackson.databind.ObjectMapper;
@@ -183,6 +186,61 @@ class AgentJobEventListenerTest extends BaseUnitTest {
     }
 
     // Test Groups
+
+    @Nested
+    class TombstonedWorkTests {
+
+        @ParameterizedTest
+        @ValueSource(strings = {"created", "ready", "synchronized", "merged", "closed", "reviewed"})
+        void shouldHoldOccasionBeforeAdmissionWhenPullRequestIsTombstoned(String event) {
+            PullRequest pr = mockPullRequest("abc123", "feature", "main");
+            Repository repository = new Repository();
+            repository.setId(REPO_REF.id());
+            repository.setNameWithOwner(REPO_REF.nameWithOwner());
+            pr.setRepository(repository);
+            pr.setTitle("Test PR");
+            pr.setDeletedAt(Instant.now());
+            when(pullRequestRepository.findByIdWithAllForGate(PR_ID)).thenReturn(Optional.of(pr));
+            boolean merged = event.equals("merged");
+            Issue.State state = merged || event.equals("closed") ? Issue.State.CLOSED : Issue.State.OPEN;
+            pr.setState(state);
+            pr.setMerged(merged);
+            var data = createPrData(state, false, merged);
+            var context = webhookContext(WORKSPACE_ID);
+            switch (event) {
+                case "created" -> listener.onPullRequestCreated(new ScmDomainEvent.PullRequestCreated(data, context));
+                case "ready" -> listener.onPullRequestReady(new ScmDomainEvent.PullRequestReady(data, context));
+                case "synchronized" ->
+                    listener.onPullRequestSynchronized(new ScmDomainEvent.PullRequestSynchronized(data, context));
+                case "merged" -> listener.onPullRequestMerged(new ScmDomainEvent.PullRequestMerged(data, context));
+                case "closed" ->
+                    listener.onPullRequestClosed(new ScmDomainEvent.PullRequestClosed(data, false, context));
+                case "reviewed" ->
+                    listener.onReviewSubmitted(new ScmDomainEvent.ReviewSubmitted(createReviewData(), context));
+                default -> throw new AssertionError(event);
+            }
+
+            verify(signalRecorder).markRefused(any(), eq(SignalStateReason.ARTIFACT_NOT_VISIBLE));
+            verifyNoInteractions(practiceReviewDetectionGate, agentJobService);
+        }
+
+        /**
+         * Pins the order against the branch-info check: missing refs leave the occasion RECORDED, which
+         * would silently swallow the hold if the tombstone check moved below it.
+         */
+        @Test
+        void shouldHoldTombstonedPullRequestEvenWhenBranchInformationIsMissing() {
+            PullRequest pr = mockPullRequest(null, null, null);
+            pr.setDeletedAt(Instant.now());
+            when(pullRequestRepository.findByIdWithAllForGate(PR_ID)).thenReturn(Optional.of(pr));
+
+            listener.onPullRequestCreated(new ScmDomainEvent.PullRequestCreated(
+                    createPrData(Issue.State.OPEN, false, false), webhookContext(WORKSPACE_ID)));
+
+            verify(signalRecorder).markRefused(any(), eq(SignalStateReason.ARTIFACT_NOT_VISIBLE));
+            verifyNoInteractions(practiceReviewDetectionGate, agentJobService);
+        }
+    }
 
     @Nested
     class FilteringTests {

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/job/IssueAgentJobEventListenerTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/job/IssueAgentJobEventListenerTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import de.tum.cit.aet.hephaestus.agent.AgentJobType;
@@ -41,6 +42,8 @@ import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 
@@ -162,6 +165,31 @@ class IssueAgentJobEventListenerTest extends BaseUnitTest {
     }
 
     // Test Groups
+
+    @Nested
+    class TombstonedWorkTests {
+
+        @ParameterizedTest
+        @ValueSource(strings = {"created", "updated", "closed"})
+        void shouldHoldOccasionBeforeAdmissionWhenIssueIsTombstoned(String event) {
+            Issue.State state = event.equals("closed") ? Issue.State.CLOSED : Issue.State.OPEN;
+            Issue issue = createIssue(state);
+            issue.setDeletedAt(Instant.now());
+            when(issueRepository.findByIdWithRepositoryAndAssignees(ISSUE_ID)).thenReturn(Optional.of(issue));
+            var data = createIssueData(state);
+            var context = webhookContext(WORKSPACE_ID);
+            switch (event) {
+                case "created" -> listener.onIssueCreated(new ScmDomainEvent.IssueCreated(data, context));
+                case "updated" ->
+                    listener.onIssueUpdated(new ScmDomainEvent.IssueUpdated(data, Set.of("body"), context));
+                case "closed" -> listener.onIssueClosed(new ScmDomainEvent.IssueClosed(data, null, context));
+                default -> throw new AssertionError(event);
+            }
+
+            verify(signalRecorder).markRefused(any(), eq(SignalStateReason.ARTIFACT_NOT_VISIBLE));
+            verifyNoInteractions(practiceReviewDetectionGate, agentJobService);
+        }
+    }
 
     @Nested
     class FilteringTests {

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/job/UpstreamDeletedWorkReadScopeIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/job/UpstreamDeletedWorkReadScopeIntegrationTest.java
@@ -2,8 +2,21 @@ package de.tum.cit.aet.hephaestus.agent.job;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
+import de.tum.cit.aet.hephaestus.agent.AgentJobType;
 import de.tum.cit.aet.hephaestus.agent.context.providers.mentor.MentorContextQueryRepository;
+import de.tum.cit.aet.hephaestus.agent.handler.IssueReviewSubmissionRequest;
+import de.tum.cit.aet.hephaestus.agent.handler.PullRequestReviewSubmissionRequest;
+import de.tum.cit.aet.hephaestus.integration.core.events.EventContext;
+import de.tum.cit.aet.hephaestus.integration.core.events.RepositoryRef;
+import de.tum.cit.aet.hephaestus.integration.core.events.ScmDomainEvent;
+import de.tum.cit.aet.hephaestus.integration.core.events.ScmEventPayload;
 import de.tum.cit.aet.hephaestus.integration.core.signal.ArtifactKind;
 import de.tum.cit.aet.hephaestus.integration.core.signal.ArtifactSignal;
 import de.tum.cit.aet.hephaestus.integration.core.signal.ArtifactSignalRepository;
@@ -15,6 +28,7 @@ import de.tum.cit.aet.hephaestus.integration.core.signal.SignalRecorder;
 import de.tum.cit.aet.hephaestus.integration.core.signal.SignalRevision;
 import de.tum.cit.aet.hephaestus.integration.core.signal.SignalState;
 import de.tum.cit.aet.hephaestus.integration.core.signal.SignalStateReason;
+import de.tum.cit.aet.hephaestus.integration.scm.domain.common.DataSource;
 import de.tum.cit.aet.hephaestus.integration.scm.domain.issue.Issue;
 import de.tum.cit.aet.hephaestus.integration.scm.domain.issue.IssueRepository;
 import de.tum.cit.aet.hephaestus.integration.scm.domain.pullrequest.PullRequest;
@@ -23,18 +37,22 @@ import de.tum.cit.aet.hephaestus.integration.scm.domain.repository.Repository;
 import de.tum.cit.aet.hephaestus.integration.scm.domain.repository.RepositoryRepository;
 import de.tum.cit.aet.hephaestus.integration.scm.domain.signal.ScmSignals;
 import de.tum.cit.aet.hephaestus.integration.scm.domain.user.User;
+import de.tum.cit.aet.hephaestus.practices.review.GateDecision;
 import de.tum.cit.aet.hephaestus.practices.review.PracticeReviewDetectionGate;
+import de.tum.cit.aet.hephaestus.practices.review.TriggerMode;
 import de.tum.cit.aet.hephaestus.workspace.AbstractWorkspaceIntegrationTest;
 import de.tum.cit.aet.hephaestus.workspace.AccountType;
 import de.tum.cit.aet.hephaestus.workspace.RepositoryToMonitor;
 import de.tum.cit.aet.hephaestus.workspace.RepositoryToMonitorRepository;
 import de.tum.cit.aet.hephaestus.workspace.Workspace;
+import de.tum.cit.aet.hephaestus.workspace.WorkspaceResolver;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.transaction.support.TransactionTemplate;
@@ -48,7 +66,9 @@ import org.springframework.transaction.support.TransactionTemplate;
  * the request path answers {@link SignalStateReason#ARTIFACT_GONE}. Everything the drift tombstone
  * promises to be able to undo must still see it: the upsert that resurrects it, and the gate loader the
  * pending-signal resubmitters read, which holds the occasion as {@link
- * SignalStateReason#ARTIFACT_NOT_VISIBLE} rather than retiring it.
+ * SignalStateReason#ARTIFACT_NOT_VISIBLE} rather than retiring it. A live event reaching the listener
+ * while the row is tombstoned takes the same hold, and the row the reaper would pick up is asserted
+ * here rather than inferred.
  *
  * <p>Both kinds are exercised because {@code Issue} and {@code PullRequest} share one table and the
  * issue side additionally has to hold its {@code TYPE(i) = Issue} discriminator.
@@ -95,6 +115,9 @@ class UpstreamDeletedWorkReadScopeIntegrationTest extends AbstractWorkspaceInteg
 
     @Autowired
     private TransactionTemplate transactionTemplate;
+
+    @Autowired
+    private WorkspaceResolver workspaceResolver;
 
     private Workspace workspace;
     private User author;
@@ -262,6 +285,110 @@ class UpstreamDeletedWorkReadScopeIntegrationTest extends AbstractWorkspaceInteg
         assertThat(released.getStateReason())
                 .isNotIn(SignalStateReason.ARTIFACT_NOT_VISIBLE, SignalStateReason.ARTIFACT_GONE);
         assertThat(released.getState()).isNotEqualTo(SignalState.PENDING);
+    }
+
+    @Test
+    void aLivePullRequestEventIsHeldWhileTheWorkIsTombstonedAndSubmittedOnceAnUpsertRestoresIt() {
+        var data = ScmEventPayload.PullRequestData.from(gateLoadedPullRequest());
+        var event = new ScmDomainEvent.PullRequestCreated(data, webhookContext());
+        var jobs = mock(AgentJobService.class);
+        var detectionGate = mock(PracticeReviewDetectionGate.class);
+        var listener = new AgentJobEventListener(
+                jobs, pullRequestRepository, detectionGate, workspaceResolver, signalRecorder);
+        tombstonePullRequest();
+
+        transactionTemplate.executeWithoutResult(status -> listener.onPullRequestCreated(event));
+
+        ArtifactSignal held = artifactSignalRepository
+                .findForArtifact(workspace.getId(), ScmSignals.PULL_REQUEST.value(), pullRequestId)
+                .getFirst();
+        assertHeld(held);
+        verifyNoInteractions(jobs, detectionGate);
+
+        upsertPullRequest();
+        assertThat(gateLoadedPullRequest().getDeletedAt()).isNull();
+        var decision = new GateDecision.Detect(workspace, List.of(), 1, TriggerMode.AUTO);
+        when(detectionGate.evaluate(any(), eq(ScmSignals.PULL_REQUEST_OPENED), eq(TriggerMode.AUTO)))
+                .thenReturn(decision);
+        resubmit(new PullRequestSignalResubmitter(jobs, pullRequestRepository, detectionGate, signalRecorder), held);
+
+        var request = ArgumentCaptor.forClass(PullRequestReviewSubmissionRequest.class);
+        verify(jobs)
+                .submit(
+                        eq(workspace.getId()),
+                        eq(AgentJobType.PULL_REQUEST_REVIEW),
+                        request.capture(),
+                        eq(held.key()),
+                        eq(decision));
+        PullRequest restored = gateLoadedPullRequest();
+        assertThat(request.getValue().pullRequest().id()).isEqualTo(restored.getId());
+        assertThat(request.getValue().pullRequest().title()).isEqualTo(restored.getTitle());
+        assertThat(request.getValue().headRefOid()).isEqualTo(restored.getHeadRefOid());
+        assertThat(request.getValue().headRefName()).isEqualTo(restored.getHeadRefName());
+        assertThat(request.getValue().baseRefName()).isEqualTo(restored.getBaseRefName());
+        assertThat(request.getValue().triggerSignal()).isEqualTo(ScmSignals.PULL_REQUEST_OPENED);
+    }
+
+    @Test
+    void aLiveIssueEventIsHeldWhileTheWorkIsTombstonedAndSubmittedOnceAnUpsertRestoresIt() {
+        var data = transactionTemplate.execute(status -> ScmEventPayload.IssueData.from(gateLoadedIssue()));
+        assertNotNull(data);
+        var event = new ScmDomainEvent.IssueCreated(data, webhookContext());
+        var jobs = mock(AgentJobService.class);
+        var detectionGate = mock(PracticeReviewDetectionGate.class);
+        var listener =
+                new IssueAgentJobEventListener(jobs, issueRepository, detectionGate, workspaceResolver, signalRecorder);
+        tombstoneIssue();
+
+        transactionTemplate.executeWithoutResult(status -> listener.onIssueCreated(event));
+
+        ArtifactSignal held = artifactSignalRepository
+                .findForArtifact(workspace.getId(), ScmSignals.ISSUE.value(), issueId)
+                .getFirst();
+        assertHeld(held);
+        verifyNoInteractions(jobs, detectionGate);
+
+        upsertIssue();
+        assertThat(gateLoadedIssue().getDeletedAt()).isNull();
+        var decision = new GateDecision.Detect(workspace, List.of(), 1, TriggerMode.AUTO);
+        when(detectionGate.evaluateIssue(any(), eq(ScmSignals.ISSUE_OPENED), eq(TriggerMode.AUTO)))
+                .thenReturn(decision);
+        resubmit(new IssueSignalResubmitter(jobs, issueRepository, detectionGate, signalRecorder), held);
+
+        var request = ArgumentCaptor.forClass(IssueReviewSubmissionRequest.class);
+        verify(jobs)
+                .submit(
+                        eq(workspace.getId()),
+                        eq(AgentJobType.ISSUE_REVIEW),
+                        request.capture(),
+                        eq(held.key()),
+                        eq(decision));
+        Issue restored = gateLoadedIssue();
+        assertThat(request.getValue().issueId()).isEqualTo(restored.getId());
+        assertThat(request.getValue().issueNumber()).isEqualTo(restored.getNumber());
+        assertThat(request.getValue().repositoryId()).isEqualTo(repository.getId());
+        assertThat(request.getValue().title()).isEqualTo(restored.getTitle());
+        assertThat(request.getValue().body()).isEqualTo(restored.getBody());
+        assertThat(request.getValue().triggerSignal()).isEqualTo(ScmSignals.ISSUE_OPENED);
+    }
+
+    private void assertHeld(ArtifactSignal held) {
+        assertThat(held.getState()).isEqualTo(SignalState.PENDING);
+        assertThat(held.getStateReason()).isEqualTo(SignalStateReason.ARTIFACT_NOT_VISIBLE);
+        assertThat(held.getDiscoveredVia()).isEqualTo(DiscoveredVia.EVENT);
+        assertThat(retryableSignalIds()).contains(held.getId());
+    }
+
+    private EventContext webhookContext() {
+        return new EventContext(
+                UUID.randomUUID(),
+                Instant.now(),
+                workspace.getId(),
+                new RepositoryRef(repository.getId(), repository.getNameWithOwner(), "main"),
+                DataSource.WEBHOOK,
+                "opened",
+                UUID.randomUUID().toString(),
+                null);
     }
 
     /**

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/scm/gitlab/pullrequest/GitLabMergeRequestMessageHandlerIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/scm/gitlab/pullrequest/GitLabMergeRequestMessageHandlerIntegrationTest.java
@@ -3,11 +3,27 @@ package de.tum.cit.aet.hephaestus.integration.scm.gitlab.pullrequest;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
+import de.tum.cit.aet.hephaestus.agent.AgentJobType;
+import de.tum.cit.aet.hephaestus.agent.handler.PullRequestReviewSubmissionRequest;
+import de.tum.cit.aet.hephaestus.agent.job.AgentJobEventListener;
+import de.tum.cit.aet.hephaestus.agent.job.AgentJobService;
+import de.tum.cit.aet.hephaestus.agent.job.PullRequestSignalResubmitter;
 import de.tum.cit.aet.hephaestus.integration.core.connection.IdentityProvider;
 import de.tum.cit.aet.hephaestus.integration.core.connection.IdentityProviderRepository;
 import de.tum.cit.aet.hephaestus.integration.core.connection.IdentityProviderType;
 import de.tum.cit.aet.hephaestus.integration.core.events.ScmDomainEvent;
+import de.tum.cit.aet.hephaestus.integration.core.signal.ArtifactSignal;
+import de.tum.cit.aet.hephaestus.integration.core.signal.ArtifactSignalRepository;
+import de.tum.cit.aet.hephaestus.integration.core.signal.SignalRecorder;
+import de.tum.cit.aet.hephaestus.integration.core.signal.SignalState;
+import de.tum.cit.aet.hephaestus.integration.core.signal.SignalStateReason;
 import de.tum.cit.aet.hephaestus.integration.scm.domain.issue.Issue;
 import de.tum.cit.aet.hephaestus.integration.scm.domain.issue.IssueRepository;
 import de.tum.cit.aet.hephaestus.integration.scm.domain.organization.Organization;
@@ -18,13 +34,18 @@ import de.tum.cit.aet.hephaestus.integration.scm.domain.pullrequestreview.PullRe
 import de.tum.cit.aet.hephaestus.integration.scm.domain.pullrequestreview.PullRequestReviewRepository;
 import de.tum.cit.aet.hephaestus.integration.scm.domain.repository.Repository;
 import de.tum.cit.aet.hephaestus.integration.scm.domain.repository.RepositoryRepository;
+import de.tum.cit.aet.hephaestus.integration.scm.domain.signal.ScmSignals;
 import de.tum.cit.aet.hephaestus.integration.scm.domain.user.UserRepository;
 import de.tum.cit.aet.hephaestus.integration.scm.gitlab.pullrequest.dto.GitLabMergeRequestEventDTO;
+import de.tum.cit.aet.hephaestus.practices.review.GateDecision;
+import de.tum.cit.aet.hephaestus.practices.review.PracticeReviewDetectionGate;
+import de.tum.cit.aet.hephaestus.practices.review.TriggerMode;
 import de.tum.cit.aet.hephaestus.testconfig.BaseIntegrationTest;
 import de.tum.cit.aet.hephaestus.testconfig.RecordingScmEventListener;
 import de.tum.cit.aet.hephaestus.workspace.AccountType;
 import de.tum.cit.aet.hephaestus.workspace.Workspace;
 import de.tum.cit.aet.hephaestus.workspace.WorkspaceRepository;
+import de.tum.cit.aet.hephaestus.workspace.WorkspaceResolver;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
@@ -34,6 +55,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.transaction.support.TransactionTemplate;
@@ -123,8 +145,18 @@ class GitLabMergeRequestMessageHandlerIntegrationTest extends BaseIntegrationTes
     @Autowired
     private RecordingScmEventListener eventListener;
 
+    @Autowired
+    private ArtifactSignalRepository artifactSignalRepository;
+
+    @Autowired
+    private SignalRecorder signalRecorder;
+
+    @Autowired
+    private WorkspaceResolver workspaceResolver;
+
     private Repository savedRepo;
     private IdentityProvider savedProvider;
+    private Workspace savedWorkspace;
 
     @BeforeEach
     void setUp() {
@@ -591,6 +623,75 @@ class GitLabMergeRequestMessageHandlerIntegrationTest extends BaseIntegrationTes
         }
     }
 
+    // Tombstoned Work
+
+    @Nested
+    class TombstonedWork {
+
+        /**
+         * The hold is provider-neutral, so this proves it on the GitLab adapter's own path: the merge
+         * request, the domain event and the restoring delivery all come from real webhook payloads rather
+         * than from a hand-built {@code ScmDomainEvent}.
+         *
+         * <p>The listener is constructed here because {@code hephaestus.agent.enabled} is off in the
+         * integration profile, and driven inside a transaction because its {@code REQUIRES_NEW} proxy is
+         * bypassed by direct construction.
+         */
+        @Test
+        void tombstonedMergeRequestHoldsItsOccasionUntilAFurtherDeliveryRestoresIt() throws Exception {
+            handler.handleEvent(loadPayload("merge_request.open"));
+            ScmDomainEvent.PullRequestCreated created = eventListener
+                    .ofType(ScmDomainEvent.PullRequestCreated.class)
+                    .getFirst();
+            long pullRequestId = pullRequestRepository
+                    .findByRepositoryIdAndNumber(savedRepo.getId(), MR3_IID)
+                    .orElseThrow()
+                    .getId();
+            assertThat(issueRepository.tombstonePullRequestsByRepositoryIdAndNumbers(
+                            savedRepo.getId(), List.of(MR3_IID), Instant.now()))
+                    .isEqualTo(1);
+
+            var jobs = mock(AgentJobService.class);
+            var gate = mock(PracticeReviewDetectionGate.class);
+            var listener =
+                    new AgentJobEventListener(jobs, pullRequestRepository, gate, workspaceResolver, signalRecorder);
+            transactionTemplate.executeWithoutResult(status -> listener.onPullRequestCreated(created));
+
+            ArtifactSignal held = artifactSignalRepository
+                    .findForArtifact(savedWorkspace.getId(), ScmSignals.PULL_REQUEST.value(), pullRequestId)
+                    .getFirst();
+            assertThat(held.getState()).isEqualTo(SignalState.PENDING);
+            assertThat(held.getStateReason()).isEqualTo(SignalStateReason.ARTIFACT_NOT_VISIBLE);
+            verifyNoInteractions(jobs, gate);
+
+            handler.handleEvent(loadPayload("merge_request.reopen"));
+            assertThat(pullRequestRepository
+                            .findById(pullRequestId)
+                            .orElseThrow()
+                            .getDeletedAt())
+                    .isNull();
+
+            var decision = new GateDecision.Detect(savedWorkspace, List.of(), 1, TriggerMode.AUTO);
+            when(gate.evaluate(any(), eq(ScmSignals.PULL_REQUEST_OPENED), eq(TriggerMode.AUTO)))
+                    .thenReturn(decision);
+            transactionTemplate.executeWithoutResult(status ->
+                    new PullRequestSignalResubmitter(jobs, pullRequestRepository, gate, signalRecorder).resubmit(held));
+
+            var request = ArgumentCaptor.forClass(PullRequestReviewSubmissionRequest.class);
+            verify(jobs)
+                    .submit(
+                            eq(savedWorkspace.getId()),
+                            eq(AgentJobType.PULL_REQUEST_REVIEW),
+                            request.capture(),
+                            eq(held.key()),
+                            eq(decision));
+            assertThat(request.getValue().pullRequest().id()).isEqualTo(pullRequestId);
+            assertThat(request.getValue().headRefName()).isEqualTo(MR3_SOURCE_BRANCH);
+            assertThat(request.getValue().baseRefName()).isEqualTo(MR3_TARGET_BRANCH);
+            assertThat(request.getValue().triggerSignal()).isEqualTo(ScmSignals.PULL_REQUEST_OPENED);
+        }
+    }
+
     // Helpers
 
     private GitLabMergeRequestEventDTO loadPayload(String filename) throws IOException {
@@ -638,7 +739,7 @@ class GitLabMergeRequestMessageHandlerIntegrationTest extends BaseIntegrationTes
         workspace.setOrganization(org);
         workspace.setAccountLogin(FIXTURE_ORG_LOGIN);
         workspace.setAccountType(AccountType.ORG);
-        workspaceRepository.save(workspace);
+        savedWorkspace = workspaceRepository.save(workspace);
     }
 
     private static long persistedId(IdentityProvider provider) {


### PR DESCRIPTION
## What changed and why

A webhook that arrives between a reconciliation sweep and the next ordinary sync could still spend a
practice review on work the mirror has tombstoned, and deliver feedback about it. The two other
paths already refused: an explicitly requested review answers `ARTIFACT_GONE`, and a re-offered
pending occasion is held with `ARTIFACT_NOT_VISIBLE`. The live-event path read the same gate loaders,
which deliberately still return tombstoned rows, and neither the detection gate nor `AgentJobService`
reads `deleted_at`.

`AgentJobEventListener` and `IssueAgentJobEventListener` now check the tombstone after the occasion
is recorded and before admission, and hold it with the retryable `ARTIFACT_NOT_VISIBLE`. Holding
rather than dropping is the choice this PR makes: a drift tombstone is reversible by design, so a
sweep that guessed wrong costs a delay instead of a review, and the machinery already exists —
`SignalState.PENDING` → `PendingSignalReaper` → the existing resubmitters. No new state, no new
reason, no new scheduler.

The rule the three paths now share is one sentence: **an automatic occasion is held, an explicit
request is refused terminally.** The glossary states it and the pipeline document says where the
check sits.

The check is deliberately below `record()` and below the `context.isSync()` return: a sync-discovered
occasion stays `RECORDED`, because sync records history and no live delivery has claimed that row
yet.

Fixes #1825.

## How to test

```
vp run check:affected
cd server && MANAGEMENT_PORT=0 SERVER_PORT=0 ./mvnw -f application/pom.xml \
  -Dtest='AgentJobEventListenerTest,IssueAgentJobEventListenerTest' -Dsurefire.includedGroups=unit test --batch-mode
cd server && MANAGEMENT_PORT=0 SERVER_PORT=0 ./mvnw -f application/pom.xml \
  -Dtest='UpstreamDeletedWorkReadScopeIntegrationTest,GitLabMergeRequestMessageHandlerIntegrationTest' \
  -Dsurefire.includedGroups=integration test --batch-mode
```

- Unit: all six pull-request handlers and all three issue handlers hold the occasion and never reach
  the gate or the job service; one case pins the ordering against the branch-info check, which is
  the one thing a careless rebase would silently break.
- Integration, GitHub: a live event is held, the ledger row is one the reaper's own query will pick
  up, and after a shared upsert restores the row the resubmitter submits a job carrying the restored
  refs and title.
- Integration, GitLab: the same, driven through the adapter. A real `merge_request.open` payload goes
  through `GitLabMergeRequestMessageHandler`, its published `PullRequestCreated` is the event the
  listener holds, and a later real `merge_request.reopen` delivery is what brings the row back.

## Release impact

`.changeset/hold-live-reviews-of-swept-work.md`, patch. No operator action: no schema change, no new
setting, and `ARTIFACT_NOT_VISIBLE` already has its API and UI label.

## Notes for reviewers

- ADR 0024 gets a dated update block that supersedes the live-event gap named in the 2026-09-04
  update and leaves that update standing, per `docs/decisions/README.md` rule 1. The index row
  appends #1825 to the enumerated amendment list rather than collapsing it.
- The reviewer-attribution fix that rode along in the first revision is now #1877. It is a separate
  pre-existing defect, reachable on `main` through any retryable gate refusal, and it is not about
  tombstones. Land this first; #1877 rebases onto it.
- Slack and Outline are deliberately untouched — Slack's deletion is irreversible and Outline has no
  resubmitter. The ADR update says so.
