### PR TITLE
test(server): keep a developer's git signing out of the test repositories

### DIFF
--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/context/providers/GitDiffOperationsJGitTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/context/providers/GitDiffOperationsJGitTest.java
@@ -3,6 +3,7 @@ package de.tum.cit.aet.hephaestus.agent.context.providers;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import de.tum.cit.aet.hephaestus.testconfig.BaseUnitTest;
+import de.tum.cit.aet.hephaestus.testconfig.GitTestFixtures;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -42,6 +43,7 @@ class GitDiffOperationsJGitTest extends BaseUnitTest {
     void setUp() throws GitAPIException, IOException {
         git = Git.init().setDirectory(repoDir.toFile()).setInitialBranch("main").call();
         repo = git.getRepository();
+        GitTestFixtures.disableSigning(repo);
 
         write("a.txt", "line one\nline two\nline three\n");
         baseSha = commit("initial");

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/scm/domain/workdir/GitRepositoryManagerTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/scm/domain/workdir/GitRepositoryManagerTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.mock;
 
 import de.tum.cit.aet.hephaestus.integration.core.fabric.FabricLayout;
 import de.tum.cit.aet.hephaestus.testconfig.BaseUnitTest;
+import de.tum.cit.aet.hephaestus.testconfig.GitTestFixtures;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -79,6 +80,7 @@ class GitRepositoryManagerTest extends BaseUnitTest {
 
     private Git createSourceRepo() throws GitAPIException, IOException {
         Git git = Git.init().setDirectory(sourceRepoPath.toFile()).call();
+        GitTestFixtures.disableSigning(git.getRepository());
         Path file = sourceRepoPath.resolve("README.md");
         Files.writeString(file, "# Test Repository\n");
         git.add().addFilepattern("README.md").call();
@@ -202,6 +204,7 @@ class GitRepositoryManagerTest extends BaseUnitTest {
                 String replacementHead;
                 try (Git replacement =
                         Git.init().setDirectory(replacementPath.toFile()).call()) {
+                    GitTestFixtures.disableSigning(replacement.getRepository());
                     Files.writeString(replacementPath.resolve("replacement.txt"), "replacement\n");
                     replacement.add().addFilepattern("replacement.txt").call();
                     replacementHead = replacement

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/testconfig/GitTestFixtures.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/testconfig/GitTestFixtures.java
@@ -1,0 +1,22 @@
+package de.tum.cit.aet.hephaestus.testconfig;
+
+import org.eclipse.jgit.lib.Repository;
+
+/** Shared fixtures for tests that drive a real JGit repository. */
+public final class GitTestFixtures {
+
+    private GitTestFixtures() {}
+
+    /**
+     * JGit resolves {@code commit.gpgsign} and {@code tag.gpgsign} from the JVM's real
+     * {@code ~/.gitconfig}, which it reads unconditionally (there is no JGit equivalent of
+     * {@code GIT_CONFIG_GLOBAL} or {@code GIT_CONFIG_NOSYSTEM}). A developer following
+     * `CONTRIBUTING.md` § Signed Commits has both set, so every fixture repository must turn
+     * signing back off in its own local config, the only layer a test controls.
+     */
+    public static void disableSigning(Repository repository) {
+        var config = repository.getConfig();
+        config.setBoolean("commit", null, "gpgsign", false);
+        config.setBoolean("tag", null, "gpgsign", false);
+    }
+}


### PR DESCRIPTION
## What changed and why

A developer following `CONTRIBUTING.md` § Signed Commits sets `gpg.format=ssh` and
`commit.gpgsign=true` in their global git config. JGit reads that config unconditionally when it
resolves `commit.gpgsign` for a `CommitCommand` — there is no JGit equivalent of git's
`GIT_CONFIG_GLOBAL` or `GIT_CONFIG_NOSYSTEM` environment variables (confirmed against the
`org.eclipse.jgit` 7.7.1 jar: neither `SystemReader` nor `FS` reads either name; `openUserConfig`
resolves the config path from `FS.userHome()` + `.gitconfig` unconditionally). With that config set,
44 server unit tests that create commits through JGit's `CommitCommand`
(`GitDiffOperationsJGitTest`, `GitRepositoryManagerTest`) failed with
`No signer for ssh signatures. Use another signature type for git config gpg.format, or do not sign.`

Since JGit does not honor the environment variables that would isolate a surefire fork from the
real `~/.gitconfig`, the fix disables signing on each fixture repository's own local config instead
— the one config layer a test controls, and one that always wins over the inherited global. A
shared `GitTestFixtures.disableSigning(Repository)` helper is called right after each `Git.init()`
in the two affected test classes, so the fix lives in one place rather than three call sites.

## How to test

- Reproduced on a host with `gpg.format=ssh` + `commit.gpgsign=true` in `~/.gitconfig`:
  `cd server && MANAGEMENT_PORT=0 SERVER_PORT=0 ./mvnw -f application/pom.xml -Dtest='*Jgit*,*Git*' test`
  failed with 44 `UnsupportedSigningFormatException` errors before this change.
- After the change, the same command passes (`Tests run: 1427, Failures: 0, Errors: 0`), with the
  host's signing config left untouched.
- Also verified the same tests still pass with the host's global `commit.gpgsign`/`tag.gpgsign` set
  to `false`, so the fix does not depend on either state.
- Full unit suite: `vp run test:server:unit` — 6962 tests, 0 failures, 0 errors.
- `vp run format`, `vp run check:affected`, `vp run check` all pass.

## Release impact

Test-only change; no changeset. `verify-changesets`'s shipped-path filter excludes
`server/application/src/test`, so this diff carries no release note.

## Notes for reviewers

Best place to start: `server/application/src/test/java/de/tum/cit/aet/hephaestus/testconfig/GitTestFixtures.java`.
