### PR TITLE
docs: deleting a rationale comment needs the same justification as adding one

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -281,7 +281,9 @@ change that ships, never a measurement or a verdict alone.
   unavailable, kept POSIX-compatible.
 - Comments say what the code cannot — a constraint, a platform behaviour, a rejected alternative —
   and move when the code moves. Nothing in them is a run number, a measured duration or an
-  incident.
+  incident. Deleting one of these needs the same justification as adding one: either the code now
+  says it, or it moved to its one home. A pass that strips comments across files is its own pull
+  request, never a rider on a fix.
 - Our users read feedback about their own work. A wrong claim, a stale label or a lying spinner
   costs trust that a fast fix does not buy back.
 


### PR DESCRIPTION
## What changed and why

`AGENTS.md` § Taste told writers what a comment is for but said nothing about deleting one, and this
week PRs #1852, #1853, #1854, #1855, #1856 and #1864 each stripped dozens of constraint, platform-behaviour
and rejected-alternative comments as a rider on an unrelated fix, costing a day of review to restore
`AuthMetrics`'s class Javadoc, the `anonymizeAuditRows` legal-basis note, the sandbox policy's CVE
citation and a ledger's invariants. The bullet now says deleting one of these comments needs the same
justification as adding one — either the code now says it or it moves to its one home — and that a
comment pass across files is its own pull request, never a rider on a fix. Checked
`docs/contributor/coding-guidelines.mdx` and every `.claude/skills/*/SKILL.md` for a second copy of the
rule; none exists, so no pointer was needed.

## How to test

`pnpm exec vp run check` (includes `gate:instructions`, which mirrors `.agents/skills/` and stays green).

## Release impact

No changeset: this only changes contributor instructions, not shipped code.

## Notes for reviewers

Docs-only change to `AGENTS.md` § Taste; no code, schema or wire-contract surface touched.