### PR TITLE
fix(webapp): the transparency notice interrupts the page you asked for

### DIFF
--- a/.changeset/one-consent-gate.md
+++ b/.changeset/one-consent-gate.md
@@ -1,0 +1,8 @@
+---
+"hephaestus": patch
+---
+
+The transparency notice now interrupts the page you were opening instead of taking you somewhere
+else: the address bar keeps the page you asked for while you answer, and you land back on it. And if
+the notice itself cannot be loaded, you keep working on the page rather than meeting an error screen
+— the server still withholds anything that needs your answer.

--- a/webapp/src/routes/-consent-gate.test.tsx
+++ b/webapp/src/routes/-consent-gate.test.tsx
@@ -1,50 +1,95 @@
 import { QueryClient } from "@tanstack/react-query";
+import { createMemoryHistory, createRouter } from "@tanstack/react-router";
+import { HttpResponse, http } from "msw";
 import { describe, expect, it, vi } from "vitest";
 
 import { consentIsPending } from "@/integrations/auth/guard";
+import { workspaceListItem } from "@/mocks/fixtures/workspaces";
+import { unauthenticatedUser } from "@/mocks/handlers";
+import { server } from "@/mocks/server";
+import { routeTree } from "@/routeTree.gen";
+
+// `router.load()` lazily imports each matched route's module, so a case pays its transform cost.
+vi.setConfig({ testTimeout: 15_000 });
+
+const DEEP_LINK = "/w/acme/mentor/thread-1?message=hi";
 
 /**
- * The gate the root route consults before anything below it loads. Everything else about the notice
- * is covered by the dialog's stories; what matters here is which way the gate errs, because the
- * server refuses every gated call until the notice is answered.
+ * The gate every authenticated route consults before anything below it loads. Everything else about
+ * the notice is covered by the dialog's stories; what matters here is which way the gate errs,
+ * because the server refuses every gated call until the notice is answered.
  */
-/** The generated query keys carry the operation name, which is what tells the two apart. */
-function asksAboutConsent(options: unknown): boolean {
-	return JSON.stringify(options).toLowerCase().includes("consent");
-}
-
 describe("consent gate", () => {
-	/** A signed-in reader: the current-user query resolves first, then the consent status. */
-	function clientAnswering(status: { completed: boolean }) {
-		const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-		vi.spyOn(client, "query").mockImplementation((options) =>
-			asksAboutConsent(options) ? Promise.resolve(status) : Promise.resolve({ id: 1 }),
-		);
-		return client;
+	function newClient() {
+		return new QueryClient({ defaultOptions: { queries: { retry: false } } });
+	}
+
+	function noticeAnswered(completed: boolean) {
+		server.use(http.get("*/user/consent", () => HttpResponse.json({ completed })));
 	}
 
 	it("lets the application load once the notice has been answered", async () => {
-		await expect(consentIsPending(clientAnswering({ completed: true }))).resolves.toBe(false);
+		noticeAnswered(true);
+		await expect(consentIsPending(newClient())).resolves.toBe(false);
 	});
 
 	it("holds the application back while the notice is outstanding", async () => {
-		await expect(consentIsPending(clientAnswering({ completed: false }))).resolves.toBe(true);
+		noticeAnswered(false);
+		await expect(consentIsPending(newClient())).resolves.toBe(true);
 	});
 
 	it("never asks on behalf of a signed-out visitor", async () => {
 		// The landing page waits on this, and the only answer it could get is 401.
-		const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-		const query = vi.spyOn(client, "query").mockResolvedValue(undefined);
-		await expect(consentIsPending(client)).resolves.toBe(false);
-		for (const [options] of query.mock.calls) expect(asksAboutConsent(options)).toBe(false);
+		let asked = false;
+		server.use(
+			unauthenticatedUser,
+			http.get("*/user/consent", () => {
+				asked = true;
+				return HttpResponse.json({ completed: false });
+			}),
+		);
+
+		await expect(consentIsPending(newClient())).resolves.toBe(false);
+		expect(asked).toBe(false);
 	});
 
 	it("lets the application load when it cannot tell, rather than blocking everyone", async () => {
 		// Blocking here would put an undismissable notice in front of every reader whenever this one
 		// call failed, with no way out but a reload — and it would not be protective either, because
 		// the server refuses the gated calls itself. A reader who owes the notice still meets that.
-		const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-		vi.spyOn(client, "query").mockRejectedValue(new Error("unreachable"));
-		await expect(consentIsPending(client)).resolves.toBe(false);
+		server.use(http.get("*/user/consent", () => HttpResponse.error()));
+
+		await expect(consentIsPending(newClient())).resolves.toBe(false);
+	});
+});
+
+/** The same gate as the authenticated subtree runs it, driven through the generated tree. */
+describe("authenticated route gate", () => {
+	async function land(url: string) {
+		server.use(http.get("*/workspaces", () => HttpResponse.json([workspaceListItem("acme")])));
+		const router = createRouter({
+			routeTree,
+			history: createMemoryHistory({ initialEntries: [url] }),
+			context: { queryClient: new QueryClient(), auth: undefined },
+		});
+		await router.load();
+		return router.state.location;
+	}
+
+	it("puts the outstanding notice over the page the reader asked for", async () => {
+		server.use(http.get("*/user/consent", () => HttpResponse.json({ completed: false })));
+
+		const location = await land(DEEP_LINK);
+
+		expect(location.pathname).toBe("/consent");
+		expect(location.search).toMatchObject({ returnTo: DEEP_LINK });
+		// The address bar stays on the page, so the notice reads as that page pausing.
+		expect(location.maskedLocation?.href).toBe(DEEP_LINK);
+	});
+
+	it("opens the page anyway when the notice cannot be loaded", async () => {
+		server.use(http.get("*/user/consent", () => HttpResponse.error()));
+
+		expect((await land(DEEP_LINK)).href).toBe(DEEP_LINK);
 	});
 });

--- a/webapp/src/routes/_authenticated.tsx
+++ b/webapp/src/routes/_authenticated.tsx
@@ -1,9 +1,8 @@
 import { createFileRoute, Outlet, redirect } from "@tanstack/react-router";
 
-import { getConsentStatusOptions } from "@/api/@tanstack/react-query.gen";
 import { Spinner } from "@/components/ui/spinner";
 import { useAuth } from "@/integrations/auth/AuthContext";
-import { resolveCurrentUser } from "@/integrations/auth/guard";
+import { consentIsPending, resolveCurrentUser } from "@/integrations/auth/guard";
 
 // This route will be a parent for all routes that require authentication
 export const Route = createFileRoute("/_authenticated")({
@@ -19,9 +18,14 @@ export const Route = createFileRoute("/_authenticated")({
 				search: { returnTo: location.href },
 			});
 		}
-		const consent = await context.queryClient.query(getConsentStatusOptions({}));
-		if (!consent.completed) {
-			throw redirect({ to: "/consent", search: { returnTo: location.href } });
+		// The mask keeps the address bar on the page the reader asked for, so the notice reads as an
+		// interruption of that page rather than a trip to somewhere else.
+		if (await consentIsPending(context.queryClient)) {
+			throw redirect({
+				to: "/consent",
+				search: { returnTo: location.href },
+				mask: { to: location.pathname, search: location.search },
+			});
 		}
 	},
 	pendingComponent: () => (


### PR DESCRIPTION
## What changed and why

#1838 gave the home route the shared consent gate — `consentIsPending`, a redirect and a `mask`.
`_authenticated`, the route every signed-in page actually inherits, was still running its own
version:

```ts
const consent = await context.queryClient.query(getConsentStatusOptions({}));
if (!consent.completed) throw redirect({ to: "/consent", search: { returnTo: location.href } });
```

Two things follow from that. The query is uncaught, so a reader whose notice call fails is thrown
out of `beforeLoad` into the error boundary — even though the notice is not what they came for, and
the server withholds the gated calls by itself anyway. And the redirect carries no `mask`, so the
address bar leaves the page the reader was opening and reads `/consent`, which makes an interruption
look like a detour.

The route now calls `consentIsPending` and masks back to the page it interrupted, so there is one
consent gate rather than two spellings of it.

Part of the cleanup #1866 opened. That PR's "one repository link" bullet is dropped: #1851 owns the
`REPO_URL` constant and the organization migration, and lands it with its own test and its own home
module. Its `security.txt` canonical line belongs to that same migration and is dropped here too.

## How to test

```bash
vp run check
vp run test:webapp
```

`-consent-gate.test.tsx` now drives the generated route tree through MSW instead of spying on
`queryClient.query` and sniffing generated query keys: landing on `/w/acme/mentor/thread-1?message=hi`
with the notice outstanding leaves the router on `/consent` while the masked location is still that
deep link, and the same landing with `GET /user/consent` failing opens the page.

## Release impact

`.changeset/one-consent-gate.md`, patch, user voice. No operator action.

## Notes for reviewers

`AGENTS.md` § Hit every surface:

- **UI states** — no component changed; `ConsentDialog` keeps every branch and story it has.
- **Reverse states** — the gate is one-way by design: a notice cannot be un-answered, and the way
  out of the dialog is declining and signing out, which it already offers.
- **Both admin consoles / wire contract / schema / integrations / runtime roles / channels** — not
  applicable; no shared admin component, no DTO, no entity and no adapter is touched.
- **Docs by audience** — no user- or operator-facing statement changes: the notice is described
  where it already is, and the change is which URL the address bar shows while answering it.
- **Release note** — the changeset above.

No visual evidence: nothing renders differently. What changes is the URL the reader sees while the
dialog is open, and whether a failed notice call reaches the error boundary — both covered by the
route cases above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Unanswered transparency notices now redirect users to a consent page and return them to their originally requested page after completion.
  - The original page remains visible in the address bar during the consent flow.

- **Bug Fixes**
  - Pages remain usable when the transparency notice cannot be loaded, while access to gated content remains restricted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->