### PR TITLE
docs: explain what Hephaestus keeps and how to erase it

### DIFF
--- a/docs/sidebars.user.ts
+++ b/docs/sidebars.user.ts
@@ -6,7 +6,7 @@ const sidebars: SidebarsConfig = {
 			type: "category",
 			label: "Start here",
 			collapsible: false,
-			items: ["overview", "getting-started"],
+			items: ["overview", "getting-started", "privacy"],
 		},
 		{
 			type: "category",

--- a/docs/user/ai-mentor.mdx
+++ b/docs/user/ai-mentor.mdx
@@ -62,4 +62,4 @@ The developer and human reviewers remain responsible for decisions about the wor
 
 When a workspace admin connects Slack, you can message Heph in a direct message. Slack direct messages and web-app chats have separate conversation histories.
 
-Workspace admins can separately enable monitored channels as context. Monitoring starts only after Hephaestus posts a visible announcement, and individual privacy controls apply. See your account settings or the Slack App Home for the controls available to you.
+Workspace admins can separately enable monitored channels as context. Monitoring starts only after Hephaestus posts a visible announcement, and individual privacy controls apply. See [Your data in Hephaestus](./privacy.mdx#your-choices-and-right-to-object) for the Slack privacy controls and what they do not erase.

--- a/docs/user/overview.mdx
+++ b/docs/user/overview.mdx
@@ -38,6 +38,10 @@ Connected GitHub, GitLab, Slack, and Outline integrations provide project activi
 
 Workspace admins can enable achievements, leagues, and a weekly leaderboard of review activity. A weekly Slack digest can also be configured. These features are separate from practice feedback. See [Leaderboard](./leaderboard) for details.
 
+## Your data and privacy
+
+Read [Your data in Hephaestus](./privacy.mdx) to understand what connected services share, how AI uses it, how long copies remain, and how to request access, correction, or erasure — even if you have never signed in.
+
 ## Terms used in this guide
 
 - **Engineering practice:** an observable way of working, such as keeping a change reviewable or explaining why it is needed.

--- a/docs/user/privacy.mdx
+++ b/docs/user/privacy.mdx
@@ -1,0 +1,156 @@
+---
+id: privacy
+title: Your data in Hephaestus
+description: What Hephaestus reads, who can see it, how long it stays, and how to request access or erasure.
+---
+
+Hephaestus reads connected project work to give you practice feedback and help you talk it through with Heph.
+**Your work can be processed even if you have never signed in.**
+
+Open **Privacy** in the app's footer for your instance's responsible organisation, privacy contact, legal
+bases, providers, and data locations. This guide explains the product; that notice covers your deployment.
+If the notice or contact is missing, ask the organisation running your instance.
+
+## What Hephaestus reads
+
+Workspace admins choose the connected sources and enabled features:
+
+- **GitHub and GitLab:** contributor profiles, repository and team membership, issues, pull requests or merge
+  requests, reviews, comments, discussions, and commit metadata. Practice reviews can also read relevant code
+  changes and a limited repository snapshot.
+- **Slack:** identities, privacy choices, your direct conversations with Heph, and new messages in monitored
+  channels. Channel monitoring requires separate activation, a visible announcement, and participant privacy
+  controls; connecting Slack alone does not activate it.
+- **Outline:** selected collections and documents, their content, and author information.
+
+These sources provide context for practice reviews and mentoring. A connection does not authorise every use
+of its content. Hephaestus records **observations and practice feedback**, including observations that never
+become comments. Optional achievements, leagues, and leaderboards use workspace activity separately.
+
+Your sign-in details, linked accounts, memberships, preferences, chats, and feedback reactions support your
+account and conversations. Product-feedback submissions and survey answers or dismissals support product improvement.
+Authentication events (including IP address and browser information), settings-change history, review
+diagnostics, and AI usage accounting support security, troubleshooting, and spending controls.
+
+The app uses essential cookies and browser storage for sign-in, security, and preferences. Optional **Sentry
+error monitoring** sends error reports only if the operator configures it and you opt in.
+
+Do not include secrets or unnecessary personal or sensitive information in chats, source content, or feedback.
+
+## AI processing and visibility
+
+Enabled AI features send relevant code, discussion, documents, conversation history, and observation evidence
+to the workspace's configured AI provider. **Self-hosting does not necessarily keep AI requests local.** Ask
+your workspace admin which provider is configured; your instance's Privacy notice covers recipients,
+international transfers, retention, and training terms.
+
+Practice feedback is advisory; it does not grade you or replace human review.
+
+- Workspace members can see the activity and feedback their workspace makes available; workspace admins can
+  see practice observations.
+- Publicly viewable workspaces allow public read access without signing in, but do not make private chats
+  public. Your instance's contributor list is also public.
+- Feedback posted on GitHub, GitLab, or Slack is visible to that destination's audience.
+- Instance operators can access stored data for operation and privacy requests. Product-feedback and survey
+  submissions are available to instance admins.
+
+## Your choices and right to object
+
+- **Comments and Slack reminders:** in **User settings → Practice feedback**, turn this off to stop new
+  comments on your work and related Slack reminders. **Reviews still run and admins can still see
+  observations.** Turning it back on allows new deliveries; neither action removes existing comments.
+- **Slack channel messages:** in the Hephaestus App Home, select **Stop using my messages** to stop collection
+  and erase your collected channel messages and related conversation observations and feedback. **Allow
+  future messages** permits new collection without restoring deleted data. This does not erase mentor DMs,
+  unrelated repository feedback, Slack's copy, or [separately retained copies](#copies-outside-active-records).
+- **Academic research participation:** where offered, use **User settings → Academic research participation →
+  Participate in academic research**. Withdrawal stops new research processing, not ordinary practice reviews
+  or all existing data storage.
+- **Optional error reports:** open **Cookie preferences** in the app footer, or **User settings → Privacy →
+  Change cookie choices**, to grant or withdraw consent where this option is offered.
+
+### Object to processing
+
+Contact your instance's privacy contact to object to processing or request access, correction, restriction,
+or erasure as applicable. Turning off comments, leaving a workspace, or never signing in does not stop
+processing. Your instance's notice also explains how to complain to a supervisory authority.
+
+## Get a copy of your data
+
+Open **User settings → Danger Zone → Export my data → Request export**. When ready, select **Download**.
+If generation fails, use **Retry export**; contact the operator for repeated failures or stalls. Downloads
+expire **48 hours** after preparation.
+
+The JSON file contains your account, linked sign-in identities, memberships, account features, preferences,
+and authentication history—not credentials or session secrets. Keep it private.
+
+**The self-service export is limited.** Request conversations, observations and feedback (including
+never-delivered results), recognition, mirrored source content, product-feedback submissions, survey
+responses, and other retained copies through your instance's privacy contact. Obtain original
+source-platform exports from those platforms separately.
+
+## Delete your account or request wider erasure
+
+Open **User settings → Danger Zone → Delete account**, select **Delete**, and follow the confirmation prompt.
+You are signed out on all devices immediately. After the default **48-hour cooldown**, scheduled cleanup
+removes your sign-in details, linked identities, product-feedback submissions, and survey responses, leaving
+an account record with its contact details cleared. There is no self-service undo; contact the operator
+promptly if the request was a mistake.
+
+**Account deletion is not complete person erasure.** Contributor profiles, conversations, observations,
+feedback, and other retained copies need a wider request. Disconnecting a source or removing a workspace
+is not a substitute, and deletion in Hephaestus does not delete your original work on connected services.
+
+Whether or not you have an account, send the instance's privacy contact your workspace, relevant provider
+profile or Slack identity, and links to affected work or feedback. The operator must verify which records
+belong to you. Do not send passwords, tokens, or unnecessary identity documents.
+
+Include already-posted feedback explicitly: correction or removal requires a separate, best-effort operator
+request. Ask for the request's scope, status, and any retention or lawful exceptions.
+
+## How long data stays
+
+Every category has its own window and an operator can change several of them, so the exact durations are
+stated once, in the [record of processing](/admin/dsms/record-of-processing): it lists each shipped window
+and which of them an operator controls. Your instance's Privacy notice states what your deployment
+applies. Scheduled removal follows eligibility and may require later successful runs to finish. Account
+and export timing is described above.
+
+### Project content
+
+- **GitHub and GitLab:** active copies stay while a workspace monitors the source. Removing the last relevant
+  connection or repository monitor removes them. Shared sources remain for other monitoring workspaces;
+  contributor profiles can remain independently and need operator-assisted erasure.
+- **Slack channel threads:** kept for a rolling window measured from the thread's latest message, so an
+  active thread can still contain much older messages. This window does not apply to mentor DMs.
+- **Outline:** selected content stays while its collection and connection remain active.
+- **Web chats, Slack mentor DMs, memberships, and recognition:** retained with their workspace records;
+  removed through workspace removal or verified person erasure.
+- **Product-feedback and survey submissions:** no automatic time-based expiry; removed with account deletion,
+  with their workspace where applicable, or through verified erasure.
+
+### Security and review history
+
+- **Authentication history:** expires in monthly batches. Account erasure redacts identifying
+  authentication details.
+- **Settings-change history:** expires on its own window. Account erasure detaches actor references, not
+  the change record.
+- **Review diagnostics:** become eligible for removal once the job has been finished for long enough. Job
+  history becomes eligible later, and only when observations and feedback no longer reference it. Pending
+  delivery delays both.
+- **Review working copies and unreferenced evidence files:** become eligible for cleanup on their own window.
+- **AI usage accounting:** contains token counts, costs, and run identifiers, not message content, and is
+  kept long enough for annual accounting; an operator can extend that for a legal obligation.
+- **Other operational and administration history:** some records of who configured or requested an operation
+  have no automatic expiry and survive account or workspace removal. Include them in a verified erasure request.
+
+### Copies outside active records
+
+- **Buffered integration events:** expire within hours for Slack and Outline, and within months for GitHub
+  and GitLab, under the shipped limits. Storage limits can shorten retention; individual erasure cannot
+  selectively remove these copies.
+- **Logs, support bundles, and backups:** container logs rotate by size, not age. The operator controls
+  support-bundle and backup retention. These copies do not support immediate selective erasure; ask about
+  expiry and how erased data is handled after a restore.
+- **AI-provider copies and posted feedback:** governed by the provider's policies. Completed AI requests
+  cannot be retracted; posted feedback follows the separate removal process above.


### PR DESCRIPTION
## What changed and why

The user guide never said what Hephaestus reads, who can see it, how long copies stay, or how to ask
for access or erasure. Those facts existed only for operators, in `docs/admin/dsms/`, and for one
deployment, in its legal notice — neither is written for the person the data is about. Nothing told a
reader the thing that matters most: their work can be processed even if they have never signed in.

**Your data in Hephaestus** is that page, in the product's voice and linked from the overview, the
sidebar and the mentor guide. It covers what each connected source contributes, what AI processing
sends where, who can see observations and practice feedback, the privacy controls that exist and what
each one does *not* undo, the self-service export and its limits, account deletion and the wider
erasure request, and how long each category of data stays.

Every control it tells the reader to open is named exactly as the product names it, including the
Slack App Home actions and the footer's Privacy link. Retention keeps one home: the page says which
category expires and points at the record of processing, which lists the durations and says which of
them an operator can change, rather than restating a dozen numbers that nothing keeps in sync.

Part of #1606. That issue also asks for its epic's remaining-scope prose to be replaced by links to
it, which is an edit to the issue rather than a change that ships here, so this does not close it.

## How to test

```bash
vp run format
vp run docs:lint
vp run docs:build
vp run check:affected
```

`docs:build` resolves the cross-guide links, including the pointer from the page into the record of
processing. In the documentation preview, follow **Overview → Your data and privacy** and the mentor
guide's privacy link, then check that account deletion, wider person erasure and separately retained
copies read as three different things.

## Release impact

No changeset: this changes documentation only, and nothing under `server/`, `webapp/` or `docker/`.
No operator action.

## Notes for reviewers

The bundled TUM legal notice (`webapp/public/legal/profiles/tumaet/privacy.md`) is deliberately not
touched. Its erasure and retention wording is less accurate than this page — account deletion does
not remove contributor profiles or preferences, for one — but it is a published Art. 13/14 statement
for a named operator, so it needs the maintainer's own edit after AET sign-off, not a documentation
pull request.

The page's claims about what account deletion removes match #1849, which fixes the erasure defect
found while writing it. The two PRs share no files.
