### PR TITLE
fix(server): a retried review occasion keeps the reviewer as its subject

### DIFF
--- a/.changeset/retried-review-feedback-keeps-its-reviewer.md
+++ b/.changeset/retried-review-feedback-keeps-its-reviewer.md
@@ -1,0 +1,5 @@
+---
+"hephaestus": patch
+---
+
+Feedback about a code review you left is now addressed to you rather than to the author of the pull request when the review had to be retried after a pause, such as a spent budget or an inactive workspace.

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/handler/PullRequestReviewSubmissionRequest.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/handler/PullRequestReviewSubmissionRequest.java
@@ -74,6 +74,12 @@ public record PullRequestReviewSubmissionRequest(
         this(pullRequest, headRefName, headRefOid, baseRefName, null, null, null, null);
     }
 
+    /** The same request filed under a named population; {@code null} falls back to the origin rule above. */
+    public PullRequestReviewSubmissionRequest withOrigin(@Nullable ObservationOrigin origin) {
+        return new PullRequestReviewSubmissionRequest(
+                pullRequest, headRefName, headRefOid, baseRefName, triggerSignal, origin, reviewId, aboutUserId);
+    }
+
     public static PullRequestReviewSubmissionRequest forSubmittedReview(
             ScmEventPayload.PullRequestData pullRequest,
             String headRefName,

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/job/PullRequestSignalResubmitter.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/job/PullRequestSignalResubmitter.java
@@ -9,12 +9,15 @@ import de.tum.cit.aet.hephaestus.integration.core.signal.PendingSignalResubmitte
 import de.tum.cit.aet.hephaestus.integration.core.signal.SignalKey;
 import de.tum.cit.aet.hephaestus.integration.core.signal.SignalRecorder;
 import de.tum.cit.aet.hephaestus.integration.core.signal.SignalStateReason;
+import de.tum.cit.aet.hephaestus.integration.core.spi.ReviewSubject;
 import de.tum.cit.aet.hephaestus.integration.scm.domain.pullrequest.PullRequest;
 import de.tum.cit.aet.hephaestus.integration.scm.domain.pullrequest.PullRequestRepository;
+import de.tum.cit.aet.hephaestus.integration.scm.domain.pullrequestreview.PullRequestReviewRepository;
 import de.tum.cit.aet.hephaestus.integration.scm.domain.signal.ScmSignals;
 import de.tum.cit.aet.hephaestus.practices.review.GateDecision;
 import de.tum.cit.aet.hephaestus.practices.review.PracticeReviewDetectionGate;
 import de.tum.cit.aet.hephaestus.practices.review.TriggerMode;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -40,16 +43,19 @@ public class PullRequestSignalResubmitter implements PendingSignalResubmitter {
     private final PullRequestRepository pullRequestRepository;
     private final PracticeReviewDetectionGate practiceReviewDetectionGate;
     private final SignalRecorder signalRecorder;
+    private final PullRequestReviewRepository reviewRepository;
 
     public PullRequestSignalResubmitter(
             AgentJobService agentJobService,
             PullRequestRepository pullRequestRepository,
             PracticeReviewDetectionGate practiceReviewDetectionGate,
-            SignalRecorder signalRecorder) {
+            SignalRecorder signalRecorder,
+            PullRequestReviewRepository reviewRepository) {
         this.agentJobService = agentJobService;
         this.pullRequestRepository = pullRequestRepository;
         this.practiceReviewDetectionGate = practiceReviewDetectionGate;
         this.signalRecorder = signalRecorder;
+        this.reviewRepository = reviewRepository;
     }
 
     @Override
@@ -78,27 +84,59 @@ public class PullRequestSignalResubmitter implements PendingSignalResubmitter {
             return;
         }
 
-        switch (practiceReviewDetectionGate.evaluate(pr, key.signalName(), TriggerMode.AUTO)) {
+        // The subject of a submitted-review occasion is the reviewer, and the only thing that still knows
+        // which review that was is the occasion's own revision: the pull request has since moved on and
+        // its author is a different person.
+        ScmEventPayload.@Nullable ReviewData reviewData = null;
+        if (key.signalName().equals(ScmSignals.PULL_REQUEST_REVIEWED)) {
+            reviewData = key.revision()
+                    .eventId()
+                    .flatMap(reviewId -> reviewRepository.findByIdAndPullRequestId(reviewId, pr.getId()))
+                    .flatMap(ScmEventPayload.ReviewData::from)
+                    .orElse(null);
+            if (reviewData == null) {
+                log.debug("Pending signal's review no longer belongs to its pull request: prId={}", pr.getId());
+                signalRecorder.markRefused(key, SignalStateReason.ARTIFACT_GONE);
+                return;
+            }
+            if (reviewData.authorId() == null) {
+                log.debug("Pending signal's review has no linked reviewer: reviewId={}", reviewData.id());
+                signalRecorder.markRefused(key, SignalStateReason.SUBJECT_UNLINKED);
+                return;
+            }
+        }
+
+        GateDecision decision = reviewData == null
+                ? practiceReviewDetectionGate.evaluate(pr, key.signalName(), TriggerMode.AUTO)
+                : practiceReviewDetectionGate.evaluate(
+                        pr, key.signalName(), TriggerMode.AUTO, new ReviewSubject(reviewData.authorId(), true));
+        switch (decision) {
             case GateDecision.Skip skip -> {
                 log.debug("Pending signal now skipped by practice gate: prId={}, reason={}", pr.getId(), skip.reason());
                 signalRecorder.markRefused(key, skip.resolvedSignalReason());
             }
-            case GateDecision.Detect detect ->
-                agentJobService.submit(
-                        detect.workspace().getId(),
-                        AgentJobType.PULL_REQUEST_REVIEW,
-                        new PullRequestReviewSubmissionRequest(
-                                ScmEventPayload.PullRequestData.from(pr),
+            case GateDecision.Detect detect -> {
+                ScmEventPayload.PullRequestData prData = ScmEventPayload.PullRequestData.from(pr);
+                PullRequestReviewSubmissionRequest request = reviewData == null
+                        ? new PullRequestReviewSubmissionRequest(
+                                prData, pr.getHeadRefName(), pr.getHeadRefOid(), pr.getBaseRefName(), key.signalName())
+                        : PullRequestReviewSubmissionRequest.forSubmittedReview(
+                                prData,
                                 pr.getHeadRefName(),
                                 pr.getHeadRefOid(),
                                 pr.getBaseRefName(),
                                 key.signalName(),
-                                // Carried from the ledger row rather than defaulted: a re-offered signal keeps the
-                                // population it was discovered for, so a campaign's budget-deferred tail cannot land
-                                // in the live series hours after the campaign paused.
-                                SignalOrigins.observationOriginOf(signal.getDiscoveredVia())),
+                                reviewData);
+                agentJobService.submit(
+                        detect.workspace().getId(),
+                        AgentJobType.PULL_REQUEST_REVIEW,
+                        // Carried from the ledger row rather than defaulted: a re-offered signal keeps the
+                        // population it was discovered for, so a campaign's budget-deferred tail cannot land
+                        // in the live series hours after the campaign paused.
+                        request.withOrigin(SignalOrigins.observationOriginOf(signal.getDiscoveredVia())),
                         key,
                         detect);
+            }
         }
     }
 }

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/core/signal/SignalRevision.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/core/signal/SignalRevision.java
@@ -100,13 +100,20 @@ public record SignalRevision(String value) {
         return new SignalRevision(RevisionScheme.EVENT_ID.prefix() + eventId);
     }
 
-    /** The event {@link #ofEventId} encoded here, or empty when another scheme minted this revision. */
+    /**
+     * The event {@link #ofEventId} encoded here, or empty when another scheme minted this revision or
+     * a persisted value predates a grammar the constructor no longer rejects.
+     */
     public Optional<Long> eventId() {
         if (scheme().orElse(null) != RevisionScheme.EVENT_ID) {
             return Optional.empty();
         }
-        return Optional.of(
-                Long.parseLong(value.substring(RevisionScheme.EVENT_ID.prefix().length())));
+        try {
+            return Optional.of(Long.parseLong(
+                    value.substring(RevisionScheme.EVENT_ID.prefix().length())));
+        } catch (NumberFormatException e) {
+            return Optional.empty();
+        }
     }
 
     /** The scheme that produced this revision, read back off its prefix. */

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/core/signal/SignalRevision.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/core/signal/SignalRevision.java
@@ -100,6 +100,15 @@ public record SignalRevision(String value) {
         return new SignalRevision(RevisionScheme.EVENT_ID.prefix() + eventId);
     }
 
+    /** The event {@link #ofEventId} encoded here, or empty when another scheme minted this revision. */
+    public Optional<Long> eventId() {
+        if (scheme().orElse(null) != RevisionScheme.EVENT_ID) {
+            return Optional.empty();
+        }
+        return Optional.of(
+                Long.parseLong(value.substring(RevisionScheme.EVENT_ID.prefix().length())));
+    }
+
     /** The scheme that produced this revision, read back off its prefix. */
     public Optional<RevisionScheme> scheme() {
         for (RevisionScheme scheme : RevisionScheme.values()) {

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/core/signal/SignalRevision.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/core/signal/SignalRevision.java
@@ -109,8 +109,9 @@ public record SignalRevision(String value) {
             return Optional.empty();
         }
         try {
-            return Optional.of(Long.parseLong(
-                    value.substring(RevisionScheme.EVENT_ID.prefix().length())));
+            long eventId = Long.parseLong(
+                    value.substring(RevisionScheme.EVENT_ID.prefix().length()));
+            return eventId > 0 ? Optional.of(eventId) : Optional.empty();
         } catch (NumberFormatException e) {
             return Optional.empty();
         }

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/domain/pullrequestreview/PullRequestReviewRepository.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/domain/pullrequestreview/PullRequestReviewRepository.java
@@ -26,6 +26,8 @@ import org.springframework.stereotype.Repository;
 @Repository
 @WorkspaceAgnostic("Reviews scoped through pull_request_id -> repository.workspace_id")
 public interface PullRequestReviewRepository extends JpaRepository<PullRequestReview, Long> {
+    Optional<PullRequestReview> findByIdAndPullRequestId(Long id, Long pullRequestId);
+
     Optional<PullRequestReview> findByNativeIdAndProviderId(Long nativeId, Long providerId);
 
     List<PullRequestReview> findAllByPullRequestIdAndProviderId(Long pullRequestId, Long providerId);

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/job/ScmSignalResubmitterTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/job/ScmSignalResubmitterTest.java
@@ -1,9 +1,11 @@
 package de.tum.cit.aet.hephaestus.agent.job;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import de.tum.cit.aet.hephaestus.agent.AgentJobType;
@@ -12,13 +14,18 @@ import de.tum.cit.aet.hephaestus.agent.handler.PullRequestReviewSubmissionReques
 import de.tum.cit.aet.hephaestus.integration.core.signal.ArtifactSignal;
 import de.tum.cit.aet.hephaestus.integration.core.signal.DiscoveredVia;
 import de.tum.cit.aet.hephaestus.integration.core.signal.SignalRecorder;
+import de.tum.cit.aet.hephaestus.integration.core.signal.SignalRevision;
 import de.tum.cit.aet.hephaestus.integration.core.signal.SignalStateReason;
+import de.tum.cit.aet.hephaestus.integration.core.spi.ReviewSubject;
 import de.tum.cit.aet.hephaestus.integration.scm.domain.issue.Issue;
 import de.tum.cit.aet.hephaestus.integration.scm.domain.issue.IssueRepository;
 import de.tum.cit.aet.hephaestus.integration.scm.domain.pullrequest.PullRequest;
 import de.tum.cit.aet.hephaestus.integration.scm.domain.pullrequest.PullRequestRepository;
+import de.tum.cit.aet.hephaestus.integration.scm.domain.pullrequestreview.PullRequestReview;
+import de.tum.cit.aet.hephaestus.integration.scm.domain.pullrequestreview.PullRequestReviewRepository;
 import de.tum.cit.aet.hephaestus.integration.scm.domain.repository.Repository;
 import de.tum.cit.aet.hephaestus.integration.scm.domain.signal.ScmSignals;
+import de.tum.cit.aet.hephaestus.integration.scm.domain.user.User;
 import de.tum.cit.aet.hephaestus.practices.review.GateDecision;
 import de.tum.cit.aet.hephaestus.practices.review.PracticeReviewDetectionGate;
 import de.tum.cit.aet.hephaestus.practices.review.TriggerMode;
@@ -30,6 +37,7 @@ import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 
 @Tag("unit")
@@ -37,12 +45,17 @@ class ScmSignalResubmitterTest extends BaseUnitTest {
 
     private static final long WORKSPACE_ID = 7L;
     private static final long ARTIFACT_ID = 41L;
+    private static final long REVIEW_ID = 99L;
+    private static final long REVIEWER_ID = 123L;
 
     @Mock
     private AgentJobService agentJobService;
 
     @Mock
     private PullRequestRepository pullRequestRepository;
+
+    @Mock
+    private PullRequestReviewRepository reviewRepository;
 
     @Mock
     private IssueRepository issueRepository;
@@ -73,7 +86,7 @@ class ScmSignalResubmitterTest extends BaseUnitTest {
         ArtifactSignal signal = signal(ScmSignals.PULL_REQUEST_OPENED.value());
         when(pullRequestRepository.findByIdWithAllForGate(ARTIFACT_ID)).thenReturn(Optional.of(pullRequest));
 
-        new PullRequestSignalResubmitter(agentJobService, pullRequestRepository, gate, signalRecorder).resubmit(signal);
+        pullRequestResubmitter().resubmit(signal);
 
         verify(signalRecorder).markRefused(signal.key(), SignalStateReason.ARTIFACT_NOT_VISIBLE);
         verify(gate, never()).evaluate(any(), any(), any());
@@ -103,7 +116,7 @@ class ScmSignalResubmitterTest extends BaseUnitTest {
         when(gate.evaluate(pullRequest, ScmSignals.PULL_REQUEST_OPENED, TriggerMode.AUTO))
                 .thenReturn(detection);
 
-        new PullRequestSignalResubmitter(agentJobService, pullRequestRepository, gate, signalRecorder).resubmit(signal);
+        pullRequestResubmitter().resubmit(signal);
 
         verify(agentJobService)
                 .submit(
@@ -146,6 +159,69 @@ class ScmSignalResubmitterTest extends BaseUnitTest {
         verify(agentJobService, never()).submit(any(), any(), any(), any(), any());
     }
 
+    @Test
+    void shouldKeepTheReviewerAsTheSubjectOfARetriedSubmittedReviewOccasion() {
+        PullRequest pullRequest = pullRequest();
+        ArtifactSignal signal = signal(ScmSignals.PULL_REQUEST_REVIEWED.value());
+        signal.setRevision(SignalRevision.ofEventId(REVIEW_ID).value());
+        when(pullRequestRepository.findByIdWithAllForGate(ARTIFACT_ID)).thenReturn(Optional.of(pullRequest));
+        when(reviewRepository.findByIdAndPullRequestId(REVIEW_ID, ARTIFACT_ID)).thenReturn(Optional.of(review()));
+        GateDecision.Detect detection = detection();
+        when(gate.evaluate(
+                        pullRequest,
+                        ScmSignals.PULL_REQUEST_REVIEWED,
+                        TriggerMode.AUTO,
+                        new ReviewSubject(REVIEWER_ID, true)))
+                .thenReturn(detection);
+
+        pullRequestResubmitter().resubmit(signal);
+
+        var request = ArgumentCaptor.forClass(PullRequestReviewSubmissionRequest.class);
+        verify(agentJobService)
+                .submit(
+                        eq(WORKSPACE_ID),
+                        eq(AgentJobType.PULL_REQUEST_REVIEW),
+                        request.capture(),
+                        eq(signal.key()),
+                        eq(detection));
+        assertThat(request.getValue().reviewId()).isEqualTo(REVIEW_ID);
+        assertThat(request.getValue().aboutUserId()).isEqualTo(REVIEWER_ID);
+        verify(signalRecorder, never()).markRefused(any(), any());
+    }
+
+    @Test
+    void shouldRetireASubmittedReviewOccasionWhoseReviewNoLongerBelongsToItsPullRequest() {
+        ArtifactSignal signal = signal(ScmSignals.PULL_REQUEST_REVIEWED.value());
+        signal.setRevision(SignalRevision.ofEventId(REVIEW_ID).value());
+        when(pullRequestRepository.findByIdWithAllForGate(ARTIFACT_ID)).thenReturn(Optional.of(pullRequest()));
+        when(reviewRepository.findByIdAndPullRequestId(REVIEW_ID, ARTIFACT_ID)).thenReturn(Optional.empty());
+
+        pullRequestResubmitter().resubmit(signal);
+
+        verify(signalRecorder).markRefused(signal.key(), SignalStateReason.ARTIFACT_GONE);
+        verifyNoInteractions(gate, agentJobService);
+    }
+
+    @Test
+    void shouldHoldASubmittedReviewOccasionWhoseReviewerIsNotLinkedYet() {
+        ArtifactSignal signal = signal(ScmSignals.PULL_REQUEST_REVIEWED.value());
+        signal.setRevision(SignalRevision.ofEventId(REVIEW_ID).value());
+        PullRequestReview review = review();
+        review.setAuthor(null);
+        when(pullRequestRepository.findByIdWithAllForGate(ARTIFACT_ID)).thenReturn(Optional.of(pullRequest()));
+        when(reviewRepository.findByIdAndPullRequestId(REVIEW_ID, ARTIFACT_ID)).thenReturn(Optional.of(review));
+
+        pullRequestResubmitter().resubmit(signal);
+
+        verify(signalRecorder).markRefused(signal.key(), SignalStateReason.SUBJECT_UNLINKED);
+        verifyNoInteractions(gate, agentJobService);
+    }
+
+    private PullRequestSignalResubmitter pullRequestResubmitter() {
+        return new PullRequestSignalResubmitter(
+                agentJobService, pullRequestRepository, gate, signalRecorder, reviewRepository);
+    }
+
     private GateDecision.Detect detection() {
         return new GateDecision.Detect(workspace, List.of(), 1, TriggerMode.AUTO);
     }
@@ -170,6 +246,17 @@ class ScmSignalResubmitterTest extends BaseUnitTest {
         pullRequest.setHeadRefOid("abc123");
         pullRequest.setBaseRefName("main");
         return pullRequest;
+    }
+
+    private PullRequestReview review() {
+        User reviewer = new User();
+        reviewer.setId(REVIEWER_ID);
+        PullRequestReview review = new PullRequestReview();
+        review.setId(REVIEW_ID);
+        review.setPullRequest(pullRequest());
+        review.setAuthor(reviewer);
+        review.setState(PullRequestReview.State.APPROVED);
+        return review;
     }
 
     private Issue issue() {

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/job/UpstreamDeletedWorkReadScopeIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/job/UpstreamDeletedWorkReadScopeIntegrationTest.java
@@ -314,7 +314,10 @@ class UpstreamDeletedWorkReadScopeIntegrationTest extends AbstractWorkspaceInteg
         var decision = new GateDecision.Detect(workspace, List.of(), 1, TriggerMode.AUTO);
         when(detectionGate.evaluate(any(), eq(ScmSignals.PULL_REQUEST_OPENED), eq(TriggerMode.AUTO)))
                 .thenReturn(decision);
-        resubmit(new PullRequestSignalResubmitter(jobs, pullRequestRepository, detectionGate, signalRecorder), held);
+        resubmit(
+                new PullRequestSignalResubmitter(
+                        jobs, pullRequestRepository, detectionGate, signalRecorder, reviewRepository),
+                held);
 
         var request = ArgumentCaptor.forClass(PullRequestReviewSubmissionRequest.class);
         verify(jobs)

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/job/UpstreamDeletedWorkReadScopeIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/job/UpstreamDeletedWorkReadScopeIntegrationTest.java
@@ -33,6 +33,7 @@ import de.tum.cit.aet.hephaestus.integration.scm.domain.issue.Issue;
 import de.tum.cit.aet.hephaestus.integration.scm.domain.issue.IssueRepository;
 import de.tum.cit.aet.hephaestus.integration.scm.domain.pullrequest.PullRequest;
 import de.tum.cit.aet.hephaestus.integration.scm.domain.pullrequest.PullRequestRepository;
+import de.tum.cit.aet.hephaestus.integration.scm.domain.pullrequestreview.PullRequestReviewRepository;
 import de.tum.cit.aet.hephaestus.integration.scm.domain.repository.Repository;
 import de.tum.cit.aet.hephaestus.integration.scm.domain.repository.RepositoryRepository;
 import de.tum.cit.aet.hephaestus.integration.scm.domain.signal.ScmSignals;
@@ -91,6 +92,9 @@ class UpstreamDeletedWorkReadScopeIntegrationTest extends AbstractWorkspaceInteg
 
     @Autowired
     private PullRequestRepository pullRequestRepository;
+
+    @Autowired
+    private PullRequestReviewRepository reviewRepository;
 
     @Autowired
     private IssueRepository issueRepository;
@@ -396,7 +400,8 @@ class UpstreamDeletedWorkReadScopeIntegrationTest extends AbstractWorkspaceInteg
      * profile leaves off, so they are built from the same beans the container would inject.
      */
     private PullRequestSignalResubmitter pullRequestResubmitter() {
-        return new PullRequestSignalResubmitter(agentJobService, pullRequestRepository, gate, signalRecorder);
+        return new PullRequestSignalResubmitter(
+                agentJobService, pullRequestRepository, gate, signalRecorder, reviewRepository);
     }
 
     private IssueSignalResubmitter issueResubmitter() {

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/core/signal/SignalGrammarTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/core/signal/SignalGrammarTest.java
@@ -127,6 +127,25 @@ class SignalGrammarTest extends BaseUnitTest {
             assertThat(SignalRevision.ofContentDigest("a", "b").value().length())
                     .isLessThanOrEqualTo(128);
         }
+
+        @Test
+        void shouldReadBackTheEventIdItWasMintedFrom() {
+            assertThat(SignalRevision.ofEventId(42L).eventId()).contains(42L);
+        }
+
+        @Test
+        void shouldReportNoEventIdForAnotherScheme() {
+            assertThat(SignalRevision.ofHeadCommit("abc123").eventId()).isEmpty();
+        }
+
+        @Test
+        void shouldReportNoEventIdRatherThanThrowForAPersistedRowTheConstructorNoLongerWrites() {
+            // The column only enforces the grammar, not the per-scheme suffix, so a row written before
+            // eventId() existed — or edited by hand — can carry a non-numeric tail under this prefix.
+            SignalRevision fromColumn = new SignalRevision("event~not-a-number");
+
+            assertThat(fromColumn.eventId()).isEmpty();
+        }
     }
 
     @Nested

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/core/signal/SignalGrammarTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/core/signal/SignalGrammarTest.java
@@ -146,6 +146,14 @@ class SignalGrammarTest extends BaseUnitTest {
 
             assertThat(fromColumn.eventId()).isEmpty();
         }
+
+        @Test
+        void shouldReportNoEventIdForAPersistedRowCarryingAnIdOfEventIdNeverMints() {
+            // ofEventId(long) only ever mints a positive id, but the grammar admits '-' and '0', so a
+            // hand-edited or pre-validation row can carry a suffix this scheme's constructor never wrote.
+            assertThat(new SignalRevision("event~0").eventId()).isEmpty();
+            assertThat(new SignalRevision("event~-1").eventId()).isEmpty();
+        }
     }
 
     @Nested

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/scm/gitlab/pullrequest/GitLabMergeRequestMessageHandlerIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/scm/gitlab/pullrequest/GitLabMergeRequestMessageHandlerIntegrationTest.java
@@ -674,8 +674,9 @@ class GitLabMergeRequestMessageHandlerIntegrationTest extends BaseIntegrationTes
             var decision = new GateDecision.Detect(savedWorkspace, List.of(), 1, TriggerMode.AUTO);
             when(gate.evaluate(any(), eq(ScmSignals.PULL_REQUEST_OPENED), eq(TriggerMode.AUTO)))
                     .thenReturn(decision);
-            transactionTemplate.executeWithoutResult(status ->
-                    new PullRequestSignalResubmitter(jobs, pullRequestRepository, gate, signalRecorder).resubmit(held));
+            transactionTemplate.executeWithoutResult(status -> new PullRequestSignalResubmitter(
+                            jobs, pullRequestRepository, gate, signalRecorder, reviewRepository)
+                    .resubmit(held));
 
             var request = ArgumentCaptor.forClass(PullRequestReviewSubmissionRequest.class);
             verify(jobs)


### PR DESCRIPTION
## What changed and why

A pull-request review that was submitted, refused for a liftable reason and later re-offered by the
pending-signal reaper came back as a review *of the pull request*, addressed to its author. The
occasion's reviewer was lost: `PullRequestSignalResubmitter` rebuilt the submission request from the
pull request alone, so the reviewer whose work the occasion was about never reached the job. Anyone
whose review occasion was held — an inactive workspace, a spent budget, an unlinked subject, an
unavailable model — got feedback about their review delivered to somebody else.

The occasion already carries the answer: a `scm.pull_request.reviewed` occasion is keyed on the
review's identity (`ScmSignals.pullRequestReviewKey` → `SignalRevision.ofEventId`). The resubmitter
now reads that identity back, loads the review scoped to the occasion's pull request, and submits
through `PullRequestReviewSubmissionRequest.forSubmittedReview`, which is the same factory the live
listener uses and which already carries the "a submitted review must have an author" invariant. A
revision that names no review the pull request still owns retires the occasion as `ARTIFACT_GONE`; a
review whose author is not linked yet holds it as `SUBJECT_UNLINKED`.

`SignalRevision.eventId()` is new and is where the `event~` encoding is read back, beside the
`ofEventId` factory that writes it. `withOrigin` replaces the hand-rolled 8-argument construction so
the discovered-via origin still rides along without the factory's invariant being re-implemented.

Part of #1825's family of tombstone fixes; split out of #1852 because it is reachable on `main`
today through any retryable gate refusal and is not about tombstones at all.

## How to test

```
vp run check:affected
cd server && MANAGEMENT_PORT=0 SERVER_PORT=0 ./mvnw -f application/pom.xml \
  -Dtest='ScmSignalResubmitterTest,PullRequestReviewHandlerTest' -Dsurefire.includedGroups=unit test --batch-mode
cd server && MANAGEMENT_PORT=0 SERVER_PORT=0 ./mvnw -f application/pom.xml \
  -Dtest='UpstreamDeletedWorkReadScopeIntegrationTest,GitLabMergeRequestMessageHandlerIntegrationTest' \
  -Dsurefire.includedGroups=integration test --batch-mode
```

`ScmSignalResubmitterTest` gains three cases: a retried submitted-review occasion whose captured
submission carries the review id and the reviewer as `aboutUserId`; a revision naming a review that
belongs to a different pull request; and a review whose author is not linked.

## Release impact

`.changeset/retried-review-feedback-keeps-its-reviewer.md`, patch. No operator action: nothing to
migrate and no setting changes. Occasions already held on an instance are corrected on their next
sweep.

## Notes for reviewers

- Start at `PullRequestSignalResubmitter.resubmit`. Everything else follows from it.
- **Rebased onto `main` now that #1852 is merged.** #1852 added a direct construction of
  `PullRequestSignalResubmitter` in each of `UpstreamDeletedWorkReadScopeIntegrationTest` and
  `GitLabMergeRequestMessageHandlerIntegrationTest`, both against the four-argument constructor this
  branch extends to five. No textual conflict flagged it; the rebase compiled clean and both call
  sites are updated to pass `reviewRepository`, with the affected suites run above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Retried pull-request review feedback is now addressed to the reviewer who submitted the review, rather than the pull-request author.
  - Reviews that are no longer associated with the pull request are handled safely during retry processing.
  - Invalid or unsupported signal revisions no longer cause errors when their event ID cannot be recovered.

- **Tests**
  - Added coverage for reviewer retention, unlinked reviews, and invalid signal revisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->