### PR TITLE
fix(server): removing a label no longer fails the sync under workspace isolation

### DIFF
--- a/.changeset/label-removal-survives-tenancy-enforcement.md
+++ b/.changeset/label-removal-survives-tenancy-enforcement.md
@@ -4,5 +4,5 @@
 
 Removing a label from an issue or pull request no longer fails the sync that noticed it. Workspace
 isolation rejected the statement that unlinks a label, so a repository whose labels changed upstream
-stopped following them; the check now recognises that statement as one keyed entirely by ids the
-server already holds, and keeps rejecting anything broader.
+stopped following them; the check now recognises that one statement, on the join tables Hibernate
+declares, and keeps rejecting everything broader.

--- a/.changeset/label-removal-survives-tenancy-enforcement.md
+++ b/.changeset/label-removal-survives-tenancy-enforcement.md
@@ -3,6 +3,5 @@
 ---
 
 Removing a label from an issue or pull request no longer fails the sync that noticed it. Workspace
-isolation rejected the statement that unlinks a label, so a repository whose labels changed upstream
-stopped following them; the check now recognises that one statement, on the join tables Hibernate
-declares, and keeps rejecting everything broader.
+isolation had rejected the statement that unlinks a label, so a repository whose labels changed
+upstream stopped following them.

--- a/.changeset/label-removal-survives-tenancy-enforcement.md
+++ b/.changeset/label-removal-survives-tenancy-enforcement.md
@@ -1,0 +1,8 @@
+---
+"hephaestus": patch
+---
+
+Removing a label from an issue or pull request no longer fails the sync that noticed it. Workspace
+isolation rejected the statement that unlinks a label, so a repository whose labels changed upstream
+stopped following them; the check now recognises that statement as one keyed entirely by ids the
+server already holds, and keeps rejecting anything broader.

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/tenancy/WorkspaceScopedTables.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/tenancy/WorkspaceScopedTables.java
@@ -92,6 +92,7 @@ public class WorkspaceScopedTables {
             "databasechangeloglock");
 
     private volatile Set<String> scopedTables = Set.of();
+    private volatile Set<String> manyToManyJoinTables = Set.of();
     private final ObjectProvider<EntityManagerFactory> entityManagerFactoryProvider;
 
     /**
@@ -126,7 +127,13 @@ public class WorkspaceScopedTables {
         // and a bare SELECT against them leaks cross-workspace if not joined to a scoped
         // parent. Collections owned via a foreign-key column on the child entity resolve
         // to the child's own table — already added in the entity walk above.
-        metamodel.forEachCollectionDescriptor(collection -> addIfScoped(tables, collection.getTableName()));
+        Set<String> joinTables = new TreeSet<>();
+        metamodel.forEachCollectionDescriptor(collection -> {
+            addIfScoped(tables, collection.getTableName());
+            // A many-to-many join table is the one shape whose rows Hibernate deletes by both
+            // foreign keys; the inspector allows exactly that statement, for exactly these tables.
+            if (collection.isManyToMany()) addIfScoped(joinTables, collection.getTableName());
+        });
 
         // Fail-fast: zero scoped tables from a non-empty entity set means the Hibernate
         // mapping metamodel call chain regressed. A silently-empty set would turn the
@@ -137,6 +144,7 @@ public class WorkspaceScopedTables {
                     + "Check Hibernate MappingMetamodel API compatibility.");
         }
         this.scopedTables = Set.copyOf(tables);
+        this.manyToManyJoinTables = Set.copyOf(joinTables);
         log.info(
                 "WorkspaceScopedTables populated: {} workspace-scoped tables (incl. join tables), {} global",
                 scopedTables.size(),
@@ -154,6 +162,11 @@ public class WorkspaceScopedTables {
     /** Workspace-scoped physical table names (lowercase). Empty until ApplicationReady fires. */
     public Set<String> scopedTables() {
         return scopedTables;
+    }
+
+    /** True iff the table is a {@code @ManyToMany} join table, per the mapping metamodel. */
+    public boolean isManyToManyJoinTable(String tableName) {
+        return tableName != null && manyToManyJoinTables.contains(tableName.toLowerCase(Locale.ROOT));
     }
 
     /** True iff the table requires a {@code workspace_id} predicate on every query. */

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/tenancy/WorkspaceScopedTables.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/tenancy/WorkspaceScopedTables.java
@@ -153,7 +153,11 @@ public class WorkspaceScopedTables {
 
     private static void addIfScoped(Set<String> tables, String rawName) {
         if (rawName == null || rawName.isBlank()) return;
-        String name = rawName.toLowerCase(Locale.ROOT);
+        // The inspector compares bare, lowercase names; a schema-qualified or quoted metamodel
+        // name must land in the same form or it never matches.
+        String name = rawName.substring(rawName.lastIndexOf('.') + 1)
+                .replace("\"", "")
+                .toLowerCase(Locale.ROOT);
         if (!GLOBAL_TABLES.contains(name)) {
             tables.add(name);
         }

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/tenancy/WorkspaceStatementInspector.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/tenancy/WorkspaceStatementInspector.java
@@ -85,33 +85,46 @@ public class WorkspaceStatementInspector implements StatementInspector {
     /** One surrogate-key predicate: {@code id = ?} or {@code <anything>_id = ?}, optionally quoted. */
     private static final String KEY_EQUALS_PARAMETER = "\"?(?:id|[A-Za-z_][A-Za-z0-9_]*_id)\"?\\s*=\\s*\\?";
 
+    /** One foreign-key predicate, {@code <anything>_id = ?}, optionally quoted. */
+    private static final String FOREIGN_KEY_EQUALS_PARAMETER = "\"?[A-Za-z_][A-Za-z0-9_]*_id\"?\\s*=\\s*\\?";
+
     /**
-     * Matches Hibernate-emitted DML on rows identified solely by surrogate keys —
-     * {@code DELETE FROM table WHERE id = ?}, {@code UPDATE table SET ... WHERE id = ?}, and the
-     * join-table row a many-to-many element removal deletes,
-     * {@code DELETE FROM issue_label WHERE issue_id = ? AND label_id = ?}. Every predicate column
-     * must be a key ({@code id} or {@code *_id}), conjoined; nothing else.
+     * Matches Hibernate-emitted DML on a single row identified solely by primary key —
+     * {@code DELETE FROM table WHERE id = ?} or
+     * {@code UPDATE table SET ... WHERE id = ?} (no other predicate columns).
      *
-     * <p>These are tenancy-safe by construction: the rows were already loaded into the
-     * persistence context within a workspace-checked transaction, and surrogate keys are opaque
-     * to anything a request could supply. Allowing this pattern aligns with how Spring Data
-     * {@code delete(entity)}/{@code save(entity)} and Hibernate's collection persisters synthesise
-     * SQL, without requiring every scoped repository to wear {@code @WorkspaceAgnostic} just to
-     * satisfy the inspector.
+     * <p>These are tenancy-safe by construction: the row was already loaded into the
+     * persistence context within a workspace-checked transaction, and the surrogate {@code id}
+     * uniquely identifies it. Allowing this pattern aligns with how Spring Data
+     * {@code delete(entity)}/{@code save(entity)} synthesise SQL, without requiring every
+     * scoped repository to wear {@code @WorkspaceAgnostic} just to satisfy the inspector.
      *
-     * <p>The pattern is intentionally narrow: a non-key column anywhere in the predicate (e.g.
-     * {@code WHERE issue_id = ? AND name = ?}) breaks the match and falls through to the
+     * <p>The pattern is intentionally narrow: any additional condition (e.g.
+     * {@code WHERE id = ? AND something_else}) breaks the match and falls through to the
      * standard {@code workspace_id} check, preserving enforcement for hand-written queries.
      */
     private static final Pattern PK_ONLY_DML_PATTERN = Pattern.compile(
             "^\\s*(?:DELETE\\s+FROM|UPDATE)\\s+\"?[A-Za-z_][A-Za-z0-9_]*\"?" + "(?:\\s+SET\\s+.+?)?"
                     + "\\s+WHERE\\s+" + KEY_EQUALS_PARAMETER
-                    + "(?:\\s+AND\\s+" + KEY_EQUALS_PARAMETER + ")*"
                     +
                     // Optional @Version optimistic-lock predicate: AND version = ?
                     "(?:\\s+AND\\s+\"?version\"?\\s*=\\s*\\?)?"
                     + "\\s*$",
             Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
+
+    /**
+     * Matches the one statement Hibernate emits to remove an element of a {@code @ManyToMany}:
+     * the join-table row deleted by both of its foreign keys,
+     * {@code DELETE FROM issue_label WHERE issue_id = ? AND label_id = ?}. Fully anchored, DELETE
+     * only, exactly two key predicates, so neither a comment nor a SET clause can hide anything
+     * in it. Which tables it may apply to is not a naming convention: the captured table must be
+     * a many-to-many join table in the mapping metamodel, so an entity table with two
+     * {@code *_id} columns never qualifies however it is named.
+     */
+    private static final Pattern JOIN_TABLE_ROW_DELETE_PATTERN = Pattern.compile(
+            "^\\s*DELETE\\s+FROM\\s+\"?([A-Za-z_][A-Za-z0-9_]*)\"?\\s+WHERE\\s+" + FOREIGN_KEY_EQUALS_PARAMETER
+                    + "\\s+AND\\s+" + FOREIGN_KEY_EQUALS_PARAMETER + "\\s*$",
+            Pattern.CASE_INSENSITIVE);
 
     /**
      * Matches a Hibernate-emitted load that pins the result set to a single row (or a
@@ -200,6 +213,11 @@ public class WorkspaceStatementInspector implements StatementInspector {
         // Hibernate-emitted single-row PK DML is safe: the row was already loaded
         // within a workspace-checked scope and identified by a surrogate primary key.
         if (PK_ONLY_DML_PATTERN.matcher(sql).matches()) {
+            return Decision.ok();
+        }
+        Matcher joinTableRowDelete = JOIN_TABLE_ROW_DELETE_PATTERN.matcher(sql);
+        if (joinTableRowDelete.matches()
+                && scopedTables.isManyToManyJoinTable(unqualify(joinTableRowDelete.group(1)))) {
             return Decision.ok();
         }
         // Hibernate-emitted entity load / lazy-fetch by PK is safe for the same reason —

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/tenancy/WorkspaceStatementInspector.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/tenancy/WorkspaceStatementInspector.java
@@ -85,9 +85,6 @@ public class WorkspaceStatementInspector implements StatementInspector {
     /** One surrogate-key predicate: {@code id = ?} or {@code <anything>_id = ?}, optionally quoted. */
     private static final String KEY_EQUALS_PARAMETER = "\"?(?:id|[A-Za-z_][A-Za-z0-9_]*_id)\"?\\s*=\\s*\\?";
 
-    /** One foreign-key predicate, {@code <anything>_id = ?}, optionally quoted. */
-    private static final String FOREIGN_KEY_EQUALS_PARAMETER = "\"?[A-Za-z_][A-Za-z0-9_]*_id\"?\\s*=\\s*\\?";
-
     /**
      * Matches Hibernate-emitted DML on a single row identified solely by primary key —
      * {@code DELETE FROM table WHERE id = ?} or
@@ -122,8 +119,9 @@ public class WorkspaceStatementInspector implements StatementInspector {
      * {@code *_id} columns never qualifies however it is named.
      */
     private static final Pattern JOIN_TABLE_ROW_DELETE_PATTERN = Pattern.compile(
-            "^\\s*DELETE\\s+FROM\\s+\"?([A-Za-z_][A-Za-z0-9_]*)\"?\\s+WHERE\\s+" + FOREIGN_KEY_EQUALS_PARAMETER
-                    + "\\s+AND\\s+" + FOREIGN_KEY_EQUALS_PARAMETER + "\\s*$",
+            "^\\s*DELETE\\s+FROM\\s+\"?([A-Za-z_][A-Za-z0-9_]*)\"?\\s+WHERE\\s+"
+                    + "\"?([A-Za-z_][A-Za-z0-9_]*_id)\"?\\s*=\\s*\\?\\s+AND\\s+"
+                    + "\"?([A-Za-z_][A-Za-z0-9_]*_id)\"?\\s*=\\s*\\?\\s*$",
             Pattern.CASE_INSENSITIVE);
 
     /**
@@ -217,6 +215,8 @@ public class WorkspaceStatementInspector implements StatementInspector {
         }
         Matcher joinTableRowDelete = JOIN_TABLE_ROW_DELETE_PATTERN.matcher(sql);
         if (joinTableRowDelete.matches()
+                // Two different foreign keys: the row's whole key, not one key named twice.
+                && !joinTableRowDelete.group(2).equalsIgnoreCase(joinTableRowDelete.group(3))
                 && scopedTables.isManyToManyJoinTable(unqualify(joinTableRowDelete.group(1)))) {
             return Decision.ok();
         }

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/tenancy/WorkspaceStatementInspector.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/tenancy/WorkspaceStatementInspector.java
@@ -82,24 +82,31 @@ public class WorkspaceStatementInspector implements StatementInspector {
             "(?:\\bFROM\\b|\\bJOIN\\b|\\bUPDATE\\b)\\s+(\"?[A-Za-z_][A-Za-z0-9_]*\"?(?:\\s*\\.\\s*\"?[A-Za-z_][A-Za-z0-9_]*\"?)?)",
             Pattern.CASE_INSENSITIVE);
 
+    /** One surrogate-key predicate: {@code id = ?} or {@code <anything>_id = ?}, optionally quoted. */
+    private static final String KEY_EQUALS_PARAMETER = "\"?(?:id|[A-Za-z_][A-Za-z0-9_]*_id)\"?\\s*=\\s*\\?";
+
     /**
-     * Matches Hibernate-emitted DML on a single row identified solely by primary key —
-     * {@code DELETE FROM table WHERE id = ?} or
-     * {@code UPDATE table SET ... WHERE id = ?} (no other predicate columns).
+     * Matches Hibernate-emitted DML on rows identified solely by surrogate keys —
+     * {@code DELETE FROM table WHERE id = ?}, {@code UPDATE table SET ... WHERE id = ?}, and the
+     * join-table row a many-to-many element removal deletes,
+     * {@code DELETE FROM issue_label WHERE issue_id = ? AND label_id = ?}. Every predicate column
+     * must be a key ({@code id} or {@code *_id}), conjoined; nothing else.
      *
-     * <p>These are tenancy-safe by construction: the row was already loaded into the
-     * persistence context within a workspace-checked transaction, and the surrogate {@code id}
-     * uniquely identifies it. Allowing this pattern aligns with how Spring Data
-     * {@code delete(entity)}/{@code save(entity)} synthesise SQL, without requiring every
-     * scoped repository to wear {@code @WorkspaceAgnostic} just to satisfy the inspector.
+     * <p>These are tenancy-safe by construction: the rows were already loaded into the
+     * persistence context within a workspace-checked transaction, and surrogate keys are opaque
+     * to anything a request could supply. Allowing this pattern aligns with how Spring Data
+     * {@code delete(entity)}/{@code save(entity)} and Hibernate's collection persisters synthesise
+     * SQL, without requiring every scoped repository to wear {@code @WorkspaceAgnostic} just to
+     * satisfy the inspector.
      *
-     * <p>The pattern is intentionally narrow: any additional condition (e.g.
-     * {@code WHERE id = ? AND something_else}) breaks the match and falls through to the
+     * <p>The pattern is intentionally narrow: a non-key column anywhere in the predicate (e.g.
+     * {@code WHERE issue_id = ? AND name = ?}) breaks the match and falls through to the
      * standard {@code workspace_id} check, preserving enforcement for hand-written queries.
      */
     private static final Pattern PK_ONLY_DML_PATTERN = Pattern.compile(
             "^\\s*(?:DELETE\\s+FROM|UPDATE)\\s+\"?[A-Za-z_][A-Za-z0-9_]*\"?" + "(?:\\s+SET\\s+.+?)?"
-                    + "\\s+WHERE\\s+\"?(?:id|[A-Za-z_][A-Za-z0-9_]*_id)\"?\\s*=\\s*\\?"
+                    + "\\s+WHERE\\s+" + KEY_EQUALS_PARAMETER
+                    + "(?:\\s+AND\\s+" + KEY_EQUALS_PARAMETER + ")*"
                     +
                     // Optional @Version optimistic-lock predicate: AND version = ?
                     "(?:\\s+AND\\s+\"?version\"?\\s*=\\s*\\?)?"

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/tenancy/WorkspaceStatementInspectorTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/tenancy/WorkspaceStatementInspectorTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.when;
 
 import de.tum.cit.aet.hephaestus.testconfig.BaseUnitTest;
 import io.micrometer.core.instrument.Counter;
+import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -169,27 +170,40 @@ class WorkspaceStatementInspectorTest extends BaseUnitTest {
     }
 
     @Test
-    void deleteJoinTableRowByAllOfItsKeysIsAllowed() {
+    void deleteManyToManyJoinTableRowByBothKeysIsAllowed() {
         // Removing one element of a @ManyToMany: Hibernate deletes the join-table row by both
-        // foreign keys. Both are surrogate keys the persistence context already held, so this is
-        // the same argument as delete-by-id; requiring workspace_id here fails every label removal.
+        // foreign keys. The table is known from the mapping metamodel, not from its name.
         WorkspaceStatementInspector inspector = newInspector(TenancyEnforcement.THROW);
+        when(scopedTables.isManyToManyJoinTable("issue_label")).thenReturn(true);
         inspector.inspect("delete from issue_label where issue_id=? and label_id=?");
-        verifyNoInteractions(reporter, scopedTables);
+        inspector.inspect("DELETE FROM \"issue_label\" WHERE \"issue_id\"=? AND \"label_id\"=?");
+        verifyNoInteractions(reporter);
     }
 
     @Test
-    void deleteJoinTableRowWithDisjunctionStillRequiresWorkspaceId() {
-        // A disjunction broadens the row set past the keyed rows, so it is not the shape
-        // Hibernate emits and gets the standard check.
+    void twoForeignKeysOnAnEntityTableStillRequireWorkspaceId() {
+        // feedback.id is the key; recipient_user_id and about_user_id are ordinary columns, so
+        // this shape must not pass on the strength of two *_id names.
+        WorkspaceStatementInspector inspector = newInspector(TenancyEnforcement.LOG);
+        when(scopedTables.isScoped("feedback")).thenReturn(true);
+        String sql = "delete from feedback where recipient_user_id=? and about_user_id=?";
+        inspector.inspect(sql);
+        verify(reporter).report(sql, Set.of("feedback"), TenancyEnforcement.LOG);
+    }
+
+    @Test
+    void joinTableAllowanceIsDeleteByBothKeysAndNothingElse() {
         WorkspaceStatementInspector inspector = newInspector(TenancyEnforcement.LOG);
         when(scopedTables.isScoped("issue_label")).thenReturn(true);
-        inspector.inspect("delete from issue_label where issue_id=? or label_id=?");
-        verify(reporter)
-                .report(
-                        "delete from issue_label where issue_id=? or label_id=?",
-                        Set.of("issue_label"),
-                        TenancyEnforcement.LOG);
+        when(scopedTables.isManyToManyJoinTable("issue_label")).thenReturn(true);
+        for (String sql : List.of(
+                "delete from issue_label where issue_id=? or label_id=?",
+                "delete from issue_label where issue_id=? and name=?",
+                "update issue_label set label_id=? where issue_id=? and label_id=?",
+                "delete from issue_label where issue_id=? and label_id=? and version=?")) {
+            inspector.inspect(sql);
+            verify(reporter).report(sql, Set.of("issue_label"), TenancyEnforcement.LOG);
+        }
     }
 
     @Test

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/tenancy/WorkspaceStatementInspectorTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/tenancy/WorkspaceStatementInspectorTest.java
@@ -169,6 +169,30 @@ class WorkspaceStatementInspectorTest extends BaseUnitTest {
     }
 
     @Test
+    void deleteJoinTableRowByAllOfItsKeysIsAllowed() {
+        // Removing one element of a @ManyToMany: Hibernate deletes the join-table row by both
+        // foreign keys. Both are surrogate keys the persistence context already held, so this is
+        // the same argument as delete-by-id; requiring workspace_id here fails every label removal.
+        WorkspaceStatementInspector inspector = newInspector(TenancyEnforcement.THROW);
+        inspector.inspect("delete from issue_label where issue_id=? and label_id=?");
+        verifyNoInteractions(reporter, scopedTables);
+    }
+
+    @Test
+    void deleteJoinTableRowWithDisjunctionStillRequiresWorkspaceId() {
+        // A disjunction broadens the row set past the keyed rows, so it is not the shape
+        // Hibernate emits and gets the standard check.
+        WorkspaceStatementInspector inspector = newInspector(TenancyEnforcement.LOG);
+        when(scopedTables.isScoped("issue_label")).thenReturn(true);
+        inspector.inspect("delete from issue_label where issue_id=? or label_id=?");
+        verify(reporter)
+                .report(
+                        "delete from issue_label where issue_id=? or label_id=?",
+                        Set.of("issue_label"),
+                        TenancyEnforcement.LOG);
+    }
+
+    @Test
     void optimisticLockUpdateIsAllowed() {
         // Hibernate appends "AND version = ?" to UPDATEs for entities with @Version.
         WorkspaceStatementInspector inspector = newInspector(TenancyEnforcement.THROW);
@@ -179,8 +203,8 @@ class WorkspaceStatementInspectorTest extends BaseUnitTest {
 
     @Test
     void deleteWithExtraPredicateStillRequiresWorkspaceId() {
-        // PK-only allowance MUST NOT extend to multi-column deletes — those are likely
-        // hand-written queries where we still want the workspace_id discipline.
+        // The key-only allowance covers conjunctions of keys, never a non-key column: that is a
+        // hand-written query where we still want the workspace_id discipline.
         WorkspaceStatementInspector inspector = newInspector(TenancyEnforcement.LOG);
         when(scopedTables.isScoped("practice")).thenReturn(true);
         inspector.inspect("delete from practice where id=? and slug=?");

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/scm/github/label/GitHubLabelMessageHandlerIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/scm/github/label/GitHubLabelMessageHandlerIntegrationTest.java
@@ -3,6 +3,7 @@ package de.tum.cit.aet.hephaestus.integration.scm.github.label;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import de.tum.cit.aet.hephaestus.core.tenancy.WorkspaceScopedTables;
 import de.tum.cit.aet.hephaestus.integration.core.connection.IdentityProvider;
 import de.tum.cit.aet.hephaestus.integration.core.connection.IdentityProviderRepository;
 import de.tum.cit.aet.hephaestus.integration.core.connection.IdentityProviderType;
@@ -86,6 +87,9 @@ class GitHubLabelMessageHandlerIntegrationTest extends BaseIntegrationTest {
 
     @Autowired
     private IssueRepository issueRepository;
+
+    @Autowired
+    private WorkspaceScopedTables workspaceScopedTables;
 
     @Autowired
     private ObjectMapper objectMapper;
@@ -482,6 +486,58 @@ class GitHubLabelMessageHandlerIntegrationTest extends BaseIntegrationTest {
                 });
             });
         }
+    }
+
+    @Test
+    void shouldRemoveALabelFromAnIssueUnderTenancyEnforcement() throws Exception {
+        // Hibernate unlinks the label with "delete from issue_label where issue_id=? and
+        // label_id=?", the one statement the inspector allows on a declared join table. This runs
+        // against the real mapping metamodel and the enforcement mode the tests boot with, so a
+        // regression fails the commit here the way it failed the sync on staging.
+        assertThat(workspaceScopedTables.isManyToManyJoinTable("issue_label")).isTrue();
+        assertThat(workspaceScopedTables.isManyToManyJoinTable("issue")).isFalse();
+
+        handler.handleEvent(loadPayload("label.created"));
+        Label label = labelRepository
+                .findByNativeIdAndProviderId(FIXTURE_LABEL_ID, providerId())
+                .orElseThrow();
+        // A second label stays on the issue: with the collection still non-empty after the
+        // removal, Hibernate deletes the one row by both keys rather than clearing the issue's
+        // rows by owner key, which the single-key path allowed all along.
+        Label keptLabel = new Label();
+        keptLabel.setNativeId(FIXTURE_LABEL_ID + 1);
+        keptLabel.setProvider(gitProvider);
+        keptLabel.setRepository(testRepository);
+        keptLabel.setName("kept");
+        keptLabel.setColor("00ff00");
+        keptLabel.setCreatedAt(Instant.now());
+        keptLabel.setUpdatedAt(Instant.now());
+        keptLabel = labelRepository.save(keptLabel);
+
+        Issue issue = new Issue();
+        issue.setNativeId(67890L);
+        issue.setNumber(2);
+        issue.setTitle("Labelled, then less so");
+        issue.setState(Issue.State.OPEN);
+        issue.setRepository(testRepository);
+        issue.setCreatedAt(Instant.now());
+        issue.setUpdatedAt(Instant.now());
+        issue.setProvider(gitProvider);
+        issue.getLabels().add(label);
+        issue.getLabels().add(keptLabel);
+        Long issueId = issueRepository.save(issue).getId();
+
+        Long removedLabelId = label.getId();
+        transactionTemplate.executeWithoutResult(status -> {
+            Issue labelled = issueRepository.findById(issueId).orElseThrow();
+            labelled.getLabels().removeIf(l -> removedLabelId.equals(l.getId()));
+        });
+
+        Long keptLabelId = keptLabel.getId();
+        transactionTemplate.executeWithoutResult(status -> assertThat(
+                        issueRepository.findById(issueId).orElseThrow().getLabels())
+                .singleElement()
+                .satisfies(l -> assertThat(l.getId()).isEqualTo(keptLabelId)));
     }
 
     private Long providerId() {


### PR DESCRIPTION
## Problem

Staging's GitHub label sync for one scope failed its commit ninety-nine times in a day with

```text
Tenancy violation: workspace-scoped table(s) queried without workspace_id predicate: [issue_label]
```

Hibernate removes one element of the `Issue.labels` many-to-many with `delete from issue_label where issue_id=? and label_id=?`. `WorkspaceStatementInspector` allows DML keyed by a single surrogate key but nothing with a second predicate, so the join-table row delete fell through to the `workspace_id` check and, in the default `THROW` mode, rolled the whole sync back. Any label removed upstream therefore never left the issue.

## Fix

`WorkspaceScopedTables` records which tables the mapping metamodel declares as `@ManyToMany` join tables. The inspector accepts exactly one new statement: a `DELETE` on such a table keyed by both of its foreign keys, fully anchored, DELETE only, two predicates and nothing else. The general single-key fast path is unchanged. An entity table that happens to have two `*_id` columns, an `UPDATE`, a disjunction, a third predicate, or a `WHERE` hidden in a comment all still get the standard check.

## Verification

- `WorkspaceStatementInspectorTest`: the join-table row delete passes (plain and quoted) only when the registry says the table is a join table; `delete from feedback where recipient_user_id=? and about_user_id=?` is still reported; on the join table itself an `OR`, a non-key column, an `UPDATE`, and a third predicate are all still reported.
- `TenancyBypassTest`, `TenancyEnforcementPropertiesTest`, `MultiTenancyArchitectureTest`, `DataIsolationArchitectureTest`, `CodeQualityTest` green locally.

Fixes #1858.
