### PR TITLE
fix(auth): end an impersonation when the reasons for it end

### DIFF
--- a/.changeset/impersonation-bounds.md
+++ b/.changeset/impersonation-bounds.md
@@ -1,0 +1,12 @@
+---
+"hephaestus": patch
+---
+
+Impersonating an account now ends when it should. It cannot outlive the operator's own session, it
+ends as soon as the operator stops being an instance administrator, and it ends if the account being
+impersonated is promoted to instance administrator — the case an operator could previously reach only
+by starting over. Each of these returns the operator to their own session and is recorded in the
+audit viewer as the end of the impersonation, with the reason.
+
+Leaving an impersonation that has already ended is now refused instead of quietly handing back a
+session, and an ordinary session can no longer be renewed past its absolute lifetime.

--- a/.changeset/impersonation-bounds.md
+++ b/.changeset/impersonation-bounds.md
@@ -5,8 +5,10 @@
 Impersonating an account now ends when it should. It cannot outlive the operator's own session, it
 ends as soon as the operator stops being an instance administrator, and it ends if the account being
 impersonated is promoted to instance administrator — the case an operator could previously reach only
-by starting over. Each of these returns the operator to their own session and is recorded in the
-audit viewer as the end of the impersonation, with the reason.
+by starting over. The time-box running out or the target being promoted return the operator to their
+own session and are recorded in the audit viewer as the end of the impersonation, with the reason; the
+operator's own session ending or the operator no longer being an instance administrator end the
+impersonation outright.
 
 Leaving an impersonation that has already ended is now refused instead of quietly handing back a
 session, and an ordinary session can no longer be renewed past its absolute lifetime.

--- a/docs/admin/configuration-readiness.mdx
+++ b/docs/admin/configuration-readiness.mdx
@@ -109,6 +109,15 @@ multi-factor authentication: an identity provider that still holds a session may
 asking for anything, so enforce MFA at the provider. A refused action is not replayed once access is
 confirmed — review it and submit it again.
 
+### Session and impersonation deadlines
+
+A session ends at `hephaestus.auth.session-max-lifetime` (default `12h`) no matter how active it is;
+renewing an access token rolls within that deadline and never past it. An impersonation ends at
+`hephaestus.auth.impersonation-max-lifetime` (default `1h`), or sooner — when the operator's own
+session ends, when the operator stops being an instance admin, or when the account being impersonated
+is promoted to instance admin. Each of these returns the operator to their own session and records an
+`IMPERSONATION_END` entry in the audit viewer; none of them requires anyone to sign in again.
+
 ## LLM proxy
 
 Worker roles must leave `hephaestus.llm.egress.allow-loopback=false`. Provider credentials and model

--- a/docs/admin/configuration-readiness.mdx
+++ b/docs/admin/configuration-readiness.mdx
@@ -113,10 +113,11 @@ confirmed — review it and submit it again.
 
 A session ends at `hephaestus.auth.session-max-lifetime` (default `12h`) no matter how active it is;
 renewing an access token rolls within that deadline and never past it. An impersonation ends at
-`hephaestus.auth.impersonation-max-lifetime` (default `1h`), or sooner — when the operator's own
-session ends, when the operator stops being an instance admin, or when the account being impersonated
-is promoted to instance admin. Each of these returns the operator to their own session and records an
-`IMPERSONATION_END` entry in the audit viewer; none of them requires anyone to sign in again.
+`hephaestus.auth.impersonation-max-lifetime` (default `1h`), or sooner — when its time-box is reached
+or when the account being impersonated is promoted to instance admin, both of which return the
+operator to their own session and record an `IMPERSONATION_END` entry in the audit viewer; neither
+requires anyone to sign in again. The operator's own session ending, or the operator no longer being
+an instance admin, ends the impersonation outright instead — there is no session left to return to.
 
 ## LLM proxy
 

--- a/docs/contributor/instance-admin.md
+++ b/docs/contributor/instance-admin.md
@@ -113,7 +113,8 @@ would want the confirmation to unlock.
 
 `begin` stamps an absolute ceiling `imp_exp` (`hephaestus.auth.impersonation-max-lifetime`, default
 1h); the issuer caps each token's `exp` at `min(now + accessTtl, imp_exp, session_exp)`, and
-`refresh` drops the `act` claim (auto-exit) once it passes. `imp_exp` is the binding limit: the webapp
+`refresh` drops the `act` claim (auto-exit) when the exit-skew window before it is reached, not only
+once it has fully passed — see below. `imp_exp` is the binding limit: the webapp
 keeps the session alive across access-token expiry (`use-session-keep-alive.ts`, mounted from
 `main.tsx`), so an impersonation ends at the ceiling rather than at `accessTtl`.
 

--- a/docs/contributor/instance-admin.md
+++ b/docs/contributor/instance-admin.md
@@ -112,10 +112,32 @@ would want the confirmation to unlock.
 ## Impersonation time-box
 
 `begin` stamps an absolute ceiling `imp_exp` (`hephaestus.auth.impersonation-max-lifetime`, default
-1h); the issuer caps each token's `exp` at `min(now + accessTtl, imp_exp)`, and `refresh` drops the
-`act` claim (auto-exit) once it passes. `imp_exp` is the binding limit: the webapp keeps the session
-alive across access-token expiry (`use-session-keep-alive.ts`, mounted from `main.tsx`), so an
-impersonation ends at the ceiling rather than at `accessTtl`.
+1h); the issuer caps each token's `exp` at `min(now + accessTtl, imp_exp, session_exp)`, and
+`refresh` drops the `act` claim (auto-exit) once it passes. `imp_exp` is the binding limit: the webapp
+keeps the session alive across access-token expiry (`use-session-keep-alive.ts`, mounted from
+`main.tsx`), so an impersonation ends at the ceiling rather than at `accessTtl`.
+
+Rotation is where an impersonation ends, so `refresh` is where the rest of the bounds live:
+
+- **A minute before the ceiling**, not at it. A token minted at `imp_exp` would be born expired, so
+  the operator would be signed out rather than returned to their own session. The window is
+  `IMPERSONATION_EXIT_SKEW` and must stay at or above the SPA's `REFRESH_SKEW_MS`, which decides when
+  the rotation happens at all.
+- **The operator's own session bounds it.** `begin` carries the operator's `session_exp` onto the
+  impersonation token and `refresh` refuses to rotate past it, so acting as someone else can never
+  outlive the session that started it. A token with no ceiling at all predates the ceiling and is
+  ended rather than renewed.
+- **The operator must still be one.** Demoting or suspending an operator revokes their own sessions,
+  but an impersonation token's subject is the *target*, so it survives that sweep; `refresh` re-reads
+  the operator and ends the session when they are no longer an active instance admin.
+- **A target promoted mid-session exits.** `begin` refuses admin-to-admin impersonation, and a
+  rotation must not be a way around that refusal; the auto-exit is audited with reason
+  `TARGET_PROMOTED` rather than `EXPIRED`.
+
+Both auto-exits are audited as `IMPERSONATION_END` with the `(target, operator)` pair and counted as
+`auth.impersonation.auto_exit{reason}`. Exiting by hand refuses (401) when the impersonation was
+already ended by any of these paths, rather than minting a session something else deliberately
+closed.
 
 ## Elevated workspace access
 

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/auth/AuthSessionService.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/auth/AuthSessionService.java
@@ -18,8 +18,10 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.time.Clock;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
+import java.util.Locale;
 import java.util.UUID;
 import org.jspecify.annotations.Nullable;
 import org.springframework.stereotype.Service;
@@ -74,6 +76,14 @@ public class AuthSessionService {
         clearCookie(response);
     }
 
+    /**
+     * How long before {@code imp_exp} a rotation already exits. A token minted at the deadline would be
+     * born expired, so the operator would be signed out instead of returned to their own session. Keep
+     * this at or above the SPA's {@code REFRESH_SKEW_MS} in {@code use-session-keep-alive.ts}, which
+     * decides when that rotation happens.
+     */
+    private static final Duration IMPERSONATION_EXIT_SKEW = Duration.ofSeconds(60);
+
     /** Rotate: revoke the presenting token, mint a fresh one (preserving impersonation), set cookie. */
     @Transactional
     public void refresh(
@@ -109,6 +119,22 @@ public class AuthSessionService {
                 clearCookie(response);
                 return;
             }
+            // The absolute session ceiling is the one deadline a rolling refresh must not be able to
+            // step over, so it is enforced here rather than only re-stamped onto the new token. A token
+            // that carries no ceiling at all predates the ceiling and is ended rather than renewed.
+            if (sessionExpiresAt == null || !clock.instant().isBefore(sessionExpiresAt)) {
+                metrics.recordRefreshResult(AuthMetrics.RefreshResult.NOOP);
+                clearCookie(response);
+                return;
+            }
+            // An impersonation is only ever as legitimate as the operator behind it. Suspending or
+            // demoting an operator revokes their own sessions, but the impersonation token's subject is
+            // the target, so it survives that sweep — this is where it ends.
+            if (impersonatorId != null && !isActiveInstanceAdmin(impersonatorId)) {
+                metrics.recordRefreshResult(AuthMetrics.RefreshResult.SUSPENDED);
+                clearCookie(response);
+                return;
+            }
             HephaestusJwtIssuer.Token token;
             if (impersonatorId == null) {
                 // Ordinary (non-impersonation) rotation — carry the absolute session ceiling forward so
@@ -121,9 +147,12 @@ public class AuthSessionService {
                         .event(AuthEvent.EventType.TOKEN_REFRESH, AuthEvent.Result.SUCCESS)
                         .account(accountId)
                         .record();
-            } else if (impersonationExpired(impersonationExpiresAt)) {
+            } else if (impersonationExpired(impersonationExpiresAt) || isAppAdmin(account)) {
                 // Impersonation time-box reached: auto-exit to the operator (mint an operator token
                 // with NO act claim) rather than renewing the impersonation forever via silent refresh.
+                // A target promoted to APP_ADMIN mid-session exits the same way: begin refuses
+                // admin-to-admin impersonation, and a rotation must not be a way around that refusal.
+                String exitReason = isAppAdmin(account) ? "TARGET_PROMOTED" : "EXPIRED";
                 token = jwtIssuer.issue(
                         principalFactory.forAccountId(impersonatorId),
                         TokenConstraints.session(sessionExpiresAt, context.authTime()),
@@ -132,10 +161,12 @@ public class AuthSessionService {
                         .event(AuthEvent.EventType.IMPERSONATION_END, AuthEvent.Result.SUCCESS)
                         .account(accountId)
                         .actingAccount(impersonatorId)
-                        .details("{\"reason\":\"EXPIRED\"}")
+                        .details("{\"reason\":\"" + exitReason + "\"}")
                         .record();
+                metrics.recordImpersonationAutoExit(exitReason.toLowerCase(Locale.ROOT));
             } else {
-                // Impersonation rotation: re-cap the new token at the same imp_exp ceiling.
+                // Impersonation rotation: re-cap the new token at the same imp_exp ceiling, and carry the
+                // operator's session ceiling so impersonating cannot outlive the session that began it.
                 token = jwtIssuer.issue(
                         principalFactory.forAccountId(accountId),
                         new TokenConstraints(
@@ -144,6 +175,7 @@ public class AuthSessionService {
                 authEventLogger
                         .event(AuthEvent.EventType.TOKEN_REFRESH, AuthEvent.Result.SUCCESS)
                         .account(accountId)
+                        .actingAccount(impersonatorId)
                         .record();
             }
             setCookie(response, token);
@@ -172,12 +204,22 @@ public class AuthSessionService {
     }
 
     /**
-     * Whether an impersonation session has hit its absolute time-box. A missing ceiling is treated as
-     * expired (fail-safe: a legacy impersonation token without {@code imp_exp} auto-exits on its next
-     * refresh rather than living forever).
+     * Whether an impersonation session has reached — or is within {@link #IMPERSONATION_EXIT_SKEW} of —
+     * its absolute time-box. A missing ceiling is treated as expired (fail-safe: a legacy impersonation
+     * token without {@code imp_exp} auto-exits on its next refresh rather than living forever).
      */
     private boolean impersonationExpired(@Nullable Instant impersonationExpiresAt) {
-        return impersonationExpiresAt == null || !clock.instant().isBefore(impersonationExpiresAt);
+        return impersonationExpiresAt == null
+                || !clock.instant().plus(IMPERSONATION_EXIT_SKEW).isBefore(impersonationExpiresAt);
+    }
+
+    private static boolean isAppAdmin(Account account) {
+        return account.getAppRole() == Account.AppRole.APP_ADMIN;
+    }
+
+    private boolean isActiveInstanceAdmin(Long accountId) {
+        Account operator = accountRepository.findById(accountId).orElse(null);
+        return operator != null && operator.getStatus() == Account.Status.ACTIVE && isAppAdmin(operator);
     }
 
     /** Active (non-revoked, non-expired) sessions for an account. */

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/auth/impersonation/ImpersonationService.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/auth/impersonation/ImpersonationService.java
@@ -86,6 +86,8 @@ public class ImpersonationService {
      *
      * @param operatorAuthTime the operator's {@code auth_time}, stamped onto the impersonation token so
      *                         exiting returns to a session as old as the one that began it.
+     * @param operatorSessionExpiresAt the operator's absolute session deadline, carried onto the
+     *     impersonation token so impersonating cannot outlive the session that started it.
      */
     @Transactional
     public Result begin(
@@ -93,7 +95,9 @@ public class ImpersonationService {
             Long targetAccountId,
             String reason,
             @Nullable Instant operatorAuthTime,
+            @Nullable Instant operatorSessionExpiresAt,
             @Nullable HttpServletRequest request) {
+        requireLiveSession(operatorSessionExpiresAt);
         if (reason == null || reason.isBlank()) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "impersonation reason is required");
         }
@@ -125,7 +129,8 @@ public class ImpersonationService {
         Instant impersonationExpiresAt = clock.instant().plus(properties.impersonationMaxLifetime());
         HephaestusJwtIssuer.Token token = jwtIssuer.issue(
                 principalFactory.forAccount(target),
-                TokenConstraints.impersonation(operatorAccountId, impersonationExpiresAt, null, operatorAuthTime),
+                TokenConstraints.impersonation(
+                        operator.getId(), impersonationExpiresAt, operatorSessionExpiresAt, operatorAuthTime),
                 request);
 
         authEventLogger
@@ -150,11 +155,18 @@ public class ImpersonationService {
             Long targetAccountId,
             UUID currentJti,
             @Nullable Instant operatorAuthTime,
+            @Nullable Instant operatorSessionExpiresAt,
             @Nullable HttpServletRequest request) {
-        issuedJwtRepository.revoke(currentJti, clock.instant(), IssuedJwt.RevokedReason.IMPERSONATION_EXIT);
+        requireLiveSession(operatorSessionExpiresAt);
+        // The conditional revoke affects 0 rows when this jti was already ended — by a concurrent exit,
+        // a force sign-out, or the auto-exit on refresh. Minting an operator token anyway would hand
+        // back a session that something else deliberately closed.
+        if (issuedJwtRepository.revoke(currentJti, clock.instant(), IssuedJwt.RevokedReason.IMPERSONATION_EXIT) == 0) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "impersonation session is no longer active");
+        }
         HephaestusJwtIssuer.Token token = jwtIssuer.issue(
                 principalFactory.forAccountId(operatorAccountId),
-                TokenConstraints.session(null, operatorAuthTime),
+                TokenConstraints.session(operatorSessionExpiresAt, operatorAuthTime),
                 request);
 
         authEventLogger
@@ -168,6 +180,17 @@ public class ImpersonationService {
                 targetAccountId);
 
         return new Result(token, operatorAccountId, null);
+    }
+
+    /**
+     * The operator's absolute session deadline governs both ends of an impersonation. Without it, an
+     * operator whose own session has lapsed could still start one — or return from one into a session
+     * that no longer exists.
+     */
+    private void requireLiveSession(@Nullable Instant operatorSessionExpiresAt) {
+        if (operatorSessionExpiresAt == null || !clock.instant().isBefore(operatorSessionExpiresAt)) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "operator session has expired");
+        }
     }
 
     /**

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/auth/impersonation/ImpersonationService.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/auth/impersonation/ImpersonationService.java
@@ -158,6 +158,13 @@ public class ImpersonationService {
             @Nullable Instant operatorSessionExpiresAt,
             @Nullable HttpServletRequest request) {
         requireLiveSession(operatorSessionExpiresAt);
+        // Suspending or demoting an operator revokes their own sessions, but the impersonation token's
+        // subject is the target, so a manual exit is a second way back to an operator identity that no
+        // longer holds it — the same gate refresh applies before it will rotate this pair.
+        if (!isActiveInstanceAdmin(operatorAccountId)) {
+            throw new ResponseStatusException(
+                    HttpStatus.UNAUTHORIZED, "operator is no longer an active instance admin");
+        }
         // The conditional revoke affects 0 rows when this jti was already ended — by a concurrent exit,
         // a force sign-out, or the auto-exit on refresh. Minting an operator token anyway would hand
         // back a session that something else deliberately closed.
@@ -191,6 +198,13 @@ public class ImpersonationService {
         if (operatorSessionExpiresAt == null || !clock.instant().isBefore(operatorSessionExpiresAt)) {
             throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "operator session has expired");
         }
+    }
+
+    private boolean isActiveInstanceAdmin(Long accountId) {
+        Account operator = accountRepository.findById(accountId).orElse(null);
+        return operator != null
+                && operator.getStatus() == Account.Status.ACTIVE
+                && operator.getAppRole() == Account.AppRole.APP_ADMIN;
     }
 
     /**

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/auth/impersonation/ImpersonationService.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/auth/impersonation/ImpersonationService.java
@@ -130,7 +130,7 @@ public class ImpersonationService {
         HephaestusJwtIssuer.Token token = jwtIssuer.issue(
                 principalFactory.forAccount(target),
                 TokenConstraints.impersonation(
-                        operator.getId(), impersonationExpiresAt, operatorSessionExpiresAt, operatorAuthTime),
+                        operatorAccountId, impersonationExpiresAt, operatorSessionExpiresAt, operatorAuthTime),
                 request);
 
         authEventLogger

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/auth/jwt/HephaestusJwtIssuer.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/auth/jwt/HephaestusJwtIssuer.java
@@ -10,6 +10,7 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.time.Clock;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -101,6 +102,10 @@ public class HephaestusJwtIssuer {
         if (sessionExpiresAt != null && sessionExpiresAt.isBefore(expiresAt)) {
             expiresAt = sessionExpiresAt;
         }
+        // JWT deadlines are serialized as whole seconds, so the wire token expires at the truncated
+        // instant. issued_jwt keeps the untruncated one, and its active-token check would then answer
+        // "still valid" for the fraction of a second the presented token is already expired.
+        expiresAt = expiresAt.truncatedTo(ChronoUnit.SECONDS);
         UUID jti = UUID.randomUUID();
         JWK signingKey = keyService.currentSigningKey();
         JwtClaimsSet.Builder claims = JwtClaimsSet.builder()

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/auth/metrics/AuthMetrics.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/auth/metrics/AuthMetrics.java
@@ -193,4 +193,18 @@ public class AuthMetrics {
                 .register(registry)
                 .increment();
     }
+
+    /**
+     * Count one impersonation ended by a rotation rather than by the operator. {@code reason} is a fixed
+     * set ({@code expired}, {@code target_promoted}), so cardinality stays bounded. A rising
+     * {@code target_promoted} rate is worth looking at: it means operators are promoting the accounts
+     * they are impersonating.
+     */
+    public void recordImpersonationAutoExit(String reason) {
+        Counter.builder(CoreMetrics.AUTH_IMPERSONATION_AUTO_EXIT)
+                .description("Impersonations ended by a token rotation, tagged by reason.")
+                .tag("reason", reason)
+                .register(registry)
+                .increment();
+    }
 }

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/auth/web/AuthLifecycleController.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/auth/web/AuthLifecycleController.java
@@ -78,7 +78,12 @@ public class AuthLifecycleController {
     public ResponseEntity<Void> impersonate(
             @Valid @RequestBody ImpersonateRequestDTO body, HttpServletRequest request, HttpServletResponse response) {
         ImpersonationService.Result result = impersonationService.begin(
-                CurrentAccount.requireId(), body.targetAccountId(), body.reason(), CurrentAccount.authTime(), request);
+                CurrentAccount.requireId(),
+                body.targetAccountId(),
+                body.reason(),
+                CurrentAccount.authTime(),
+                CurrentAccount.sessionExpiresAt(),
+                request);
         sessionService.setCookie(response, result.token());
         return ResponseEntity.noContent().build();
     }
@@ -96,6 +101,7 @@ public class AuthLifecycleController {
                 CurrentAccount.requireId(),
                 CurrentAccount.requireJti(),
                 CurrentAccount.authTime(),
+                CurrentAccount.sessionExpiresAt(),
                 request);
         sessionService.setCookie(response, result.token());
         return ResponseEntity.noContent().build();

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/metrics/CoreMetrics.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/metrics/CoreMetrics.java
@@ -3,6 +3,7 @@ package de.tum.cit.aet.hephaestus.core.metrics;
 public final class CoreMetrics {
 
     public static final String AUTH_AUDIT_WRITE_FAILED = "auth.audit.write_failed";
+    public static final String AUTH_IMPERSONATION_AUTO_EXIT = "auth.impersonation.auto_exit";
     public static final String AUTH_ISSUED_JWT_PRUNED = "auth.issued_jwt.pruned";
     public static final String AUTH_LOGIN = "auth.login";
     public static final String AUTH_RATELIMIT_BACKEND_ERROR = "auth.ratelimit.backend_error";

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/auth/AuthSessionServiceTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/auth/AuthSessionServiceTest.java
@@ -256,7 +256,8 @@ class AuthSessionServiceTest extends BaseUnitTest {
                 mock(HttpServletRequest.class),
                 new MockHttpServletResponse());
 
-        verify(jwtIssuer).issue(any(), eq(TokenConstraints.session(SESSION_CEILING, AUTH_TIME)), any(HttpServletRequest.class));
+        verify(jwtIssuer)
+                .issue(any(), eq(TokenConstraints.session(SESSION_CEILING, AUTH_TIME)), any(HttpServletRequest.class));
         AuthEventData event = capturedEvent();
         assertThat(event.type()).isEqualTo(AuthEvent.EventType.IMPERSONATION_END);
         assertThat(event.details()).contains("TARGET_PROMOTED");
@@ -329,7 +330,8 @@ class AuthSessionServiceTest extends BaseUnitTest {
                 mock(HttpServletRequest.class),
                 new MockHttpServletResponse());
 
-        verify(jwtIssuer).issue(any(), eq(TokenConstraints.session(SESSION_CEILING, AUTH_TIME)), any(HttpServletRequest.class));
+        verify(jwtIssuer)
+                .issue(any(), eq(TokenConstraints.session(SESSION_CEILING, AUTH_TIME)), any(HttpServletRequest.class));
         assertThat(capturedEvent().details()).contains("EXPIRED");
     }
 

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/auth/AuthSessionServiceTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/auth/AuthSessionServiceTest.java
@@ -56,6 +56,9 @@ class AuthSessionServiceTest extends BaseUnitTest {
     /** The sign-in behind the presenting token; a rotation must copy it, never restamp it. */
     private static final Instant AUTH_TIME = NOW.minus(Duration.ofMinutes(3));
 
+    /** A live absolute session ceiling; a rotation past it, or with none at all, ends the session. */
+    private static final Instant SESSION_CEILING = NOW.plus(Duration.ofHours(6));
+
     private static final long ACCOUNT_ID = 42L;
 
     private IssuedJwtRepository issuedJwtRepository;
@@ -119,6 +122,14 @@ class AuthSessionServiceTest extends BaseUnitTest {
         return account;
     }
 
+    private static Account activeAdmin(long id) {
+        Account operator = new Account("Operator");
+        operator.setId(id);
+        operator.setStatus(Account.Status.ACTIVE);
+        operator.setAppRole(Account.AppRole.APP_ADMIN);
+        return operator;
+    }
+
     /** The single audit event written during the call (fails if zero or more than one was written). */
     private AuthEventData capturedEvent() {
         ArgumentCaptor<AuthEventData> captor = ArgumentCaptor.forClass(AuthEventData.class);
@@ -155,6 +166,7 @@ class AuthSessionServiceTest extends BaseUnitTest {
         when(issuedJwtRepository.revoke(eq(jti), any(), eq(IssuedJwt.RevokedReason.ROTATE)))
                 .thenReturn(1);
         when(accountRepository.findById(ACCOUNT_ID)).thenReturn(Optional.of(activeAccount()));
+        when(accountRepository.findById(operatorId)).thenReturn(Optional.of(activeAdmin(operatorId)));
         JwtPrincipal operatorPrincipal = new JwtPrincipal(operatorId, "operator", null, Set.of("app_admin"));
         when(principalFactory.forAccountId(operatorId)).thenReturn(operatorPrincipal);
         when(jwtIssuer.issue(any(), any(), any()))
@@ -166,17 +178,17 @@ class AuthSessionServiceTest extends BaseUnitTest {
         service.refresh(
                 ACCOUNT_ID,
                 jti,
-                ctx(operatorId, NOW.minus(Duration.ofSeconds(1)), null),
+                ctx(operatorId, NOW.minus(Duration.ofSeconds(1)), SESSION_CEILING),
                 mock(HttpServletRequest.class),
                 new MockHttpServletResponse());
 
         assertThat(refreshResult("success")).isEqualTo(1.0);
         // Minted for the OPERATOR principal with no impersonator — the act claim is dropped, ending the
-        // impersonation — and carrying the operator's own auth_time, which the exit must not renew.
+        // impersonation — and re-capped at the operator's unchanged session ceiling and auth_time.
         verify(jwtIssuer)
                 .issue(
                         eq(operatorPrincipal),
-                        eq(TokenConstraints.session(null, AUTH_TIME)),
+                        eq(TokenConstraints.session(SESSION_CEILING, AUTH_TIME)),
                         any(HttpServletRequest.class));
         // The auto-exit is audited as IMPERSONATION_END attributed to BOTH parties, reason EXPIRED.
         AuthEventData event = capturedEvent();
@@ -194,6 +206,7 @@ class AuthSessionServiceTest extends BaseUnitTest {
         when(issuedJwtRepository.revoke(eq(jti), any(), eq(IssuedJwt.RevokedReason.ROTATE)))
                 .thenReturn(1);
         when(accountRepository.findById(ACCOUNT_ID)).thenReturn(Optional.of(activeAccount()));
+        when(accountRepository.findById(operatorId)).thenReturn(Optional.of(activeAdmin(operatorId)));
         when(jwtIssuer.issue(any(), any(), any()))
                 .thenReturn(new HephaestusJwtIssuer.Token("imp-token", UUID.randomUUID(), ceiling));
 
@@ -201,21 +214,123 @@ class AuthSessionServiceTest extends BaseUnitTest {
         service.refresh(
                 ACCOUNT_ID,
                 jti,
-                ctx(operatorId, ceiling, null),
+                ctx(operatorId, ceiling, SESSION_CEILING),
                 mock(HttpServletRequest.class),
                 new MockHttpServletResponse());
 
         assertThat(refreshResult("success")).isEqualTo(1.0);
-        // Re-minted with the act claim preserved and capped at the unchanged ceiling.
+        // Re-minted with the act claim preserved, capped at the unchanged imp_exp, and still bounded by
+        // the operator's session ceiling.
         verify(jwtIssuer)
                 .issue(
                         any(),
-                        eq(new TokenConstraints(operatorId, ceiling, null, AUTH_TIME)),
+                        eq(new TokenConstraints(operatorId, ceiling, SESSION_CEILING, AUTH_TIME)),
                         any(HttpServletRequest.class));
         // An in-box impersonation rotation is audited as an ordinary TOKEN_REFRESH (not a re-BEGIN).
         AuthEventData event = capturedEvent();
         assertThat(event.type()).isEqualTo(AuthEvent.EventType.TOKEN_REFRESH);
         assertThat(event.accountId()).isEqualTo(ACCOUNT_ID);
+    }
+
+    @Test
+    void refresh_whenTheTargetWasPromotedToAdmin_autoExitsToOperator() {
+        UUID jti = UUID.randomUUID();
+        long operatorId = 7L;
+        when(issuedJwtRepository.revoke(eq(jti), any(), eq(IssuedJwt.RevokedReason.ROTATE)))
+                .thenReturn(1);
+        Account promotedTarget = activeAccount();
+        promotedTarget.setAppRole(Account.AppRole.APP_ADMIN);
+        when(accountRepository.findById(ACCOUNT_ID)).thenReturn(Optional.of(promotedTarget));
+        when(accountRepository.findById(operatorId)).thenReturn(Optional.of(activeAdmin(operatorId)));
+        when(principalFactory.forAccountId(operatorId))
+                .thenReturn(new JwtPrincipal(operatorId, "operator", null, Set.of("app_admin")));
+        when(jwtIssuer.issue(any(), any(), any()))
+                .thenReturn(
+                        new HephaestusJwtIssuer.Token("op-token", UUID.randomUUID(), NOW.plus(Duration.ofMinutes(15))));
+
+        // begin refuses admin-to-admin impersonation; a rotation must not become a way around it.
+        service.refresh(
+                ACCOUNT_ID,
+                jti,
+                ctx(operatorId, NOW.plus(Duration.ofMinutes(45)), SESSION_CEILING),
+                mock(HttpServletRequest.class),
+                new MockHttpServletResponse());
+
+        verify(jwtIssuer).issue(any(), eq(TokenConstraints.session(SESSION_CEILING, AUTH_TIME)), any(HttpServletRequest.class));
+        AuthEventData event = capturedEvent();
+        assertThat(event.type()).isEqualTo(AuthEvent.EventType.IMPERSONATION_END);
+        assertThat(event.details()).contains("TARGET_PROMOTED");
+    }
+
+    @Test
+    void refresh_whenTheOperatorIsNoLongerAnAdmin_endsTheImpersonation() {
+        UUID jti = UUID.randomUUID();
+        long operatorId = 7L;
+        when(issuedJwtRepository.revoke(eq(jti), any(), eq(IssuedJwt.RevokedReason.ROTATE)))
+                .thenReturn(1);
+        when(accountRepository.findById(ACCOUNT_ID)).thenReturn(Optional.of(activeAccount()));
+        Account demoted = activeAdmin(operatorId);
+        demoted.setAppRole(Account.AppRole.USER);
+        when(accountRepository.findById(operatorId)).thenReturn(Optional.of(demoted));
+
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        // Demotion revokes the operator's own sessions, but this token's subject is the target, so it
+        // would otherwise survive that sweep.
+        service.refresh(
+                ACCOUNT_ID,
+                jti,
+                ctx(operatorId, NOW.plus(Duration.ofMinutes(45)), SESSION_CEILING),
+                mock(HttpServletRequest.class),
+                response);
+
+        assertThat(refreshResult("suspended")).isEqualTo(1.0);
+        assertCookieCleared(response);
+        verify(jwtIssuer, never()).issue(any(), any(), any());
+    }
+
+    @Test
+    void refresh_whenTheSessionCeilingHasPassed_endsTheSession() {
+        UUID jti = UUID.randomUUID();
+        when(issuedJwtRepository.revoke(eq(jti), any(), eq(IssuedJwt.RevokedReason.ROTATE)))
+                .thenReturn(1);
+        when(accountRepository.findById(ACCOUNT_ID)).thenReturn(Optional.of(activeAccount()));
+
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        service.refresh(
+                ACCOUNT_ID,
+                jti,
+                ctx(null, null, NOW.minus(Duration.ofSeconds(1))),
+                mock(HttpServletRequest.class),
+                response);
+
+        assertThat(refreshResult("noop")).isEqualTo(1.0);
+        assertCookieCleared(response);
+        verify(jwtIssuer, never()).issue(any(), any(), any());
+    }
+
+    @Test
+    void refresh_withinTheExitSkewOfTheTimeBox_alreadyExitsSoTheNewTokenIsNotBornExpired() {
+        UUID jti = UUID.randomUUID();
+        long operatorId = 7L;
+        when(issuedJwtRepository.revoke(eq(jti), any(), eq(IssuedJwt.RevokedReason.ROTATE)))
+                .thenReturn(1);
+        when(accountRepository.findById(ACCOUNT_ID)).thenReturn(Optional.of(activeAccount()));
+        when(accountRepository.findById(operatorId)).thenReturn(Optional.of(activeAdmin(operatorId)));
+        when(principalFactory.forAccountId(operatorId))
+                .thenReturn(new JwtPrincipal(operatorId, "operator", null, Set.of("app_admin")));
+        when(jwtIssuer.issue(any(), any(), any()))
+                .thenReturn(
+                        new HephaestusJwtIssuer.Token("op-token", UUID.randomUUID(), NOW.plus(Duration.ofMinutes(15))));
+
+        service.refresh(
+                ACCOUNT_ID,
+                jti,
+                ctx(operatorId, NOW.plus(Duration.ofSeconds(30)), SESSION_CEILING),
+                mock(HttpServletRequest.class),
+                new MockHttpServletResponse());
+
+        verify(jwtIssuer).issue(any(), eq(TokenConstraints.session(SESSION_CEILING, AUTH_TIME)), any(HttpServletRequest.class));
+        assertThat(capturedEvent().details()).contains("EXPIRED");
     }
 
     @Test
@@ -226,7 +341,7 @@ class AuthSessionServiceTest extends BaseUnitTest {
                 .thenReturn(0);
 
         MockHttpServletResponse response = new MockHttpServletResponse();
-        service.refresh(ACCOUNT_ID, jti, ctx(null, null, null), mock(HttpServletRequest.class), response);
+        service.refresh(ACCOUNT_ID, jti, ctx(null, null, SESSION_CEILING), mock(HttpServletRequest.class), response);
 
         assertThat(refreshResult("noop")).isEqualTo(1.0);
         assertThat(refreshResult("success")).isZero();
@@ -245,7 +360,7 @@ class AuthSessionServiceTest extends BaseUnitTest {
         when(accountRepository.findById(ACCOUNT_ID)).thenReturn(Optional.of(suspended));
 
         MockHttpServletResponse response = new MockHttpServletResponse();
-        service.refresh(ACCOUNT_ID, jti, ctx(null, null, null), mock(HttpServletRequest.class), response);
+        service.refresh(ACCOUNT_ID, jti, ctx(null, null, SESSION_CEILING), mock(HttpServletRequest.class), response);
 
         assertThat(refreshResult("suspended")).isEqualTo(1.0);
         // A suspended account cannot keep its session — the cookie must be cleared on the early return.
@@ -261,7 +376,11 @@ class AuthSessionServiceTest extends BaseUnitTest {
         when(accountRepository.findById(ACCOUNT_ID)).thenReturn(Optional.empty());
 
         service.refresh(
-                ACCOUNT_ID, jti, ctx(null, null, null), mock(HttpServletRequest.class), new MockHttpServletResponse());
+                ACCOUNT_ID,
+                jti,
+                ctx(null, null, SESSION_CEILING),
+                mock(HttpServletRequest.class),
+                new MockHttpServletResponse());
 
         assertThat(refreshResult("suspended")).isEqualTo(1.0);
     }
@@ -277,7 +396,7 @@ class AuthSessionServiceTest extends BaseUnitTest {
         when(jwtIssuer.issue(any(), any(), any())).thenReturn(token);
 
         MockHttpServletResponse response = new MockHttpServletResponse();
-        service.refresh(ACCOUNT_ID, jti, ctx(null, null, null), mock(HttpServletRequest.class), response);
+        service.refresh(ACCOUNT_ID, jti, ctx(null, null, SESSION_CEILING), mock(HttpServletRequest.class), response);
 
         assertThat(refreshResult("success")).isEqualTo(1.0);
         var cookie = response.getCookie("__Host-HEPHAESTUS_AT");
@@ -325,7 +444,7 @@ class AuthSessionServiceTest extends BaseUnitTest {
         assertThatThrownBy(() -> service.refresh(
                         ACCOUNT_ID,
                         jti,
-                        ctx(null, null, null),
+                        ctx(null, null, SESSION_CEILING),
                         mock(HttpServletRequest.class),
                         new MockHttpServletResponse()))
                 .isInstanceOf(IllegalStateException.class);

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/auth/ImpersonationLifecycleIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/auth/ImpersonationLifecycleIntegrationTest.java
@@ -1,0 +1,214 @@
+package de.tum.cit.aet.hephaestus.core.auth;
+
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import de.tum.cit.aet.hephaestus.core.auth.audit.AuthEvent;
+import de.tum.cit.aet.hephaestus.core.auth.audit.AuthEventRepository;
+import de.tum.cit.aet.hephaestus.core.auth.domain.Account;
+import de.tum.cit.aet.hephaestus.core.auth.domain.AccountRepository;
+import de.tum.cit.aet.hephaestus.core.auth.jwt.HephaestusJwtIssuer;
+import de.tum.cit.aet.hephaestus.core.auth.jwt.IssuedJwtRepository;
+import de.tum.cit.aet.hephaestus.core.auth.jwt.JwtPrincipalFactory;
+import de.tum.cit.aet.hephaestus.core.auth.jwt.RevocationAwareJwtDecoder;
+import de.tum.cit.aet.hephaestus.testconfig.RealAuthIntegrationTest;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseCookie;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+/**
+ * What bounds an impersonation, over the wire and against a real database: the absolute ceiling
+ * survives a rotation unchanged, the rotation itself is where the impersonation ends, and the
+ * operator's own session bounds both.
+ */
+@Sql(scripts = "/db/auth-event-sequence.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+class ImpersonationLifecycleIntegrationTest extends RealAuthIntegrationTest {
+
+    @Autowired
+    private WebTestClient webTestClient;
+
+    @Autowired
+    private AccountRepository accountRepository;
+
+    @Autowired
+    private AuthEventRepository authEventRepository;
+
+    @Autowired
+    private HephaestusJwtIssuer jwtIssuer;
+
+    @Autowired
+    private JwtPrincipalFactory principalFactory;
+
+    @Autowired
+    private IssuedJwtRepository issuedJwts;
+
+    @Autowired
+    private RevocationAwareJwtDecoder jwtDecoder;
+
+    @Test
+    void aRotationWithinTheTimeBoxKeepsEveryDeadlineItStartedWith() {
+        Account operator = persist("Operator", Account.AppRole.APP_ADMIN);
+        Account target = persist("Target", Account.AppRole.USER);
+        Instant sessionCeiling = Instant.now().plus(Duration.ofHours(12)).truncatedTo(ChronoUnit.SECONDS);
+
+        String impersonationToken = beginImpersonation(operatorToken(operator, sessionCeiling), id(target));
+        Jwt claims = jwtDecoder.decode(impersonationToken);
+        assertThat(claims.getSubject()).isEqualTo(String.valueOf(id(target)));
+        assertThat(claims.getClaimAsMap("act")).containsEntry("sub", String.valueOf(id(operator)));
+        long impExp = requireNonNull(claims.<Long>getClaim("imp_exp"));
+        assertThat(claims.<Long>getClaim("session_exp")).isEqualTo(sessionCeiling.getEpochSecond());
+
+        Jwt rotated = jwtDecoder.decode(refresh(impersonationToken));
+        assertThat(rotated.getSubject()).isEqualTo(String.valueOf(id(target)));
+        assertThat(rotated.getClaimAsMap("act")).containsEntry("sub", String.valueOf(id(operator)));
+        assertThat(rotated.<Long>getClaim("imp_exp"))
+                .as("imp_exp is absolute: a rotation re-caps at it rather than extending it")
+                .isEqualTo(impExp);
+        assertThat(rotated.<Long>getClaim("session_exp")).isEqualTo(sessionCeiling.getEpochSecond());
+
+        // The wire deadline and the database's active-token check must agree to the second, or a token
+        // the browser has already stopped sending would still read as active.
+        Instant wireExpiry = requireNonNull(rotated.getExpiresAt());
+        assertThat(wireExpiry).isBeforeOrEqualTo(Instant.ofEpochSecond(impExp));
+        UUID jti = UUID.fromString(rotated.getId());
+        assertThat(issuedJwts.findActive(jti, wireExpiry.minusMillis(1))).isPresent();
+        assertThat(issuedJwts.findActive(jti, wireExpiry)).isEmpty();
+    }
+
+    @Test
+    void aRotationNearTheCeilingReturnsTheOperatorToTheirOwnSession() {
+        Account operator = persist("Operator", Account.AppRole.APP_ADMIN);
+        Account target = persist("Target", Account.AppRole.USER);
+        Instant sessionCeiling = Instant.now().plus(Duration.ofHours(12)).truncatedTo(ChronoUnit.SECONDS);
+        // Inside the exit skew: a token minted at this ceiling would be born expired, so the rotation
+        // must end the impersonation instead of renewing it.
+        Instant nearCeiling = Instant.now().plus(Duration.ofSeconds(45)).truncatedTo(ChronoUnit.SECONDS);
+        String impersonationToken = jwtIssuer
+                .issue(principalFactory.forAccount(target), id(operator), nearCeiling, sessionCeiling, null)
+                .value();
+
+        Jwt exited = jwtDecoder.decode(refresh(impersonationToken));
+        assertThat(exited.getSubject()).isEqualTo(String.valueOf(id(operator)));
+        assertThat(exited.hasClaim("act")).isFalse();
+        assertThat(exited.hasClaim("imp_exp")).isFalse();
+        assertThat(exited.<Long>getClaim("session_exp")).isEqualTo(sessionCeiling.getEpochSecond());
+
+        assertThat(impersonationEndsFor(target)).singleElement().satisfies(end -> {
+            assertThat(end.getActingAccountId()).isEqualTo(id(operator));
+            assertThat(end.getDetails()).contains("EXPIRED");
+        });
+    }
+
+    @Test
+    void promotingTheTargetMidSessionEndsTheImpersonationOnTheNextRotation() {
+        Account operator = persist("Operator", Account.AppRole.APP_ADMIN);
+        Account target = persist("Target", Account.AppRole.USER);
+        Instant sessionCeiling = Instant.now().plus(Duration.ofHours(12));
+        String impersonationToken = beginImpersonation(operatorToken(operator, sessionCeiling), id(target));
+
+        target.setAppRole(Account.AppRole.APP_ADMIN);
+        accountRepository.save(target);
+
+        Jwt exited = jwtDecoder.decode(refresh(impersonationToken));
+        assertThat(exited.getSubject()).isEqualTo(String.valueOf(id(operator)));
+        assertThat(exited.hasClaim("act"))
+                .as("begin refuses admin-to-admin impersonation; a rotation is not a way around it")
+                .isFalse();
+
+        assertThat(impersonationEndsFor(target))
+                .singleElement()
+                .satisfies(end -> assertThat(end.getDetails()).contains("TARGET_PROMOTED"));
+    }
+
+    /**
+     * A token that carries no absolute ceiling predates the ceiling. Returning from it would hand back
+     * an operator session with nothing bounding it, so it is refused rather than renewed — the same
+     * fail-safe the rotation applies.
+     */
+    @Test
+    void anImpersonationWithNoSessionCeilingIsRefusedRatherThanReturnedFrom() {
+        Account operator = persist("Operator", Account.AppRole.APP_ADMIN);
+        Account target = persist("Target", Account.AppRole.USER);
+        String uncappedImpersonation = jwtIssuer
+                .issue(
+                        principalFactory.forAccount(target),
+                        id(operator),
+                        Instant.now().plus(Duration.ofMinutes(30)),
+                        null,
+                        null)
+                .value();
+
+        webTestClient
+                .post()
+                .uri("/auth/impersonate:exit")
+                .headers(h -> h.setBearerAuth(uncappedImpersonation))
+                .exchange()
+                .expectStatus()
+                .isUnauthorized();
+
+        assertThat(impersonationEndsFor(target)).isEmpty();
+    }
+
+    private List<AuthEvent> impersonationEndsFor(Account target) {
+        return authEventRepository.findByAccountSince(id(target), Instant.now().minus(1, ChronoUnit.HOURS)).stream()
+                .filter(e -> e.getEventType() == AuthEvent.EventType.IMPERSONATION_END)
+                .toList();
+    }
+
+    private String operatorToken(Account operator, Instant sessionExpiresAt) {
+        return jwtIssuer
+                .issue(principalFactory.forAccount(operator), null, null, sessionExpiresAt, null)
+                .value();
+    }
+
+    private Account persist(String name, Account.AppRole role) {
+        Account account = new Account(name);
+        account.setAppRole(role);
+        account.setStatus(Account.Status.ACTIVE);
+        return accountRepository.save(account);
+    }
+
+    private static long id(Account account) {
+        return requireNonNull(account.getId());
+    }
+
+    private String beginImpersonation(String operatorToken, long targetAccountId) {
+        var result = webTestClient
+                .post()
+                .uri("/auth/impersonate")
+                .headers(h -> h.setBearerAuth(operatorToken))
+                .bodyValue(Map.of("targetAccountId", targetAccountId, "reason", "integration-test"))
+                .exchange()
+                .expectStatus()
+                .isNoContent()
+                .returnResult(Void.class);
+        ResponseCookie cookie = result.getResponseCookies().getFirst(AuthProperties.DEFAULT_COOKIE_NAME);
+        assertThat(cookie)
+                .as("impersonate must Set-Cookie the impersonation token")
+                .isNotNull();
+        return cookie.getValue();
+    }
+
+    private String refresh(String token) {
+        var result = webTestClient
+                .post()
+                .uri("/auth/refresh")
+                .headers(h -> h.setBearerAuth(token))
+                .exchange()
+                .expectStatus()
+                .isNoContent()
+                .returnResult(Void.class);
+        ResponseCookie rotated = result.getResponseCookies().getFirst(AuthProperties.DEFAULT_COOKIE_NAME);
+        assertThat(rotated).as("refresh must Set-Cookie a rotated token").isNotNull();
+        return rotated.getValue();
+    }
+}

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/auth/ImpersonationLifecycleIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/auth/ImpersonationLifecycleIntegrationTest.java
@@ -11,6 +11,7 @@ import de.tum.cit.aet.hephaestus.core.auth.jwt.HephaestusJwtIssuer;
 import de.tum.cit.aet.hephaestus.core.auth.jwt.IssuedJwtRepository;
 import de.tum.cit.aet.hephaestus.core.auth.jwt.JwtPrincipalFactory;
 import de.tum.cit.aet.hephaestus.core.auth.jwt.RevocationAwareJwtDecoder;
+import de.tum.cit.aet.hephaestus.core.auth.jwt.TokenConstraints;
 import de.tum.cit.aet.hephaestus.testconfig.RealAuthIntegrationTest;
 import java.time.Duration;
 import java.time.Instant;
@@ -93,7 +94,10 @@ class ImpersonationLifecycleIntegrationTest extends RealAuthIntegrationTest {
         // must end the impersonation instead of renewing it.
         Instant nearCeiling = Instant.now().plus(Duration.ofSeconds(45)).truncatedTo(ChronoUnit.SECONDS);
         String impersonationToken = jwtIssuer
-                .issue(principalFactory.forAccount(target), id(operator), nearCeiling, sessionCeiling, null)
+                .issue(
+                        principalFactory.forAccount(target),
+                        TokenConstraints.impersonation(id(operator), nearCeiling, sessionCeiling, null),
+                        null)
                 .value();
 
         Jwt exited = jwtDecoder.decode(refresh(impersonationToken));
@@ -141,9 +145,8 @@ class ImpersonationLifecycleIntegrationTest extends RealAuthIntegrationTest {
         String uncappedImpersonation = jwtIssuer
                 .issue(
                         principalFactory.forAccount(target),
-                        id(operator),
-                        Instant.now().plus(Duration.ofMinutes(30)),
-                        null,
+                        TokenConstraints.impersonation(
+                                id(operator), Instant.now().plus(Duration.ofMinutes(30)), null, null),
                         null)
                 .value();
 
@@ -164,9 +167,13 @@ class ImpersonationLifecycleIntegrationTest extends RealAuthIntegrationTest {
                 .toList();
     }
 
+    /** Carries a fresh {@code auth_time}: beginning an impersonation is gated on a recent sign-in. */
     private String operatorToken(Account operator, Instant sessionExpiresAt) {
         return jwtIssuer
-                .issue(principalFactory.forAccount(operator), null, null, sessionExpiresAt, null)
+                .issue(
+                        principalFactory.forAccount(operator),
+                        TokenConstraints.session(sessionExpiresAt, Instant.now()),
+                        null)
                 .value();
     }
 

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/auth/SessionRefreshLifecycleIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/auth/SessionRefreshLifecycleIntegrationTest.java
@@ -9,6 +9,8 @@ import de.tum.cit.aet.hephaestus.core.auth.jwt.HephaestusJwtIssuer;
 import de.tum.cit.aet.hephaestus.core.auth.jwt.JwtPrincipalFactory;
 import de.tum.cit.aet.hephaestus.core.auth.jwt.TokenConstraints;
 import de.tum.cit.aet.hephaestus.testconfig.RealAuthIntegrationTest;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -74,8 +76,12 @@ class SessionRefreshLifecycleIntegrationTest extends RealAuthIntegrationTest {
     @Test
     void refreshRotatesTheSessionAndKeepsAppRequestsWorkingAcrossManyCycles() {
         Account account = accountRepository.save(new Account("Rolling Rosa"));
+        // Every real login stamps the absolute ceiling; a rotation is only allowed to roll within it.
         String current = jwtIssuer
-                .issue(principalFactory.forAccount(account), TokenConstraints.session(null, null), null)
+                .issue(
+                        principalFactory.forAccount(account),
+                        TokenConstraints.session(Instant.now().plus(Duration.ofHours(12)), null),
+                        null)
                 .value();
         String csrf = fetchCsrfToken();
 
@@ -101,11 +107,11 @@ class SessionRefreshLifecycleIntegrationTest extends RealAuthIntegrationTest {
     void theAbsoluteSessionCeilingCapsTheTokenAndSurvivesRefresh() {
         Account account = accountRepository.save(new Account("Capped Cathy"));
         // A 2-minute absolute session ceiling — well under the 15-min access TTL, so it binds.
-        long ceiling = java.time.Instant.now().getEpochSecond() + 120;
+        long ceiling = Instant.now().getEpochSecond() + 120;
         String token = jwtIssuer
                 .issue(
                         principalFactory.forAccount(account),
-                        TokenConstraints.session(java.time.Instant.ofEpochSecond(ceiling), null),
+                        TokenConstraints.session(Instant.ofEpochSecond(ceiling), null),
                         null)
                 .value();
 

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/auth/impersonation/ImpersonationServiceTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/auth/impersonation/ImpersonationServiceTest.java
@@ -125,7 +125,8 @@ class ImpersonationServiceTest extends BaseUnitTest {
     void begin_whenOperatorNotAdmin_forbidden() {
         when(accountRepository.findById(1L)).thenReturn(Optional.of(account(1L, Account.AppRole.USER)));
 
-        assertThatThrownBy(() -> service.begin(1L, 2L, "support", OPERATOR_AUTH_TIME, OPERATOR_SESSION_EXPIRES_AT, null))
+        assertThatThrownBy(
+                        () -> service.begin(1L, 2L, "support", OPERATOR_AUTH_TIME, OPERATOR_SESSION_EXPIRES_AT, null))
                 .isInstanceOf(ResponseStatusException.class)
                 .satisfies(e -> assertThat(((ResponseStatusException) e).getStatusCode())
                         .isEqualTo(HttpStatus.FORBIDDEN));
@@ -138,7 +139,8 @@ class ImpersonationServiceTest extends BaseUnitTest {
     void begin_whenSelfImpersonation_badRequest() {
         when(accountRepository.findById(1L)).thenReturn(Optional.of(account(1L, Account.AppRole.APP_ADMIN)));
 
-        assertThatThrownBy(() -> service.begin(1L, 1L, "support", OPERATOR_AUTH_TIME, OPERATOR_SESSION_EXPIRES_AT, null))
+        assertThatThrownBy(
+                        () -> service.begin(1L, 1L, "support", OPERATOR_AUTH_TIME, OPERATOR_SESSION_EXPIRES_AT, null))
                 .isInstanceOf(ResponseStatusException.class)
                 .satisfies(e -> assertThat(((ResponseStatusException) e).getStatusCode())
                         .isEqualTo(HttpStatus.BAD_REQUEST));
@@ -152,7 +154,8 @@ class ImpersonationServiceTest extends BaseUnitTest {
         when(accountRepository.findById(1L)).thenReturn(Optional.of(account(1L, Account.AppRole.APP_ADMIN)));
         when(accountRepository.findById(2L)).thenReturn(Optional.empty());
 
-        assertThatThrownBy(() -> service.begin(1L, 2L, "support", OPERATOR_AUTH_TIME, OPERATOR_SESSION_EXPIRES_AT, null))
+        assertThatThrownBy(
+                        () -> service.begin(1L, 2L, "support", OPERATOR_AUTH_TIME, OPERATOR_SESSION_EXPIRES_AT, null))
                 .isInstanceOf(ResponseStatusException.class)
                 .satisfies(e -> assertThat(((ResponseStatusException) e).getStatusCode())
                         .isEqualTo(HttpStatus.NOT_FOUND));
@@ -166,7 +169,8 @@ class ImpersonationServiceTest extends BaseUnitTest {
         when(accountRepository.findById(1L)).thenReturn(Optional.of(account(1L, Account.AppRole.APP_ADMIN)));
         when(accountRepository.findById(2L)).thenReturn(Optional.of(account(2L, Account.AppRole.APP_ADMIN)));
 
-        assertThatThrownBy(() -> service.begin(1L, 2L, "support", OPERATOR_AUTH_TIME, OPERATOR_SESSION_EXPIRES_AT, null))
+        assertThatThrownBy(
+                        () -> service.begin(1L, 2L, "support", OPERATOR_AUTH_TIME, OPERATOR_SESSION_EXPIRES_AT, null))
                 .isInstanceOf(ResponseStatusException.class)
                 .satisfies(e -> assertThat(((ResponseStatusException) e).getStatusCode())
                         .isEqualTo(HttpStatus.FORBIDDEN));

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/auth/impersonation/ImpersonationServiceTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/auth/impersonation/ImpersonationServiceTest.java
@@ -51,6 +51,9 @@ class ImpersonationServiceTest extends BaseUnitTest {
     /** The operator's sign-in, which entering and leaving impersonation must both carry unchanged. */
     private static final Instant OPERATOR_AUTH_TIME = Instant.parse("2025-12-31T23:58:00Z");
 
+    /** The operator's absolute session deadline; both ends of an impersonation are bounded by it. */
+    private static final Instant OPERATOR_SESSION_EXPIRES_AT = Instant.parse("2026-01-01T12:00:00Z");
+
     @Mock
     private AccountRepository accountRepository;
 
@@ -107,7 +110,7 @@ class ImpersonationServiceTest extends BaseUnitTest {
 
         // A reason laden with characters that the old escape() missed: newline, tab, quote, backslash.
         String nastyReason = "line1\nline2\twith \"quotes\" and a \\ backslash";
-        service.begin(1L, 2L, nastyReason, OPERATOR_AUTH_TIME, null);
+        service.begin(1L, 2L, nastyReason, OPERATOR_AUTH_TIME, OPERATOR_SESSION_EXPIRES_AT, null);
 
         ArgumentCaptor<AuthEventData> captor = ArgumentCaptor.forClass(AuthEventData.class);
         verify(authEventWriter).write(captor.capture());
@@ -122,7 +125,7 @@ class ImpersonationServiceTest extends BaseUnitTest {
     void begin_whenOperatorNotAdmin_forbidden() {
         when(accountRepository.findById(1L)).thenReturn(Optional.of(account(1L, Account.AppRole.USER)));
 
-        assertThatThrownBy(() -> service.begin(1L, 2L, "support", OPERATOR_AUTH_TIME, null))
+        assertThatThrownBy(() -> service.begin(1L, 2L, "support", OPERATOR_AUTH_TIME, OPERATOR_SESSION_EXPIRES_AT, null))
                 .isInstanceOf(ResponseStatusException.class)
                 .satisfies(e -> assertThat(((ResponseStatusException) e).getStatusCode())
                         .isEqualTo(HttpStatus.FORBIDDEN));
@@ -135,7 +138,7 @@ class ImpersonationServiceTest extends BaseUnitTest {
     void begin_whenSelfImpersonation_badRequest() {
         when(accountRepository.findById(1L)).thenReturn(Optional.of(account(1L, Account.AppRole.APP_ADMIN)));
 
-        assertThatThrownBy(() -> service.begin(1L, 1L, "support", OPERATOR_AUTH_TIME, null))
+        assertThatThrownBy(() -> service.begin(1L, 1L, "support", OPERATOR_AUTH_TIME, OPERATOR_SESSION_EXPIRES_AT, null))
                 .isInstanceOf(ResponseStatusException.class)
                 .satisfies(e -> assertThat(((ResponseStatusException) e).getStatusCode())
                         .isEqualTo(HttpStatus.BAD_REQUEST));
@@ -149,7 +152,7 @@ class ImpersonationServiceTest extends BaseUnitTest {
         when(accountRepository.findById(1L)).thenReturn(Optional.of(account(1L, Account.AppRole.APP_ADMIN)));
         when(accountRepository.findById(2L)).thenReturn(Optional.empty());
 
-        assertThatThrownBy(() -> service.begin(1L, 2L, "support", OPERATOR_AUTH_TIME, null))
+        assertThatThrownBy(() -> service.begin(1L, 2L, "support", OPERATOR_AUTH_TIME, OPERATOR_SESSION_EXPIRES_AT, null))
                 .isInstanceOf(ResponseStatusException.class)
                 .satisfies(e -> assertThat(((ResponseStatusException) e).getStatusCode())
                         .isEqualTo(HttpStatus.NOT_FOUND));
@@ -163,7 +166,7 @@ class ImpersonationServiceTest extends BaseUnitTest {
         when(accountRepository.findById(1L)).thenReturn(Optional.of(account(1L, Account.AppRole.APP_ADMIN)));
         when(accountRepository.findById(2L)).thenReturn(Optional.of(account(2L, Account.AppRole.APP_ADMIN)));
 
-        assertThatThrownBy(() -> service.begin(1L, 2L, "support", OPERATOR_AUTH_TIME, null))
+        assertThatThrownBy(() -> service.begin(1L, 2L, "support", OPERATOR_AUTH_TIME, OPERATOR_SESSION_EXPIRES_AT, null))
                 .isInstanceOf(ResponseStatusException.class)
                 .satisfies(e -> assertThat(((ResponseStatusException) e).getStatusCode())
                         .isEqualTo(HttpStatus.FORBIDDEN));
@@ -184,18 +187,23 @@ class ImpersonationServiceTest extends BaseUnitTest {
                 .thenReturn(
                         new HephaestusJwtIssuer.Token("tok", UUID.randomUUID(), Instant.parse("2026-01-01T00:15:00Z")));
 
-        ImpersonationService.Result result = service.begin(1L, 2L, "support", OPERATOR_AUTH_TIME, null);
+        ImpersonationService.Result result =
+                service.begin(1L, 2L, "support", OPERATOR_AUTH_TIME, OPERATOR_SESSION_EXPIRES_AT, null);
 
         assertThat(result.targetAccountId()).isEqualTo(2L);
         assertThat(result.actingAccountId()).isEqualTo(1L);
         // act-claim contract plus the time-box: the OPERATOR is the impersonator, imp_exp is
-        // now + impersonationMaxLifetime (1h from the fixed clock), and the operator's own auth_time
-        // rides along so exiting does not look like a fresh sign-in.
+        // now + impersonationMaxLifetime (1h from the fixed clock), the operator's own auth_time
+        // rides along so exiting does not look like a fresh sign-in, and the operator's session
+        // ceiling is carried so impersonating cannot outlive the session that started it.
         verify(jwtIssuer)
                 .issue(
                         any(),
                         eq(TokenConstraints.impersonation(
-                                1L, Instant.parse("2026-01-01T01:00:00Z"), null, OPERATOR_AUTH_TIME)),
+                                1L,
+                                Instant.parse("2026-01-01T01:00:00Z"),
+                                OPERATOR_SESSION_EXPIRES_AT,
+                                OPERATOR_AUTH_TIME)),
                         any());
 
         ArgumentCaptor<AuthEventData> captor = ArgumentCaptor.forClass(AuthEventData.class);
@@ -208,19 +216,53 @@ class ImpersonationServiceTest extends BaseUnitTest {
     }
 
     @Test
+    void begin_whenTheOperatorSessionHasLapsed_unauthorized() {
+        assertThatThrownBy(() -> service.begin(
+                        1L, 2L, "support", OPERATOR_AUTH_TIME, Instant.parse("2025-12-31T23:59:00Z"), null))
+                .isInstanceOfSatisfying(
+                        ResponseStatusException.class,
+                        e -> assertThat(e.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED));
+
+        // An operator whose own session is over cannot start acting as somebody else.
+        verify(jwtIssuer, never()).issue(any(), any(), any());
+        verify(authEventWriter, never()).write(any());
+    }
+
+    @Test
+    void exit_whenTheImpersonationWasAlreadyEnded_unauthorized() {
+        UUID impersonationJti = UUID.randomUUID();
+        when(issuedJwtRepository.revoke(eq(impersonationJti), any(), eq(IssuedJwt.RevokedReason.IMPERSONATION_EXIT)))
+                .thenReturn(0);
+
+        assertThatThrownBy(() ->
+                        service.exit(1L, 2L, impersonationJti, OPERATOR_AUTH_TIME, OPERATOR_SESSION_EXPIRES_AT, null))
+                .isInstanceOfSatisfying(
+                        ResponseStatusException.class,
+                        e -> assertThat(e.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED));
+
+        // A force sign-out or an auto-exit already closed this session; exiting must not reopen one.
+        verify(jwtIssuer, never()).issue(any(), any(), any());
+    }
+
+    @Test
     void exit_revokesImpersonationJtiAndMintsOperatorToken() {
         UUID impersonationJti = UUID.randomUUID();
         when(principalFactory.forAccountId(1L))
                 .thenReturn(new JwtPrincipal(1L, "operator", "Operator", Set.of("admin")));
+        when(issuedJwtRepository.revoke(eq(impersonationJti), any(), eq(IssuedJwt.RevokedReason.IMPERSONATION_EXIT)))
+                .thenReturn(1);
         when(jwtIssuer.issue(any(), any(), any()))
                 .thenReturn(new HephaestusJwtIssuer.Token(
                         "op-tok", UUID.randomUUID(), Instant.parse("2026-01-01T00:15:00Z")));
 
-        ImpersonationService.Result result = service.exit(1L, 2L, impersonationJti, OPERATOR_AUTH_TIME, null);
+        ImpersonationService.Result result =
+                service.exit(1L, 2L, impersonationJti, OPERATOR_AUTH_TIME, OPERATOR_SESSION_EXPIRES_AT, null);
 
         verify(issuedJwtRepository).revoke(eq(impersonationJti), any(), eq(IssuedJwt.RevokedReason.IMPERSONATION_EXIT));
-        // No act claim on the operator token, and the operator's sign-in age is unchanged by the exit.
-        verify(jwtIssuer).issue(any(), eq(TokenConstraints.session(null, OPERATOR_AUTH_TIME)), any());
+        // No act claim on the operator token, the operator's sign-in age is unchanged by the exit, and
+        // the operator's own session ceiling is carried onto the returned-to token.
+        verify(jwtIssuer)
+                .issue(any(), eq(TokenConstraints.session(OPERATOR_SESSION_EXPIRES_AT, OPERATOR_AUTH_TIME)), any());
         assertThat(result.targetAccountId()).isEqualTo(1L);
         assertThat(result.actingAccountId()).isNull();
 

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/auth/impersonation/ImpersonationServiceTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/auth/impersonation/ImpersonationServiceTest.java
@@ -235,6 +235,7 @@ class ImpersonationServiceTest extends BaseUnitTest {
     @Test
     void exit_whenTheImpersonationWasAlreadyEnded_unauthorized() {
         UUID impersonationJti = UUID.randomUUID();
+        when(accountRepository.findById(1L)).thenReturn(Optional.of(account(1L, Account.AppRole.APP_ADMIN)));
         when(issuedJwtRepository.revoke(eq(impersonationJti), any(), eq(IssuedJwt.RevokedReason.IMPERSONATION_EXIT)))
                 .thenReturn(0);
 
@@ -249,8 +250,26 @@ class ImpersonationServiceTest extends BaseUnitTest {
     }
 
     @Test
+    void exit_whenTheOperatorIsNoLongerAnAdmin_unauthorized() {
+        UUID impersonationJti = UUID.randomUUID();
+        when(accountRepository.findById(1L)).thenReturn(Optional.of(account(1L, Account.AppRole.USER)));
+
+        assertThatThrownBy(() ->
+                        service.exit(1L, 2L, impersonationJti, OPERATOR_AUTH_TIME, OPERATOR_SESSION_EXPIRES_AT, null))
+                .isInstanceOfSatisfying(
+                        ResponseStatusException.class,
+                        e -> assertThat(e.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED));
+
+        // A demoted operator must not be able to manually exit into an ordinary token either — the same
+        // gate refresh applies before it will rotate this pair.
+        verify(jwtIssuer, never()).issue(any(), any(), any());
+        verify(issuedJwtRepository, never()).revoke(any(), any(), any());
+    }
+
+    @Test
     void exit_revokesImpersonationJtiAndMintsOperatorToken() {
         UUID impersonationJti = UUID.randomUUID();
+        when(accountRepository.findById(1L)).thenReturn(Optional.of(account(1L, Account.AppRole.APP_ADMIN)));
         when(principalFactory.forAccountId(1L))
                 .thenReturn(new JwtPrincipal(1L, "operator", "Operator", Set.of("admin")));
         when(issuedJwtRepository.revoke(eq(impersonationJti), any(), eq(IssuedJwt.RevokedReason.IMPERSONATION_EXIT)))

--- a/webapp/src/integrations/auth/use-session-keep-alive.ts
+++ b/webapp/src/integrations/auth/use-session-keep-alive.ts
@@ -22,7 +22,12 @@ import { refreshAccessToken } from "./session-refresh";
  * @see https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html
  */
 
-/** Renew this long before expiry so a request never races a just-lapsed token. */
+/**
+ * Renew this long before expiry so a request never races a just-lapsed token. It is also the window
+ * in which the server ends an impersonation instead of rotating it (`IMPERSONATION_EXIT_SKEW` in
+ * `AuthSessionService`): shortening this one without shortening that one leaves an impersonation
+ * whose last rotation mints a token that is already expired.
+ */
 const REFRESH_SKEW_MS = 60_000;
 /** Coalesce activity bookkeeping so the listeners are effectively free on a busy page. */
 const ACTIVITY_THROTTLE_MS = 10_000;


### PR DESCRIPTION
## What changed and why

An impersonation is bounded by its own absolute ceiling (`imp_exp`), but nothing bounded it by the
operator behind it. Three ways out of that box existed:

- **The operator's own session was irrelevant.** `begin` never looked at it and the impersonation
  token carried no `session_exp`, so acting as someone else could outlive the session that started
  it — and a refresh of an ordinary session could roll straight past its absolute lifetime.
- **A demoted or suspended operator kept impersonating.** Demotion revokes the operator's own
  sessions, but an impersonation token's subject is the *target*, so it survives that sweep.
- **A target promoted mid-session stayed impersonated.** `begin` refuses admin-to-admin
  impersonation; a rotation did not, so promoting the account you are impersonating was a way around
  the refusal.

`refresh` is where an impersonation ends, so that is where the bounds now live: it carries the
operator's session ceiling and refuses to roll past it, re-reads the operator and ends the session
when they are no longer an active instance admin, and exits with reason `TARGET_PROMOTED` when the
target has been promoted. The exit happens a minute *before* the ceiling rather than at it —
a token minted at `imp_exp` would be born expired, so the operator would be signed out instead of
returned to their own session. That window is coupled by comment to the SPA's `REFRESH_SKEW_MS`,
which decides when the rotation happens at all.

Two smaller correctness fixes ride with it because they are the same mechanism: exiting by hand now
refuses when the impersonation was already ended by another path, rather than minting a session
something else deliberately closed; and a token's wire deadline is truncated to whole seconds, so
the database's active-token check agrees with the token the browser actually holds.

Part of #1323 — acceptance criterion 3 ("impersonation cannot outlive its `imp_exp` even across a
token refresh; covered by an integration test").

## How to test

```
pnpm exec vp run check
pnpm exec vp run test:server:unit
cd server && MANAGEMENT_PORT=0 SERVER_PORT=0 ./mvnw -pl application -am package \
  -Dspring-boot.repackage.skip=true -Dsurefire.includedGroups=integration -Dparallel=none \
  -Dtest='ImpersonationLifecycleIntegrationTest,SessionRefreshLifecycleIntegrationTest,CookieAuthenticationIntegrationTest,AccountAdminRoleIntegrationTest,StaleAuthCookieEvictionIntegrationTest,AccountControllerIntegrationTest' \
  -DfailIfNoTests=false --batch-mode
```

`ImpersonationLifecycleIntegrationTest` drives it over the wire against a real database: a rotation
inside the box keeps `imp_exp`, `session_exp` and the `act` claim unchanged and the wire deadline
agrees with `issued_jwt.findActive` to the second; a rotation inside the exit skew returns the
operator to their own session and audits `EXPIRED`; promoting the target mid-session audits
`TARGET_PROMOTED`; and an impersonation carrying no session ceiling is refused rather than returned
from.

## Release impact

`.changeset/impersonation-bounds.md` (`patch`). No operator action and no migration. One behaviour an
operator may notice: an impersonation in flight across the upgrade carries no `session_exp`, so it
ends at its next rotation rather than continuing — the operator signs back into their own session.

## Notes for reviewers

- **This is one of four concerns split out of #1864**, all based on `main`. It touches neither
  `db/master.xml` nor `webapp/src/api/**`.
- `refresh` and `ImpersonationService` overlap textually with #1864 (the recent-sign-in
  gate). Both build on `main` on their own; whichever lands second needs a rebase, not a redesign.
- The exit skew is the one tunable number here. It is a constant rather than a property because it is
  meaningful only in relation to the SPA's refresh skew, and changing one without the other
  reintroduces the born-expired token.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Sessions now end at their configured maximum lifetime, even when actively renewed.
  - Impersonation ends automatically when its time limit is reached, the operator’s session or administrator status ends, or the target becomes an instance administrator.
  - Automatic endings return operators to their own sessions and appear in the audit viewer with a reason.
  - Exiting an already-ended impersonation is now rejected instead of issuing a replacement session.

- **Documentation**
  - Added configuration guidance for session and impersonation deadlines, renewal behavior, and automatic termination conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->