### PR TITLE
feat(ci): fail when the OpenSSF Scorecard regresses

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,5 @@
+# security/semgrep/ is a Semgrep rule pack: its fixtures deliberately carry unused parameters and
+# other patterns the rules exist to flag, which CodeQL's own queries (e.g. "useless parameter")
+# otherwise report as findings in code that is never shipped.
+paths-ignore:
+  - security/semgrep/**

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -172,6 +172,7 @@ jobs:
               - '.agents/**'
               - 'opencode.json'
               - 'renovate.json'
+              - 'security/scorecard-baseline.json'
               - 'openapitools.json'
               - 'jean.json'
               - 'project.code-workspace'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,49 @@
+name: CodeQL
+
+# Advanced setup, not GitHub's managed default setup: only advanced setup reads a committed
+# `config-file`, and `security/semgrep/**` needs `paths-ignore` (docs/contributor/ci-cd.mdx §
+# CodeQL configuration).
+on:
+  push:
+    branches: [main]
+  pull_request:
+  merge_group:
+  schedule:
+    - cron: "15 5 * * 1"
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [actions, java-kotlin, javascript-typescript]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+        with:
+          languages: ${{ matrix.language }}
+          # The repository has no Kotlin, and CodeQL supports build-mode: none for Java without it.
+          build-mode: none
+          config-file: ./.github/codeql/codeql-config.yml
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+        with:
+          category: /language:${{ matrix.language }}

--- a/.github/workflows/scorecard-ratchet.yml
+++ b/.github/workflows/scorecard-ratchet.yml
@@ -1,0 +1,42 @@
+name: Scorecard ratchet
+
+# Separate from scorecard.yml: OpenSSF allows the publishing job only allowlisted actions, and its
+# publishing is supported on the events that workflow already declares.
+on:
+  push:
+    branches: [main]
+  branch_protection_rule:
+  schedule:
+    - cron: "23 4 * * 1"
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ratchet:
+    name: Scorecard regression
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: package.json
+      - name: Enforce the published baseline
+        run: node scripts/check-scorecard.ts
+      - name: Preserve ratchet evidence
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: scorecard-ratchet-${{ github.sha }}
+          path: tmp/scorecard-assessment.json
+          if-no-files-found: warn
+          retention-days: 14

--- a/docs/contributor/ci-cd.mdx
+++ b/docs/contributor/ci-cd.mdx
@@ -117,7 +117,7 @@ changesets rather than adding one. [Release management](./release-management.mdx
 | --- | --- | --- | --- |
 | Dependency vulnerability gate | Security workflow | owns the dependency verdict; blocks fixable high or critical findings in every dependency the checkout resolves | required Security workflow |
 | GitHub dependency review | pull requests | reports the advisories a pull request introduces, with their patched versions; holds no verdict | Security workflow summary |
-| CodeQL default setup | managed by GitHub | repository SAST policy | code scanning |
+| CodeQL advanced setup | pull requests, merge groups, `main` pushes, and weekly | repository SAST policy | code scanning |
 | TruffleHog and GitHub push protection | pull requests and pushes | block verified secrets | Security workflow and repository protection |
 | Trivy filesystem scan | Security workflow | a scanner error blocks; findings of every severity are report-only | code scanning |
 | Semgrep TLS policy | pull requests, merge groups, and `main` pushes | fails on a rule violation or a scanner error | code scanning and a run artifact |
@@ -171,6 +171,16 @@ Semgrep reports; it is not a required check. The digest-pinned scanner runs with
 credentials over a read-only checkout, and `.github/workflows/semgrep.yml` owns the commands that
 reproduce a run locally. A pull request from a fork gets the scan verdict but no code-scanning row,
 because GitHub caps a fork token's `security-events` access at read.
+
+### CodeQL configuration
+
+`.github/workflows/codeql.yml` runs CodeQL under advanced setup: only advanced setup reads a
+committed config file, and `.github/codeql/codeql-config.yml` excludes `security/semgrep/**`,
+whose fixtures deliberately carry the patterns the Semgrep rules exist to flag — unused parameters
+among them — which CodeQL's own queries otherwise report in code that is never shipped. Advanced
+setup replaces GitHub's managed default setup; switching a repository between the two is a one-time
+manual step under **Settings → Advanced Security → Code scanning → CodeQL analysis → Switch to
+advanced → Disable CodeQL**, not something a workflow file can do.
 
 ### Scorecard baseline
 

--- a/docs/contributor/ci-cd.mdx
+++ b/docs/contributor/ci-cd.mdx
@@ -124,6 +124,7 @@ changesets rather than adding one. [Release management](./release-management.mdx
 | Image vulnerability policy | image build and release | blocks fixable high or critical findings | build summary and release evidence |
 | Weekly image rescans | `rescan-main-images.yml`, `rescan-release-images.yml` | the `main` rescan upserts one tracking issue; the release rescan fails and comments on the vulnerability response issue | issues and run artifacts |
 | OpenSSF Scorecard | `main` pushes, branch-protection changes, and weekly; never on pull requests | reports | code scanning and a run artifact |
+| Scorecard ratchet | the same events, plus on demand | fails when an enforced check scores below `security/scorecard-baseline.json` | job summary and a run artifact |
 | Renovate | configured schedule and vulnerability alerts | pull requests require normal review and CI | dependency dashboard |
 
 One check owns the dependency verdict: the dependency vulnerability gate in `ci-security-scan.yml`,
@@ -170,6 +171,23 @@ Semgrep reports; it is not a required check. The digest-pinned scanner runs with
 credentials over a read-only checkout, and `.github/workflows/semgrep.yml` owns the commands that
 reproduce a run locally. A pull request from a fork gets the scan verdict but no code-scanning row,
 because GitHub caps a fork token's `security-events` access at read.
+
+### Scorecard baseline
+
+`security/scorecard-baseline.json` owns the minimum every enforced Scorecard check must hold and the
+four exclusions, each with its reason. Checks are compared one at a time, so an improvement cannot
+offset a regression, and a check the baseline does not name is not enforced. Lowering a minimum also
+edits the map in `scripts/check-scorecard.test.ts`, so the change is visible in the pull request that
+makes it.
+
+`scripts/check-scorecard.ts` reads the posture OpenSSF publishes for this repository — the latest
+published assessment, not necessarily the current commit — and fails on a regression, a missing
+enforced check, evidence that predates the baseline or is more than eight days old, and on an API or
+parsing failure. `scorecard-ratchet.yml` runs it on `main` pushes, branch-protection changes, weekly
+and on demand, and keeps the fetched assessment as an artifact. It is a workflow of its own because
+[OpenSSF restricts the publishing job](https://github.com/ossf/scorecard-action#workflow-restrictions)
+to allowlisted actions. Reproduce it with `node scripts/check-scorecard.ts`, or
+`node --test scripts/check-scorecard.test.ts` without network access.
 
 ## Environments
 
@@ -279,6 +297,7 @@ why the label is the authority, and which alternatives were priced and declined,
 | `rescan-release-images.yml` | Weekly, manual | Rescans the latest published release's images and reports drift on the vulnerability response issue |
 | `ci-profile.yml` | Weekly, manual | Profiles server integration tests and Spring contexts |
 | `ci-server-clean-reference.yml` | Weekly, manual | Records cold server phases and compares generated JARs |
+| `scorecard-ratchet.yml` | Push to main, branch-protection change, weekly, manual | Fails when a Scorecard check drops below the committed baseline |
 | `deploy-preview.yml` | `preview` label added, or a push, reopen or ready-for-review on a labelled PR | Waits for this commit's attested CI images, deploys them, and registers the native GitHub deployment |
 | `cleanup-preview.yml` | Label removed, PR closed or drafted | Removes and verifies resources, then retains a cleanup tombstone |
 | `reconcile-previews.yml` | Nightly, manual | Re-sends teardown for any preview environment whose pull request is closed, drafted or unlabelled |

--- a/scripts/check-scorecard.test.ts
+++ b/scripts/check-scorecard.test.ts
@@ -1,0 +1,192 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { test } from "node:test";
+import { pathToFileURL } from "node:url";
+
+import { checkScorecard } from "./check-scorecard.ts";
+import { asArray, asRecord, readJsonFile } from "./lib/json.ts";
+
+const baseline = asRecord(await readJsonFile("security/scorecard-baseline.json"), "baseline");
+const now = Date.parse("2026-09-05T19:00:22Z");
+const assessment = () => ({
+	date: "2026-09-05T19:00:22Z",
+	repo: { name: baseline.repository },
+	checks: structuredClone(asArray(baseline.checks, "checks")).map((check) =>
+		asRecord(check, "check"),
+	),
+});
+
+/** The audit #1653 recorded, restated so that lowering a minimum is a deliberate edit here too. */
+const enforced: Record<string, number> = {
+	"Binary-Artifacts": 10,
+	"CI-Tests": 10,
+	"Code-Review": 10,
+	"Dangerous-Workflow": 10,
+	"Dependency-Update-Tool": 10,
+	License: 10,
+	Maintained: 10,
+	"Pinned-Dependencies": 10,
+	SAST: 10,
+	"Security-Policy": 10,
+	"Token-Permissions": 10,
+	Vulnerabilities: 10,
+	"Signed-Releases": 8,
+	"Branch-Protection": 4,
+};
+
+void test("the committed baseline enforces the recorded minimums", () => {
+	const excluded = asRecord(baseline.excluded, "excluded");
+	assert.deepEqual(
+		Object.fromEntries(
+			asArray(baseline.checks, "checks")
+				.map((check) => asRecord(check, "check"))
+				.filter((check) => !Object.hasOwn(excluded, String(check.name)))
+				.map((check) => [check.name, check.score]),
+		),
+		enforced,
+	);
+});
+
+void test("the committed baseline passes and improvements do not compensate for regressions", () => {
+	assert.deepEqual(checkScorecard(baseline, assessment(), now), []);
+	const value = assessment();
+	for (const check of value.checks) {
+		if (check.name === "Branch-Protection") check.score = 10;
+		if (check.name === "Pinned-Dependencies") check.score = 9;
+	}
+	assert.deepEqual(checkScorecard(baseline, value, now), ["Pinned-Dependencies: 9 (minimum 10)"]);
+});
+
+void test("each enforced check independently rejects any drop or missing evidence", () => {
+	for (const [name, minimum] of Object.entries(enforced)) {
+		const value = assessment();
+		assert.deepEqual(
+			checkScorecard(
+				baseline,
+				{ ...value, checks: value.checks.filter((check) => check.name !== name) },
+				now,
+			),
+			[`${name}: missing (minimum ${minimum})`],
+		);
+		for (const check of value.checks) if (check.name === name) check.score = minimum - 1;
+		assert.deepEqual(checkScorecard(baseline, value, now), [
+			`${name}: ${minimum - 1} (minimum ${minimum})`,
+		]);
+	}
+});
+
+void test("only the four deliberate exclusions may drop without failure", () => {
+	const value = assessment();
+	for (const check of value.checks)
+		if (["Contributors", "CII-Best-Practices", "Fuzzing", "Packaging"].includes(String(check.name)))
+			check.score = -1;
+	assert.deepEqual(checkScorecard(baseline, value, now), []);
+});
+
+void test("new checks do not silently become a new policy", () => {
+	const value = assessment();
+	value.checks.push({ name: "New-Check", score: 0 });
+	assert.deepEqual(checkScorecard(baseline, value, now), []);
+});
+
+void test("rejects stale, future, invalid and pre-baseline assessments", () => {
+	for (const date of ["2026-08-01", "2026-09-04T18:00:00Z", "2026-09-06", "not-a-date"])
+		assert.throws(() => checkScorecard(baseline, { ...assessment(), date }, now));
+	assert.throws(() => checkScorecard(baseline, assessment(), now + 8 * 86_400_000 + 1), /stale/);
+	assert.deepEqual(checkScorecard(baseline, assessment(), now + 8 * 86_400_000), []);
+});
+
+void test("rejects malformed, duplicate and wrong-repository evidence", () => {
+	for (const value of [null, {}, { ...assessment(), repo: { name: "github.com/attacker/repo" } }]) {
+		assert.throws(() => checkScorecard(baseline, value, now));
+	}
+	for (const score of [null, "10", 11, -2, 9.5])
+		assert.throws(() =>
+			checkScorecard(baseline, { ...assessment(), checks: [{ name: "SAST", score }] }, now),
+		);
+	assert.throws(
+		() =>
+			checkScorecard(
+				baseline,
+				{
+					...assessment(),
+					checks: [
+						{ name: "SAST", score: 10 },
+						{ name: "SAST", score: 10 },
+					],
+				},
+				now,
+			),
+		/duplicate/,
+	);
+});
+
+void test("invalid policy cannot pass vacuously", () => {
+	for (const change of [
+		{ checks: [] },
+		{ checks: [{ name: "SAST", score: -1 }], excluded: {} },
+		{ checks: [{ name: "SAST", score: 10 }], excluded: { SAST: "All checks disabled" } },
+		{ excluded: { SAST: "" } },
+		{ excluded: { Typo: "reason" } },
+		{ date: "invalid" },
+	])
+		assert.throws(() => checkScorecard({ ...baseline, ...change }, assessment(), now));
+});
+
+void test("the CLI preserves regression evidence and fails on transport and JSON errors", async (t) => {
+	const directory = await mkdtemp(join(tmpdir(), "scorecard-cli-"));
+	t.after(() => rm(directory, { recursive: true, force: true }));
+	await mkdir(join(directory, "security"));
+	await writeFile(join(directory, "security/scorecard-baseline.json"), JSON.stringify(baseline));
+	const preload = join(directory, "fetch.mjs");
+	await writeFile(
+		preload,
+		`globalThis.fetch = async () => new Response(process.env.RESPONSE_BODY, { status: Number(process.env.RESPONSE_STATUS) });`,
+	);
+	const summary = join(directory, "summary.md");
+	const evidence = join(directory, "tmp/scorecard-assessment.json");
+	const current = { ...assessment(), date: new Date().toISOString() };
+	const regression = {
+		...current,
+		checks: current.checks.filter((check) => check.name !== "SAST"),
+	};
+	for (const [name, status, body, failure] of [
+		["passing assessment", 200, JSON.stringify(current), false],
+		["missing check", 200, JSON.stringify(regression), true],
+		["HTTP failure", 503, "service unavailable", true],
+		["invalid JSON", 200, "not JSON", true],
+	] as const) {
+		await t.test(name, async () => {
+			await rm(summary, { force: true });
+			await rm(evidence, { force: true });
+			const result = spawnSync(
+				process.execPath,
+				["--import", pathToFileURL(preload).href, resolve("scripts/check-scorecard.ts")],
+				{
+					cwd: directory,
+					timeout: 10_000,
+					encoding: "utf8",
+					env: {
+						...process.env,
+						GITHUB_STEP_SUMMARY: summary,
+						RESPONSE_BODY: body,
+						RESPONSE_STATUS: String(status),
+					},
+				},
+			);
+			assert.equal(result.status, failure ? 1 : 0, result.stderr);
+			if (status === 200 && body !== "not JSON") {
+				assert.deepEqual(JSON.parse(await readFile(evidence, "utf8")), JSON.parse(body));
+				assert.match(
+					await readFile(summary, "utf8"),
+					failure ? /SAST: missing/ : /All enforced checks meet/,
+				);
+			} else {
+				await assert.rejects(readFile(evidence), { code: "ENOENT" });
+			}
+		});
+	}
+});

--- a/scripts/check-scorecard.ts
+++ b/scripts/check-scorecard.ts
@@ -1,0 +1,78 @@
+import { appendFile, mkdir, writeFile } from "node:fs/promises";
+
+import { asArray, asRecord, asString, readJsonFile } from "./lib/json.ts";
+
+function scores(value: unknown): Map<string, number> {
+	const result = new Map<string, number>();
+	for (const item of asArray(value, "checks")) {
+		const check = asRecord(item, "check");
+		const name = asString(check.name, "check.name");
+		const score = check.score;
+		if (
+			!name ||
+			result.has(name) ||
+			typeof score !== "number" ||
+			!Number.isInteger(score) ||
+			score < -1 ||
+			score > 10
+		)
+			throw new Error(`Invalid or duplicate check: ${name}`);
+		result.set(name, score);
+	}
+	return result;
+}
+
+export function checkScorecard(
+	baselineValue: unknown,
+	assessmentValue: unknown,
+	now = Date.now(),
+): string[] {
+	const baseline = asRecord(baselineValue, "baseline");
+	const assessment = asRecord(assessmentValue, "assessment");
+	const repository = asString(baseline.repository, "baseline.repository");
+	if (asRecord(assessment.repo, "repo").name !== repository)
+		throw new Error("Assessment belongs to a different repository");
+	const date = Date.parse(asString(assessment.date, "assessment.date"));
+	// The published assessment refreshes on each push to main; eight days tolerates a quiet week.
+	if (!Number.isFinite(date) || date > now + 5 * 60_000 || now - date > 8 * 86_400_000)
+		throw new Error("Assessment is stale or has an invalid/future date");
+	const baselineDate = Date.parse(asString(baseline.date, "baseline.date"));
+	if (!Number.isFinite(baselineDate)) throw new Error("Invalid baseline date");
+	if (date < baselineDate) throw new Error("Assessment predates the baseline");
+	const expected = scores(baseline.checks);
+	const actual = scores(assessment.checks);
+	const excluded = asRecord(baseline.excluded, "baseline.excluded");
+	for (const [name, reason] of Object.entries(excluded)) {
+		if (!expected.has(name) || !asString(reason, `exclusion ${name}`).trim())
+			throw new Error(`Invalid exclusion: ${name}`);
+	}
+	const enforced = [...expected].filter(([name]) => !Object.hasOwn(excluded, name));
+	if (enforced.length === 0 || enforced.some(([, minimum]) => minimum < 0))
+		throw new Error("Baseline must enforce at least one check with nonnegative minimums");
+	const failures: string[] = [];
+	for (const [name, minimum] of enforced) {
+		const current = actual.get(name);
+		if (current === undefined || current < minimum)
+			failures.push(`${name}: ${current ?? "missing"} (minimum ${minimum})`);
+	}
+	return failures;
+}
+
+async function main() {
+	const baseline = asRecord(await readJsonFile("security/scorecard-baseline.json"), "baseline");
+	const repository = asString(baseline.repository, "baseline.repository");
+	const response = await fetch(`https://api.scorecard.dev/projects/${repository}`, {
+		signal: AbortSignal.timeout(30_000),
+	});
+	if (!response.ok) throw new Error(`Scorecard API returned HTTP ${response.status}`);
+	const assessment: unknown = await response.json();
+	await mkdir("tmp", { recursive: true });
+	await writeFile("tmp/scorecard-assessment.json", `${JSON.stringify(assessment, null, 2)}\n`);
+	const failures = checkScorecard(baseline, assessment);
+	const summary = `## Scorecard ratchet\n\n${failures.length ? failures.map((failure) => `- ${failure}`).join("\n") : "All enforced checks meet the committed baseline."}\n`;
+	process.stdout.write(summary);
+	if (process.env.GITHUB_STEP_SUMMARY) await appendFile(process.env.GITHUB_STEP_SUMMARY, summary);
+	if (failures.length) process.exitCode = 1;
+}
+
+if (import.meta.main) await main();

--- a/scripts/ci-contract.test.ts
+++ b/scripts/ci-contract.test.ts
@@ -1803,6 +1803,35 @@ void test("Semgrep scans PRs, main and merge queues without a privileged trigger
 	);
 });
 
+void test("CodeQL runs advanced setup and excludes the Semgrep fixtures it would otherwise flag", async () => {
+	const source = await readFile(".github/workflows/codeql.yml", "utf8");
+	const workflow = parseDocument(source);
+	for (const trigger of ["pull_request", "push", "merge_group", "schedule"])
+		assert.ok(workflow.hasIn(["on", trigger]), `codeql.yml must run on ${trigger}`);
+	assert.equal(workflow.hasIn(["on", "pull_request_target"]), false);
+	const permissions = workflow.getIn(["jobs", "analyze", "permissions"]);
+	assert.ok(isMap(permissions));
+	assert.deepEqual(permissions.toJSON(), {
+		actions: "read",
+		contents: "read",
+		"security-events": "write",
+	});
+	for (const action of ["github/codeql-action/init", "github/codeql-action/analyze"])
+		for (const match of source.matchAll(new RegExp(`uses: ${action}@([\\w.-]+)`, "g")))
+			assert.match(match[1] ?? "", /^[a-f0-9]{40}$/, `${action} must be pinned by commit`);
+	const init = step(workflow, ["jobs", "analyze"], "github/codeql-action/init");
+	assert.equal(init.get("build-mode"), "none");
+	assert.equal(init.get("config-file"), "./.github/codeql/codeql-config.yml");
+	assert.match(String(init.get("languages")), /^\$\{\{ *matrix\.language *\}\}$/);
+	const analyze = step(workflow, ["jobs", "analyze"], "github/codeql-action/analyze");
+	assert.match(String(analyze.get("category")), /^\/language:\$\{\{ *matrix\.language *\}\}$/);
+	const config = asRecord(
+		parseDocument(await readFile(".github/codeql/codeql-config.yml", "utf8")).toJSON(),
+		"codeql-config.yml",
+	);
+	assert.deepEqual(config["paths-ignore"], ["security/semgrep/**"]);
+});
+
 void test("every Semgrep rule ships a positive and a negative fixture", async () => {
 	const files = await posixGlob("security/semgrep/*");
 	const rulesets = files.filter((file) => file.endsWith(".yaml"));

--- a/scripts/ci-contract.test.ts
+++ b/scripts/ci-contract.test.ts
@@ -1692,6 +1692,35 @@ void test("installs dependencies in every job that calls vp", async () => {
 	assert.deepEqual(offenders, [], "A job that calls vp must install dependencies first");
 });
 
+void test("the Scorecard ratchet runs on every event that can move a score, outside publishing", async () => {
+	const workflow = parseDocument(await readFile(".github/workflows/scorecard-ratchet.yml", "utf8"));
+	for (const trigger of ["push", "branch_protection_rule", "schedule", "workflow_dispatch"])
+		assert.ok(workflow.hasIn(["on", trigger]), `the ratchet must run on ${trigger}`);
+	assert.equal(workflow.getIn(["jobs", "ratchet", "permissions", "contents"]), "read");
+	assert.equal(workflow.hasIn(["jobs", "ratchet", "permissions", "id-token"]), false);
+	assert.equal(
+		step(workflow, ["jobs", "ratchet"], "actions/upload-artifact").get("path"),
+		"tmp/scorecard-assessment.json",
+	);
+	assert.match(
+		pathFilter(await readFile(".github/workflows/cicd.yml", "utf8"), "tooling"),
+		/security\/scorecard-baseline\.json/,
+	);
+
+	// The publishing workflow may only run allowlisted actions, which is why the ratchet is not a job in it.
+	const publishing = parseDocument(await readFile(".github/workflows/scorecard.yml", "utf8"));
+	const steps = publishing.getIn(["jobs", "analysis", "steps"]);
+	assert.ok(isSeq(steps));
+	for (const item of steps.items) {
+		assert.ok(isMap(item));
+		assert.equal(item.get("run"), undefined);
+		assert.match(
+			String(item.get("uses")),
+			/^(actions\/(checkout|upload-artifact)|github\/codeql-action\/upload-sarif|ossf\/scorecard-action)@/,
+		);
+	}
+});
+
 // A toolchain claim is a job: every leg of the task graph is one matrix entry of one job, the Vite+
 // shell and the hook dispatcher run on Windows as one of them, and the documented first command of
 // a contributor runs from a clone that has nothing but the launcher.

--- a/security/scorecard-baseline.json
+++ b/security/scorecard-baseline.json
@@ -1,0 +1,84 @@
+{
+	"repository": "github.com/hephaestus-build/Hephaestus",
+	"date": "2026-09-04T19:00:22Z",
+	"checks": [
+		{
+			"name": "Binary-Artifacts",
+			"score": 10
+		},
+		{
+			"name": "CI-Tests",
+			"score": 10
+		},
+		{
+			"name": "Code-Review",
+			"score": 10
+		},
+		{
+			"name": "Dangerous-Workflow",
+			"score": 10
+		},
+		{
+			"name": "Dependency-Update-Tool",
+			"score": 10
+		},
+		{
+			"name": "License",
+			"score": 10
+		},
+		{
+			"name": "Maintained",
+			"score": 10
+		},
+		{
+			"name": "Pinned-Dependencies",
+			"score": 10
+		},
+		{
+			"name": "SAST",
+			"score": 10
+		},
+		{
+			"name": "Security-Policy",
+			"score": 10
+		},
+		{
+			"name": "Token-Permissions",
+			"score": 10
+		},
+		{
+			"name": "Vulnerabilities",
+			"score": 10
+		},
+		{
+			"name": "Signed-Releases",
+			"score": 8
+		},
+		{
+			"name": "Branch-Protection",
+			"score": 4
+		},
+		{
+			"name": "Contributors",
+			"score": 3
+		},
+		{
+			"name": "CII-Best-Practices",
+			"score": 0
+		},
+		{
+			"name": "Fuzzing",
+			"score": 0
+		},
+		{
+			"name": "Packaging",
+			"score": -1
+		}
+	],
+	"excluded": {
+		"Contributors": "Organization diversity is not a repository engineering control.",
+		"CII-Best-Practices": "An OpenSSF badge is a separate adoption decision.",
+		"Fuzzing": "Fuzzing adoption is a separate policy decision.",
+		"Packaging": "Releases publish images rather than registry packages."
+	}
+}


### PR DESCRIPTION
## What changed and why

OpenSSF Scorecard publishes this repository's supply-chain posture on every push to `main`, but
nothing fails when a score falls. A regression is visible only to whoever opens the dashboard.

`security/scorecard-baseline.json` commits the audited minimum for every check and the four
exclusions, each with its reason. `scripts/check-scorecard.ts` reads the published assessment and
fails when an enforced check scores below its minimum, when an enforced check is missing, when the
evidence predates the baseline or is more than eight days old, and when the API or the response
cannot be read. Each check is compared on its own, so an improvement elsewhere cannot pay for a
regression.

`scorecard-ratchet.yml` runs it on pushes to `main`, on `branch_protection_rule`, weekly and on
demand — the events that can move a score, so a relaxed branch-protection setting surfaces the same
day and a repair can be confirmed without waiting for the cron. It is a workflow of its own because
OpenSSF allows the publishing job only allowlisted actions, and its publishing does not support
`workflow_dispatch`.

This also excludes `security/semgrep/**` from CodeQL, in the same lane: CodeQL's default setup has
no path-exclusion mechanism, and its "useless parameter" query fired on the Semgrep fixtures'
deliberately-unused parameters, blocking #1846. `.github/workflows/codeql.yml` switches the
repository to advanced setup — the only setup a committed `config-file` works from — and
`.github/codeql/codeql-config.yml` carries the `paths-ignore`. Switching between default and
advanced setup is a one-time manual step under Settings, documented next to the workflow.

Part of [#1653](https://github.com/hephaestus-build/Hephaestus/issues/1653), which also owns the
Semgrep leg. This PR does not close it: three of that issue's four *Done when* bullets are verdicts
observed after a merge rather than changes that ship, which the issue needs to re-word under
`CONTRIBUTING.md` § Issues.

## How to test

- `vp run format` and `vp run check` — green.
- `node --test scripts/check-scorecard.test.ts scripts/ci-contract.test.ts` — 13 and 51 passing.
- `node scripts/check-scorecard.ts` against the live assessment — exit 0, "All enforced checks meet
  the committed baseline."
- Lowering a committed minimum fails the suite: `Branch-Protection` 4 → 0 and `Signed-Releases`
  8 → 7 each turn two tests red, so a quiet downgrade cannot ride along in the JSON.
- Removing `workflow_dispatch`, `push` or `branch_protection_rule` from the workflow, or the
  baseline from the `tooling` path filter, each fails the contract test.
- Removing the CodeQL `config-file`, its `build-mode: none`, or the `security/semgrep/**` entry from
  `codeql-config.yml` each fails the new contract test.
- `actionlint` and `zizmor 1.29.0 --min-confidence medium` on `scorecard-ratchet.yml`, `codeql.yml`
  and `cicd.yml` — no findings.

## Release impact

CI, repository policy, tests and contributor documentation only. Nothing shipped changes, so there
is no changeset — `.changeset/README.md` scopes that requirement to `server/`, `webapp/` and
`docker/` — no migration and no operator action.

## Notes for reviewers

Start with `security/scorecard-baseline.json` and `scripts/check-scorecard.ts`; the CodeQL exclusion
is a smaller, independent addition in `.github/workflows/codeql.yml` and
`.github/codeql/codeql-config.yml`.

The baseline records only what it enforces: the aggregate score and the engine version were dropped
rather than committed unread. The ratchet is a floor, not a self-raising ratchet — a score that
improves does not lift the minimum, which is what #1653 asked for ("improve deliberately").

It judges the latest published assessment, which is refreshed on each push to `main` and is not
necessarily the current commit. `Contributors`, `CII-Best-Practices`, `Fuzzing` and `Packaging` are
excluded by name because engineering practice in this repository does not move them, and a check
Scorecard adds later is not enforced until the baseline names it.

This shared the `.github/workflows/**` lane with the Semgrep leg (#1846) and rebases cleanly now
that it is on `main`.
