### PR TITLE
refactor(webapp): one consent gate, one repository link, and tests that drive behaviour

### DIFF
--- a/.changeset/the-notice-retries-in-place.md
+++ b/.changeset/the-notice-retries-in-place.md
@@ -1,0 +1,7 @@
+---
+"hephaestus": patch
+---
+
+When the transparency notice cannot be loaded, the dialog offers to try again in place rather than
+asking you to reload the page. Every link to the source repository points at `hephaestus-build`, and
+the security policy's canonical address is on `hephaestus.build`.

--- a/webapp/public/.well-known/security.txt
+++ b/webapp/public/.well-known/security.txt
@@ -2,6 +2,6 @@
 Contact: https://github.com/hephaestus-build/Hephaestus/security/advisories/new
 Contact: mailto:felixtj.dietrich@tum.de
 Policy: https://github.com/hephaestus-build/Hephaestus/blob/main/SECURITY.md
-Canonical: https://hephaestus.aet.cit.tum.de/.well-known/security.txt
+Canonical: https://hephaestus.build/.well-known/security.txt
 Preferred-Languages: en, de
 Expires: 2027-07-16T00:00:00Z

--- a/webapp/src/components/admin/practice-catalog/occasion-moments.test.ts
+++ b/webapp/src/components/admin/practice-catalog/occasion-moments.test.ts
@@ -46,7 +46,7 @@ describe("momentBands", () => {
 		]);
 	});
 
-	it("warns that an issue's middle moment repeats, because binding it is a decision about volume", () => {
+	it("reads an issue as start, one repeating middle moment, and end", () => {
 		const bands = momentBands(mockIssueWorkType.signals);
 
 		expect(
@@ -56,7 +56,6 @@ describe("momentBands", () => {
 			["during", ["scm.issue.updated"]],
 			["end", ["scm.issue.closed"]],
 		]);
-		expect(momentDef("scm.issue.updated").repeats).toBe(true);
 	});
 
 	it("gives a document its own three moments under the same three bands", () => {

--- a/webapp/src/components/auth/ConsentDialog.stories.tsx
+++ b/webapp/src/components/auth/ConsentDialog.stories.tsx
@@ -25,7 +25,6 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
 
-/** Nothing can be submitted until the required acceptance is given. */
 export const RequiresAcceptance: Story = {
 	play: async ({ args }) => {
 		const dialog = within(await screen.findByRole("dialog"));
@@ -43,7 +42,6 @@ export const RequiresAcceptance: Story = {
 	},
 };
 
-/** The optional choice is off until it is chosen, and never gates the button. */
 export const ResearchIsOptional: Story = {
 	play: async ({ args }) => {
 		const dialog = within(await screen.findByRole("dialog"));
@@ -60,7 +58,6 @@ export const ResearchIsOptional: Story = {
 
 export const Submitting: Story = { args: { submitting: true } };
 
-/** The choice reached the server and was refused; the reader is told and can retry. */
 export const SubmitFailed: Story = {
 	args: { failedToSubmit: true },
 	play: async () => {
@@ -69,10 +66,6 @@ export const SubmitFailed: Story = {
 	},
 };
 
-/** Still open while the notice loads, so the application never paints behind it first. */
-export const Loading: Story = { args: { notice: undefined } };
-
-/** The notice could not be fetched. The reader stays blocked, because the choice is still required. */
 export const FailedToLoad: Story = {
 	args: { notice: undefined, failedToLoad: true },
 	play: async () => {
@@ -81,7 +74,6 @@ export const FailedToLoad: Story = {
 	},
 };
 
-/** A mandatory dialog still needs a way out: declining is an answer, not a dead end. */
 export const CanDeclineAndSignOut: Story = {
 	play: async ({ args }) => {
 		const dialog = within(await screen.findByRole("dialog"));
@@ -90,7 +82,6 @@ export const CanDeclineAndSignOut: Story = {
 	},
 };
 
-/** The load failure offers a retry rather than stranding the reader on a reload instruction. */
 export const FailedToLoadCanRetry: Story = {
 	args: { notice: undefined, failedToLoad: true },
 	play: async ({ args }) => {

--- a/webapp/src/components/auth/ConsentDialog.tsx
+++ b/webapp/src/components/auth/ConsentDialog.tsx
@@ -23,17 +23,14 @@ export interface ConsentChoice {
 }
 
 interface ConsentDialogProps {
-	/** The notice to show. While it is loading the dialog is already open, so the app never flashes. */
+	/** Absent only when loading it failed. */
 	notice: ConsentStatus | undefined;
-	/** The notice could not be loaded; the app stays blocked because the choice is still required. */
 	failedToLoad?: boolean;
 	onSubmit: (choice: ConsentChoice) => void;
 	/** Declining is an answer too: without a way out, the only exit from a trapped surface is the tab. */
 	onSignOut: () => void;
-	/** Retry loading the notice, so a failed fetch is not a dead end. */
 	onRetry: () => void;
 	submitting?: boolean;
-	/** The choice reached the server and was not stored. */
 	failedToSubmit?: boolean;
 }
 
@@ -61,11 +58,8 @@ export function ConsentDialog({
 	const researchHeadingId = useId();
 
 	return (
-		// Held open: a request to close is ignored rather than unsupported, because the server refuses
-		// every other call until the choice is recorded and a closeable dialog would leave an
-		// application that answers nothing.
 		<Dialog open modal onOpenChange={() => undefined}>
-			<DialogContent showCloseButton={false} className="sm:max-w-xl" aria-describedby={undefined}>
+			<DialogContent showCloseButton={false} className="sm:max-w-xl">
 				<DialogHeader>
 					<DialogTitle>How Hephaestus uses your data</DialogTitle>
 					<DialogDescription>
@@ -75,12 +69,12 @@ export function ConsentDialog({
 					</DialogDescription>
 				</DialogHeader>
 
-				{failedToLoad ? (
+				{failedToLoad || !notice ? (
 					<>
 						<DialogBody>
 							<p role="alert" className="text-muted-foreground">
-								We couldn't load the notice just now. Reload the page to try again — this choice is
-								needed before Hephaestus can show you anything.
+								We couldn't load the notice just now. This choice is needed before Hephaestus can
+								show you anything.
 							</p>
 						</DialogBody>
 						<DialogFooter className="flex-col items-stretch gap-3 sm:flex-col sm:items-stretch">
@@ -92,7 +86,7 @@ export function ConsentDialog({
 							</Button>
 						</DialogFooter>
 					</>
-				) : notice ? (
+				) : (
 					<>
 						<DialogBody className="space-y-6 leading-6">
 							<div className="space-y-4">
@@ -112,9 +106,8 @@ export function ConsentDialog({
 								</a>
 							</div>
 
-							{/* The research invitation stands on its own, as a thing worth doing, rather than as a
-							    second checkbox under the legal one. It stays unticked: consent has to be an act
-							    the reader takes, and a pre-ticked box is not one. */}
+							{/* Its own section rather than a second checkbox under the legal one, and never
+							    pre-ticked: consent is an act the reader takes. */}
 							<section
 								aria-labelledby={researchHeadingId}
 								className="bg-primary/5 ring-primary/20 space-y-3 rounded-lg p-4 ring-1"
@@ -187,10 +180,6 @@ export function ConsentDialog({
 							</DialogFooter>
 						</form>
 					</>
-				) : (
-					<DialogBody className="flex justify-center py-8">
-						<Spinner className="size-6" aria-label="Loading the transparency notice" />
-					</DialogBody>
 				)}
 			</DialogContent>
 		</Dialog>

--- a/webapp/src/components/auth/LandingSignInCta.tsx
+++ b/webapp/src/components/auth/LandingSignInCta.tsx
@@ -10,9 +10,7 @@ import { cn } from "@/lib/utils";
 type ButtonSize = ComponentPropsWithoutRef<typeof Button>["size"];
 
 interface LandingSignInCtaProps {
-	isSignedIn: boolean;
 	onSignIn: (idpHint: string) => void;
-	onGoToDashboard?: () => void;
 	size?: ButtonSize;
 	className?: string;
 }
@@ -21,23 +19,9 @@ interface LandingSignInCtaProps {
  * One call-to-action instead of a wall of provider buttons repeated across every section: `/login`
  * stays the single place a provider is chosen, so a visitor never picks one twice.
  */
-export function LandingSignInCta({
-	isSignedIn,
-	onSignIn,
-	onGoToDashboard,
-	size = "lg",
-	className,
-}: LandingSignInCtaProps) {
+export function LandingSignInCta({ onSignIn, size = "lg", className }: LandingSignInCtaProps) {
 	const navigate = useNavigate();
 	const { data: providers } = useQuery(listIdentityProvidersOptions());
-
-	if (isSignedIn) {
-		return (
-			<Button size={size} className={cn("gap-2", className)} onClick={onGoToDashboard}>
-				Go to dashboard <ArrowRight className="h-4 w-4" />
-			</Button>
-		);
-	}
 
 	const handleSignIn = () => {
 		// One provider → straight to OAuth (no pointless picker). Several (or not yet known) → the

--- a/webapp/src/components/core/Footer.tsx
+++ b/webapp/src/components/core/Footer.tsx
@@ -6,6 +6,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { optionalIntegrationsAvailable, requestConsentReopen } from "@/integrations/consent";
 import { hasText } from "@/lib/text";
 import { cn } from "@/lib/utils";
+import { REPO_URL } from "@/lib/version";
 
 export interface FooterProps {
 	className?: string;
@@ -46,7 +47,7 @@ export default function Footer({ className, isProduction, buildInfo }: FooterPro
 					</a>
 					. Source on{" "}
 					<a
-						href="https://github.com/hephaestus-build/Hephaestus"
+						href={REPO_URL}
 						target="_blank"
 						rel="noopener noreferrer"
 						className="font-medium underline underline-offset-4 hover:text-foreground"
@@ -65,7 +66,7 @@ export default function Footer({ className, isProduction, buildInfo }: FooterPro
 							About
 						</Link>
 						<a
-							href="https://github.com/hephaestus-build/Hephaestus/releases"
+							href={`${REPO_URL}/releases`}
 							target="_blank"
 							rel="noopener noreferrer"
 							className="text-sm text-muted-foreground hover:text-foreground hover:underline underline-offset-4"
@@ -102,7 +103,7 @@ export default function Footer({ className, isProduction, buildInfo }: FooterPro
 									<TooltipTrigger
 										render={
 											<a
-												href={`https://github.com/hephaestus-build/Hephaestus/tree/${buildInfo.branch}`}
+												href={`${REPO_URL}/tree/${buildInfo.branch}`}
 												target="_blank"
 												rel="noopener noreferrer"
 												aria-label={`View branch ${buildInfo.branch}`}
@@ -122,7 +123,7 @@ export default function Footer({ className, isProduction, buildInfo }: FooterPro
 									<TooltipTrigger
 										render={
 											<a
-												href={`https://github.com/hephaestus-build/Hephaestus/commit/${buildInfo.commit}`}
+												href={`${REPO_URL}/commit/${buildInfo.commit}`}
 												target="_blank"
 												rel="noopener noreferrer"
 												aria-label={`View commit ${buildInfo.commit.substring(0, 7)}`}

--- a/webapp/src/components/core/sidebar/NavFooter.tsx
+++ b/webapp/src/components/core/sidebar/NavFooter.tsx
@@ -7,6 +7,7 @@ import {
 	SidebarMenuItem,
 	SidebarSeparator,
 } from "@/components/ui/sidebar";
+import { REPO_URL } from "@/lib/version";
 
 interface NavFooterProps {
 	isAppAdmin?: boolean;
@@ -41,7 +42,7 @@ export function NavFooter({ isAppAdmin = false }: NavFooterProps) {
 				<SidebarMenuItem>
 					<SidebarMenuButton
 						tooltip="Report issue"
-						render={<a href="https://github.com/hephaestus-build/Hephaestus/issues/new/choose" />}
+						render={<a href={`${REPO_URL}/issues/new/choose`} />}
 					>
 						<Bug />
 						<span>Report&nbsp;issue</span>
@@ -51,9 +52,7 @@ export function NavFooter({ isAppAdmin = false }: NavFooterProps) {
 					<SidebarMenuButton
 						tooltip="Request a feature"
 						className="text-provider-upsell-foreground hover:text-provider-upsell-foreground hover:bg-provider-upsell-foreground/10 dark:hover:bg-provider-upsell-foreground/10"
-						render={
-							<a href="https://github.com/hephaestus-build/Hephaestus/discussions/new/choose" />
-						}
+						render={<a href={`${REPO_URL}/discussions/new/choose`} />}
 					>
 						<Sparkles />
 						<span>Request&nbsp;a&nbsp;feature</span>

--- a/webapp/src/components/info/about/AboutCallToActionSection.tsx
+++ b/webapp/src/components/info/about/AboutCallToActionSection.tsx
@@ -1,6 +1,7 @@
 import { Github } from "@/components/icons/brand";
 import { Badge } from "@/components/ui/badge";
 import { buttonVariants } from "@/components/ui/button";
+import { REPO_URL } from "@/lib/version";
 
 export function AboutCallToActionSection() {
 	return (
@@ -20,7 +21,7 @@ export function AboutCallToActionSection() {
 			</p>
 			<div className="flex flex-col sm:flex-row gap-4 justify-center">
 				<a
-					href="https://github.com/ls1intum/Hephaestus"
+					href={REPO_URL}
 					target="_blank"
 					rel="noopener noreferrer"
 					className={buttonVariants({ size: "lg" })}

--- a/webapp/src/components/info/landing/LandingCtaSection.stories.tsx
+++ b/webapp/src/components/info/landing/LandingCtaSection.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { expect, fn } from "storybook/test";
+import { fn } from "storybook/test";
 import { LandingCtaSection } from "./LandingCtaSection";
 
 const meta = {
@@ -8,32 +8,14 @@ const meta = {
 	tags: ["autodocs"],
 	args: {
 		onSignIn: fn(),
-		onGoToDashboard: fn(),
 	},
 } satisfies Meta<typeof LandingCtaSection>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
-	args: {
-		isSignedIn: false,
-	},
-};
-
-export const SignedIn: Story = {
-	args: {
-		isSignedIn: true,
-	},
-	play: async ({ canvas }) => {
-		await expect(canvas.queryByRole("link", { name: /Read the installation guide/ })).toBeNull();
-		await expect(canvas.getByRole("button", { name: /dashboard/i })).toBeVisible();
-	},
-};
+export const Default: Story = {};
 
 export const DarkMode: Story = {
-	args: {
-		isSignedIn: false,
-	},
 	globals: { theme: "dark" },
 };

--- a/webapp/src/components/info/landing/LandingCtaSection.tsx
+++ b/webapp/src/components/info/landing/LandingCtaSection.tsx
@@ -6,15 +6,9 @@ import styles from "./LandingVisuals.module.css";
 
 interface LandingCtaSectionProps {
 	onSignIn: (idpHint: string) => void;
-	onGoToDashboard?: () => void;
-	isSignedIn: boolean;
 }
 
-export function LandingCtaSection({
-	onSignIn,
-	onGoToDashboard,
-	isSignedIn,
-}: LandingCtaSectionProps) {
+export function LandingCtaSection({ onSignIn }: LandingCtaSectionProps) {
 	return (
 		<section
 			aria-labelledby="landing-cta-heading"
@@ -40,18 +34,10 @@ export function LandingCtaSection({
 						Start with the work in front of you
 					</h2>
 					<p className="mx-auto mt-4 max-w-2xl text-lg leading-relaxed text-muted-foreground lg:mx-0">
-						{isSignedIn
-							? "Open your workspace to read your feedback or ask about recent work."
-							: "Sign in to see feedback on the work you are already doing, and ask it anything about it."}
+						Sign in to see feedback on the work you are already doing, and ask it anything about it.
 					</p>
 					<div className="mt-6 flex w-full flex-col justify-center gap-3 sm:flex-row lg:justify-start">
-						<LandingSignInCta
-							isSignedIn={isSignedIn}
-							onSignIn={onSignIn}
-							onGoToDashboard={onGoToDashboard}
-							size="lg"
-							className="w-full sm:w-auto"
-						/>
+						<LandingSignInCta onSignIn={onSignIn} size="lg" className="w-full sm:w-auto" />
 						<a
 							href="https://docs.hephaestus.build/user/overview"
 							target="_blank"
@@ -64,21 +50,19 @@ export function LandingCtaSection({
 							<ArrowRight aria-hidden="true" />
 						</a>
 					</div>
-					{!isSignedIn && (
-						<p className="mt-5 text-sm text-muted-foreground">
-							Running your own deployment?{" "}
-							<a
-								className="font-medium text-foreground underline underline-offset-4"
-								href="https://docs.hephaestus.build/admin/install"
-								target="_blank"
-								rel="noopener noreferrer"
-							>
-								Read the installation guide
-								<span className="sr-only"> (opens in a new tab)</span>
-							</a>
-							.
-						</p>
-					)}
+					<p className="mt-5 text-sm text-muted-foreground">
+						Running your own deployment?{" "}
+						<a
+							className="font-medium text-foreground underline underline-offset-4"
+							href="https://docs.hephaestus.build/admin/install"
+							target="_blank"
+							rel="noopener noreferrer"
+						>
+							Read the installation guide
+							<span className="sr-only"> (opens in a new tab)</span>
+						</a>
+						.
+					</p>
 				</div>
 			</div>
 		</section>

--- a/webapp/src/components/info/landing/LandingHeroSection.stories.tsx
+++ b/webapp/src/components/info/landing/LandingHeroSection.stories.tsx
@@ -8,8 +8,6 @@ const meta = {
 	tags: ["autodocs"],
 	args: {
 		onSignIn: fn(),
-		onGoToDashboard: fn(),
-		isSignedIn: false,
 	},
 } satisfies Meta<typeof LandingHeroSection>;
 
@@ -21,13 +19,6 @@ export const Default: Story = {
 		// One DOM serves the scattered and the stacked composition; a second copy means the
 		// two layouts have drifted apart.
 		await expect(canvas.getAllByText("Export reports to CSV")).toHaveLength(1);
-	},
-};
-
-export const SignedIn: Story = {
-	args: { isSignedIn: true },
-	play: async ({ canvas }) => {
-		await expect(canvas.getByRole("button", { name: /dashboard/i })).toBeVisible();
 	},
 };
 

--- a/webapp/src/components/info/landing/LandingHeroSection.tsx
+++ b/webapp/src/components/info/landing/LandingHeroSection.tsx
@@ -5,6 +5,7 @@ import { GithubIcon, GitlabIcon } from "@/components/icons/brand";
 import { Badge } from "@/components/ui/badge";
 import { buttonVariants } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import { REPO_URL } from "@/lib/version";
 import {
 	LandingCluster,
 	LandingFeedbackCard,
@@ -21,8 +22,6 @@ import styles from "./LandingVisuals.module.css";
 
 interface LandingHeroSectionProps {
 	onSignIn: (idpHint: string) => void;
-	onGoToDashboard?: () => void;
-	isSignedIn: boolean;
 }
 
 const itemVariants = {
@@ -204,11 +203,7 @@ export function HeroScene() {
 	);
 }
 
-export function LandingHeroSection({
-	onSignIn,
-	onGoToDashboard,
-	isSignedIn,
-}: LandingHeroSectionProps) {
+export function LandingHeroSection({ onSignIn }: LandingHeroSectionProps) {
 	const reduceMotion = useReducedMotion();
 	return (
 		<section
@@ -266,14 +261,12 @@ export function LandingHeroSection({
 						className="relative z-10 mt-8 flex w-full flex-col items-center gap-3 sm:w-auto sm:flex-row"
 					>
 						<LandingSignInCta
-							isSignedIn={isSignedIn}
 							onSignIn={onSignIn}
-							onGoToDashboard={onGoToDashboard}
 							size="lg"
 							className="h-11 w-full px-5 shadow-lg shadow-primary/10 sm:w-auto"
 						/>
 						<a
-							href="https://github.com/ls1intum/Hephaestus"
+							href={REPO_URL}
 							target="_blank"
 							rel="noopener noreferrer"
 							className={cn(

--- a/webapp/src/components/info/landing/LandingPage.stories.tsx
+++ b/webapp/src/components/info/landing/LandingPage.stories.tsx
@@ -11,31 +11,18 @@ const meta = {
 	},
 	args: {
 		onSignIn: fn(),
-		onGoToDashboard: fn(),
 	},
 } satisfies Meta<typeof LandingPage>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
-	args: {
-		isSignedIn: false,
-	},
-};
-
-export const SignedIn: Story = {
-	args: {
-		isSignedIn: true,
-	},
-};
+export const Default: Story = {};
 
 export const Mobile: Story = {
-	args: { isSignedIn: false },
 	parameters: { viewport: { defaultViewport: "reflow" }, chromatic: { viewports: [320] } },
 };
 
 export const DarkMode: Story = {
-	args: { isSignedIn: false },
 	globals: { theme: "dark" },
 };

--- a/webapp/src/components/info/landing/LandingPage.tsx
+++ b/webapp/src/components/info/landing/LandingPage.tsx
@@ -6,26 +6,16 @@ import { LandingProjectOriginsSection } from "./LandingProjectOriginsSection";
 
 interface LandingPageProps {
 	onSignIn: (idpHint: string) => void;
-	onGoToDashboard?: () => void;
-	isSignedIn?: boolean;
 }
 
-export function LandingPage({ onSignIn, onGoToDashboard, isSignedIn = false }: LandingPageProps) {
+export function LandingPage({ onSignIn }: LandingPageProps) {
 	return (
 		<div className="flex flex-col">
-			<LandingHeroSection
-				onSignIn={onSignIn}
-				onGoToDashboard={onGoToDashboard}
-				isSignedIn={isSignedIn}
-			/>
+			<LandingHeroSection onSignIn={onSignIn} />
 			<LandingFeaturesSection />
 			<LandingProjectOriginsSection />
 			<LandingFaqSection />
-			<LandingCtaSection
-				onSignIn={onSignIn}
-				onGoToDashboard={onGoToDashboard}
-				isSignedIn={isSignedIn}
-			/>
+			<LandingCtaSection onSignIn={onSignIn} />
 		</div>
 	);
 }

--- a/webapp/src/hooks/use-active-workspace.ts
+++ b/webapp/src/hooks/use-active-workspace.ts
@@ -14,14 +14,11 @@ export function useActiveWorkspaceSlug() {
 	const query = useQuery({
 		...listWorkspacesOptions(),
 		enabled: isAuthenticated && !authLoading,
-		staleTime: 30_000,
-		refetchOnWindowFocus: true,
 	});
 	const workspaces = Array.isArray(query.data) ? query.data : NO_WORKSPACES;
 	const workspaceSlug = useParams({ strict: false, select: (params) => params.workspaceSlug });
-	// The app chrome renders on every route, including the ones whose URL names no workspace, and a
-	// member of workspaces must not be shown as belonging to none. `workspaceSlug` stays the only
-	// source for workspace-scoped data, so the two are separate values rather than one fallback.
+	// Two values, not one fallback: the app chrome also renders on routes whose URL names no
+	// workspace, while `workspaceSlug` stays the only source for workspace-scoped data.
 	const chromeWorkspaceSlug = workspaceSlug ?? workspaces[0]?.workspaceSlug;
 	const chromeWorkspace = workspaces.find(
 		(workspace) => workspace.workspaceSlug === chromeWorkspaceSlug,
@@ -30,6 +27,7 @@ export function useActiveWorkspaceSlug() {
 	return {
 		workspaceSlug,
 		chromeWorkspaceSlug,
+		chromeWorkspace,
 		workspaces,
 		// A workspace is SCM-backed; SLACK (an identity provider) never reaches SCM-only UI, but the
 		// generated type includes it, so narrow to the SCM ProviderType with a GITHUB fallback.

--- a/webapp/src/hooks/use-mentor-chat.test.tsx
+++ b/webapp/src/hooks/use-mentor-chat.test.tsx
@@ -46,6 +46,7 @@ function activeWorkspace(
 	return {
 		workspaceSlug: "test-workspace",
 		chromeWorkspaceSlug: "test-workspace",
+		chromeWorkspace: undefined,
 		workspaces: [],
 		providerType: "GITHUB",
 		isLoading: false,

--- a/webapp/src/hooks/use-workspace-access.ts
+++ b/webapp/src/hooks/use-workspace-access.ts
@@ -6,10 +6,10 @@ import { hasMinimumWorkspaceRole } from "@/lib/workspace-roles";
 
 import { useActiveWorkspaceSlug } from "./use-active-workspace";
 
-/** Read by the app chrome, which renders on every route, so the slug is the chrome's, not the URL's. */
 export function useWorkspaceAccess() {
 	const {
 		chromeWorkspaceSlug,
+		chromeWorkspace,
 		workspaces,
 		isLoading: workspacesLoading,
 	} = useActiveWorkspaceSlug();
@@ -24,6 +24,7 @@ export function useWorkspaceAccess() {
 
 	return {
 		chromeWorkspaceSlug,
+		chromeWorkspace,
 		workspaces,
 		role,
 		isAdmin: hasMinimumWorkspaceRole(role, "ADMIN"),

--- a/webapp/src/hooks/use-workspace-switcher.test.tsx
+++ b/webapp/src/hooks/use-workspace-switcher.test.tsx
@@ -39,21 +39,14 @@ function SwitchWorkspace() {
 	);
 }
 
-/**
- * `mountAtRoot` puts the switcher above every match, which is where `__root.tsx` renders it —
- * the placement the whole portable branch rests on, since `to: "."` resolves from the deepest
- * match of the current location rather than from the calling component's route.
- */
-function renderRoute(initialEntry: string, path: string, { mountAtRoot = false } = {}) {
+function renderRoute(initialEntry: string, path: string) {
 	const rootRoute = createRootRoute({
-		component: mountAtRoot
-			? () => (
-					<>
-						<SwitchWorkspace />
-						<Outlet />
-					</>
-				)
-			: Outlet,
+		component: () => (
+			<>
+				<SwitchWorkspace />
+				<Outlet />
+			</>
+		),
 	});
 	const workspaceRoute = createRoute({
 		getParentRoute: () => rootRoute,
@@ -63,10 +56,9 @@ function renderRoute(initialEntry: string, path: string, { mountAtRoot = false }
 	const currentRoute = createRoute({
 		getParentRoute: () => workspaceRoute,
 		path,
-		component: mountAtRoot ? () => null : SwitchWorkspace,
+		component: () => null,
 	});
-	// The workspace home's own schema and search middleware, not a copy: which of its options survive
-	// a switch is the thing under test, so a key added to the retain list is tested here too.
+	// The workspace home's own schema and middleware, so the retain list under test is the real one.
 	const indexRoute = createRoute({
 		getParentRoute: () => workspaceRoute,
 		path: "/",
@@ -112,23 +104,8 @@ async function clickWorkspaceSwitch() {
 describe("useWorkspaceSwitcher", () => {
 	beforeEach(() => vi.clearAllMocks());
 
-	it("keeps a portable route", async () => {
-		const router = renderRoute("/w/alpha/teams?tab=members", "teams");
-
-		await clickWorkspaceSwitch();
-
-		await waitFor(() => expect(router.state.location.href).toBe("/w/beta/teams"));
-		expect(toast.info).not.toHaveBeenCalled();
-	});
-
 	it("clears the leaderboard's team filter and keeps its workspace-independent options", async () => {
-		const router = renderRoute(
-			"/w/alpha?team=Backend&sort=LEAGUE_POINTS&mode=INDIVIDUAL",
-			"teams",
-			{
-				mountAtRoot: true,
-			},
-		);
+		const router = renderRoute("/w/alpha?team=Backend&sort=LEAGUE_POINTS&mode=INDIVIDUAL", "teams");
 
 		await clickWorkspaceSwitch();
 
@@ -139,8 +116,8 @@ describe("useWorkspaceSwitcher", () => {
 		);
 	});
 
-	it("keeps a portable route when the switcher is mounted above every match", async () => {
-		const router = renderRoute("/w/alpha/teams?tab=members", "teams", { mountAtRoot: true });
+	it("keeps a portable route", async () => {
+		const router = renderRoute("/w/alpha/teams?tab=members", "teams");
 
 		await clickWorkspaceSwitch();
 
@@ -160,22 +137,21 @@ describe("useWorkspaceSwitcher", () => {
 	});
 
 	it.each([
-		["mentor thread", "/w/alpha/mentor/thread-1?message=foreign", "mentor/$threadId"],
-		["user profile", "/w/alpha/user/octocat?group=foreign", "user/$username"],
+		["mentor thread", "/w/alpha/mentor/thread-1?message=foreign", "mentor/$threadId", "message"],
+		["user profile", "/w/alpha/user/octocat?group=foreign", "user/$username", "group"],
 		[
 			"practice",
 			"/w/alpha/admin/practices/testing?status=foreign",
 			"admin/practices/$practiceSlug",
+			"status",
 		],
-	])("falls back to workspace home from a %s", async (_name, initialEntry, path) => {
+	])("falls back to workspace home from a %s", async (_name, initialEntry, path, searchKey) => {
 		const router = renderRoute(initialEntry, path);
 
 		await clickWorkspaceSwitch();
 
-		// The workspace home writes its own defaults into the URL; nothing of the previous page's.
-		await waitFor(() =>
-			expect(router.state.location.href).toBe("/w/beta?team=all&sort=SCORE&mode=INDIVIDUAL"),
-		);
+		await waitFor(() => expect(router.state.location.pathname).toBe("/w/beta"));
+		expect(router.state.location.search).not.toHaveProperty(searchKey);
 		expect(toast.info).toHaveBeenCalledExactlyOnceWith("Switched to Beta workspace", {
 			description:
 				"This page is specific to the previous workspace, so Hephaestus opened the new workspace's home page.",

--- a/webapp/src/hooks/use-workspace-switcher.ts
+++ b/webapp/src/hooks/use-workspace-switcher.ts
@@ -5,14 +5,16 @@ export function useWorkspaceSwitcher() {
 	const navigate = useNavigate();
 	const params = useParams({ strict: false });
 	const currentWorkspaceSlug = params.workspaceSlug;
-	// A route is portable only when `workspaceSlug` is the only thing in the URL that names a
-	// workspace-scoped row: any second path param names a row the new workspace does not have.
+	// Any path param besides `workspaceSlug` names a row of the current workspace, which the new one
+	// does not have.
 	const portable =
 		currentWorkspaceSlug !== undefined &&
 		Object.keys(params).every((parameter) => parameter === "workspaceSlug");
 
-	// The destination route's search middleware runs after this updater, so clearing the search leaves
-	// each route to declare which of its own options are portable through `retainSearchParams`.
+	// `to: "."` resolves from the current location's deepest match, not from the route that rendered
+	// the caller, so the switcher can live in the app chrome. The destination's search middleware runs
+	// after this updater, so clearing the search leaves each route to declare which of its own options
+	// are portable through `retainSearchParams`.
 	return async (workspace: { displayName: string; workspaceSlug: string }) => {
 		const { displayName, workspaceSlug } = workspace;
 		if (workspaceSlug === currentWorkspaceSlug) return;

--- a/webapp/src/integrations/auth/guard.ts
+++ b/webapp/src/integrations/auth/guard.ts
@@ -155,18 +155,16 @@ export function safeReturnTo(value: string | undefined): string {
  * and skip the work; the notice is then put to the reader in place, over the page they were opening.
  */
 export async function consentIsPending(queryClient: QueryClient): Promise<boolean> {
-	// Only a signed-in reader can owe it. Asking on a public page would spend a request that can only
-	// answer 401, on the landing page's critical path, for every anonymous visitor.
+	// Only a signed-in reader can owe it; asking for an anonymous visitor would only ever answer 401,
+	// on the landing page's critical path.
 	if (!(await resolveCurrentUser(queryClient))) return false;
 	try {
 		const status = await queryClient.query(getConsentStatusOptions({}));
 		return !status.completed;
 	} catch {
-		// Only an explicit "not answered" blocks the application. Treating an unanswerable question as
-		// outstanding would put an undismissable notice in front of every reader whenever this one
-		// call failed, with no way out but a reload — and it would not even be protective, because the
-		// server refuses the gated calls itself. A reader who does owe the notice still meets that
-		// refusal; a reader who does not keeps working.
+		// Only an explicit "not answered" blocks: treating a failed call as outstanding would put an
+		// undismissable notice in front of every reader, and protect nothing — the server refuses the
+		// gated calls itself.
 		return false;
 	}
 }

--- a/webapp/src/integrations/tanstack-query/root-provider.tsx
+++ b/webapp/src/integrations/tanstack-query/root-provider.tsx
@@ -2,24 +2,21 @@ import { MutationCache, QueryCache, QueryClient, QueryClientProvider } from "@ta
 
 import { captureException } from "@/integrations/sentry";
 
+/**
+ * The default of 0 refetches on every mount, refocus and reconnect, which stacks with the SSE hints
+ * and poll intervals already keeping this app fresh and hits the same endpoint in bursts. 30s
+ * deduplicates those passive triggers without weakening a deliberate one: invalidation marks a query
+ * stale regardless of `staleTime`, so a hint or mutation still refetches immediately.
+ *
+ * Not `Infinity`: SSE hint delivery is at-most-once, so `refetchOnWindowFocus` (default `true`) must
+ * stay armed as the catch-up-after-absence healer.
+ */
+export const QUERY_STALE_TIME_MS = 30_000;
+
 const queryClient = new QueryClient({
 	queryCache: new QueryCache({ onError: (error) => captureException(error) }),
 	mutationCache: new MutationCache({ onError: (error) => captureException(error) }),
-	defaultOptions: {
-		queries: {
-			/**
-			 * The default of 0 refetches on every mount, refocus and reconnect, which stacks with the
-			 * SSE hints and poll intervals already keeping this app fresh and hits the same endpoint in
-			 * bursts. 30s deduplicates those passive triggers without weakening a deliberate one:
-			 * invalidation marks a query stale regardless of `staleTime`, so a hint or mutation still
-			 * refetches immediately.
-			 *
-			 * Not `Infinity`: SSE hint delivery is at-most-once, so `refetchOnWindowFocus` (default
-			 * `true`) must stay armed as the catch-up-after-absence healer.
-			 */
-			staleTime: 30_000,
-		},
-	},
+	defaultOptions: { queries: { staleTime: QUERY_STALE_TIME_MS } },
 });
 
 export function getContext() {

--- a/webapp/src/lib/version.test.ts
+++ b/webapp/src/lib/version.test.ts
@@ -8,7 +8,7 @@ describe("resolveHeaderBadge", () => {
 		expect(badge).toStrictEqual({
 			kind: "release",
 			label: "v0.73.2",
-			href: "https://github.com/ls1intum/Hephaestus/releases/tag/v0.73.2",
+			href: "https://github.com/hephaestus-build/Hephaestus/releases/tag/v0.73.2",
 			tooltip: "View release notes",
 			ariaLabel: "View release v0.73.2",
 		});

--- a/webapp/src/lib/version.ts
+++ b/webapp/src/lib/version.ts
@@ -1,4 +1,4 @@
-const REPO_URL = "https://github.com/ls1intum/Hephaestus";
+export const REPO_URL = "https://github.com/hephaestus-build/Hephaestus";
 const SEMVER = /^\d+\.\d+\.\d+$/;
 
 export type EnvironmentTone = "staging" | "preview" | "local";

--- a/webapp/src/mocks/fixtures/workspaces.ts
+++ b/webapp/src/mocks/fixtures/workspaces.ts
@@ -1,9 +1,8 @@
 import type { WorkspaceListItem } from "@/api/types.gen";
 
 /**
- * One entry of `GET /workspaces`. `createdAt` is a real `Date` — the shape the generated response
- * transformer produces — so the same value can seed the query cache directly and, through
- * `HttpResponse.json`, serialise to the ISO string a response carries.
+ * `createdAt` is a `Date`, the transformed shape, so one value both seeds the query cache and
+ * serialises through `HttpResponse.json` to the ISO string the wire carries.
  */
 export function workspaceListItem(
 	workspaceSlug: string,

--- a/webapp/src/routes/-chrome-route.test.tsx
+++ b/webapp/src/routes/-chrome-route.test.tsx
@@ -10,10 +10,6 @@ import { ROUTE_RENDER_WAIT, renderRouteAt } from "@/test/router-harness";
 // A case mounts the whole app chrome, whose route modules are imported lazily.
 vi.setConfig({ testTimeout: 30_000 });
 
-/**
- * `/settings` and the instance console name no workspace in their URL, and the chrome renders on
- * both — so a member of workspaces must not be told there they belong to none.
- */
 describe("app chrome on a route with no workspace in the URL", () => {
 	beforeEach(() => {
 		server.use(

--- a/webapp/src/routes/-consent-gate.test.tsx
+++ b/webapp/src/routes/-consent-gate.test.tsx
@@ -1,50 +1,44 @@
 import { QueryClient } from "@tanstack/react-query";
-import { describe, expect, it, vi } from "vitest";
+import { HttpResponse, http } from "msw";
+import { describe, expect, it } from "vitest";
 
 import { consentIsPending } from "@/integrations/auth/guard";
+import { server } from "@/mocks/server";
 
-/**
- * The gate the root route consults before anything below it loads. Everything else about the notice
- * is covered by the dialog's stories; what matters here is which way the gate errs, because the
- * server refuses every gated call until the notice is answered.
- */
-/** The generated query keys carry the operation name, which is what tells the two apart. */
-function asksAboutConsent(options: unknown): boolean {
-	return JSON.stringify(options).toLowerCase().includes("consent");
+function newClient() {
+	return new QueryClient({ defaultOptions: { queries: { retry: false } } });
+}
+
+function noticeAnswered(completed: boolean) {
+	server.use(http.get("*/user/consent", () => HttpResponse.json({ completed })));
 }
 
 describe("consent gate", () => {
-	/** A signed-in reader: the current-user query resolves first, then the consent status. */
-	function clientAnswering(status: { completed: boolean }) {
-		const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-		vi.spyOn(client, "query").mockImplementation((options) =>
-			asksAboutConsent(options) ? Promise.resolve(status) : Promise.resolve({ id: 1 }),
-		);
-		return client;
-	}
-
 	it("lets the application load once the notice has been answered", async () => {
-		await expect(consentIsPending(clientAnswering({ completed: true }))).resolves.toBe(false);
+		noticeAnswered(true);
+		await expect(consentIsPending(newClient())).resolves.toBe(false);
 	});
 
 	it("holds the application back while the notice is outstanding", async () => {
-		await expect(consentIsPending(clientAnswering({ completed: false }))).resolves.toBe(true);
+		noticeAnswered(false);
+		await expect(consentIsPending(newClient())).resolves.toBe(true);
 	});
 
 	it("never asks on behalf of a signed-out visitor", async () => {
-		// The landing page waits on this, and the only answer it could get is 401.
-		const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-		const query = vi.spyOn(client, "query").mockResolvedValue(undefined);
-		await expect(consentIsPending(client)).resolves.toBe(false);
-		for (const [options] of query.mock.calls) expect(asksAboutConsent(options)).toBe(false);
+		let asked = false;
+		server.use(
+			http.get("*/user", () => new HttpResponse(null, { status: 401 })),
+			http.get("*/user/consent", () => {
+				asked = true;
+				return HttpResponse.json({ completed: false });
+			}),
+		);
+		await expect(consentIsPending(newClient())).resolves.toBe(false);
+		expect(asked).toBe(false);
 	});
 
 	it("lets the application load when it cannot tell, rather than blocking everyone", async () => {
-		// Blocking here would put an undismissable notice in front of every reader whenever this one
-		// call failed, with no way out but a reload — and it would not be protective either, because
-		// the server refuses the gated calls itself. A reader who owes the notice still meets that.
-		const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-		vi.spyOn(client, "query").mockRejectedValue(new Error("unreachable"));
-		await expect(consentIsPending(client)).resolves.toBe(false);
+		server.use(http.get("*/user/consent", () => HttpResponse.error()));
+		await expect(consentIsPending(newClient())).resolves.toBe(false);
 	});
 });

--- a/webapp/src/routes/__root.tsx
+++ b/webapp/src/routes/__root.tsx
@@ -262,9 +262,8 @@ function HeaderContainer() {
 	const effectiveUsername = workspaceUserLogin ?? username;
 	const effectiveName =
 		workspaceUserName ?? (userProfile && `${userProfile.firstName} ${userProfile.lastName}`);
-	// Feedback about the product reaches instance administrators either way; carrying the chrome's
-	// workspace lets them answer a member in context, and the instance-only path is for an account
-	// that belongs to no workspace at all.
+	// Feedback sent from a route that names no workspace still carries the chrome's, so instance
+	// administrators can answer the member in context.
 	const feedback = useSubmitProductFeedback(chromeWorkspaceSlug);
 
 	return (
@@ -305,10 +304,8 @@ function AppSidebarContainer() {
 	const navigate = useNavigate();
 	const switchWorkspace = useWorkspaceSwitcher();
 	const workspaceAccess = useWorkspaceAccess();
-	const { chromeWorkspaceSlug, workspaces } = workspaceAccess;
+	const { chromeWorkspaceSlug, chromeWorkspace, workspaces } = workspaceAccess;
 	const hasWorkspace = Boolean(chromeWorkspaceSlug);
-	const workspaceList = Array.isArray(workspaces) ? workspaces : [];
-	const activeWorkspace = workspaceList.find((ws) => ws.workspaceSlug === chromeWorkspaceSlug);
 	const integrationCatalogQuery = useQuery({
 		...getIntegrationCatalogOptions({ path: { workspaceSlug: chromeWorkspaceSlug ?? "" } }),
 		enabled: workspaceAccess.isAdmin && Boolean(chromeWorkspaceSlug),
@@ -320,9 +317,9 @@ function AppSidebarContainer() {
 	const integrationKinds = [
 		...new Set([
 			...integrationCatalog.map((entry) => entry.kind),
-			...(activeWorkspace?.providerType === "GITLAB"
+			...(chromeWorkspace?.providerType === "GITLAB"
 				? (["GITLAB"] as const)
-				: activeWorkspace?.providerType === "GITHUB"
+				: chromeWorkspace?.providerType === "GITHUB"
 					? (["GITHUB"] as const)
 					: []),
 		]),
@@ -349,7 +346,7 @@ function AppSidebarContainer() {
 		return null;
 	}
 
-	const handleWorkspaceChange = (ws: typeof activeWorkspace) => {
+	const handleWorkspaceChange = (ws: typeof chromeWorkspace) => {
 		if (!ws) return;
 		void switchWorkspace(ws);
 	};
@@ -366,8 +363,8 @@ function AppSidebarContainer() {
 			hasMentorAccess={hasMentorAccess}
 			integrationKinds={integrationKinds}
 			context={sidebarContext}
-			workspaces={workspaceList}
-			activeWorkspace={activeWorkspace}
+			workspaces={workspaces}
+			activeWorkspace={chromeWorkspace}
 			onWorkspaceChange={handleWorkspaceChange}
 			onAddWorkspace={handleAddWorkspace}
 			workspacesLoading={workspaceAccess.isLoading}

--- a/webapp/src/routes/_authenticated.tsx
+++ b/webapp/src/routes/_authenticated.tsx
@@ -1,9 +1,8 @@
 import { createFileRoute, Outlet, redirect } from "@tanstack/react-router";
 
-import { getConsentStatusOptions } from "@/api/@tanstack/react-query.gen";
 import { Spinner } from "@/components/ui/spinner";
 import { useAuth } from "@/integrations/auth/AuthContext";
-import { resolveCurrentUser } from "@/integrations/auth/guard";
+import { consentIsPending, resolveCurrentUser } from "@/integrations/auth/guard";
 
 // This route will be a parent for all routes that require authentication
 export const Route = createFileRoute("/_authenticated")({
@@ -19,9 +18,12 @@ export const Route = createFileRoute("/_authenticated")({
 				search: { returnTo: location.href },
 			});
 		}
-		const consent = await context.queryClient.query(getConsentStatusOptions({}));
-		if (!consent.completed) {
-			throw redirect({ to: "/consent", search: { returnTo: location.href } });
+		if (await consentIsPending(context.queryClient)) {
+			throw redirect({
+				to: "/consent",
+				search: { returnTo: location.href },
+				mask: { to: location.pathname, search: location.search },
+			});
 		}
 	},
 	pendingComponent: () => (

--- a/webapp/src/routes/_authenticated/w/$workspaceSlug/-route.test.ts
+++ b/webapp/src/routes/_authenticated/w/$workspaceSlug/-route.test.ts
@@ -4,6 +4,7 @@ import { HttpResponse, http } from "msw";
 import { describe, expect, it, vi } from "vitest";
 
 import { listWorkspacesQueryKey } from "@/api/@tanstack/react-query.gen";
+import { QUERY_STALE_TIME_MS } from "@/integrations/tanstack-query/root-provider";
 import { workspaceListItem } from "@/mocks/fixtures/workspaces";
 import { server } from "@/mocks/server";
 import { routeTree } from "@/routeTree.gen";
@@ -12,8 +13,7 @@ import { routeTree } from "@/routeTree.gen";
 vi.setConfig({ testTimeout: 15_000 });
 
 const DEEP_LINK = "/w/foreign/mentor/thread-1?message=stale";
-// The workspace home writes its own schema defaults into the URL it lands on.
-const WORKSPACE_HOME = "/w/acme?team=all&sort=SCORE&mode=INDIVIDUAL";
+const WORKSPACE_HOME = "/w/acme";
 
 function listWorkspaces(...slugs: string[]) {
 	server.use(
@@ -28,41 +28,40 @@ async function land(url: string, queryClient = new QueryClient()) {
 		context: { queryClient, auth: undefined },
 	});
 	await router.load();
-	return router.state.location;
+	return router.state.location.pathname;
 }
 
-/** The gate every `/w/<slug>/…` route inherits, driven through the generated tree. */
 describe("workspace route gate", () => {
 	it("opens a workspace the account can reach", async () => {
 		listWorkspaces("acme");
-		expect((await land("/w/acme")).href).toBe("/w/acme");
+		expect(await land("/w/acme")).toBe(WORKSPACE_HOME);
 	});
 
 	it("returns an inaccessible workspace's deep link to an accessible workspace home", async () => {
 		listWorkspaces("acme");
-		expect((await land(DEEP_LINK)).href).toBe(WORKSPACE_HOME);
+		expect(await land(DEEP_LINK)).toBe(WORKSPACE_HOME);
 	});
 
 	it("returns to the home page when no workspace is accessible", async () => {
 		listWorkspaces();
-		expect((await land(DEEP_LINK)).href).toBe("/");
+		expect(await land(DEEP_LINK)).toBe("/");
 	});
 
 	it("keeps the route when the workspace list cannot be fetched", async () => {
 		server.use(http.get("*/workspaces", () => HttpResponse.error()));
-		expect((await land(DEEP_LINK)).href).toBe(DEEP_LINK);
+		expect(await land(DEEP_LINK)).toBe("/w/foreign/mentor/thread-1");
 	});
 
 	it("opens a just-created workspace the cache carries before the server lists it", async () => {
 		listWorkspaces("acme");
-		// The app's own `staleTime` (`integrations/tanstack-query/root-provider.tsx`), so the gate
-		// answers from the list the creation wizard wrote rather than refetching past it.
-		const queryClient = new QueryClient({ defaultOptions: { queries: { staleTime: 30_000 } } });
+		const queryClient = new QueryClient({
+			defaultOptions: { queries: { staleTime: QUERY_STALE_TIME_MS } },
+		});
 		queryClient.setQueryData(listWorkspacesQueryKey(), [
 			workspaceListItem("acme"),
 			workspaceListItem("brand-new"),
 		]);
 
-		expect((await land("/w/brand-new", queryClient)).href).toBe("/w/brand-new");
+		expect(await land("/w/brand-new", queryClient)).toBe("/w/brand-new");
 	});
 });

--- a/webapp/src/routes/_authenticated/w/$workspaceSlug/route.tsx
+++ b/webapp/src/routes/_authenticated/w/$workspaceSlug/route.tsx
@@ -2,17 +2,15 @@ import { createFileRoute, Outlet, redirect } from "@tanstack/react-router";
 
 import { listWorkspacesOptions } from "@/api/@tanstack/react-query.gen";
 
-/** Workspace gate: a directory layout, so every route under `w/$workspaceSlug/` inherits it. */
-// The gate answers on navigation only. A workspace revoked while a reader sits on one of its pages
-// surfaces as the server's own 403s rather than a redirect; recovering mid-session meant carrying
-// the old path into another workspace, which is the navigation this route exists to prevent.
+// Every route under `w/$workspaceSlug/` inherits this gate. It answers on navigation only: a
+// workspace revoked while a reader sits on one of its pages surfaces as the server's own 403s, since
+// a redirect from a mounted page would carry that page's path into another workspace.
 export const Route = createFileRoute("/_authenticated/w/$workspaceSlug")({
 	beforeLoad: async ({ context, params }) => {
 		const workspaces = await context.queryClient
 			.query(listWorkspacesOptions())
 			.catch(() => undefined);
-		// A list that cannot be fetched is not revoked access: keep the route rather than evicting
-		// the reader on a network error.
+		// A list that cannot be fetched is not revoked access.
 		if (!workspaces) return;
 		if (workspaces.some((workspace) => workspace.workspaceSlug === params.workspaceSlug)) return;
 

--- a/webapp/src/routes/consent.tsx
+++ b/webapp/src/routes/consent.tsx
@@ -42,12 +42,7 @@ function ConsentPage() {
 	const navigate = useNavigate();
 	const queryClient = useQueryClient();
 	const { logout } = useAuth();
-	const { data, isError, refetch } = useQuery({
-		...getConsentStatusOptions({}),
-		// The guard above has just resolved this; refetching immediately would only risk replacing a
-		// usable notice with an error state.
-		staleTime: 30_000,
-	});
+	const { data, isError, refetch } = useQuery(getConsentStatusOptions({}));
 	const mutation = useMutation({
 		...completeFirstLoginConsentMutation(),
 		onSuccess: (status) => {

--- a/webapp/src/routes/index.tsx
+++ b/webapp/src/routes/index.tsx
@@ -19,14 +19,7 @@ export const Route = createFileRoute("/")({
 	beforeLoad: async ({ context }) => {
 		const user = await resolveCurrentUser(context.queryClient);
 		if (!user) return;
-		// Every gated call is refused until the transparency notice is answered, and "/" is the page a
-		// reader lands on after signing in — so without this the first thing a new account meets is
-		// the error boundary. `_authenticated` has always done this; only this route was missing it.
-		//
-		// A redirect rather than a flag: suppressing what renders would not stop the routes below from
-		// running their own guards, which fetch too. Aborting the match is what actually stops them.
-		// The mask keeps the address bar on the page the reader asked for, so the notice reads as an
-		// interruption of that page rather than a trip to somewhere else.
+		// The workspace list below is a gated call, refused until the notice is answered.
 		if (await consentIsPending(context.queryClient)) {
 			throw redirect({
 				to: "/consent",
@@ -56,7 +49,6 @@ function IndexPage() {
 	);
 }
 
-/** Only reached signed out, so the landing page needs no signed-in affordance. */
 function LandingContainer() {
 	const { login } = useAuth();
 	return <LandingPage onSignIn={(idpHint) => login(idpHint, "/")} />;

--- a/webapp/src/routes/login.tsx
+++ b/webapp/src/routes/login.tsx
@@ -59,9 +59,8 @@ function LoginPage() {
 	return (
 		<LoginCard
 			title="Welcome to Hephaestus"
-			// Two sentences, not five: the detail belongs in the transparency notice. But the fact that
-			// signing in shares a provider identity has to be here, because it is the decision being
-			// made on this page — a notice shown afterwards cannot inform it.
+			// Sharing the provider identity is the decision made on this page, so it is said here; the
+			// notice shown afterwards cannot inform it.
 			description={
 				<span className="space-y-2">
 					<span className="block">Your AI mentor for growing as a software engineer.</span>


### PR DESCRIPTION
## What changed and why

Follow-up to the webapp changes merged in #1783, #1838 and #1829. Three routes had grown their own copy of a decision that already had a home, and a few tests proved wiring rather than behaviour:

- **Consent gate.** The authenticated layout fetched the consent status itself and redirected on `!completed`; the home route used `consentIsPending`, which also decides what happens when the status cannot be fetched. Both routes now use the helper and mask the address bar the same way.
- **Consent dialog.** The notice is resolved before the dialog mounts, so the spinner branch could never render; it is gone, along with a `Loading` story for it. When loading fails, the copy no longer tells you to reload the page above a button that retries in place, and the dialog's description is wired to Base UI instead of being suppressed.
- **Landing page.** The signed-in branch (`isSignedIn`, `onGoToDashboard`, the "Go to dashboard" button) was unreachable: the home route redirects a signed-in reader before the landing page renders. Removed from the page, both sections and their stories.
- **Repository links.** Eight hard-coded GitHub URLs now come from the exported `REPO_URL`, and `security.txt`'s canonical address points at `hephaestus.build`.
- **Query defaults.** `staleTime: 30_000` and `refetchOnWindowFocus: true` were restated on two queries; those are the client defaults. The default now has one exported home, which the workspace-gate test uses instead of a hand-copied number.
- **Tests.** The consent-gate test drives the helper through MSW instead of spying on `queryClient.query`; the workspace-switcher and workspace-route tests lose their duplicated cases and hand-copied fixtures; a test that asserted a table constant is dropped.

## How to test

CI runs Vitest, the type check and the Storybook browser suite. Locally:

```bash
vp run typecheck:webapp
vp run test:webapp
vp run --filter webapp test:storybook
```

I ran the first two: type check clean, 1056 tests across 140 files plus 168 lint-rule tests green. The Storybook browser suite would not start a browser on my machine (the connection closes before any story runs, for untouched stories too), so CI is the proof for the changed stories: `ConsentDialog`, `LandingHeroSection`, `LandingCtaSection` and `LandingPage`.

Manual smoke test: sign in with an account that has not answered the transparency notice, block `GET /user/consent` in devtools, and confirm the dialog shows a **Try again** button and no reload instruction; unblock and press it, and the notice loads in place.

## Release impact

[.changeset/the-notice-retries-in-place.md](https://github.com/hephaestus-build/Hephaestus/blob/refactor/webapp-cleanup/.changeset/the-notice-retries-in-place.md), a patch. No operator action.

## Notes for reviewers

- Second layer of a four-layer stack; base is `refactor/server-cleanup`. The layers touch disjoint files.
- The consent dialog's failed-to-load copy is the only visible change. I could not capture before/after screenshots because no browser runs in this environment; the `FailedToLoad` story renders the changed state.
