### PR TITLE
fix(auth): audit a login-provider change only once the database accepts it

### DIFF
--- a/.changeset/login-provider-audit-after-commit.md
+++ b/.changeset/login-provider-audit-after-commit.md
@@ -1,0 +1,8 @@
+---
+"hephaestus": patch
+---
+
+A login-provider change that the database refuses no longer appears in the audit viewer as if it had
+succeeded. Moving a provider onto a base URL another provider already uses is rejected, and the
+rejection now happens before the change is recorded, so the trail matches what the instance actually
+has configured.

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/auth/provider/LoginProviderService.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/auth/provider/LoginProviderService.java
@@ -357,7 +357,11 @@ public class LoginProviderService {
     }
 
     private LoginProvider persist(LoginProvider provider) {
-        LoginProvider saved = repository.save(provider);
+        // Flush here rather than at commit: an update mutates a managed entity, so a UNIQUE(type,
+        // base_url) violation would otherwise surface after the caller has already recorded a SUCCESS.
+        // That row is written in its own REQUIRES_NEW transaction, so it outlives the rollback and the
+        // trail keeps a change that never happened.
+        LoginProvider saved = repository.saveAndFlush(provider);
         registrationCache.evict(saved.getRegistrationId());
         return saved;
     }

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/auth/provider/LoginProviderServiceTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/auth/provider/LoginProviderServiceTest.java
@@ -271,7 +271,7 @@ class LoginProviderServiceTest extends BaseUnitTest {
     @Test
     void createSelfHostedGitlabDefaultsScopesAndEvictsCache() {
         when(repository.existsByRegistrationId("gitlab-acme")).thenReturn(false);
-        when(repository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        when(repository.saveAndFlush(any())).thenAnswer(inv -> inv.getArgument(0));
 
         LoginProvider created = adminService().create(gitlabDraft("gitlab-acme", "https://gitlab.acme.test/", null));
 
@@ -288,7 +288,7 @@ class LoginProviderServiceTest extends BaseUnitTest {
 
         assertThatThrownBy(() -> adminService().create(gitlabDraft("gitlab-acme", "https://gitlab.acme.test", null)))
                 .isInstanceOf(ResponseStatusException.class);
-        verify(repository, never()).save(any());
+        verify(repository, never()).saveAndFlush(any());
     }
 
     @Test
@@ -297,7 +297,7 @@ class LoginProviderServiceTest extends BaseUnitTest {
         assertThatThrownBy(() -> adminService()
                         .create(gitlabDraft("gitlab-x", "https://gitlab.acme.test", "openid profile read_user")))
                 .isInstanceOf(ResponseStatusException.class);
-        verify(repository, never()).save(any());
+        verify(repository, never()).saveAndFlush(any());
     }
 
     @Test
@@ -310,7 +310,7 @@ class LoginProviderServiceTest extends BaseUnitTest {
                                 "gitlab",
                                 new LoginProviderService.Patch(null, null, null, null, "openid read_user", null)))
                 .isInstanceOf(ResponseStatusException.class);
-        verify(repository, never()).save(any());
+        verify(repository, never()).saveAndFlush(any());
     }
 
     @Test
@@ -318,7 +318,7 @@ class LoginProviderServiceTest extends BaseUnitTest {
         // OUTLINE mirrors the GITLAB self-hosted shape: per-instance base URL (validated), plain OAuth2
         // with a pinned minimal "read" scope — see LoginProviderService.OUTLINE_SCOPES.
         when(repository.existsByRegistrationId("outline-acme")).thenReturn(false);
-        when(repository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        when(repository.saveAndFlush(any())).thenAnswer(inv -> inv.getArgument(0));
 
         LoginProvider created = adminService().create(outlineDraft("outline-acme", "https://wiki.acme.test/", null));
 
@@ -335,7 +335,7 @@ class LoginProviderServiceTest extends BaseUnitTest {
         assertThatThrownBy(
                         () -> adminService().create(outlineDraft("outline-x", "https://wiki.acme.test", "openid read")))
                 .isInstanceOf(ResponseStatusException.class);
-        verify(repository, never()).save(any());
+        verify(repository, never()).saveAndFlush(any());
     }
 
     @Test
@@ -346,7 +346,7 @@ class LoginProviderServiceTest extends BaseUnitTest {
         assertThatThrownBy(() -> adminService()
                         .update("outline", new LoginProviderService.Patch(null, null, null, null, "openid read", null)))
                 .isInstanceOf(ResponseStatusException.class);
-        verify(repository, never()).save(any());
+        verify(repository, never()).saveAndFlush(any());
     }
 
     @Test
@@ -354,14 +354,14 @@ class LoginProviderServiceTest extends BaseUnitTest {
         // SSRF / HTTPS guard: the Outline base URL takes the same ServerUrlValidator posture as GitLab.
         assertThatThrownBy(() -> adminService().create(outlineDraft("outline-x", "http://wiki.acme.test", null)))
                 .isInstanceOf(ResponseStatusException.class);
-        verify(repository, never()).save(any());
+        verify(repository, never()).saveAndFlush(any());
     }
 
     @Test
     void createRejectsUnapprovedOutlineOrigin() {
         assertThatThrownBy(() -> adminService().create(outlineDraft("outline-x", "https://wiki.denied.test", null)))
                 .isInstanceOf(ResponseStatusException.class);
-        verify(repository, never()).save(any());
+        verify(repository, never()).saveAndFlush(any());
     }
 
     @Test
@@ -382,7 +382,7 @@ class LoginProviderServiceTest extends BaseUnitTest {
         assertThatThrownBy(() -> adminService()
                         .update("github", new LoginProviderService.Patch(null, null, null, null, null, false)))
                 .isInstanceOf(ResponseStatusException.class);
-        verify(repository, never()).save(any());
+        verify(repository, never()).saveAndFlush(any());
     }
 
     @Test
@@ -418,7 +418,7 @@ class LoginProviderServiceTest extends BaseUnitTest {
         LoginProvider outline = outlineProvider("outline", "sealed");
         when(repository.findByRegistrationId("outline")).thenReturn(Optional.of(outline));
         when(repository.findByEnabledTrueOrderByDisplayNameAsc()).thenReturn(List.of(outline));
-        when(repository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        when(repository.saveAndFlush(any())).thenAnswer(inv -> inv.getArgument(0));
 
         LoginProvider saved =
                 adminService().update("outline", new LoginProviderService.Patch(null, null, null, null, null, false));
@@ -449,14 +449,14 @@ class LoginProviderServiceTest extends BaseUnitTest {
         // SSRF / HTTPS guard: ServerUrlValidator rejects http:// (and loopback/internal) base URLs.
         assertThatThrownBy(() -> adminService().create(gitlabDraft("gitlab-x", "http://gitlab.acme.test", null)))
                 .isInstanceOf(ResponseStatusException.class);
-        verify(repository, never()).save(any());
+        verify(repository, never()).saveAndFlush(any());
     }
 
     @Test
     void updateLeavesSealedSecretUnchangedWhenPatchSecretIsNullOrBlank() {
         LoginProvider existing = gitlabProvider("gitlab", "sealed-secret");
         when(repository.findByRegistrationId("gitlab")).thenReturn(Optional.of(existing));
-        when(repository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        when(repository.saveAndFlush(any())).thenAnswer(inv -> inv.getArgument(0));
 
         adminService().update("gitlab", new LoginProviderService.Patch("Renamed", null, null, null, null, null));
         assertThat(existing.getClientSecret()).isEqualTo("sealed-secret"); // null secret → unchanged
@@ -469,7 +469,7 @@ class LoginProviderServiceTest extends BaseUnitTest {
     void updateReplacesSecretWhenPatchSecretIsPresent() {
         LoginProvider existing = gitlabProvider("gitlab", "old-secret");
         when(repository.findByRegistrationId("gitlab")).thenReturn(Optional.of(existing));
-        when(repository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        when(repository.saveAndFlush(any())).thenAnswer(inv -> inv.getArgument(0));
 
         adminService().update("gitlab", new LoginProviderService.Patch(null, null, null, "new-secret", null, null));
         assertThat(existing.getClientSecret()).isEqualTo("new-secret");
@@ -491,7 +491,7 @@ class LoginProviderServiceTest extends BaseUnitTest {
     @Test
     void adminMutationsLandOnTheAuthEventTrail() {
         when(repository.existsByRegistrationId("gitlab-acme")).thenReturn(false);
-        when(repository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        when(repository.saveAndFlush(any())).thenAnswer(inv -> inv.getArgument(0));
         LoginProvider existing = gitlabProvider("gitlab-acme", "sealed");
         when(repository.findByRegistrationId("gitlab-acme")).thenReturn(Optional.of(existing));
         // Two enabled providers, so neither disable nor delete trips the last-provider lockout guard.
@@ -521,7 +521,7 @@ class LoginProviderServiceTest extends BaseUnitTest {
         LoginProvider existing = gitlabProvider("gitlab-acme", "old-secret");
         when(repository.findByRegistrationId("gitlab-acme")).thenReturn(Optional.of(existing));
         when(repository.findByEnabledTrueOrderByDisplayNameAsc()).thenReturn(List.of(existing));
-        when(repository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        when(repository.saveAndFlush(any())).thenAnswer(inv -> inv.getArgument(0));
 
         adminService()
                 .update(

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/auth/web/LoginProviderAdminControllerIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/auth/web/LoginProviderAdminControllerIntegrationTest.java
@@ -2,6 +2,8 @@ package de.tum.cit.aet.hephaestus.core.auth.web;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import de.tum.cit.aet.hephaestus.core.auth.audit.AuthEvent;
+import de.tum.cit.aet.hephaestus.core.auth.audit.AuthEventRepository;
 import de.tum.cit.aet.hephaestus.testconfig.TestAuthUtils;
 import de.tum.cit.aet.hephaestus.testconfig.WithAdminUser;
 import de.tum.cit.aet.hephaestus.testconfig.WithUser;
@@ -10,6 +12,7 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.reactive.server.WebTestClient;
 
 /**
@@ -17,10 +20,14 @@ import org.springframework.test.web.reactive.server.WebTestClient;
  * ({@code app_admin}) may manage login providers, the create response carries the upstream redirect
  * URI, and the sealed client secret is never returned.
  */
+@Sql(scripts = "/db/auth-event-sequence.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
 class LoginProviderAdminControllerIntegrationTest extends AbstractWorkspaceIntegrationTest {
 
     @Autowired
     private WebTestClient webTestClient;
+
+    @Autowired
+    private AuthEventRepository authEventRepository;
 
     @Test
     @WithUser
@@ -108,5 +115,71 @@ class LoginProviderAdminControllerIntegrationTest extends AbstractWorkspaceInteg
                 .expectBody()
                 .jsonPath("$[?(@.registrationId == 'gitlab-actest')]")
                 .exists();
+    }
+
+    /**
+     * Moving a provider onto another's base URL violates {@code uq_login_provider_type_base_url}. The
+     * change is flushed at commit, long after the handler has recorded a SUCCESS in its own
+     * {@code REQUIRES_NEW} transaction — so without an explicit flush the trail keeps a row describing
+     * a change that never happened.
+     */
+    @Test
+    @WithAdminUser
+    void aRefusedUpdateLeavesNoSuccessOnTheTrail() {
+        createGitLabProvider("gitlab-taken", "https://gitlab.taken.test")
+                .expectStatus()
+                .isCreated();
+        createGitLabProvider("gitlab-mover", "https://gitlab.mover.test")
+                .expectStatus()
+                .isCreated();
+
+        webTestClient
+                .patch()
+                .uri("/admin/login-providers/gitlab-mover")
+                .headers(TestAuthUtils.withCurrentUser())
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(Map.of("baseUrl", "https://gitlab.taken.test"))
+                .exchange()
+                .expectStatus()
+                .is4xxClientError();
+
+        webTestClient
+                .get()
+                .uri("/admin/login-providers")
+                .headers(TestAuthUtils.withCurrentUser())
+                .exchange()
+                .expectStatus()
+                .isOk()
+                .expectBody()
+                .jsonPath("$[?(@.registrationId == 'gitlab-mover')].baseUrl")
+                .isEqualTo("https://gitlab.mover.test");
+
+        assertThat(authEventRepository.findAll())
+                .filteredOn(e -> e.getEventType() == AuthEvent.EventType.LOGIN_PROVIDER_UPDATED)
+                .isEmpty();
+    }
+
+    private WebTestClient.ResponseSpec createGitLabProvider(String registrationId, String baseUrl) {
+        return webTestClient
+                .post()
+                .uri("/admin/login-providers")
+                .headers(TestAuthUtils.withCurrentUser())
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(Map.of(
+                        "registrationId",
+                        registrationId,
+                        "type",
+                        "GITLAB",
+                        "displayName",
+                        "Duplicate GitLab",
+                        "baseUrl",
+                        baseUrl,
+                        "clientId",
+                        "acme-client-id",
+                        "clientSecret",
+                        "super-secret-value",
+                        "scopes",
+                        "read_user"))
+                .exchange();
     }
 }

--- a/server/application/src/test/resources/db/auth-event-sequence.sql
+++ b/server/application/src/test/resources/db/auth-event-sequence.sql
@@ -1,0 +1,4 @@
+-- auth_event.id is allocated by AuthEventSequence, not by Hibernate, so the schema Hibernate
+-- generates for the real-auth integration tests does not contain the sequence. Without it every
+-- audit write is swallowed as a failure and the trail an assertion is looking for is never there.
+CREATE SEQUENCE IF NOT EXISTS auth_event_id_seq;


### PR DESCRIPTION
## What changed and why

Changing a login provider's base URL to one another provider already uses violates
`uq_login_provider_type_base_url`. An update mutates a managed entity, so that violation surfaced at
commit — *after* the handler had already recorded `LOGIN_PROVIDER_UPDATED` / SUCCESS. The audit row
is written in its own `REQUIRES_NEW` transaction, so it outlived the rollback: the audit viewer
showed a change the instance never made.

Flushing the write before the audit call puts the refusal first. One line, plus the reason.

## How to test

```
pnpm exec vp run check
cd server && MANAGEMENT_PORT=0 SERVER_PORT=0 ./mvnw -pl application -am package \
  -Dspring-boot.repackage.skip=true -Dsurefire.includedGroups=integration -Dparallel=none \
  -Dtest='LoginProviderAdminControllerIntegrationTest' -DfailIfNoTests=false --batch-mode
```

`aRefusedUpdateLeavesNoSuccessOnTheTrail` creates two providers, moves one onto the other's base URL,
and asserts the request is refused, the stored base URL is unchanged, and no
`LOGIN_PROVIDER_UPDATED` row exists. Reverting `saveAndFlush` to `save` was verified to turn it red.

## Release impact

`.changeset/login-provider-audit-after-commit.md` (`patch`). No operator action, no migration.

## Notes for reviewers

- **This is one of four concerns split out of #1864**, all based on `main`. It touches one production
  line and one test file, and neither `db/master.xml` nor `webapp/src/api/**`.
- The `create` path was already safe: an `IDENTITY` id forces an immediate INSERT, so the constraint
  fires inside `save`. Only `update` was exposed.
