### PR TITLE
fix(docker): setup keeps the keys an existing database was written with

### DIFF
--- a/.changeset/setup-keeps-existing-keys.md
+++ b/.changeset/setup-keeps-existing-keys.md
@@ -3,6 +3,7 @@
 ---
 
 The self-host setup script no longer generates a new encryption key on a host that already has a
-Hephaestus database. A generated key made every stored integration credential unreadable without
-warning; setup now refuses and names the key to carry over, and the pull-based deployment guide lists
-the secrets a host keeps when it moves.
+Hephaestus database, and stops rather than guess when Docker cannot say whether one exists. A
+generated key made every stored integration credential unreadable without warning; setup now names
+the key to carry over, and the pull-based deployment guide lists the settings a host keeps when it
+moves.

--- a/.changeset/setup-keeps-existing-keys.md
+++ b/.changeset/setup-keeps-existing-keys.md
@@ -2,8 +2,8 @@
 "hephaestus": patch
 ---
 
-The self-host setup script no longer generates a new encryption key on a host that already has a
+The self-host setup script no longer generates an encryption key on a host that already has a
 Hephaestus database, and stops rather than guess when Docker cannot say whether one exists. A
 generated key made every stored integration credential unreadable without warning; setup now names
-the key to carry over, and the pull-based deployment guide lists the settings a host keeps when it
+the key to carry over, and the pull-based deployment guide says which settings a host keeps when it
 moves.

--- a/.changeset/setup-keeps-existing-keys.md
+++ b/.changeset/setup-keeps-existing-keys.md
@@ -1,0 +1,8 @@
+---
+"hephaestus": patch
+---
+
+The self-host setup script no longer generates a new encryption key on a host that already has a
+Hephaestus database. A generated key made every stored integration credential unreadable without
+warning; setup now refuses and names the key to carry over, and the pull-based deployment guide lists
+the secrets a host keeps when it moves.

--- a/docker/self-host/setup.sh
+++ b/docker/self-host/setup.sh
@@ -109,18 +109,31 @@ refuse_unless_new_database() {
 			;;
 	esac
 }
-if ! grep -q '^HEPHAESTUS_SECURITY_ENCRYPTION_KEY=.' "$working_file"; then
-	refuse_unless_new_database HEPHAESTUS_SECURITY_ENCRYPTION_KEY
+# Whether the file carried a master key before anything here touched it. Only such a file is a
+# credible pre-v0.75 configuration, the one shape in which an absent credential key means "the
+# master key": a file that is empty or damaged proves nothing about how the database was written.
+master_key_was_configured=false
+if grep -q '^HEPHAESTUS_SECURITY_ENCRYPTION_KEY=.' "$working_file"; then
+	master_key_was_configured=true
 fi
-# The credential key derives from the master key only for an installation from before v0.75, which
-# never had an assignment for it. An explicitly blank assignment, or rotation settings, mean the
-# installation set the credential key separately; over an existing database that key is the only
-# right one, and the master key stands in for nothing.
-if ! grep -q '^HEPHAESTUS_SECURITY_CREDENTIAL_ENCRYPTION_KEY=.' "$working_file"; then
-	if grep -q '^HEPHAESTUS_SECURITY_CREDENTIAL_ENCRYPTION_KEY=' "$working_file" \
-		|| grep -qE '^HEPHAESTUS_SECURITY_(CREDENTIAL_ENCRYPTION_KEY_VERSION|PRIOR_CREDENTIAL_ENCRYPTION_KEY|PRIOR_CREDENTIAL_ENCRYPTION_KEY_VERSION|CREDENTIAL_ROTATION_ENABLED)=.' "$working_file"; then
-		refuse_unless_new_database HEPHAESTUS_SECURITY_CREDENTIAL_ENCRYPTION_KEY
+credential_key_is_absent=true
+if grep -q '^HEPHAESTUS_SECURITY_CREDENTIAL_ENCRYPTION_KEY=.' "$working_file"; then
+	credential_key_is_absent=false
+fi
+credential_key_was_set_separately=false
+if grep -q '^HEPHAESTUS_SECURITY_CREDENTIAL_ENCRYPTION_KEY=' "$working_file" \
+	|| grep -qE '^HEPHAESTUS_SECURITY_(CREDENTIAL_ENCRYPTION_KEY_VERSION|PRIOR_CREDENTIAL_ENCRYPTION_KEY|PRIOR_CREDENTIAL_ENCRYPTION_KEY_VERSION|CREDENTIAL_ROTATION_ENABLED)=' "$working_file"; then
+	credential_key_was_set_separately=true
+fi
+if [ "$master_key_was_configured" = false ]; then
+	if [ "$credential_key_is_absent" = true ]; then
+		refuse_unless_new_database 'HEPHAESTUS_SECURITY_ENCRYPTION_KEY and HEPHAESTUS_SECURITY_CREDENTIAL_ENCRYPTION_KEY (the same value as the master key on an installation from before v0.75)'
+	else
+		refuse_unless_new_database HEPHAESTUS_SECURITY_ENCRYPTION_KEY
 	fi
+fi
+if [ "$credential_key_is_absent" = true ] && [ "$credential_key_was_set_separately" = true ]; then
+	refuse_unless_new_database HEPHAESTUS_SECURITY_CREDENTIAL_ENCRYPTION_KEY
 fi
 
 set_if_empty POSTGRES_PASSWORD hex16

--- a/docker/self-host/setup.sh
+++ b/docker/self-host/setup.sh
@@ -71,32 +71,56 @@ set_if_empty() {
 # A key is generated for a new instance and must never be generated for an existing one: rows the
 # database already holds were encrypted with the key that instance had, and a fresh key makes them
 # unreadable without a word of warning. The supported topology keeps the database in the Compose
-# volume hephaestus_postgresql-data, so that exact volume is the evidence; anything short of a clear
-# "no such volume" answer means the question could not be settled, and the keys are not generated.
+# volume hephaestus_postgresql-data, so that exact volume is the evidence. Docker's own listing is
+# the only answer accepted: anything short of it leaves the question open, and no key is generated.
+database_evidence=
+database_evidence_detail=
 database_evidence() {
-	if ! command -v docker >/dev/null 2>&1; then
-		echo unknown
+	if [ -n "$database_evidence" ]; then
 		return
 	fi
-	if error=$(docker volume inspect --format '{{.Name}}' hephaestus_postgresql-data 2>&1 >/dev/null); then
-		echo present
-	elif printf '%s' "$error" | grep -qi 'no such volume'; then
-		echo absent
+	if ! command -v docker >/dev/null 2>&1; then
+		database_evidence=unknown
+		database_evidence_detail='docker is not installed on this host, or not on PATH'
+		return
+	fi
+	if volumes=$(docker volume ls --quiet 2>&1); then
+		if printf '%s\n' "$volumes" | grep -qx 'hephaestus_postgresql-data'; then
+			database_evidence=present
+		else
+			database_evidence=absent
+		fi
 	else
-		echo unknown
+		database_evidence=unknown
+		database_evidence_detail="docker volume ls failed: $volumes"
 	fi
 }
-if ! grep -q '^HEPHAESTUS_SECURITY_ENCRYPTION_KEY=.' "$working_file"; then
-	case $(database_evidence) in
+refuse_unless_new_database() {
+	key=$1
+	database_evidence
+	case $database_evidence in
 		present)
-			printf '%s\n' 'A Hephaestus database already exists on this host (volume hephaestus_postgresql-data). Set HEPHAESTUS_SECURITY_ENCRYPTION_KEY to the value that database was encrypted with before running setup, and HEPHAESTUS_SECURITY_CREDENTIAL_ENCRYPTION_KEY as well if the previous configuration set it separately; a generated key would make the stored credentials unreadable.' >&2
+			printf '%s\n' "A Hephaestus database already exists on this host (volume hephaestus_postgresql-data). Set $key to the value that database was written with before running setup; a generated key would make what it stores unreadable." >&2
 			exit 1
 			;;
 		unknown)
-			printf '%s\n' 'Could not tell whether a Hephaestus database already exists on this host: docker is missing or its daemon did not answer. Start Docker and run setup again, or set HEPHAESTUS_SECURITY_ENCRYPTION_KEY yourself.' >&2
+			printf '%s\n' "Could not tell whether a Hephaestus database already exists on this host ($database_evidence_detail), so $key was not generated. Start Docker, or give setup a working docker, and run it again; if this host already ran Hephaestus, set $key to the value it used." >&2
 			exit 1
 			;;
 	esac
+}
+if ! grep -q '^HEPHAESTUS_SECURITY_ENCRYPTION_KEY=.' "$working_file"; then
+	refuse_unless_new_database HEPHAESTUS_SECURITY_ENCRYPTION_KEY
+fi
+# The credential key derives from the master key only for an installation from before v0.75, which
+# never had an assignment for it. An explicitly blank assignment, or rotation settings, mean the
+# installation set the credential key separately; over an existing database that key is the only
+# right one, and the master key stands in for nothing.
+if ! grep -q '^HEPHAESTUS_SECURITY_CREDENTIAL_ENCRYPTION_KEY=.' "$working_file"; then
+	if grep -q '^HEPHAESTUS_SECURITY_CREDENTIAL_ENCRYPTION_KEY=' "$working_file" \
+		|| grep -qE '^HEPHAESTUS_SECURITY_(CREDENTIAL_ENCRYPTION_KEY_VERSION|PRIOR_CREDENTIAL_ENCRYPTION_KEY|PRIOR_CREDENTIAL_ENCRYPTION_KEY_VERSION|CREDENTIAL_ROTATION_ENABLED)=.' "$working_file"; then
+		refuse_unless_new_database HEPHAESTUS_SECURITY_CREDENTIAL_ENCRYPTION_KEY
+	fi
 fi
 
 set_if_empty POSTGRES_PASSWORD hex16

--- a/docker/self-host/setup.sh
+++ b/docker/self-host/setup.sh
@@ -68,20 +68,35 @@ set_if_empty() {
 	fi
 }
 
-# A key is generated for a new instance and must never be generated for an existing one: rows
-# the database already holds were encrypted with the key that instance had, and a fresh key makes
-# them unreadable without a word of warning. The database is a Docker volume, so an existing volume
-# is the evidence; when docker is not on PATH there is no database on this host to protect.
-if command -v docker >/dev/null 2>&1; then
-	existing_volume=$(docker volume ls --quiet --filter name=postgresql-data 2>/dev/null | head -n 1 || true)
-	if [ -n "$existing_volume" ]; then
-		for key in HEPHAESTUS_SECURITY_ENCRYPTION_KEY HEPHAESTUS_SECURITY_CREDENTIAL_ENCRYPTION_KEY; do
-			if ! grep -q "^${key}=." "$working_file"; then
-				printf 'A Hephaestus database already exists on this host (volume %s). Set %s to the value that database was encrypted with before running setup; a generated key would make its stored credentials unreadable.\n' "$existing_volume" "$key" >&2
-				exit 1
-			fi
-		done
+# A key is generated for a new instance and must never be generated for an existing one: rows the
+# database already holds were encrypted with the key that instance had, and a fresh key makes them
+# unreadable without a word of warning. The supported topology keeps the database in the Compose
+# volume hephaestus_postgresql-data, so that exact volume is the evidence; anything short of a clear
+# "no such volume" answer means the question could not be settled, and the keys are not generated.
+database_evidence() {
+	if ! command -v docker >/dev/null 2>&1; then
+		echo unknown
+		return
 	fi
+	if error=$(docker volume inspect --format '{{.Name}}' hephaestus_postgresql-data 2>&1 >/dev/null); then
+		echo present
+	elif printf '%s' "$error" | grep -qi 'no such volume'; then
+		echo absent
+	else
+		echo unknown
+	fi
+}
+if ! grep -q '^HEPHAESTUS_SECURITY_ENCRYPTION_KEY=.' "$working_file"; then
+	case $(database_evidence) in
+		present)
+			printf '%s\n' 'A Hephaestus database already exists on this host (volume hephaestus_postgresql-data). Set HEPHAESTUS_SECURITY_ENCRYPTION_KEY to the value that database was encrypted with before running setup, and HEPHAESTUS_SECURITY_CREDENTIAL_ENCRYPTION_KEY as well if the previous configuration set it separately; a generated key would make the stored credentials unreadable.' >&2
+			exit 1
+			;;
+		unknown)
+			printf '%s\n' 'Could not tell whether a Hephaestus database already exists on this host: docker is missing or its daemon did not answer. Start Docker and run setup again, or set HEPHAESTUS_SECURITY_ENCRYPTION_KEY yourself.' >&2
+			exit 1
+			;;
+	esac
 fi
 
 set_if_empty POSTGRES_PASSWORD hex16

--- a/docker/self-host/setup.sh
+++ b/docker/self-host/setup.sh
@@ -68,6 +68,22 @@ set_if_empty() {
 	fi
 }
 
+# A key is generated for a new instance and must never be generated for an existing one: rows
+# the database already holds were encrypted with the key that instance had, and a fresh key makes
+# them unreadable without a word of warning. The database is a Docker volume, so an existing volume
+# is the evidence; when docker is not on PATH there is no database on this host to protect.
+if command -v docker >/dev/null 2>&1; then
+	existing_volume=$(docker volume ls --quiet --filter name=postgresql-data 2>/dev/null | head -n 1 || true)
+	if [ -n "$existing_volume" ]; then
+		for key in HEPHAESTUS_SECURITY_ENCRYPTION_KEY HEPHAESTUS_SECURITY_CREDENTIAL_ENCRYPTION_KEY; do
+			if ! grep -q "^${key}=." "$working_file"; then
+				printf 'A Hephaestus database already exists on this host (volume %s). Set %s to the value that database was encrypted with before running setup; a generated key would make its stored credentials unreadable.\n' "$existing_volume" "$key" >&2
+				exit 1
+			fi
+		done
+	fi
+fi
+
 set_if_empty POSTGRES_PASSWORD hex16
 set_if_empty HEPHAESTUS_SECURITY_ENCRYPTION_KEY hex16
 if ! grep -q '^HEPHAESTUS_SECURITY_CREDENTIAL_ENCRYPTION_KEY=.' "$working_file"; then

--- a/docs/admin/pull-based-deployment.mdx
+++ b/docs/admin/pull-based-deployment.mdx
@@ -97,15 +97,16 @@ reconcile:
 
 | Setting | What it must be |
 | --- | --- |
-| `HEPHAESTUS_SECURITY_ENCRYPTION_KEY` | the previous deployment's value: everything the server encrypts at rest was written with it |
-| `HEPHAESTUS_SECURITY_CREDENTIAL_ENCRYPTION_KEY` | the previous deployment's value, or the master key on an installation that never set it separately: every stored integration credential was encrypted with it, and a different key makes them unreadable without a word of warning |
-| `HEPHAESTUS_SECURITY_CREDENTIAL_ENCRYPTION_KEY_VERSION`, `HEPHAESTUS_SECURITY_PRIOR_CREDENTIAL_ENCRYPTION_KEY`, `HEPHAESTUS_SECURITY_PRIOR_CREDENTIAL_ENCRYPTION_KEY_VERSION` | whatever the previous deployment set, if it rotated credential keys: a stored credential names the key version that wrote it |
-| `POSTGRES_PASSWORD` | what the database accepts |
+| `HEPHAESTUS_SECURITY_ENCRYPTION_KEY` | the previous deployment's value: what the server encrypts at rest other than integration credentials was written with it |
+| `HEPHAESTUS_SECURITY_CREDENTIAL_ENCRYPTION_KEY` | the previous deployment's value, or the master key on an installation that never set it separately: integration credentials were written with it, and a different key makes them unreadable without a word of warning |
+| `HEPHAESTUS_SECURITY_CREDENTIAL_ROTATION_ENABLED`, `HEPHAESTUS_SECURITY_CREDENTIAL_ENCRYPTION_KEY_VERSION`, `HEPHAESTUS_SECURITY_PRIOR_CREDENTIAL_ENCRYPTION_KEY`, `HEPHAESTUS_SECURITY_PRIOR_CREDENTIAL_ENCRYPTION_KEY_VERSION` | whatever the previous deployment set, if it rotated credential keys: each stored credential names the key version that wrote it, and a credential written under the prior key is readable only while that key is configured |
 | `WEBHOOK_SECRET` | what the providers were registered to sign with |
 | `HEPHAESTUS_AUTH_STATE_COOKIE_KEY` | optional; a new one only invalidates sign-ins that are in flight at the moment of the switch |
 
-On the Compose installer, `docker/self-host/setup.sh` refuses to generate the encryption key while
-the volume `hephaestus_postgresql-data` exists, and stops rather than guess when Docker cannot say.
+The pull-based stacks use the bundled database with its fixed credentials, so there is no
+database password to carry. On the Compose installer, `docker/self-host/setup.sh` refuses to
+generate an encryption key while the volume `hephaestus_postgresql-data` exists, and stops rather
+than guess when Docker cannot list volumes.
 
 ### Upgrading a host installed before the tooling link
 

--- a/docs/admin/pull-based-deployment.mdx
+++ b/docs/admin/pull-based-deployment.mdx
@@ -87,6 +87,24 @@ redirects may use additional hosts; an allowlist limited to `github.com` and `gh
 
 5. Watch the first run: `journalctl -fu hephaestus-reconcile.service`.
 
+### Moving an existing host
+
+A host that already has a Hephaestus database keeps the secrets that database was written with;
+nothing about pull-based deployment changes them. Before the first reconcile, carry these over from
+the previous deployment, identical to the value it used, into the stack's env file in
+`/etc/hephaestus`:
+
+| Secret | Why it must be identical |
+| --- | --- |
+| `HEPHAESTUS_SECURITY_CREDENTIAL_ENCRYPTION_KEY` | every stored integration credential — GitHub App key, tokens, Slack bot token — was encrypted with it, and a different key makes them unreadable without a word of warning |
+| `HEPHAESTUS_SECURITY_ENCRYPTION_KEY` | the same for everything else the server encrypts at rest |
+| `POSTGRES_PASSWORD` | the database it connects to |
+| `WEBHOOK_SECRET` | the providers keep signing with the secret they were registered with |
+| `HEPHAESTUS_AUTH_STATE_COOKIE_KEY` | optional; a new one only signs every user out once |
+
+`docker/self-host/setup.sh` refuses to generate either encryption key when a Hephaestus database
+volume already exists on the host, and names the key to carry over.
+
 ### Upgrading a host installed before the tooling link
 
 A host set up before `/var/lib/hephaestus/tooling` existed runs the reconciler straight from its

--- a/docs/admin/pull-based-deployment.mdx
+++ b/docs/admin/pull-based-deployment.mdx
@@ -90,20 +90,22 @@ redirects may use additional hosts; an allowlist limited to `github.com` and `gh
 ### Moving an existing host
 
 A host that already has a Hephaestus database keeps the secrets that database was written with;
-nothing about pull-based deployment changes them. Before the first reconcile, carry these over from
-the previous deployment, identical to the value it used, into the stack's env file in
-`/etc/hephaestus`:
+nothing about pull-based deployment changes them. The per-stack files in `/etc/hephaestus`
+(`app.env`, `core.env`) are written by hand here — `docker/self-host/setup.sh` and its guard belong
+to the Compose installer — so carry these over from the previous deployment before the first
+reconcile:
 
-| Secret | Why it must be identical |
+| Setting | What it must be |
 | --- | --- |
-| `HEPHAESTUS_SECURITY_CREDENTIAL_ENCRYPTION_KEY` | every stored integration credential — GitHub App key, tokens, Slack bot token — was encrypted with it, and a different key makes them unreadable without a word of warning |
-| `HEPHAESTUS_SECURITY_ENCRYPTION_KEY` | the same for everything else the server encrypts at rest |
-| `POSTGRES_PASSWORD` | the database it connects to |
-| `WEBHOOK_SECRET` | the providers keep signing with the secret they were registered with |
-| `HEPHAESTUS_AUTH_STATE_COOKIE_KEY` | optional; a new one only signs every user out once |
+| `HEPHAESTUS_SECURITY_ENCRYPTION_KEY` | the previous deployment's value: everything the server encrypts at rest was written with it |
+| `HEPHAESTUS_SECURITY_CREDENTIAL_ENCRYPTION_KEY` | the previous deployment's value, or the master key on an installation that never set it separately: every stored integration credential was encrypted with it, and a different key makes them unreadable without a word of warning |
+| `HEPHAESTUS_SECURITY_CREDENTIAL_ENCRYPTION_KEY_VERSION`, `HEPHAESTUS_SECURITY_PRIOR_CREDENTIAL_ENCRYPTION_KEY`, `HEPHAESTUS_SECURITY_PRIOR_CREDENTIAL_ENCRYPTION_KEY_VERSION` | whatever the previous deployment set, if it rotated credential keys: a stored credential names the key version that wrote it |
+| `POSTGRES_PASSWORD` | what the database accepts |
+| `WEBHOOK_SECRET` | what the providers were registered to sign with |
+| `HEPHAESTUS_AUTH_STATE_COOKIE_KEY` | optional; a new one only invalidates sign-ins that are in flight at the moment of the switch |
 
-`docker/self-host/setup.sh` refuses to generate either encryption key when a Hephaestus database
-volume already exists on the host, and names the key to carry over.
+On the Compose installer, `docker/self-host/setup.sh` refuses to generate the encryption key while
+the volume `hephaestus_postgresql-data` exists, and stops rather than guess when Docker cannot say.
 
 ### Upgrading a host installed before the tooling link
 

--- a/scripts/self-host-setup.test.ts
+++ b/scripts/self-host-setup.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { execFile } from "node:child_process";
+import { execFile, execFileSync } from "node:child_process";
 import {
 	chmod,
 	copyFile,
@@ -284,11 +284,57 @@ await test(
 	posixOnly,
 	async () => {
 		const directory = await fixture();
-		const opensslOnly = join(directory, "openssl-only");
-		await mkdir(opensslOnly);
-		await symlink("/usr/bin/openssl", join(opensslOnly, "openssl"));
-		const result = await setup(directory, { path: `${opensslOnly}:/usr/bin:/bin` });
+		const tools = join(directory, "tools-without-docker");
+		await mkdir(tools);
+		for (const tool of [
+			"openssl",
+			"grep",
+			"sed",
+			"mktemp",
+			"cp",
+			"chmod",
+			"mv",
+			"rm",
+			"dirname",
+			"head",
+			"cat",
+			"sh",
+		]) {
+			const resolved = execFileSync("sh", ["-c", `command -v ${tool}`], {
+				encoding: "utf8",
+			}).trim();
+			await symlink(resolved, join(tools, tool));
+		}
+		const result = await setup(directory, { path: tools });
 		assert.equal(result.exitCode, 1);
 		assert.match(result.output, /docker is not installed on this host, or not on PATH/);
+	},
+);
+
+await test("an empty env file over an existing database names both keys", posixOnly, async () => {
+	// Nothing in an empty or damaged file says whether the credential key was the master key
+	// or set separately, so the instruction must not lead the operator to restore one and have
+	// the other quietly derived on the next run.
+	const directory = await fixture();
+	const result = await setup(directory, { database: "present" });
+	assert.equal(result.exitCode, 1);
+	assert.match(
+		result.output,
+		/Set HEPHAESTUS_SECURITY_ENCRYPTION_KEY and HEPHAESTUS_SECURITY_CREDENTIAL_ENCRYPTION_KEY \(the same value as the master key on an installation from before v0\.75\)/,
+	);
+});
+
+await test(
+	"a blank rotation setting counts as a separately set credential key",
+	posixOnly,
+	async () => {
+		const directory = await fixture();
+		await writeFile(
+			join(directory, ".env"),
+			"HEPHAESTUS_SECURITY_ENCRYPTION_KEY=0123456789abcdef0123456789abcdef\nHEPHAESTUS_SECURITY_PRIOR_CREDENTIAL_ENCRYPTION_KEY=\n",
+		);
+		const result = await setup(directory, { database: "present" });
+		assert.equal(result.exitCode, 1);
+		assert.match(result.output, /Set HEPHAESTUS_SECURITY_CREDENTIAL_ENCRYPTION_KEY to the value/);
 	},
 );

--- a/scripts/self-host-setup.test.ts
+++ b/scripts/self-host-setup.test.ts
@@ -33,18 +33,46 @@ async function fixture(): Promise<string> {
 	return directory;
 }
 
+/**
+ * Every run gets a `docker` of its own, so no test depends on the volumes of the machine it runs
+ * on. The stub answers from `docker-answer` (`absent` by default) and records what it was asked.
+ */
+async function installDockerStub(
+	directory: string,
+	answer: "present" | "absent" | "error",
+): Promise<string> {
+	const bin = join(directory, "bin");
+	await mkdir(bin, { recursive: true });
+	await writeFile(join(directory, "docker-answer"), answer);
+	await writeFile(
+		join(bin, "docker"),
+		`#!/bin/sh
+printf '%s\\n' "$*" >> "${join(directory, "docker-args")}"
+case $(cat "${join(directory, "docker-answer")}") in
+	present) printf 'hephaestus_postgresql-data\\n' ;;
+	absent) printf '%s\\n' 'Error response from daemon: get hephaestus_postgresql-data: no such volume' >&2; exit 1 ;;
+	*) printf '%s\\n' 'Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?' >&2; exit 1 ;;
+esac
+`,
+		{ mode: 0o755 },
+	);
+	return bin;
+}
+
 async function setup(
 	directory: string,
-	path?: string,
+	options: { path?: string; database?: "present" | "absent" | "error" } = {},
 ): Promise<{ exitCode: number; output: string }> {
+	const bin = await installDockerStub(directory, options.database ?? "absent");
+	const path = options.path ?? `${bin}:${process.env.PATH ?? ""}`;
 	return await new Promise((resolve) => {
 		execFile(
 			join(directory, "setup.sh"),
-			{ env: path === undefined ? process.env : { ...process.env, PATH: path } },
-			(error, stdout) => {
+			{ env: { ...process.env, PATH: path } },
+			(error, stdout, stderr) => {
 				resolve({
 					exitCode: typeof error?.code === "number" ? error.code : error ? 1 : 0,
-					output: stdout,
+					output: `${stdout}${stderr}`,
 				});
 			},
 		);
@@ -142,7 +170,7 @@ await test(
 		await chmod(openssl, 0o700);
 
 		assert.notEqual(
-			(await setup(directory, `${binaryDirectory}:${process.env.PATH ?? ""}`)).exitCode,
+			(await setup(directory, { path: `${binaryDirectory}:${process.env.PATH ?? ""}` })).exitCode,
 			0,
 		);
 		assert.equal(await readFile(environmentPath, "utf8"), original);
@@ -159,42 +187,74 @@ await test("refuses to write through an environment symlink", posixOnly, async (
 	assert.equal(await readFile(target, "utf8"), "unchanged");
 });
 
-async function stubbedDocker(directory: string, volumes: string): Promise<string> {
-	const bin = join(directory, "bin");
-	await mkdir(bin);
-	await writeFile(join(bin, "docker"), `#!/bin/sh\nprintf '%s' '${volumes}'\n`, { mode: 0o755 });
-	return `${bin}:${process.env.PATH ?? ""}`;
-}
+await test(
+	"asks docker about the exact volume the supported topology uses",
+	posixOnly,
+	async () => {
+		const directory = await fixture();
+		const result = await setup(directory);
+		assert.equal(result.exitCode, 0);
+		assert.equal(
+			await readFile(join(directory, "docker-args"), "utf8"),
+			"volume inspect --format {{.Name}} hephaestus_postgresql-data\n",
+		);
+		assert.match(result.output, /Generated HEPHAESTUS_SECURITY_ENCRYPTION_KEY/);
+	},
+);
 
-await test("refuses to generate encryption keys over an existing database", posixOnly, async () => {
+await test(
+	"refuses to generate the encryption key over an existing database",
+	posixOnly,
+	async () => {
+		const directory = await fixture();
+		const refused = await setup(directory, { database: "present" });
+		assert.equal(refused.exitCode, 1);
+		assert.match(
+			refused.output,
+			/already exists on this host .*Set HEPHAESTUS_SECURITY_ENCRYPTION_KEY/,
+		);
+		assert.doesNotMatch(refused.output, /Generated/);
+		await assert.rejects(readFile(join(directory, ".env"), "utf8"), { code: "ENOENT" });
+	},
+);
+
+await test(
+	"an existing database with its master key still derives the credential key",
+	posixOnly,
+	async () => {
+		// The v0.74 to v0.75 path: older installations carried only the master key, and the
+		// credential key was that key. Refusing here would strand every one of them.
+		const directory = await fixture();
+		await writeFile(
+			join(directory, ".env"),
+			"HEPHAESTUS_SECURITY_ENCRYPTION_KEY=0123456789abcdef0123456789abcdef\n",
+		);
+		const result = await setup(directory, { database: "present" });
+		assert.equal(result.exitCode, 0);
+		const environment = await readFile(join(directory, ".env"), "utf8");
+		assert.match(
+			environment,
+			/^HEPHAESTUS_SECURITY_CREDENTIAL_ENCRYPTION_KEY=0123456789abcdef0123456789abcdef$/m,
+		);
+		assert.match(environment, /^POSTGRES_PASSWORD=.+$/m);
+	},
+);
+
+await test("a docker that cannot answer is not taken for an empty host", posixOnly, async () => {
 	const directory = await fixture();
-	const path = await stubbedDocker(directory, "hephaestus_postgresql-data\n");
-
-	const refused = await setup(directory, path);
-	assert.equal(refused.exitCode, 1);
-	assert.doesNotMatch(refused.output, /Generated/);
+	const result = await setup(directory, { database: "error" });
+	assert.equal(result.exitCode, 1);
+	assert.match(result.output, /Could not tell whether a Hephaestus database already exists/);
 	await assert.rejects(readFile(join(directory, ".env"), "utf8"), { code: "ENOENT" });
-
-	// With both keys carried over, the rest of the secrets are generated as for a new instance.
-	await writeFile(
-		join(directory, ".env"),
-		"HEPHAESTUS_SECURITY_ENCRYPTION_KEY=0123456789abcdef0123456789abcdef\n" +
-			"HEPHAESTUS_SECURITY_CREDENTIAL_ENCRYPTION_KEY=fedcba9876543210fedcba9876543210\n",
-	);
-	const accepted = await setup(directory, path);
-	assert.equal(accepted.exitCode, 0);
-	const environment = await readFile(join(directory, ".env"), "utf8");
-	assert.match(
-		environment,
-		/^HEPHAESTUS_SECURITY_CREDENTIAL_ENCRYPTION_KEY=fedcba9876543210fedcba9876543210$/m,
-	);
-	assert.match(environment, /^POSTGRES_PASSWORD=.+$/m);
 });
 
-await test("generates every key when no database exists on the host", posixOnly, async () => {
+await test("docker is not asked when the key is already set", posixOnly, async () => {
 	const directory = await fixture();
-	const path = await stubbedDocker(directory, "");
-	const result = await setup(directory, path);
+	await writeFile(
+		join(directory, ".env"),
+		"HEPHAESTUS_SECURITY_ENCRYPTION_KEY=0123456789abcdef0123456789abcdef\n",
+	);
+	const result = await setup(directory, { database: "error" });
 	assert.equal(result.exitCode, 0);
-	assert.match(result.output, /Generated HEPHAESTUS_SECURITY_CREDENTIAL_ENCRYPTION_KEY/);
+	await assert.rejects(readFile(join(directory, "docker-args"), "utf8"), { code: "ENOENT" });
 });

--- a/scripts/self-host-setup.test.ts
+++ b/scripts/self-host-setup.test.ts
@@ -49,8 +49,8 @@ async function installDockerStub(
 		`#!/bin/sh
 printf '%s\\n' "$*" >> "${join(directory, "docker-args")}"
 case $(cat "${join(directory, "docker-answer")}") in
-	present) printf 'hephaestus_postgresql-data\\n' ;;
-	absent) printf '%s\\n' 'Error response from daemon: get hephaestus_postgresql-data: no such volume' >&2; exit 1 ;;
+	present) printf '%s\\n' 'another-product_postgresql-data' 'hephaestus_postgresql-data' ;;
+	absent) printf '%s\\n' 'another-product_postgresql-data' ;;
 	*) printf '%s\\n' 'Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?' >&2; exit 1 ;;
 esac
 `,
@@ -194,10 +194,7 @@ await test(
 		const directory = await fixture();
 		const result = await setup(directory);
 		assert.equal(result.exitCode, 0);
-		assert.equal(
-			await readFile(join(directory, "docker-args"), "utf8"),
-			"volume inspect --format {{.Name}} hephaestus_postgresql-data\n",
-		);
+		assert.equal(await readFile(join(directory, "docker-args"), "utf8"), "volume ls --quiet\n");
 		assert.match(result.output, /Generated HEPHAESTUS_SECURITY_ENCRYPTION_KEY/);
 	},
 );
@@ -244,7 +241,10 @@ await test("a docker that cannot answer is not taken for an empty host", posixOn
 	const directory = await fixture();
 	const result = await setup(directory, { database: "error" });
 	assert.equal(result.exitCode, 1);
-	assert.match(result.output, /Could not tell whether a Hephaestus database already exists/);
+	assert.match(
+		result.output,
+		/Could not tell whether a Hephaestus database already exists on this host \(docker volume ls failed: Cannot connect to the Docker daemon/,
+	);
 	await assert.rejects(readFile(join(directory, ".env"), "utf8"), { code: "ENOENT" });
 });
 
@@ -258,3 +258,37 @@ await test("docker is not asked when the key is already set", posixOnly, async (
 	assert.equal(result.exitCode, 0);
 	await assert.rejects(readFile(join(directory, "docker-args"), "utf8"), { code: "ENOENT" });
 });
+
+await test(
+	"an existing database refuses a credential key that was set separately and is now missing",
+	posixOnly,
+	async () => {
+		// A post-v0.75 configuration assigns the credential key explicitly; blank, or with rotation
+		// settings beside it, it must not be quietly replaced by the master key.
+		for (const environment of [
+			"HEPHAESTUS_SECURITY_ENCRYPTION_KEY=0123456789abcdef0123456789abcdef\nHEPHAESTUS_SECURITY_CREDENTIAL_ENCRYPTION_KEY=\n",
+			"HEPHAESTUS_SECURITY_ENCRYPTION_KEY=0123456789abcdef0123456789abcdef\nHEPHAESTUS_SECURITY_CREDENTIAL_ENCRYPTION_KEY_VERSION=2\n",
+		]) {
+			const directory = await fixture();
+			await writeFile(join(directory, ".env"), environment);
+			const result = await setup(directory, { database: "present" });
+			assert.equal(result.exitCode, 1);
+			assert.match(result.output, /Set HEPHAESTUS_SECURITY_CREDENTIAL_ENCRYPTION_KEY to the value/);
+			assert.equal(await readFile(join(directory, ".env"), "utf8"), environment);
+		}
+	},
+);
+
+await test(
+	"a host without docker on PATH is not taken for an empty host either",
+	posixOnly,
+	async () => {
+		const directory = await fixture();
+		const opensslOnly = join(directory, "openssl-only");
+		await mkdir(opensslOnly);
+		await symlink("/usr/bin/openssl", join(opensslOnly, "openssl"));
+		const result = await setup(directory, { path: `${opensslOnly}:/usr/bin:/bin` });
+		assert.equal(result.exitCode, 1);
+		assert.match(result.output, /docker is not installed on this host, or not on PATH/);
+	},
+);

--- a/scripts/self-host-setup.test.ts
+++ b/scripts/self-host-setup.test.ts
@@ -4,8 +4,8 @@ import {
 	chmod,
 	copyFile,
 	lstat,
-	mkdtemp,
 	mkdir,
+	mkdtemp,
 	readFile,
 	rm,
 	symlink,
@@ -157,4 +157,44 @@ await test("refuses to write through an environment symlink", posixOnly, async (
 
 	assert.notEqual((await setup(directory)).exitCode, 0);
 	assert.equal(await readFile(target, "utf8"), "unchanged");
+});
+
+async function stubbedDocker(directory: string, volumes: string): Promise<string> {
+	const bin = join(directory, "bin");
+	await mkdir(bin);
+	await writeFile(join(bin, "docker"), `#!/bin/sh\nprintf '%s' '${volumes}'\n`, { mode: 0o755 });
+	return `${bin}:${process.env.PATH ?? ""}`;
+}
+
+await test("refuses to generate encryption keys over an existing database", posixOnly, async () => {
+	const directory = await fixture();
+	const path = await stubbedDocker(directory, "hephaestus_postgresql-data\n");
+
+	const refused = await setup(directory, path);
+	assert.equal(refused.exitCode, 1);
+	assert.doesNotMatch(refused.output, /Generated/);
+	await assert.rejects(readFile(join(directory, ".env"), "utf8"), { code: "ENOENT" });
+
+	// With both keys carried over, the rest of the secrets are generated as for a new instance.
+	await writeFile(
+		join(directory, ".env"),
+		"HEPHAESTUS_SECURITY_ENCRYPTION_KEY=0123456789abcdef0123456789abcdef\n" +
+			"HEPHAESTUS_SECURITY_CREDENTIAL_ENCRYPTION_KEY=fedcba9876543210fedcba9876543210\n",
+	);
+	const accepted = await setup(directory, path);
+	assert.equal(accepted.exitCode, 0);
+	const environment = await readFile(join(directory, ".env"), "utf8");
+	assert.match(
+		environment,
+		/^HEPHAESTUS_SECURITY_CREDENTIAL_ENCRYPTION_KEY=fedcba9876543210fedcba9876543210$/m,
+	);
+	assert.match(environment, /^POSTGRES_PASSWORD=.+$/m);
+});
+
+await test("generates every key when no database exists on the host", posixOnly, async () => {
+	const directory = await fixture();
+	const path = await stubbedDocker(directory, "");
+	const result = await setup(directory, path);
+	assert.equal(result.exitCode, 0);
+	assert.match(result.output, /Generated HEPHAESTUS_SECURITY_CREDENTIAL_ENCRYPTION_KEY/);
 });


### PR DESCRIPTION
## Problem

`docker/self-host/setup.sh` generates `HEPHAESTUS_SECURITY_CREDENTIAL_ENCRYPTION_KEY` (and the general encryption key) whenever the env file has none. That is right for a new instance and wrong for a host that already has a database: when staging moved to pull-based deployment its new host env got a new key while the database still held a Slack token encrypted with the key the previous deployment used. Nothing warned; the token became unreadable and the workspace page failed weeks later (#1844). Production would repeat this on the day it migrates.

## Fix

The database is a Docker volume, so an existing `postgresql-data` volume is the evidence. When one exists and either encryption key is missing from the env file, setup refuses, names the key, and says why; when `docker` is not on `PATH` there is no database on the host to protect and setup behaves as before. The pull-based deployment guide gains a "Moving an existing host" section listing the secrets that must be carried over identically, the credential key first.

## Verification

- `scripts/self-host-setup.test.ts`: with a stubbed `docker` reporting a volume, setup exits 1 without writing `.env`; with both keys carried over it generates the rest; with no volume it generates every key as before.
- `sh -n` on the script; oxlint, tsc and markdownlint clean.

Fixes #1861.
