### PR TITLE
refactor(server): one home for the retention batching loop

### DIFF
--- a/.changeset/one-home-for-retention-batching.md
+++ b/.changeset/one-home-for-retention-batching.md
@@ -1,0 +1,7 @@
+---
+---
+
+No release note: the two retention sweeps keep the batch size, the time budget and the log lines they
+already had. They now share one implementation of the batching loop instead of two copies of it, and
+a retention window configured as zero or negative is refused by the same validation every other
+duration setting uses.

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/BoundedBatchPass.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/BoundedBatchPass.java
@@ -1,0 +1,56 @@
+package de.tum.cit.aet.hephaestus.agent;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.function.IntSupplier;
+import org.slf4j.Logger;
+
+/**
+ * Runs one retention batch after another until a batch comes back short, so no single statement holds
+ * locks or generates WAL/dead-tuple pressure long enough to hurt whatever else writes the table.
+ *
+ * @param clock read between batches, so a caller's fixed clock keeps a pass deterministic
+ * @param batchSize rows one statement may touch; a batch that touches fewer ends the pass
+ * @param budget wall-clock allowance per pass, checked between full batches
+ */
+public record BoundedBatchPass(Clock clock, int batchSize, Duration budget) {
+
+    public static final int DEFAULT_BATCH_SIZE = 500;
+    public static final Duration DEFAULT_BUDGET = Duration.ofMinutes(5);
+
+    public BoundedBatchPass(Clock clock) {
+        this(clock, DEFAULT_BATCH_SIZE, DEFAULT_BUDGET);
+    }
+
+    /**
+     * One pass. {@code truncated} means the budget ended it with rows still eligible, so the backlog
+     * outlives the pass: a deployment whose every pass ends this way keeps expired data forever.
+     *
+     * @param affected rows the whole pass touched, including the batch that ran out of budget
+     */
+    public record Result(long affected, boolean truncated) {}
+
+    /**
+     * @param log the caller's logger, so the budget warning stays under the class an operator filters on
+     * @param name what the pass does, for that warning
+     * @param batch runs one statement bounded to {@link #batchSize} rows and returns how many it touched
+     */
+    public Result run(Logger log, String name, IntSupplier batch) {
+        Instant deadline = clock.instant().plus(budget);
+        long total = 0;
+        int affected;
+        do {
+            affected = batch.getAsInt();
+            total += affected;
+            if (affected == batchSize && clock.instant().isAfter(deadline)) {
+                log.warn(
+                        "Retention: {} pass hit its {} time budget with backlog remaining — resuming next run",
+                        name,
+                        budget);
+                return new Result(total, true);
+            }
+        } while (affected == batchSize);
+        return new Result(total, false);
+    }
+}

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobRetentionService.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobRetentionService.java
@@ -1,11 +1,12 @@
 package de.tum.cit.aet.hephaestus.agent.job;
 
+import de.tum.cit.aet.hephaestus.agent.BoundedBatchPass;
 import de.tum.cit.aet.hephaestus.agent.metrics.AgentMetrics;
 import de.tum.cit.aet.hephaestus.core.WorkspaceAgnostic;
 import de.tum.cit.aet.hephaestus.core.runtime.ConditionalOnServerRole;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
-import java.time.Duration;
+import java.time.Clock;
 import java.time.Instant;
 import java.util.concurrent.TimeUnit;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
@@ -21,8 +22,8 @@ import org.springframework.transaction.support.TransactionTemplate;
  * {@link AgentProperties#payloadRetention} keep everything but their bulky {@code container_logs} /
  * {@code output}, and unreferenced rows older than {@link AgentProperties#rowRetention} go entirely.
  *
- * <p>Both are batched rather than issued as one unbounded statement, so no single transaction holds
- * locks or generates WAL/dead-tuple pressure long enough to hurt the queue sharing this table.
+ * <p>Both run as {@link BoundedBatchPass} batches, so the queue sharing this table is never held up
+ * by one unbounded statement.
  */
 @ConditionalOnServerRole
 @Component
@@ -32,12 +33,10 @@ public class AgentJobRetentionService {
 
     private static final Logger log = LoggerFactory.getLogger(AgentJobRetentionService.class);
 
-    private static final int BATCH_SIZE = 500;
-
-    private static final Duration MAX_PASS_DURATION = Duration.ofMinutes(5);
-
     private final AgentJobRepository jobRepository;
     private final AgentProperties agentProperties;
+    private final Clock clock;
+    private final BoundedBatchPass pass;
     private final TransactionTemplate transactionTemplate;
     private final Counter stripped;
     private final Counter deleted;
@@ -45,10 +44,13 @@ public class AgentJobRetentionService {
     public AgentJobRetentionService(
             AgentJobRepository jobRepository,
             AgentProperties agentProperties,
+            Clock clock,
             TransactionTemplate transactionTemplate,
             MeterRegistry meterRegistry) {
         this.jobRepository = jobRepository;
         this.agentProperties = agentProperties;
+        this.clock = clock;
+        this.pass = new BoundedBatchPass(clock);
         this.transactionTemplate = transactionTemplate;
         this.stripped = Counter.builder(AgentMetrics.AGENT_JOB_RETENTION_STRIPPED)
                 .description("Terminal agent_job rows whose heavy payload columns were stripped to NULL")
@@ -61,7 +63,7 @@ public class AgentJobRetentionService {
     /**
      * {@code @SchedulerLock} single-flights this across replicas: concurrent passes cannot go faster (the
      * batches serialize on row-level contention anyway) and only multiply lock/WAL pressure.
-     * {@code lockAtMostFor} must stay above both passes' {@link #MAX_PASS_DURATION} budgets.
+     * {@code lockAtMostFor} must stay above both passes' {@link BoundedBatchPass#DEFAULT_BUDGET}.
      */
     @Scheduled(fixedDelay = 6, initialDelay = 1, timeUnit = TimeUnit.HOURS)
     @SchedulerLock(name = "agent-job-retention", lockAtMostFor = "PT20M", lockAtLeastFor = "PT10S")
@@ -71,55 +73,37 @@ public class AgentJobRetentionService {
     }
 
     private void stripPayloads() {
-        Instant cutoff = Instant.now().minus(agentProperties.payloadRetention());
-        Instant deadline = Instant.now().plus(MAX_PASS_DURATION);
-        int total = 0;
-        int batchUpdated;
-        do {
-            Integer result =
-                    transactionTemplate.execute(status -> jobRepository.stripTerminalPayloads(cutoff, BATCH_SIZE));
-            batchUpdated = result != null ? result : 0;
-            total += batchUpdated;
+        Instant cutoff = clock.instant().minus(agentProperties.payloadRetention());
+        BoundedBatchPass.Result result = pass.run(log, "strip", () -> {
+            Integer updated = transactionTemplate.execute(
+                    status -> jobRepository.stripTerminalPayloads(cutoff, pass.batchSize()));
+            int batchUpdated = updated != null ? updated : 0;
             if (batchUpdated > 0) {
                 stripped.increment(batchUpdated);
             }
-            if (batchUpdated == BATCH_SIZE && Instant.now().isAfter(deadline)) {
-                log.warn(
-                        "Retention: strip pass hit its {} time budget with backlog remaining — resuming next run",
-                        MAX_PASS_DURATION);
-                break;
-            }
-        } while (batchUpdated == BATCH_SIZE);
-        if (total > 0) {
+            return batchUpdated;
+        });
+        if (result.affected() > 0) {
             log.info(
                     "Retention: stripped payloads from {} terminal agent_job row(s) completed before {}",
-                    total,
+                    result.affected(),
                     cutoff);
         }
     }
 
     private void deleteOldRows() {
-        Instant cutoff = Instant.now().minus(agentProperties.rowRetention());
-        Instant deadline = Instant.now().plus(MAX_PASS_DURATION);
-        int total = 0;
-        int batchDeleted;
-        do {
-            Integer result = transactionTemplate.execute(
-                    status -> jobRepository.deleteUnreferencedTerminalRowsOlderThan(cutoff, BATCH_SIZE));
-            batchDeleted = result != null ? result : 0;
-            total += batchDeleted;
+        Instant cutoff = clock.instant().minus(agentProperties.rowRetention());
+        BoundedBatchPass.Result result = pass.run(log, "delete", () -> {
+            Integer removed = transactionTemplate.execute(
+                    status -> jobRepository.deleteUnreferencedTerminalRowsOlderThan(cutoff, pass.batchSize()));
+            int batchDeleted = removed != null ? removed : 0;
             if (batchDeleted > 0) {
                 deleted.increment(batchDeleted);
             }
-            if (batchDeleted == BATCH_SIZE && Instant.now().isAfter(deadline)) {
-                log.warn(
-                        "Retention: delete pass hit its {} time budget with backlog remaining — resuming next run",
-                        MAX_PASS_DURATION);
-                break;
-            }
-        } while (batchDeleted == BATCH_SIZE);
-        if (total > 0) {
-            log.info("Retention: deleted {} terminal agent_job row(s) completed before {}", total, cutoff);
+            return batchDeleted;
+        });
+        if (result.affected() > 0) {
+            log.info("Retention: deleted {} terminal agent_job row(s) completed before {}", result.affected(), cutoff);
         }
     }
 }

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/usage/LlmUsageProperties.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/usage/LlmUsageProperties.java
@@ -2,6 +2,7 @@ package de.tum.cit.aet.hephaestus.agent.usage;
 
 import jakarta.validation.constraints.NotNull;
 import java.time.Duration;
+import org.hibernate.validator.constraints.time.DurationMin;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.bind.DefaultValue;
 import org.springframework.validation.annotation.Validated;
@@ -16,13 +17,9 @@ import org.springframework.validation.annotation.Validated;
 @Validated
 @ConfigurationProperties(prefix = "hephaestus.llm.usage")
 public record LlmUsageProperties(
-        @DefaultValue("P400D") @NotNull Duration retention) {
-    /** Bean Validation has no duration-sign constraint, so the bound is checked here. */
-    public LlmUsageProperties {
-        if (retention == null || retention.isNegative() || retention.isZero()) {
-            throw new IllegalArgumentException(
-                    "hephaestus.llm.usage.retention (HEPHAESTUS_LLM_USAGE_RETENTION) must be positive, got: "
-                            + retention);
-        }
-    }
-}
+        @DefaultValue("P400D")
+        @NotNull
+        @DurationMin(
+                nanos = 1,
+                message = "hephaestus.llm.usage.retention (HEPHAESTUS_LLM_USAGE_RETENTION) must be positive")
+        Duration retention) {}

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/usage/LlmUsageRetentionSweeper.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/usage/LlmUsageRetentionSweeper.java
@@ -1,12 +1,12 @@
 package de.tum.cit.aet.hephaestus.agent.usage;
 
+import de.tum.cit.aet.hephaestus.agent.BoundedBatchPass;
 import de.tum.cit.aet.hephaestus.core.PrivacyJobMetrics;
 import de.tum.cit.aet.hephaestus.core.PrivacyJobMetrics.Job;
 import de.tum.cit.aet.hephaestus.core.PrivacyJobMetrics.Outcome;
 import de.tum.cit.aet.hephaestus.core.WorkspaceAgnostic;
 import de.tum.cit.aet.hephaestus.core.runtime.ConditionalOnServerRole;
 import java.time.Clock;
-import java.time.Duration;
 import java.time.Instant;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.slf4j.Logger;
@@ -17,10 +17,8 @@ import org.springframework.transaction.support.TransactionTemplate;
 
 /**
  * Applies storage limitation to the append-only spend ledger: usage older than
- * {@link LlmUsageProperties#retention} is deleted.
- *
- * <p>Batched rather than issued as one unbounded statement, so no single transaction holds locks or
- * generates WAL/dead-tuple pressure long enough to hurt the recorder appending to the same table.
+ * {@link LlmUsageProperties#retention} is deleted, in {@link BoundedBatchPass} batches so the
+ * recorder appending to the same table is never held up by one unbounded statement.
  */
 @ConditionalOnServerRole
 @Component
@@ -29,13 +27,10 @@ public class LlmUsageRetentionSweeper {
 
     private static final Logger log = LoggerFactory.getLogger(LlmUsageRetentionSweeper.class);
 
-    private static final int BATCH_SIZE = 500;
-
-    private static final Duration MAX_PASS_DURATION = Duration.ofMinutes(5);
-
     private final LlmUsageEventRepository repository;
     private final LlmUsageProperties properties;
     private final Clock clock;
+    private final BoundedBatchPass pass;
     private final TransactionTemplate transactionTemplate;
     private final PrivacyJobMetrics metrics;
 
@@ -48,11 +43,15 @@ public class LlmUsageRetentionSweeper {
         this.repository = repository;
         this.properties = properties;
         this.clock = clock;
+        this.pass = new BoundedBatchPass(clock);
         this.transactionTemplate = transactionTemplate;
         this.metrics = metrics;
     }
 
-    /** {@code lockAtMostFor} must stay above {@link #MAX_PASS_DURATION}, or a second replica joins the pass. */
+    /**
+     * {@code lockAtMostFor} must stay above {@link BoundedBatchPass#DEFAULT_BUDGET}, or a second replica
+     * joins the pass.
+     */
     @Scheduled(cron = "0 15 4 * * *")
     @SchedulerLock(name = "llm-usage-retention-sweep", lockAtMostFor = "PT20M", lockAtLeastFor = "PT30S")
     public void sweep() {
@@ -62,42 +61,26 @@ public class LlmUsageRetentionSweeper {
     /** @return the number of ledger rows this pass deleted */
     public long sweepNow() {
         try {
-            Pass pass = deleteExpiredInBatches();
-            metrics.record(Job.LLM_USAGE_RETENTION, pass.truncated() ? Outcome.INCOMPLETE : Outcome.SUCCESS);
-            metrics.recordAffected(Job.LLM_USAGE_RETENTION, pass.deleted());
-            return pass.deleted();
+            BoundedBatchPass.Result result = deleteExpiredInBatches();
+            metrics.record(Job.LLM_USAGE_RETENTION, result.truncated() ? Outcome.INCOMPLETE : Outcome.SUCCESS);
+            metrics.recordAffected(Job.LLM_USAGE_RETENTION, result.affected());
+            return result.affected();
         } catch (RuntimeException e) {
             metrics.record(Job.LLM_USAGE_RETENTION, Outcome.FAILURE);
             throw e;
         }
     }
 
-    /**
-     * One pass over the ledger. {@code truncated} means the time budget ended it with rows still
-     * eligible, which is not a success: a deployment whose every pass ends this way keeps expired
-     * personal data forever.
-     */
-    private record Pass(long deleted, boolean truncated) {}
-
-    private Pass deleteExpiredInBatches() {
+    /** A truncated pass leaves expired personal data in place, which is why it is not a success. */
+    private BoundedBatchPass.Result deleteExpiredInBatches() {
         Instant cutoff = clock.instant().minus(properties.retention());
-        Instant deadline = clock.instant().plus(MAX_PASS_DURATION);
-        long total = 0;
-        int batchDeleted;
-        do {
-            Integer result = transactionTemplate.execute(status -> repository.deleteExpired(cutoff, BATCH_SIZE));
-            batchDeleted = result != null ? result : 0;
-            total += batchDeleted;
-            if (batchDeleted == BATCH_SIZE && clock.instant().isAfter(deadline)) {
-                log.warn(
-                        "Retention: LLM usage pass hit its {} time budget with backlog remaining — resuming next run",
-                        MAX_PASS_DURATION);
-                return new Pass(total, true);
-            }
-        } while (batchDeleted == BATCH_SIZE);
-        if (total > 0) {
-            log.info("Retention: deleted {} llm_usage_event row(s) occurring before {}", total, cutoff);
+        BoundedBatchPass.Result result = pass.run(log, "LLM usage", () -> {
+            Integer deleted = transactionTemplate.execute(status -> repository.deleteExpired(cutoff, pass.batchSize()));
+            return deleted != null ? deleted : 0;
+        });
+        if (result.affected() > 0) {
+            log.info("Retention: deleted {} llm_usage_event row(s) occurring before {}", result.affected(), cutoff);
         }
-        return new Pass(total, false);
+        return result;
     }
 }

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/BoundedBatchPassTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/BoundedBatchPassTest.java
@@ -1,0 +1,87 @@
+package de.tum.cit.aet.hephaestus.agent;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import de.tum.cit.aet.hephaestus.testconfig.BaseUnitTest;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.function.IntSupplier;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class BoundedBatchPassTest extends BaseUnitTest {
+
+    private static final Logger log = LoggerFactory.getLogger(BoundedBatchPassTest.class);
+    private static final Instant NOW = Instant.parse("2026-09-05T12:00:00Z");
+
+    private int batches;
+
+    @Test
+    void shouldStopAtTheFirstBatchThatComesBackShort() {
+        BoundedBatchPass pass = new BoundedBatchPass(Clock.fixed(NOW, ZoneOffset.UTC), 10, Duration.ofMinutes(5));
+
+        BoundedBatchPass.Result result = pass.run(log, "strip", returning(9));
+
+        assertThat(result).isEqualTo(new BoundedBatchPass.Result(9, false));
+        assertThat(batches).isEqualTo(1);
+    }
+
+    @Test
+    void shouldKeepGoingWhileEveryBatchFillsTheBound() {
+        BoundedBatchPass pass = new BoundedBatchPass(Clock.fixed(NOW, ZoneOffset.UTC), 10, Duration.ofMinutes(5));
+
+        BoundedBatchPass.Result result = pass.run(log, "strip", returning(10, 10, 3));
+
+        assertThat(result).isEqualTo(new BoundedBatchPass.Result(23, false));
+        assertThat(batches).isEqualTo(3);
+    }
+
+    /** The backlog outlives a truncated pass, which is why the caller has to be able to tell. */
+    @Test
+    void shouldReportTruncationWhenTheBudgetRunsOutWithTheBacklogStillFull() {
+        BoundedBatchPass pass =
+                new BoundedBatchPass(new SteppingClock(Duration.ofMinutes(4)), 10, Duration.ofMinutes(5));
+
+        BoundedBatchPass.Result result = pass.run(log, "strip", returning(10, 10, 10));
+
+        assertThat(result).isEqualTo(new BoundedBatchPass.Result(20, true));
+        assertThat(batches).isEqualTo(2);
+    }
+
+    /** The last value repeats, so a pass that runs longer than the script keeps finding full batches. */
+    private IntSupplier returning(int... affected) {
+        return () -> affected[Math.min(batches++, affected.length - 1)];
+    }
+
+    /** Moves forward on every read, so a pass over full batches reaches its time budget. */
+    private static final class SteppingClock extends Clock {
+
+        private final Duration step;
+        private Instant now = NOW;
+
+        private SteppingClock(Duration step) {
+            this.step = step;
+        }
+
+        @Override
+        public Instant instant() {
+            Instant reading = now;
+            now = now.plus(step);
+            return reading;
+        }
+
+        @Override
+        public ZoneId getZone() {
+            return ZoneOffset.UTC;
+        }
+
+        @Override
+        public Clock withZone(ZoneId zone) {
+            return this;
+        }
+    }
+}

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobRetentionServiceTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobRetentionServiceTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.when;
 
 import de.tum.cit.aet.hephaestus.testconfig.BaseUnitTest;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Clock;
 import java.time.Duration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -45,7 +46,8 @@ class AgentJobRetentionServiceTest extends BaseUnitTest {
             TransactionCallback<Object> cb = inv.getArgument(0);
             return cb.doInTransaction(mock(TransactionStatus.class));
         });
-        service = new AgentJobRetentionService(jobRepository, AGENT_PROPS, transactionTemplate, meterRegistry);
+        service = new AgentJobRetentionService(
+                jobRepository, AGENT_PROPS, Clock.systemUTC(), transactionTemplate, meterRegistry);
     }
 
     @Nested


### PR DESCRIPTION
## What changed and why

`AgentJobRetentionService` and `LlmUsageRetentionSweeper` each carried their own copy of the same
batched retention pass: a `BATCH_SIZE = 500` constant, a `MAX_PASS_DURATION` of five minutes, the
`affected == batchSize && now.isAfter(deadline)` break, and the warning logged when a pass runs out
of budget. Two copies of one decision is one place for the next reader to change the wrong half.

The loop moves to `BoundedBatchPass`, a small value that owns the bound, the budget and the pass
result. Each sweep keeps its own cutoff, its own counters and its own logger — `run` takes the
caller's `Logger`, so an operator filtering on `AgentJobRetentionService` or
`LlmUsageRetentionSweeper` still sees the budget warning under the class that ran the pass. The
batch size, the budget and every log line are unchanged.

While the retention window was in hand, `LlmUsageProperties` stopped hand-checking its own bound in
a compact constructor and now carries `@DurationMin`, matching `NatsConsumerProperties` and keeping
the message that names `HEPHAESTUS_LLM_USAGE_RETENTION`.

Part of the cleanup #1865 opened; that PR also carried hunks belonging to #1851, #1853, #1856 and
#1857, which are dropped rather than re-cut here.

## How to test

```bash
vp run check
MANAGEMENT_PORT=0 SERVER_PORT=0 vp run test:server:unit
```

`BoundedBatchPassTest` is the new focused proof: a pass stops at the first short batch, keeps going
while every batch fills the bound, and reports `truncated` when the budget runs out with the backlog
still full. `AgentJobRetentionServiceTest` and `LlmUsageRetentionSweeperTest` keep asserting the
counters and the `incomplete` privacy-job outcome through the services.

## Release impact

`.changeset/one-home-for-retention-batching.md` — no release note. The sweeps keep the batch size,
the budget and the log lines they already had, so there is nothing an operator can observe. No
operator action.

## Notes for reviewers

`AGENTS.md` § Hit every surface:

- **Integrations** — not applicable; no adapter is involved.
- **Runtime roles** — both sweeps stay `@ConditionalOnServerRole`; `BoundedBatchPass` is a plain
  value, not a bean, so no role gains or loses one.
- **Wire contract / schema / channels / admin consoles / UI states / reverse states** — not
  applicable; nothing crosses HTTP, no entity changes and no UI is touched.
- **Docs by audience** — none needed: the batching rationale lives in the code that implements it,
  and no user- or operator-facing statement changes.
- **Release note** — an empty changeset, for the reason above.

`AgentJobRetentionService` now takes the `Clock` bean instead of calling `Instant.now()`, which is
what lets its cutoffs and its budget read the same clock the sweeper already used.
