### PR TITLE
fix(server): the projected league change identifies the developer through the workspace

### DIFF
--- a/.changeset/league-change-for-shared-logins.md
+++ b/.changeset/league-change-for-shared-logins.md
@@ -3,6 +3,5 @@
 ---
 
 A developer's projected league change loads even when someone else in the instance uses the same
-login on another provider. The league calculation now identifies the developer through their
-workspace membership rather than by login alone, in the profile, the scheduled league update and the
-recalculation.
+login on another provider. The league looks at the developer who is a member of your workspace, not
+at whoever shares their login.

--- a/.changeset/league-change-for-shared-logins.md
+++ b/.changeset/league-change-for-shared-logins.md
@@ -1,0 +1,8 @@
+---
+"hephaestus": patch
+---
+
+A developer's projected league change loads even when someone else in the instance uses the same
+login on another provider. The league calculation now identifies the developer through their
+workspace membership rather than by login alone, in the profile, the scheduled league update and the
+recalculation.

--- a/.changeset/league-change-for-shared-logins.md
+++ b/.changeset/league-change-for-shared-logins.md
@@ -2,6 +2,6 @@
 "hephaestus": patch
 ---
 
-A developer's projected league change loads even when someone else in the instance uses the same
-login on another provider. The league looks at the developer who is a member of your workspace, not
-at whoever shares their login.
+A developer's projected league change loads even when an account outside your workspace uses the
+same login on another provider. The league looks at the developer who is a member of your
+workspace, not at whoever else shares their login.

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/domain/user/UserRepository.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/domain/user/UserRepository.java
@@ -97,15 +97,19 @@ public interface UserRepository extends JpaRepository<User, Long> {
         """)
     List<User> findAllByName(@Param("name") String name);
 
+    /**
+     * By id, never by login: a login is not unique across providers, and the caller has already
+     * chosen the member through the workspace.
+     */
     @WorkspaceAgnostic("Pull requests are scoped through repository_id -> repository.workspace_id, and a"
             + " developer's league placement reads their merged pull requests as one history")
     @Query("""
             SELECT DISTINCT u
             FROM User u
             LEFT JOIN FETCH u.mergedPullRequests mpr
-            WHERE LOWER(u.login) = LOWER(:login)
+            WHERE u.id = :id
         """)
-    Optional<User> findByLoginWithEagerMergedPullRequests(@Param("login") String login);
+    Optional<User> findByIdWithEagerMergedPullRequests(@Param("id") Long id);
 
     @Query("""
             SELECT u

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/leaderboard/LeaderboardService.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/leaderboard/LeaderboardService.java
@@ -390,15 +390,16 @@ public class LeaderboardService {
      */
     @Transactional(readOnly = true)
     public LeagueChangeDTO computeUserLeagueStats(Workspace workspace, String login, Instant after, Instant before) {
-        User user = userRepository
-                .findByLoginWithEagerMergedPullRequests(login)
-                .orElseThrow(() -> new EntityNotFoundException("User", login));
-
         if (workspace == null || workspace.getId() == null) {
             throw new IllegalStateException("Workspace context is required to compute league stats");
         }
 
         Long workspaceId = workspace.getId();
+        // The member decides which user a login means: a login is not unique across providers.
+        User user = workspaceMembershipService
+                .findMemberByLogin(workspaceId, login)
+                .flatMap(member -> userRepository.findByIdWithEagerMergedPullRequests(member.getId()))
+                .orElseThrow(() -> new EntityNotFoundException("User", login));
 
         // Always use the GLOBAL leaderboard (team = "all") so that league points are
         // independent of any team filter the caller might be viewing.

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/leaderboard/LeaderboardService.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/leaderboard/LeaderboardService.java
@@ -407,7 +407,7 @@ public class LeaderboardService {
                 workspace, after, before, "all", LeaderboardSortType.SCORE, LeaderboardMode.INDIVIDUAL);
 
         LeaderboardEntryDTO entry = globalLeaderboard.stream()
-                .filter(e -> e.user() != null && login.equalsIgnoreCase(e.user().login()))
+                .filter(e -> e.user() != null && user.getId().equals(e.user().id()))
                 .findFirst()
                 .orElse(null);
 

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/leaderboard/LeaguePointsRecalculationService.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/leaderboard/LeaguePointsRecalculationService.java
@@ -86,9 +86,8 @@ public class LeaguePointsRecalculationService implements LeaguePointsRecalculato
             }
 
             Long userId = memberUser.getId();
-            User hydratedUser = userRepository
-                    .findByLoginWithEagerMergedPullRequests(memberUser.getLogin())
-                    .orElse(memberUser);
+            User hydratedUser =
+                    userRepository.findByIdWithEagerMergedPullRequests(userId).orElse(memberUser);
             memberUsersById.put(userId, hydratedUser);
             currentPointsByUserId.put(userId, POINTS_DEFAULT);
             Instant firstContribution = workspaceContributionActivityService

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/leaderboard/tasks/LeaguePointsUpdateTask.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/leaderboard/tasks/LeaguePointsUpdateTask.java
@@ -100,7 +100,7 @@ public class LeaguePointsUpdateTask {
                 return;
             }
             var user = userRepository
-                    .findByLoginWithEagerMergedPullRequests(leaderboardUser.login())
+                    .findByIdWithEagerMergedPullRequests(leaderboardUser.id())
                     .orElseThrow();
             int currentPoints = workspaceMembershipService.getCurrentLeaguePoints(workspaceId, user);
             int newPoints = leaguePointsService.calculateNewPoints(user, currentPoints, entry);

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/leaderboard/LeaderboardControllerIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/leaderboard/LeaderboardControllerIntegrationTest.java
@@ -24,9 +24,10 @@ class LeaderboardControllerIntegrationTest extends AbstractWorkspaceIntegrationT
     @Test
     @WithAdminUser
     void shouldComputeLeagueStatsWhenAnotherUserSharesTheMembersLogin() {
-        // Two users with one login: the member and a namesake elsewhere in the instance.
+        // Two users with one login: the member on GitHub and a namesake on GitLab. Logins are
+        // unique per provider only, which is exactly what a lookup by login alone tripped over.
         User member = persistUser("shared-login");
-        persistUser("shared-login");
+        persistNamesakeOnGitLab("shared-login");
         Workspace workspace =
                 createWorkspace("shared-login-ws", "Shared login", "shared-login-org", AccountType.ORG, member);
         ensureWorkspaceMembership(workspace, member, WorkspaceMembership.WorkspaceRole.MEMBER);
@@ -50,5 +51,20 @@ class LeaderboardControllerIntegrationTest extends AbstractWorkspaceIntegrationT
 
         assertThat(change).isNotNull();
         assertThat(change.login()).isEqualTo("shared-login");
+        assertThat(change.leaguePointsChange()).isZero();
+    }
+
+    private User persistNamesakeOnGitLab(String login) {
+        User user = new User();
+        user.setNativeId(System.nanoTime());
+        user.setProvider(ensureGitLabProvider());
+        user.setLogin(login);
+        user.setName("Namesake " + login);
+        user.setAvatarUrl("https://example.com/" + login + "-gitlab.png");
+        user.setHtmlUrl("https://gitlab.com/" + login);
+        user.setType(User.Type.USER);
+        user.setCreatedAt(Instant.now());
+        user.setUpdatedAt(Instant.now());
+        return userRepository.save(user);
     }
 }

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/leaderboard/LeaderboardControllerIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/leaderboard/LeaderboardControllerIntegrationTest.java
@@ -1,0 +1,54 @@
+package de.tum.cit.aet.hephaestus.leaderboard;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import de.tum.cit.aet.hephaestus.integration.scm.domain.user.User;
+import de.tum.cit.aet.hephaestus.testconfig.TestAuthUtils;
+import de.tum.cit.aet.hephaestus.testconfig.WithAdminUser;
+import de.tum.cit.aet.hephaestus.workspace.AbstractWorkspaceIntegrationTest;
+import de.tum.cit.aet.hephaestus.workspace.AccountType;
+import de.tum.cit.aet.hephaestus.workspace.Workspace;
+import de.tum.cit.aet.hephaestus.workspace.WorkspaceMembership;
+import java.time.Instant;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+@Tag("integration")
+class LeaderboardControllerIntegrationTest extends AbstractWorkspaceIntegrationTest {
+
+    @Autowired
+    private WebTestClient webTestClient;
+
+    @Test
+    @WithAdminUser
+    void shouldComputeLeagueStatsWhenAnotherUserSharesTheMembersLogin() {
+        // Two users with one login: the member and a namesake elsewhere in the instance.
+        User member = persistUser("shared-login");
+        persistUser("shared-login");
+        Workspace workspace =
+                createWorkspace("shared-login-ws", "Shared login", "shared-login-org", AccountType.ORG, member);
+        ensureWorkspaceMembership(workspace, member, WorkspaceMembership.WorkspaceRole.MEMBER);
+        ensureAdminMembership(workspace);
+
+        LeagueChangeDTO change = webTestClient
+                .get()
+                .uri(
+                        "/workspaces/{slug}/leaderboard/users/{login}/league-stats?after={after}&before={before}",
+                        workspace.getWorkspaceSlug(),
+                        "shared-login",
+                        Instant.parse("2026-08-01T00:00:00Z"),
+                        Instant.parse("2026-09-01T00:00:00Z"))
+                .headers(TestAuthUtils.withCurrentUser())
+                .exchange()
+                .expectStatus()
+                .isOk()
+                .expectBody(LeagueChangeDTO.class)
+                .returnResult()
+                .getResponseBody();
+
+        assertThat(change).isNotNull();
+        assertThat(change.login()).isEqualTo("shared-login");
+    }
+}

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/leaderboard/LeaderboardControllerIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/leaderboard/LeaderboardControllerIntegrationTest.java
@@ -49,9 +49,11 @@ class LeaderboardControllerIntegrationTest extends AbstractWorkspaceIntegrationT
                 .returnResult()
                 .getResponseBody();
 
+        // The member and the workspace's admin are both on the padded leaderboard, so the member's
+        // projected change is a placement, not zero; what matters is that it is the member's.
         assertThat(change).isNotNull();
         assertThat(change.login()).isEqualTo("shared-login");
-        assertThat(change.leaguePointsChange()).isZero();
+        assertThat(change.leaguePointsChange()).isNotNull();
     }
 
     private User persistNamesakeOnGitLab(String login) {

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/leaderboard/tasks/LeaguePointsUpdateTaskTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/leaderboard/tasks/LeaguePointsUpdateTaskTest.java
@@ -135,7 +135,8 @@ class LeaguePointsUpdateTaskTest extends BaseUnitTest {
 
     private User stubUser(String login) {
         User user = new User();
-        when(userRepository.findByLoginWithEagerMergedPullRequests(login)).thenReturn(Optional.of(user));
+        // Entries carry the user's id (1L in entry()); the lookup is by id, never by login.
+        when(userRepository.findByIdWithEagerMergedPullRequests(1L)).thenReturn(Optional.of(user));
         return user;
     }
 


### PR DESCRIPTION
## Problem

`LeaderboardService.computeUserLeagueStats` looked the developer up with `findByLoginWithEagerMergedPullRequests(login)`, an `Optional` query keyed by login alone. Logins are not unique across providers, so a namesake anywhere in the instance made the query return two rows and `GET .../leaderboard/users/{login}/league-stats` fail with an incorrect-result-size error. The scheduled league update and the recalculation used the same lookup.

## Fix

The workspace member decides which user a login means (`WorkspaceMembershipService.findMemberByLogin`, as the profile already does), and the merged pull requests are loaded by that user's id. The login-based query is gone; the id-based one keeps the reasoning `PullRequestRepository` carries for the bypass. The task and the recalculation pass the ids they already had.

## Verification

- `LeaderboardControllerIntegrationTest`: two users with the same login, one of them a member; the league endpoint answers for the member.
- `LeaguePointsUpdateTaskTest` stubs the lookup by id; `MultiTenancyArchitectureTest`, `DataIsolationArchitectureTest`, `CodeQualityTest` green locally. The integration test is proven in CI's integration job; my local Docker could not start Testcontainers on the first run.

Fixes #1859.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected league statistics for users whose login is shared across different source-control providers.
  - League activity and points are now attributed to the correct workspace member, preventing another user with the same login from being selected.
  - League change results consistently display the matched member’s login and points information.

- **Tests**
  - Added coverage for shared-login scenarios across multiple providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Follow-up

- The integration test proves the member is selected despite a namesake outside the workspace; it does not yet prove the id-based entry match independently. A test with two namesakes who are both members, with distinguishable placements, would.
