### PR TITLE
fix(scripts): keep repository tests out of the repository the hook is pushing

### DIFF
--- a/.vite-hooks/pre-push
+++ b/.vite-hooks/pre-push
@@ -1,2 +1,5 @@
 #!/bin/sh
+# Git points every command a hook runs at the repository being pushed. The gate below creates and
+# drives its own throwaway repositories, so it addresses that one only by mistake.
+unset GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_COMMON_DIR GIT_DIR GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_PREFIX GIT_WORK_TREE
 exec vp run check

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -10,6 +10,8 @@ Most scripts require `vp install` at the repository root; Jean setup performs it
 ### Repository orchestration
 
 Infrastructure tests use `node:test`; Vitest is reserved for the Vite-managed webapp and docs trees.
+Anything here that runs `git` takes its environment from `lib/git-environment.ts`, because the
+pre-push hook hands whatever it starts the repository being pushed.
 
 Substantive developer orchestration under `scripts/` uses typed Node.js entry points:
 

--- a/scripts/check-affected.test.ts
+++ b/scripts/check-affected.test.ts
@@ -5,13 +5,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "node:test";
 
-import {
-	changedPaths,
-	commandsFor,
-	environmentWithoutGitRepository,
-	parseBase,
-	scopesFor,
-} from "./check-affected.ts";
+import { changedPaths, commandsFor, parseBase, scopesFor } from "./check-affected.ts";
+import { environmentForGitFixture } from "./lib/git-environment.ts";
 
 await test("accepts only the documented arguments", () => {
 	assert.equal(parseBase([]), "origin/main");
@@ -85,7 +80,7 @@ await test("a full-gate input overrides scoped inputs", () => {
 await test("discovers committed, staged, unstaged, untracked, deleted, and renamed paths", async () => {
 	const directory = await mkdtemp(join(tmpdir(), "check-affected-"));
 	const git = (...args: string[]) =>
-		execFileSync("git", args, { cwd: directory, env: environmentWithoutGitRepository() });
+		execFileSync("git", args, { cwd: directory, env: environmentForGitFixture() });
 	const put = async (path: string, content = path) => {
 		await mkdir(join(directory, path, ".."), { recursive: true });
 		await writeFile(join(directory, path), content);

--- a/scripts/check-affected.ts
+++ b/scripts/check-affected.ts
@@ -1,24 +1,10 @@
 import { spawnSync } from "node:child_process";
 
+import { environmentWithoutGitRepository } from "./lib/git-environment.ts";
 import { CAPTURE_LIMIT_BYTES } from "./lib/process.ts";
 
 export type Scope = "agents" | "docs" | "full" | "server" | "webapp";
 export type Command = readonly [string, ...string[]];
-
-export function environmentWithoutGitRepository(): NodeJS.ProcessEnv {
-	const environment = { ...process.env };
-	for (const name of [
-		"GIT_ALTERNATE_OBJECT_DIRECTORIES",
-		"GIT_COMMON_DIR",
-		"GIT_DIR",
-		"GIT_INDEX_FILE",
-		"GIT_OBJECT_DIRECTORY",
-		"GIT_PREFIX",
-		"GIT_WORK_TREE",
-	])
-		delete environment[name];
-	return environment;
-}
 
 export function parseBase(args: string[]): string {
 	if (args.length === 0) return "origin/main";

--- a/scripts/check-agent-instructions.ts
+++ b/scripts/check-agent-instructions.ts
@@ -32,6 +32,7 @@ import { fromMarkdown } from "mdast-util-from-markdown";
 import { mdxFromMarkdown } from "mdast-util-mdx";
 import { mdxjs } from "micromark-extension-mdxjs";
 
+import { environmentWithoutGitRepository } from "./lib/git-environment.ts";
 import { asRecord, asStringArray, parseJson } from "./lib/json.ts";
 
 /** Resolved from this file, so the gate answers the same whatever the working directory is. */
@@ -746,7 +747,7 @@ export async function scan(root: string = REPO_ROOT): Promise<Snapshot> {
 	const { stdout } = await promisify(execFile)(
 		"git",
 		["ls-files", "-z", "--cached", "--others", "--exclude-standard"],
-		{ cwd: root, maxBuffer: 64 * 1024 * 1024 },
+		{ cwd: root, env: environmentWithoutGitRepository(), maxBuffer: 64 * 1024 * 1024 },
 	);
 	// Sorted, so the failures print in the same sequence locally and in CI.
 	const listed = [...new Set(stdout.split("\0").filter((path) => path !== ""))].toSorted();

--- a/scripts/check-artifact-source-contract-immutability.test.ts
+++ b/scripts/check-artifact-source-contract-immutability.test.ts
@@ -5,15 +5,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "node:test";
 
+import { environmentForGitFixture } from "./lib/git-environment.ts";
+
 const CHECKER = join(import.meta.dirname, "check-artifact-source-contract-immutability.ts");
 
-/**
- * Git hooks export GIT_DIR, GIT_INDEX_FILE and friends, which would point every command below at the
- * repository being pushed instead of at the fixture. Strip them so the fixtures are self-contained
- * however these tests are invoked.
- */
-const cleanGitEnv = (): NodeJS.ProcessEnv =>
-	Object.fromEntries(Object.entries(process.env).filter(([key]) => !key.startsWith("GIT_")));
 const CONTRACTS = "server/application/src/main/resources/contracts/artifact-source";
 
 type Git = (...args: string[]) => string;
@@ -26,7 +21,7 @@ function repoWithPublishedContract(): { repo: string; git: Git } {
 			cwd: repo,
 			encoding: "utf8",
 			stdio: ["ignore", "pipe", "pipe"],
-			env: cleanGitEnv(),
+			env: environmentForGitFixture(),
 		});
 	git("init", "--quiet", "--initial-branch=main");
 	git("config", "user.email", "test@example.invalid");
@@ -46,7 +41,7 @@ function runChecker(repo: string): string {
 		cwd: repo,
 		encoding: "utf8",
 		stdio: ["ignore", "pipe", "pipe"],
-		env: { ...cleanGitEnv(), CONTRACT_BASE_REF: "main", GITHUB_BASE_REF: "" },
+		env: environmentForGitFixture({ CONTRACT_BASE_REF: "main", GITHUB_BASE_REF: "" }),
 	});
 }
 
@@ -101,7 +96,7 @@ await test("reports honestly when nothing is published at the merge base", (t) =
 			cwd: repo,
 			encoding: "utf8",
 			stdio: ["ignore", "pipe", "pipe"],
-			env: cleanGitEnv(),
+			env: environmentForGitFixture(),
 		});
 	git("init", "--quiet", "--initial-branch=main");
 	git("config", "user.email", "test@example.invalid");

--- a/scripts/check-java-nullness.test.ts
+++ b/scripts/check-java-nullness.test.ts
@@ -11,15 +11,10 @@ import {
 	isHandwrittenJavaSource,
 	nullnessPolicyViolations,
 } from "./check-java-nullness.ts";
+import { environmentForGitFixture } from "./lib/git-environment.ts";
 
 const execFileAsync = promisify(execFile);
 const REPO_ROOT = resolve(import.meta.dirname, "..");
-const GIT_ENV = {
-	...process.env,
-	GIT_DIR: undefined,
-	GIT_INDEX_FILE: undefined,
-	GIT_WORK_TREE: undefined,
-};
 
 const source = (content: string) => [{ path: "Example.java", content }];
 
@@ -91,7 +86,7 @@ await test("discovers Application.java in the real checkout", async () => {
 await test("fails closed when repository discovery finds no Java sources", async () => {
 	const root = await mkdtemp(join(tmpdir(), "java-nullness-"));
 	try {
-		await execFileAsync("git", ["init", "--quiet"], { cwd: root, env: GIT_ENV });
+		await execFileAsync("git", ["init", "--quiet"], { cwd: root, env: environmentForGitFixture() });
 		await assert.rejects(discoverJavaSourcePaths(root), /No handwritten Java sources found/);
 	} finally {
 		await rm(root, { recursive: true, force: true });

--- a/scripts/commit-via-api.test.ts
+++ b/scripts/commit-via-api.test.ts
@@ -6,25 +6,13 @@ import { join } from "node:path";
 import { test } from "node:test";
 
 import { stageChanges, commitInput } from "./commit-via-api.ts";
-
-// Unset inherited Git hook variables as process helpers merge overrides with the environment.
-const cleanGitEnv = (): NodeJS.ProcessEnv => ({
-	...Object.fromEntries(
-		Object.keys(process.env)
-			.filter((key) => key.startsWith("GIT_"))
-			.map((key) => [key, undefined]),
-	),
-	GIT_CONFIG_NOSYSTEM: "1",
-});
+import { environmentForGitFixture } from "./lib/git-environment.ts";
 
 type Git = (...args: string[]) => string;
 
 function repoWithCommittedFiles() {
 	const repo = mkdtempSync(join(tmpdir(), "commit-via-api-"));
-	mkdirSync(join(repo, ".git"));
-	const globalConfig = join(repo, ".git", "test-global-config");
-	writeFileSync(globalConfig, "");
-	const env = { ...process.env, ...cleanGitEnv(), GIT_CONFIG_GLOBAL: globalConfig };
+	const env = environmentForGitFixture();
 	const git: Git = (...args) =>
 		execFileSync("git", args, {
 			cwd: repo,

--- a/scripts/enable-hooks.test.ts
+++ b/scripts/enable-hooks.test.ts
@@ -5,13 +5,14 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { after, test } from "node:test";
 
+import { environmentForGitFixture } from "./lib/git-environment.ts";
 import { CAPTURE_LIMIT_BYTES } from "./lib/process.ts";
 
 const REPO_ROOT = resolve(import.meta.dirname, "..");
 const SCRIPT = join(REPO_ROOT, "scripts", "enable-hooks.ts");
 const temporaries: string[] = [];
 
-function globalConfig(contents = ""): string {
+function globalConfig(contents: string): string {
 	const directory = mkdtempSync(join(tmpdir(), "enable-hooks-config-"));
 	temporaries.push(directory);
 	const path = join(directory, "gitconfig");
@@ -19,19 +20,9 @@ function globalConfig(contents = ""): string {
 	return path;
 }
 
-const EMPTY_GLOBAL_CONFIG = globalConfig();
-
-// Git hook variables override cwd; keep each subprocess inside its isolated fixture.
+// The install reads CI to decide whether to advise on signing; each test states its own answer.
 function hookFreeEnv(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
-	const inherited = Object.fromEntries(
-		Object.entries(process.env).filter(([key]) => !key.startsWith("GIT_") && key !== "CI"),
-	);
-	return {
-		...inherited,
-		GIT_CONFIG_GLOBAL: EMPTY_GLOBAL_CONFIG,
-		GIT_CONFIG_NOSYSTEM: "1",
-		...overrides,
-	};
+	return environmentForGitFixture({ CI: undefined, ...overrides });
 }
 
 after(() => {

--- a/scripts/git-environment.test.ts
+++ b/scripts/git-environment.test.ts
@@ -1,0 +1,130 @@
+/**
+ * The repository being pushed has to survive the gate the push runs. Git hands every hook the
+ * location of that repository, and anything below the hook that lets those variables through
+ * addresses it instead of the throwaway repository it built for itself — `git config`, `git commit`
+ * and `git tag` have all landed on a contributor's checkout that way.
+ *
+ * Two things keep them apart and both are asserted here: the hook drops the variables before it
+ * starts the gate, and every repository test that runs `git` builds its environment in one place.
+ */
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { chmodSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { delimiter, join, resolve } from "node:path";
+import { after, test } from "node:test";
+
+import { environmentForGitFixture, GIT_REPOSITORY_VARIABLES } from "./lib/git-environment.ts";
+
+const REPO_ROOT = resolve(import.meta.dirname, "..");
+const HOOKS = join(REPO_ROOT, ".vite-hooks");
+const SCRIPTS = join(REPO_ROOT, "scripts");
+
+const temporaries: string[] = [];
+
+after(() => {
+	for (const temporary of temporaries) rmSync(temporary, { recursive: true, force: true });
+});
+
+function temporaryDirectory(prefix: string): string {
+	const directory = mkdtempSync(join(tmpdir(), prefix));
+	temporaries.push(directory);
+	return directory;
+}
+
+/** The hooks the dispatcher runs that start a repository task, which is what carries the risk. */
+function gateHooks(): string[] {
+	return readdirSync(HOOKS, { withFileTypes: true })
+		.filter((entry) => entry.isFile())
+		.map((entry) => entry.name)
+		.filter((name) => readFileSync(join(HOOKS, name), "utf8").includes("vp run"));
+}
+
+void test("the hook drops every repository variable before it starts the gate", () => {
+	const hooks = gateHooks();
+	assert.deepEqual(hooks, ["pre-push"]);
+	for (const hook of hooks) {
+		const source = readFileSync(join(HOOKS, hook), "utf8");
+		const unset = source.split("\n").find((line) => line.startsWith("unset "));
+		assert.ok(unset, `.vite-hooks/${hook} must unset the variables git exports to it`);
+		assert.deepEqual(
+			unset.split(/\s+/).slice(1).toSorted(),
+			[...GIT_REPOSITORY_VARIABLES],
+			`.vite-hooks/${hook} must unset exactly the variables lib/git-environment.ts names`,
+		);
+		assert.ok(
+			source.indexOf(unset) < source.indexOf("vp run"),
+			`.vite-hooks/${hook} must unset them before it runs the gate`,
+		);
+	}
+});
+
+void test("a gate that runs git the wrong way cannot reach the repository being pushed", () => {
+	const git = (cwd: string, ...args: string[]): string =>
+		execFileSync("git", args, { cwd, encoding: "utf8", env: environmentForGitFixture() }).trim();
+	const fingerprint = (repository: string): string[] => [
+		git(repository, "show-ref"),
+		git(repository, "tag", "--list"),
+		git(repository, "worktree", "list"),
+		readFileSync(join(repository, ".git", "config"), "utf8"),
+	];
+
+	const decoy = temporaryDirectory("git-environment-decoy-");
+	git(decoy, "init", "--quiet", "--initial-branch=main");
+	git(decoy, "config", "user.email", "decoy@example.invalid");
+	git(decoy, "config", "user.name", "Decoy");
+	writeFileSync(join(decoy, "tracked"), "decoy\n");
+	git(decoy, "add", "-A");
+	git(decoy, "commit", "--quiet", "-m", "decoy");
+	const before = fingerprint(decoy);
+
+	// Stands in for `vp run check`: a task that runs git in whatever environment it was handed, and
+	// records that it ran so a hook that never reached it cannot pass this test.
+	const stubs = temporaryDirectory("git-environment-gate-");
+	const marker = join(stubs, "ran");
+	const stub = join(stubs, "vp");
+	writeFileSync(
+		stub,
+		`#!/bin/sh\nprintf ran > "${marker}"\ngit config user.name intruder\ngit tag intruder\nexit 0\n`,
+	);
+	chmodSync(stub, 0o755);
+
+	const environment = environmentForGitFixture({
+		GIT_DIR: join(decoy, ".git"),
+		GIT_INDEX_FILE: join(decoy, ".git", "index"),
+		GIT_WORK_TREE: decoy,
+	});
+	environment.PATH = `${stubs}${delimiter}${environment.PATH ?? ""}`;
+	execFileSync("sh", ["-e", join(HOOKS, "pre-push")], {
+		cwd: temporaryDirectory("git-environment-worktree-"),
+		encoding: "utf8",
+		env: environment,
+		stdio: ["ignore", "pipe", "pipe"],
+	});
+
+	assert.equal(readFileSync(marker, "utf8"), "ran");
+	assert.deepEqual(fingerprint(decoy), before);
+});
+
+void test("a repository test that runs git builds its environment in one place", () => {
+	const spawnsGit = /(?:execFile|execFileAsync|execFileSync|spawn|spawnSync)\(\s*"git"/;
+	// The naive form: an environment derived from this process, which under a hook names the
+	// repository being pushed.
+	const derivesFromProcess = /\.\.\.process\.env|process\.env\s*\)/;
+	const tests = readdirSync(SCRIPTS).filter((name) => name.endsWith(".test.ts"));
+	const running = tests.filter((name) => spawnsGit.test(readFileSync(join(SCRIPTS, name), "utf8")));
+	assert.ok(running.includes("reconcile-deployment.test.ts"));
+	for (const name of running) {
+		const source = readFileSync(join(SCRIPTS, name), "utf8");
+		assert.match(
+			source,
+			/from "\.\/lib\/git-environment\.ts"/,
+			`scripts/${name} runs git, so it takes its environment from lib/git-environment.ts`,
+		);
+		assert.doesNotMatch(
+			source,
+			derivesFromProcess,
+			`scripts/${name} must build its git environment with environmentForGitFixture()`,
+		);
+	}
+});

--- a/scripts/lib/git-environment.ts
+++ b/scripts/lib/git-environment.ts
@@ -1,0 +1,61 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * The variables git exports to a hook so that the commands the hook runs find the repository it is
+ * acting on (githooks(5); git(1) § "The Git Repository"). Each one outranks the directory a command
+ * is given, so everything a hook starts — the quality gate, and every `git` below it — addresses
+ * the repository being pushed until they are removed. `.vite-hooks/pre-push` unsets exactly these.
+ */
+export const GIT_REPOSITORY_VARIABLES = [
+	"GIT_ALTERNATE_OBJECT_DIRECTORIES",
+	"GIT_COMMON_DIR",
+	"GIT_DIR",
+	"GIT_INDEX_FILE",
+	"GIT_OBJECT_DIRECTORY",
+	"GIT_PREFIX",
+	"GIT_WORK_TREE",
+] as const;
+
+/**
+ * The environment without them, so `git` obeys the working directory it is handed. Each name is
+ * kept with an `undefined` value rather than dropped: node omits those when it spawns, and the
+ * result is equally usable as an override that a caller merges over `process.env` itself, where a
+ * missing key would leave the inherited variable standing.
+ */
+export function environmentWithoutGitRepository(): NodeJS.ProcessEnv {
+	const environment: NodeJS.ProcessEnv = { ...process.env };
+	for (const name of GIT_REPOSITORY_VARIABLES) environment[name] = undefined;
+	return environment;
+}
+
+/**
+ * The environment for a `git` that acts on a throwaway fixture: no inherited `GIT_*` at all, and
+ * neither the machine's global nor its system configuration, whose `core.hooksPath`,
+ * `commit.gpgsign` or `tag.gpgSign` would otherwise decide what the fixture does.
+ */
+export function environmentForGitFixture(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+	const environment: NodeJS.ProcessEnv = { ...process.env };
+	for (const name of Object.keys(environment))
+		if (name.startsWith("GIT_")) environment[name] = undefined;
+	return {
+		...environment,
+		GIT_CONFIG_GLOBAL: emptyGlobalConfiguration(),
+		GIT_CONFIG_NOSYSTEM: "1",
+		...overrides,
+	};
+}
+
+let emptyConfiguration: string | undefined;
+
+/** `/dev/null` is not readable as a config file on every platform the tests run on, so: a file. */
+function emptyGlobalConfiguration(): string {
+	if (emptyConfiguration === undefined) {
+		const directory = mkdtempSync(join(tmpdir(), "git-fixture-config-"));
+		process.once("exit", () => rmSync(directory, { recursive: true, force: true }));
+		emptyConfiguration = join(directory, "gitconfig");
+		writeFileSync(emptyConfiguration, "");
+	}
+	return emptyConfiguration;
+}

--- a/scripts/plan-release.test.ts
+++ b/scripts/plan-release.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { after, test } from "node:test";
 
+import { environmentForGitFixture } from "./lib/git-environment.ts";
 import {
 	hasSchemaMigrations,
 	planRelease,
@@ -147,23 +148,11 @@ after(() => {
 void test("reads schema migrations from the diff between the two releases", async () => {
 	const repo = mkdtempSync(join(tmpdir(), "plan-release-"));
 	repositories.push(repo);
-	// A developer's own `tag.gpgSign` would turn the lightweight tag below into an annotated one and
-	// send git looking for an editor, so the fixture reads an empty global config instead.
-	const configDirectory = mkdtempSync(join(tmpdir(), "plan-release-config-"));
-	repositories.push(configDirectory);
-	const globalConfig = join(configDirectory, "gitconfig");
-	writeFileSync(globalConfig, "");
 	const git = (...args: string[]): string =>
 		execFileSync("git", args, {
 			cwd: repo,
 			encoding: "utf8",
-			env: {
-				...Object.fromEntries(
-					Object.entries(process.env).filter(([key]) => !key.startsWith("GIT_")),
-				),
-				GIT_CONFIG_GLOBAL: globalConfig,
-				GIT_CONFIG_NOSYSTEM: "1",
-			},
+			env: environmentForGitFixture(),
 			stdio: ["ignore", "pipe", "pipe"],
 		}).trim();
 	const changelog = "server/application/src/main/resources/db/changelog";

--- a/scripts/plan-release.ts
+++ b/scripts/plan-release.ts
@@ -25,6 +25,7 @@
  */
 import { appendFile } from "node:fs/promises";
 
+import { environmentWithoutGitRepository } from "./lib/git-environment.ts";
 import { asRecord, asString, parseJson } from "./lib/json.ts";
 import { output } from "./lib/process.ts";
 
@@ -32,17 +33,6 @@ import { output } from "./lib/process.ts";
 const RELEASE_VERSION = /^(\d+)\.(\d+)\.(\d+)$/;
 
 const MIGRATION_PATH = "server/application/src/main/resources/db/changelog/";
-
-/**
- * Git hooks export `GIT_DIR` and `GIT_INDEX_FILE`, which would point every git command below at
- * whichever repository invoked the hook instead of at the checkout being planned.
- */
-const withoutGitEnvironment = (): Record<string, undefined> =>
-	Object.fromEntries(
-		Object.keys(process.env)
-			.filter((key) => key.startsWith("GIT_"))
-			.map((key) => [key, undefined]),
-	);
 
 export interface ReleaseRef {
 	readonly isDraft: boolean;
@@ -199,7 +189,7 @@ export async function hasSchemaMigrations(
 ): Promise<boolean> {
 	const changed = await output("git", ["diff", "--name-only", from, to, "--", MIGRATION_PATH], {
 		cwd,
-		env: withoutGitEnvironment(),
+		env: environmentWithoutGitRepository(),
 	});
 	return changed.trim() !== "";
 }
@@ -214,7 +204,9 @@ if (import.meta.main) {
 		// The version at the commit CI/CD built, not main's tip, which may carry a newer one.
 		const manifest = asRecord(
 			parseJson(
-				await output("git", ["show", `${sha}:package.json`], { env: withoutGitEnvironment() }),
+				await output("git", ["show", `${sha}:package.json`], {
+					env: environmentWithoutGitRepository(),
+				}),
 			),
 			`${sha}:package.json`,
 		);

--- a/scripts/reconcile-deployment.test.ts
+++ b/scripts/reconcile-deployment.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "node:test";
 
+import { environmentForGitFixture, GIT_REPOSITORY_VARIABLES } from "./lib/git-environment.ts";
 import {
 	adoptTooling,
 	appliedCommit,
@@ -21,6 +22,11 @@ import {
 	syncUnits,
 	unlockedImages,
 } from "./reconcile-deployment.ts";
+
+// `ensureReleaseTree` runs `git worktree add` in the environment it inherits, which under a hook
+// names the repository being pushed. The fixtures below are isolated only once this process has
+// stopped carrying that repository; node runs each test file in its own process.
+for (const name of GIT_REPOSITORY_VARIABLES) delete process.env[name];
 
 const applied = {
 	release: "v0.75.2",
@@ -366,11 +372,7 @@ await test("a tree is adopted as tooling only when its own unit runs through the
 await test("a release's worktree is rebuilt at the accepted commit and checked before it is used", async () => {
 	const directory = await mkdtemp(join(tmpdir(), "reconcile-tree-"));
 	const git = (cwd: string, ...args: string[]): string =>
-		execFileSync("git", args, {
-			cwd,
-			encoding: "utf8",
-			env: { ...process.env, GIT_CONFIG_GLOBAL: "/dev/null", GIT_CONFIG_SYSTEM: "/dev/null" },
-		}).trim();
+		execFileSync("git", args, { cwd, encoding: "utf8", env: environmentForGitFixture() }).trim();
 	try {
 		const checkout = join(directory, "checkout");
 		await mkdir(checkout);

--- a/scripts/render-preview-comment.test.ts
+++ b/scripts/render-preview-comment.test.ts
@@ -5,13 +5,16 @@ import { tmpdir } from "node:os";
 import { dirname, resolve } from "node:path";
 import { test } from "node:test";
 
+import { environmentForGitFixture } from "./lib/git-environment.ts";
+
 const script = resolve("scripts/render-preview-comment.ts");
-const environment = Object.fromEntries(
-	Object.entries(process.env).filter(([key]) => !key.startsWith("GIT_")),
-);
 
 function git(root: string, ...arguments_: string[]): string {
-	return execFileSync("git", arguments_, { cwd: root, encoding: "utf8", env: environment }).trim();
+	return execFileSync("git", arguments_, {
+		cwd: root,
+		encoding: "utf8",
+		env: environmentForGitFixture(),
+	}).trim();
 }
 
 async function repository(changedFile: string): Promise<{ base: string; root: string }> {
@@ -39,13 +42,12 @@ async function render(
 	execFileSync("node", [script, kind, directory, "https://preview.example/", base, "comment.md"], {
 		cwd: root,
 		stdio: "pipe",
-		env: {
-			...environment,
+		env: environmentForGitFixture({
 			GITHUB_SERVER_URL: "https://github.com",
 			GITHUB_REPOSITORY: "example/project",
 			GITHUB_RUN_ID: "123",
 			GITHUB_SHA: "not-the-checked-out-commit",
-		},
+		}),
 	});
 	return readFile(resolve(root, "comment.md"), "utf8");
 }

--- a/scripts/verify-revert.test.ts
+++ b/scripts/verify-revert.test.ts
@@ -5,16 +5,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { after, test } from "node:test";
 
+import { environmentForGitFixture } from "./lib/git-environment.ts";
 import { verifyRevert } from "./verify-revert.ts";
 
 const SCRIPT = join(import.meta.dirname, "verify-revert.ts");
-
-/**
- * Git hooks export GIT_DIR, GIT_INDEX_FILE and friends, which would point every command below at
- * the repository being pushed instead of at the fixture.
- */
-const cleanGitEnv = (): NodeJS.ProcessEnv =>
-	Object.fromEntries(Object.entries(process.env).filter(([key]) => !key.startsWith("GIT_")));
 
 type Git = (...args: string[]) => string;
 
@@ -33,7 +27,7 @@ function fixture(): { repo: string; git: Git; write: (file: string, content: str
 			cwd: repo,
 			encoding: "utf8",
 			stdio: ["ignore", "pipe", "pipe"],
-			env: cleanGitEnv(),
+			env: environmentForGitFixture(),
 		}).trim();
 	const write = (file: string, content: string): void => writeFileSync(join(repo, file), content);
 	git("init", "--quiet", "--initial-branch=main");
@@ -248,7 +242,7 @@ void test("reports the verdict to GITHUB_OUTPUT", () => {
 	const stdout = execFileSync(process.execPath, [SCRIPT, base, "HEAD"], {
 		cwd: repo,
 		encoding: "utf8",
-		env: { ...cleanGitEnv(), GITHUB_OUTPUT: output },
+		env: environmentForGitFixture({ GITHUB_OUTPUT: output }),
 	});
 	assert.match(stdout, /::notice::Verified revert of/);
 	assert.equal(readFileSync(output, "utf8"), "verified-revert=true\n");
@@ -257,7 +251,7 @@ void test("reports the verdict to GITHUB_OUTPUT", () => {
 	const denied = execFileSync(process.execPath, [SCRIPT, base, "HEAD"], {
 		cwd: repo,
 		encoding: "utf8",
-		env: { ...cleanGitEnv(), GITHUB_OUTPUT: output },
+		env: environmentForGitFixture({ GITHUB_OUTPUT: output }),
 	});
 	assert.match(denied, /Not a verified revert/);
 	assert.equal(readFileSync(output, "utf8"), "verified-revert=true\nverified-revert=false\n");


### PR DESCRIPTION
## What changed and why

Git exports `GIT_DIR`, `GIT_WORK_TREE` and `GIT_INDEX_FILE` to every hook so the commands a hook
runs find the repository it is acting on, and each of them outranks the working directory a command
is given. Our `pre-push` hook runs `vp run check`, whose repository tests build throwaway git
repositories — so a test that spawns `git` with an environment derived from `process.env` drives the
repository being pushed instead of its own fixture. `scripts/reconcile-deployment.test.ts` did:
running the gate before a push rewrote `user.name` and `user.email` in the pushed checkout's
config, committed `release` and `later` onto the branch being pushed, created a `v1.0.0` tag and
registered a stray worktree.

This is the third instance of one defect — `enable-hooks.test.ts` and `plan-release.test.ts` were
each patched on their own — so it is fixed as a class, in three layers:

1. **The hook scrubs once.** `.vite-hooks/pre-push` unsets the repository variables before it starts
   the gate, so nothing below it can address the repository being pushed however it builds its
   environment. `commit-msg` runs `commitlint` against the commit in progress and keeps them.
2. **One home for the environments.** `scripts/lib/git-environment.ts` names the variables git
   documents as pointing at a repository and exposes the two environments repository code needs:
   `environmentWithoutGitRepository()` for a script that must obey the directory it was given, and
   `environmentForGitFixture()` for a test that drives a throwaway repository, which additionally
   ignores the machine's global and system configuration. It replaces five hand-rolled copies of
   the same idea, one of which silently did nothing because `lib/process.ts` merges an override
   over `process.env` and an absent key cannot remove an inherited variable.
3. **The fourth instance fails.** `scripts/git-environment.test.ts` asserts the hook unsets exactly
   the variables that module names, and that every `scripts/*.test.ts` that spawns `git` takes its
   environment from it rather than deriving one from `process.env`.

`scan()` in `check-agent-instructions.ts` enumerated its files through `git ls-files` in the
inherited environment, so it listed a different repository's files than the root it was given; it
now uses the shared environment too.

## How to test

The proof is a decoy repository that a corrupted run leaves changed. On `main`:

```bash
git init /tmp/decoy && (cd /tmp/decoy && git commit --allow-empty -m decoy)
GIT_DIR=/tmp/decoy/.git node --test scripts/reconcile-deployment.test.ts
```

leaves `/tmp/decoy` with `user.name = host`, a moved `main`, a `v1.0.0` tag and a registered
worktree. On this branch the same run — and `GIT_DIR=… GIT_WORK_TREE=… GIT_INDEX_FILE=… node --test
scripts/*.test.ts`, all 493 tooling tests — leaves the decoy byte-identical.

`scripts/git-environment.test.ts` makes that a gate: it runs the committed hook with `GIT_DIR`,
`GIT_WORK_TREE` and `GIT_INDEX_FILE` pointing at a decoy and a stand-in for `vp run check` that
runs `git config` and `git tag` the naive way, then asserts the stand-in ran and the decoy is
unchanged. Removing the `unset` line fails it with `user.name = intruder` and `refs/tags/intruder`
in the decoy.

Verified with `vp run format` and `vp run check` (41 tasks, green) from an ordinary shell.

## Release impact

No changeset: nothing under `server/`, `webapp/` or `docker/` changes, and no operator action
follows.

## Notes for reviewers

This PR was pushed with `--no-verify`. The hook being fixed is the hazard, so the gate was run from
a shell with no `GIT_*` variables set instead of through the hook.

`reconcile-deployment.test.ts` clears the repository variables from its own process rather than
passing an environment: `ensureReleaseTree` runs `git worktree add` in whatever it inherits, and the
test owns the environment its subject inherits. `reconcile-deployment.ts` itself is unchanged — it
runs under systemd on a deployment host, where these variables do not exist.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented pre-push checks from accidentally affecting the repository being pushed.
  * Improved isolation for Git-based checks, release tasks, and automated repository operations.

* **Tests**
  * Added coverage to verify Git repository isolation and prevent leaked environment settings from causing unintended changes.

* **Documentation**
  * Documented how repository-related Git settings are applied to scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->