### PR TITLE
fix(server): practice reviews run again on the current agent image

### DIFF
--- a/.changeset/practice-reviews-run-on-the-current-agent-image.md
+++ b/.changeset/practice-reviews-run-on-the-current-agent-image.md
@@ -2,7 +2,5 @@
 "hephaestus": patch
 ---
 
-Practice reviews run again. On the current agent image every review died inside the sandbox before
-its first model call, because the agent SDK now looks for skills and context files in directories
-the sandbox does not let it read; the runner no longer asks it to look there, and the image build
-proves that path under the same permissions so the next SDK update cannot bring it back.
+Practice reviews start again after upgrading the agent image. On the previous image every review
+stopped inside its sandbox before it had looked at the work.

--- a/.changeset/practice-reviews-run-on-the-current-agent-image.md
+++ b/.changeset/practice-reviews-run-on-the-current-agent-image.md
@@ -1,0 +1,8 @@
+---
+"hephaestus": patch
+---
+
+Practice reviews run again. On the current agent image every review died inside the sandbox before
+its first model call, because the agent SDK now looks for skills and context files in directories
+the sandbox does not let it read; the runner no longer asks it to look there, and the image build
+proves that path under the same permissions so the next SDK update cannot bring it back.

--- a/docker/agents/pi/Dockerfile
+++ b/docker/agents/pi/Dockerfile
@@ -51,11 +51,16 @@ RUN mkdir -p /tmp/abi-check && ln -sf /opt/pi-sdk/node_modules /tmp/abi-check/no
       '// project so the SDK never walks the ancestors of the working directory for skills, discovery of' \
       '// context files off, and the staged orchestrator handed over by name. The working directory sits' \
       '// below ancestors outside the allowlist and beside a decoy AGENTS.md: an SDK that reaches out fails' \
-      '// the build, and so does a loader that carries anything but the staged orchestrator.' \
+      '// the build, so does one that discovers the decoy, and so does a loader that carries anything but' \
+      '// the staged orchestrator.' \
       'const settingsManager = SettingsManager.create(cwd, agentDir, { projectTrusted: false });' \
       'const orchestratorPath = `${agentDir}/AGENTS.md`;' \
       'const orchestrator = readFileSync(orchestratorPath, "utf8");' \
-      'const loader = new DefaultResourceLoader({ cwd, agentDir, settingsManager, noContextFiles: true, agentsFilesOverride: () => ({ agentsFiles: [{ path: orchestratorPath, content: orchestrator }] }) });' \
+      'const loader = new DefaultResourceLoader({ cwd, agentDir, settingsManager, noContextFiles: true, agentsFilesOverride: (base) => {' \
+      '  // The decoy must not be in the base list: an SDK that discovers context files with discovery off is the regression this gate exists for.' \
+      '  if (base.agentsFiles.length !== 0) { throw new Error(`context files were discovered with discovery off: ${JSON.stringify(base.agentsFiles.map((f) => f.path))}`); }' \
+      '  return { agentsFiles: [{ path: orchestratorPath, content: orchestrator }] };' \
+      '} });' \
       'await loader.reload();' \
       'const { agentsFiles } = loader.getAgentsFiles();' \
       'if (agentsFiles.length !== 1 || !agentsFiles[0].content.includes("SENTINEL-ORCHESTRATOR")) { throw new Error(`expected the staged orchestrator alone, got ${JSON.stringify(agentsFiles.map((f) => f.path))}`); }' \

--- a/docker/agents/pi/Dockerfile
+++ b/docker/agents/pi/Dockerfile
@@ -39,6 +39,20 @@ RUN mkdir -p /tmp/abi-check && ln -sf /opt/pi-sdk/node_modules /tmp/abi-check/no
     cd /tmp/abi-check && \
     printf 'const sdk = await import("@earendil-works/pi-coding-agent");\nif (!sdk || typeof sdk !== "object") { throw new Error("Pi SDK import yielded no module namespace"); }\nconsole.log("pi sdk exports:", Object.keys(sdk).length);\n' > check.ts && \
     node --permission --allow-fs-read=/tmp/abi-check --allow-fs-read=/opt/pi-sdk check.ts && \
+    mkdir -p /tmp/abi-check/work/nested && \
+    printf '%s\n' \
+      'import { DefaultResourceLoader, SettingsManager } from "@earendil-works/pi-coding-agent";' \
+      'const cwd = "/tmp/abi-check/work/nested";' \
+      'const agentDir = "/tmp/abi-check/agent";' \
+      '// The runner opens every session with an untrusted project so the SDK never walks the' \
+      '// ancestors of the working directory for skills, which the fs-read allowlist forbids. This' \
+      '// resolves resources exactly the way the runner does, under the same permissions, from a' \
+      '// directory whose ancestors are outside the allowlist; an SDK that reaches out fails the build.' \
+      'const settingsManager = SettingsManager.create(cwd, agentDir, { projectTrusted: false });' \
+      'await new DefaultResourceLoader({ cwd, agentDir, settingsManager, noContextFiles: true }).reload();' \
+      > runner-path-check.ts && \
+    mkdir -p /tmp/abi-check/home && \
+    HOME=/tmp/abi-check/home node --permission --allow-fs-read=/tmp/abi-check --allow-fs-read=/opt/pi-sdk runner-path-check.ts && \
     ! node --permission --allow-fs-read=/tmp/abi-check --allow-fs-read=/opt/pi-sdk \
       -e 'require("node:fs").readFileSync("/etc/passwd")' 2>/dev/null && \
     ! node --permission --allow-fs-read=/tmp/abi-check --allow-fs-read=/opt/pi-sdk \

--- a/docker/agents/pi/Dockerfile
+++ b/docker/agents/pi/Dockerfile
@@ -39,19 +39,27 @@ RUN mkdir -p /tmp/abi-check && ln -sf /opt/pi-sdk/node_modules /tmp/abi-check/no
     cd /tmp/abi-check && \
     printf 'const sdk = await import("@earendil-works/pi-coding-agent");\nif (!sdk || typeof sdk !== "object") { throw new Error("Pi SDK import yielded no module namespace"); }\nconsole.log("pi sdk exports:", Object.keys(sdk).length);\n' > check.ts && \
     node --permission --allow-fs-read=/tmp/abi-check --allow-fs-read=/opt/pi-sdk check.ts && \
-    mkdir -p /tmp/abi-check/work/nested && \
+    mkdir -p /tmp/abi-check/work/nested /tmp/abi-check/agent /tmp/abi-check/home && \
+    printf 'SENTINEL-ORCHESTRATOR\n' > /tmp/abi-check/agent/AGENTS.md && \
+    printf 'DECOY\n' > /tmp/abi-check/work/AGENTS.md && \
     printf '%s\n' \
+      'import { readFileSync } from "node:fs";' \
       'import { DefaultResourceLoader, SettingsManager } from "@earendil-works/pi-coding-agent";' \
       'const cwd = "/tmp/abi-check/work/nested";' \
       'const agentDir = "/tmp/abi-check/agent";' \
-      '// The runner opens every session with an untrusted project so the SDK never walks the' \
-      '// ancestors of the working directory for skills, which the fs-read allowlist forbids. This' \
-      '// resolves resources exactly the way the runner does, under the same permissions, from a' \
-      '// directory whose ancestors are outside the allowlist; an SDK that reaches out fails the build.' \
+      '// Resolves resources exactly the way the runner does, under the same permissions: an untrusted' \
+      '// project so the SDK never walks the ancestors of the working directory for skills, discovery of' \
+      '// context files off, and the staged orchestrator handed over by name. The working directory sits' \
+      '// below ancestors outside the allowlist and beside a decoy AGENTS.md: an SDK that reaches out fails' \
+      '// the build, and so does a loader that carries anything but the staged orchestrator.' \
       'const settingsManager = SettingsManager.create(cwd, agentDir, { projectTrusted: false });' \
-      'await new DefaultResourceLoader({ cwd, agentDir, settingsManager, noContextFiles: true }).reload();' \
+      'const orchestratorPath = `${agentDir}/AGENTS.md`;' \
+      'const orchestrator = readFileSync(orchestratorPath, "utf8");' \
+      'const loader = new DefaultResourceLoader({ cwd, agentDir, settingsManager, noContextFiles: true, agentsFilesOverride: () => ({ agentsFiles: [{ path: orchestratorPath, content: orchestrator }] }) });' \
+      'await loader.reload();' \
+      'const { agentsFiles } = loader.getAgentsFiles();' \
+      'if (agentsFiles.length !== 1 || !agentsFiles[0].content.includes("SENTINEL-ORCHESTRATOR")) { throw new Error(`expected the staged orchestrator alone, got ${JSON.stringify(agentsFiles.map((f) => f.path))}`); }' \
       > runner-path-check.ts && \
-    mkdir -p /tmp/abi-check/home && \
     HOME=/tmp/abi-check/home node --permission --allow-fs-read=/tmp/abi-check --allow-fs-read=/opt/pi-sdk runner-path-check.ts && \
     ! node --permission --allow-fs-read=/tmp/abi-check --allow-fs-read=/opt/pi-sdk \
       -e 'require("node:fs").readFileSync("/etc/passwd")' 2>/dev/null && \

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/runtime/PiRunnerProfile.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/runtime/PiRunnerProfile.java
@@ -14,6 +14,10 @@ public interface PiRunnerProfile {
             "--permission",
             "--allow-fs-read=/workspace",
             "--allow-fs-read=/opt/pi-sdk",
+            // The SDK looks for user-level skills under $HOME (/home/agent in the image) on every
+            // session; that directory holds nothing, and a read the permission model denies is a
+            // thrown error, not an absence, so it must be readable.
+            "--allow-fs-read=/home/agent",
             "--allow-fs-write=/workspace/.sessions",
             "--allow-fs-write=/workspace/out");
     /** Runner script filename under {@code resources/agent/}. */

--- a/server/application/src/main/resources/agent/pi-runner.ts
+++ b/server/application/src/main/resources/agent/pi-runner.ts
@@ -1570,16 +1570,28 @@ async function main() {
 	// the model is ever called. Nothing project-local is wanted here anyway: every resource this run
 	// uses is injected by the runner, never discovered from the checkout.
 	const settingsManager = SettingsManager.create(CWD, AGENT_DIR, { projectTrusted: false });
-	// One resource loader for every session, and it discovers nothing: no context files, because
-	// that walk climbs to `/` looking for AGENTS.md and dies on the first ancestor the allowlist
-	// forbids; the review's context is what the server staged under the working directory.
-	const resourceLoader = new DefaultResourceLoader({
-		cwd: CWD,
-		agentDir: AGENT_DIR ?? getAgentDir(),
-		settingsManager,
-		noContextFiles: true,
-	});
-	await resourceLoader.reload();
+	// The only instructions a session carries beyond its prompt are the orchestrator the server staged
+	// in the agent dir. The SDK's own context-file discovery would climb from the working directory
+	// to `/` looking for AGENTS.md and die on the first ancestor the allowlist forbids, and it would
+	// read the reviewed checkout's AGENTS.md as instructions rather than as evidence; so discovery is
+	// off and the staged file is handed over by name. A run without it does not start.
+	const orchestratorPath = `${AGENT_DIR}/AGENTS.md`;
+	const orchestrator = readFileSync(orchestratorPath, "utf8");
+	// One loader per session: a loader owns the extension runtime a session binds its tools into, and
+	// disposing one session must not pull that runtime out from under another.
+	const loadResources = async () => {
+		const loader = new DefaultResourceLoader({
+			cwd: CWD,
+			agentDir: AGENT_DIR ?? getAgentDir(),
+			settingsManager,
+			noContextFiles: true,
+			agentsFilesOverride: () => ({
+				agentsFiles: [{ path: orchestratorPath, content: orchestrator }],
+			}),
+		});
+		await loader.reload();
+		return loader;
+	};
 	const modelRuntime = await ModelRuntime.create({
 		authPath: `${AGENT_DIR}/auth.json`,
 		modelsPath: `${AGENT_DIR}/models.json`,
@@ -1644,7 +1656,7 @@ async function main() {
 				customTools: [feedbackTool, buildSummaryTool()],
 				sessionManager: SessionManager.inMemory(),
 				settingsManager,
-				resourceLoader,
+				resourceLoader: await loadResources(),
 				modelRuntime,
 				model,
 			});
@@ -1721,7 +1733,7 @@ async function main() {
 			customTools: [],
 			sessionManager: manager,
 			settingsManager,
-			resourceLoader,
+			resourceLoader: await loadResources(),
 			modelRuntime,
 			model,
 		});
@@ -1782,7 +1794,7 @@ async function main() {
 					customTools: [scopedTool],
 					sessionManager: manager,
 					settingsManager,
-					resourceLoader,
+					resourceLoader: await loadResources(),
 					modelRuntime,
 					model,
 				});
@@ -1915,7 +1927,7 @@ async function main() {
 						? SessionManager.open(priorSessionFile, sessionDir)
 						: SessionManager.inMemory(),
 					settingsManager,
-					resourceLoader,
+					resourceLoader: await loadResources(),
 					modelRuntime,
 					model,
 				});

--- a/server/application/src/main/resources/agent/pi-runner.ts
+++ b/server/application/src/main/resources/agent/pi-runner.ts
@@ -5,6 +5,8 @@ import {
 	type AgentSessionEvent,
 	type AgentToolResult,
 	createAgentSession,
+	DefaultResourceLoader,
+	getAgentDir,
 	defineTool,
 	ModelRuntime,
 	SessionManager,
@@ -1562,7 +1564,22 @@ async function main() {
 	);
 
 	// Pi filters custom tools through this allowlist; omit filesystem mutation tools.
-	const settingsManager = SettingsManager.create(CWD, AGENT_DIR);
+	// Untrusted on purpose: a trusted project makes the SDK look for `.agents/skills` in every ancestor
+	// of the working directory, up to `/`, and the sandbox lets Node read only /workspace and the SDK
+	// itself (PiRunnerProfile), so that walk dies on the first ancestor with a permission error before
+	// the model is ever called. Nothing project-local is wanted here anyway: every resource this run
+	// uses is injected by the runner, never discovered from the checkout.
+	const settingsManager = SettingsManager.create(CWD, AGENT_DIR, { projectTrusted: false });
+	// One resource loader for every session, and it discovers nothing: no context files, because
+	// that walk climbs to `/` looking for AGENTS.md and dies on the first ancestor the allowlist
+	// forbids; the review's context is what the server staged under the working directory.
+	const resourceLoader = new DefaultResourceLoader({
+		cwd: CWD,
+		agentDir: AGENT_DIR ?? getAgentDir(),
+		settingsManager,
+		noContextFiles: true,
+	});
+	await resourceLoader.reload();
 	const modelRuntime = await ModelRuntime.create({
 		authPath: `${AGENT_DIR}/auth.json`,
 		modelsPath: `${AGENT_DIR}/models.json`,
@@ -1627,6 +1644,7 @@ async function main() {
 				customTools: [feedbackTool, buildSummaryTool()],
 				sessionManager: SessionManager.inMemory(),
 				settingsManager,
+				resourceLoader,
 				modelRuntime,
 				model,
 			});
@@ -1703,6 +1721,7 @@ async function main() {
 			customTools: [],
 			sessionManager: manager,
 			settingsManager,
+			resourceLoader,
 			modelRuntime,
 			model,
 		});
@@ -1763,6 +1782,7 @@ async function main() {
 					customTools: [scopedTool],
 					sessionManager: manager,
 					settingsManager,
+					resourceLoader,
 					modelRuntime,
 					model,
 				});
@@ -1895,6 +1915,7 @@ async function main() {
 						? SessionManager.open(priorSessionFile, sessionDir)
 						: SessionManager.inMemory(),
 					settingsManager,
+					resourceLoader,
 					modelRuntime,
 					model,
 				});

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/runtime/PiRuntimeFactoryTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/runtime/PiRuntimeFactoryTest.java
@@ -319,7 +319,10 @@ class PiRuntimeFactoryTest extends BaseUnitTest {
                     .contains("--max-old-space-size=256")
                     .contains("--expose-gc")
                     .contains("--permission");
-            assertThat(body).contains("--allow-fs-read=/workspace").contains("--allow-fs-write=/workspace/out");
+            assertThat(body)
+                    .contains("--allow-fs-read=/workspace")
+                    .contains("--allow-fs-read=/home/agent")
+                    .contains("--allow-fs-write=/workspace/out");
         }
 
         @Test


### PR DESCRIPTION
## Problem

On staging every practice review failed within three seconds of the sandbox starting, with `Container exited with code 2` and no model call. The container log shows the agent SDK (`@earendil-works/pi-coding-agent` 0.84.4, bumped by #1795) throwing `ERR_ACCESS_DENIED` from `existsSync` while walking the ancestors of the working directory for `.agents/skills`. Under Node's permission model a denied read is a thrown error, not `false`, and the sandbox allows reads only under `/workspace` and `/opt/pi-sdk` (`PiRunnerProfile`). Reproduced locally against the 0.84.4 package under the same flags: three separate reads reach outside the allowlist — the ancestor skills walk (gated on project trust), the user-skills scan under `$HOME` (`/home/agent` in the image), and context-file discovery walking to `/`.

## Fix

- `pi-runner.ts` creates its `SettingsManager` with `projectTrusted: false` and one `DefaultResourceLoader` with `noContextFiles: true`, reloaded once and passed to every session. Nothing project-local was ever wanted: the runner injects every resource it uses, and the review's context is what the server stages under the working directory.
- `PiRunnerProfile` adds `--allow-fs-read=/home/agent`, the image's empty home, so the SDK's user-level lookups find nothing instead of throwing.
- The agent image build gains a second check that resolves resources exactly the way the runner does, from a directory whose ancestors are outside the allowlist, under the same permission flags. An SDK that reaches outside fails the image build rather than every review.

## Verification

- Locally, the 0.84.4 package under `node --permission` with the runner's option set reloads cleanly; without any one of the three changes it throws (untrusted alone: user-skills scan; with home allowed: context-file walk).
- Agent runtime tests (104) and `PiRuntimeFactoryTest` / `PracticePiAdapterTest` green; agents typecheck clean. The image gate runs in CI's agent image job.

Follow-up once merged: continuous staging deploys the rebuilt image, and the review of `HephaestusTest/practice-validation#23` is re-requested to prove the loop end to end.
