### PR TITLE
refactor(ci): promotion, smoke lock and image aliasing become tested scripts

### DIFF
--- a/.github/workflows/ci-compose-validate.yml
+++ b/.github/workflows/ci-compose-validate.yml
@@ -15,29 +15,20 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     env:
-      COMPOSE_ENV_FILES: .env,release-lock.env
+      COMPOSE_ENV_FILES: .env,smoke-lock.env
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: ./.github/actions/setup-toolchain
+        with:
+          install: "frozen"
 
       - name: Render the self-hosted stack
         working-directory: docker/self-host
         run: |
           set -euo pipefail
-          # Render what the install guide produces: the installer's generated secrets plus the
-          # values step 2 asks the operator for. Hand-filling the generated ones here would hide a
-          # required variable the installer forgets, which is how one reached a release smoke test.
-          ./setup.sh
-          sed -i \
-            -e 's|^APP_HOSTNAME=$|APP_HOSTNAME=hephaestus.example.com|' \
-            -e 's|^ACME_EMAIL=$|ACME_EMAIL=operator@example.com|' \
-            .env
-          while IFS= read -r image; do
-            name="HEPHAESTUS_IMAGE_${image^^}"
-            name=${name//-/_}
-            printf '%s=%s@sha256:%s\n' "$name" "example.invalid/${image}" "$(printf '0%.0s' {1..64})" >> release-lock.env
-          done < <(jq -r '.images[], .upstream[].name' ../../security/release-images.json)
-          printf 'IMAGE_TAG=0.0.0\nHEPHAESTUS_RELEASE=v0.0.0\nHEPHAESTUS_RELEASE_COMMIT=%s\n' \
-            "$(printf '0%.0s' {1..40})" >> release-lock.env
+          node ../../scripts/prepare-host-smoke-env.ts
+          node ../../scripts/prepare-smoke-lock.ts
           docker compose config > /dev/null
           echo "Rendered services:"
           docker compose config --services | sort
@@ -118,9 +109,6 @@ jobs:
             | jq -r '.services["reverse-proxy"].ports[].published' | sort -n | tr '\n' ' ')
           [ "$published" = "80 443 " ] || {
             echo "::error::reverse-proxy publishes '$published', expected '80 443 ' — !override was ignored"; exit 1; }
-      - uses: ./.github/actions/setup-toolchain
-        with:
-          install: "frozen"
 
       - name: Render the preview stack and assert it stays sandboxed
         run: vp run gate:preview-stack
@@ -138,13 +126,13 @@ jobs:
           # workflow supplies; this only proves each file renders, not that it is right for production.
           for stack in proxy core app; do
             docker compose -f "compose.${stack}.yaml" \
-              --env-file self-host/.env --env-file self-host/release-lock.env config --quiet
+              --env-file self-host/.env --env-file self-host/smoke-lock.env config --quiet
           done
           # No service names a serversTransport, because only the file provider can define one and
           # the app stack must render without the proxy stack. The backend timeouts therefore have
           # to reach default@internal from the edge's own static configuration, or they are absent.
           proxy=$(docker compose -f compose.proxy.yaml \
-            --env-file self-host/.env --env-file self-host/release-lock.env config)
+            --env-file self-host/.env --env-file self-host/smoke-lock.env config)
           for required in \
             'serversTransport.forwardingTimeouts.dialTimeout=10s' \
             'serversTransport.forwardingTimeouts.responseHeaderTimeout=30s'; do

--- a/.github/workflows/ci-docker-build.yml
+++ b/.github/workflows/ci-docker-build.yml
@@ -44,6 +44,11 @@ on:
         required: false
         type: string
         default: "true"
+      alias_base:
+        description: "The published commit an unchanged image is aliased from; empty when the caller builds every image"
+        required: false
+        type: string
+        default: ""
 
 permissions: {}
 
@@ -131,7 +136,10 @@ jobs:
         org.opencontainers.image.licenses=MIT
         hephaestus.component=postgres
 
-  # Preview stacks resolve every component by PR head SHA; alias verified base digests for unchanged components.
+  # Preview stacks resolve every component by PR head SHA; alias verified digests for the components
+  # this pull request left alone. They are aliased from the published commit `detect-changes`
+  # resolved, which is the pull request's base only when the default branch contains it —
+  # docs/contributor/ci-cd.mdx has the rule.
   tag-unchanged-images:
     name: "Tag unchanged images"
     if: >-
@@ -165,21 +173,26 @@ jobs:
           AGENT_IMAGES_CHANGED: ${{ inputs.agent_images_changed }}
           POSTGRES_IMAGE_CHANGED: ${{ inputs.postgres_image_changed }}
           PR_NUMBER: ${{ github.event.number }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          ALIAS_BASE: ${{ inputs.alias_base }}
           REPOSITORY: ${{ github.repository }}
           REPOSITORY_OWNER: ${{ github.repository_owner }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
 
+          [ -n "$ALIAS_BASE" ] || {
+            echo "::error::No published commit to alias from; the caller must build every image"; exit 1; }
+
           tag_image() {
             local image="ghcr.io/hephaestus-build/$1"
-            local source="$image:$BASE_SHA"
+            local source="$image:$ALIAS_BASE"
             local digest
             digest=$(docker buildx imagetools inspect --format '{{.Manifest.Digest}}' "$source" 2>/dev/null || true)
             if [[ ! "$digest" =~ ^sha256:[a-f0-9]{64}$ ]]; then
+              # The default branch's own push run may not have published yet; the pull request that
+              # merged the commit tagged the same images under its head.
               local merged_head
-              merged_head=$(gh api "repos/$REPOSITORY/commits/$BASE_SHA/pulls" \
+              merged_head=$(gh api "repos/$REPOSITORY/commits/$ALIAS_BASE/pulls" \
                 --jq '[.[] | select(.merged_at != null)][0].head.sha // empty')
               if [ -n "$merged_head" ]; then
                 source="$image:$merged_head"

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -56,9 +56,13 @@ jobs:
       # The vulnerability policy's match key includes the platform, so an arm64-only finding has to
       # be found before the release rather than by it, and only a manifest that exists can carry it.
       single-arch: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && steps.version_branch.outputs.version-branch != 'true' }}
+      # The commit an unchanged image is aliased from; scripts/resolve-alias-base.ts says how it is
+      # found and docs/contributor/ci-cd.mdx the rule.
+      alias-base: ${{ steps.alias_base.outputs.commit }}
       # Aliasing an unchanged image falls back to main's own push run, which has published nothing
-      # yet when the Version PR head is written, so that branch builds the whole set itself.
-      all-images: ${{ github.event_name != 'pull_request' || steps.version_branch.outputs.version-branch == 'true' }}
+      # yet when the Version PR head is written, so that branch builds the whole set itself; so does
+      # a pull request whose chain of bases reaches no published commit at all.
+      all-images: ${{ github.event_name != 'pull_request' || steps.version_branch.outputs.version-branch == 'true' || steps.alias_base.outputs.commit == '' }}
       # A skipped duplicate would skip the image builds the release evidence preflight needs, and
       # the gate refuses to pass the Version PR without one.
       should_skip: ${{ steps.skip_check.outputs.should_skip == 'true' && steps.version_branch.outputs.version-branch != 'true' }}
@@ -102,6 +106,20 @@ jobs:
           changed=false
           [ "$current" = "$previous" ] || changed=true
           echo "changed=$changed" >> "$GITHUB_OUTPUT"
+
+      - if: github.event_name == 'pull_request'
+        uses: ./.github/actions/setup-toolchain
+        with:
+          install: "none"
+
+      - name: Resolve the commit unchanged images are aliased from
+        id: alias_base
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: node scripts/resolve-alias-base.ts
 
       - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: filter
@@ -473,6 +491,7 @@ jobs:
       application_server_changed: ${{ (needs.detect-changes.outputs.application-server-image == 'true' || needs.detect-changes.outputs.supported-host-smoke == 'true' || needs.detect-changes.outputs.all-images == 'true') && 'true' || 'false' }}
       agent_images_changed: ${{ (needs.detect-changes.outputs.agent-images == 'true' || needs.detect-changes.outputs.docker-config == 'true' || needs.detect-changes.outputs.all-images == 'true') && 'true' || 'false' }}
       postgres_image_changed: ${{ (needs.detect-changes.outputs.postgres-image == 'true' || needs.detect-changes.outputs.docker-config == 'true' || needs.detect-changes.outputs.all-images == 'true') && 'true' || 'false' }}
+      alias_base: ${{ needs.detect-changes.outputs.alias-base }}
 
   Supported-host-smoke:
     name: "Supported-host boot smoke"

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -523,22 +523,8 @@ jobs:
           }
           trap cleanup EXIT
 
-          [[ "$APPLICATION_DIGEST" =~ ^sha256:[a-f0-9]{64}$ ]] || {
-            echo "::error::Build returned an invalid application image digest"; exit 1; }
           node ../../scripts/prepare-host-smoke-env.ts
-          placeholder="example.invalid/unused@sha256:$(printf '0%.0s' {1..64})"
-          {
-            printf 'IMAGE_TAG=%s\n' "$HEAD_SHA"
-            printf 'HEPHAESTUS_IMAGE_APPLICATION_SERVER=ghcr.io/hephaestus-build/application-server@%s\n' "$APPLICATION_DIGEST"
-            printf 'HEPHAESTUS_IMAGE_POSTGRES=ghcr.io/hephaestus-build/postgres:%s\n' "$HEAD_SHA"
-            for name in WEBAPP AGENT_PI NGINX TRAEFIK; do
-              printf 'HEPHAESTUS_IMAGE_%s=%s\n' "$name" "$placeholder"
-            done
-            jq -r '.upstream[] | select(.name == "alpine" or .name == "nats") |
-              "HEPHAESTUS_IMAGE_\(.name | ascii_upcase)=\(.repository)@\(.digest)"' \
-              ../../security/release-images.json
-          } > smoke-lock.env
-
+          node ../../scripts/prepare-smoke-lock.ts
           docker compose --env-file .env --env-file smoke-lock.env config --quiet
           docker compose --env-file .env --env-file smoke-lock.env up -d --wait \
             --wait-timeout 600 postgres nats-server application-server

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -106,81 +106,29 @@ jobs:
           sparse-checkout: security
           persist-credentials: false
 
-      - name: Resolve the release to promote
+      - name: Resolve the release to promote and write the channel
         id: release
         env:
           GH_TOKEN: ${{ github.token }}
-          REQUESTED: ${{ inputs.release }}
-          HOSTNAME: ${{ vars.APP_HOSTNAME }}
-          COMMIT: ${{ inputs.commit }}
-        run: |
-          set -euo pipefail
-          echo "environment_url=https://${HOSTNAME}" >> "$GITHUB_OUTPUT"
-
-          if [ -n "$COMMIT" ]; then
-            [ -z "$REQUESTED" ] || {
-              echo "::error::Name a release or a commit, not both"; exit 1; }
-            [[ "$COMMIT" =~ ^[0-9a-f]{40}$ ]] || {
-              echo "::error::Follow a full commit SHA, not '$COMMIT'"; exit 1; }
-            # Dispatch permission must not authorize commits outside main.
-            gh api "repos/$GITHUB_REPOSITORY/compare/$COMMIT...main" --jq .status |
-              grep -qE '^(identical|ahead)$' || {
-                echo "::error::$COMMIT is not on the default branch"; exit 1; }
-            echo "release=$COMMIT" >> "$GITHUB_OUTPUT"
-            echo "version=$COMMIT" >> "$GITHUB_OUTPUT"
-            echo "follows=commit" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          release="$REQUESTED"
-          [[ "$release" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]] || {
-            echo "::error::Promote an immutable vX.Y.Z release, not '$release'"; exit 1; }
-          # The host binds the tag's source tree to the signed release lock before applying it.
-          [ "$(gh release view "$release" --repo "$GITHUB_REPOSITORY" --json isDraft --jq .isDraft)" = false ] || {
-            echo "::error::$release is still a draft"; exit 1; }
-          echo "release=$release" >> "$GITHUB_OUTPUT"
-          echo "version=${release#v}" >> "$GITHUB_OUTPUT"
-          echo "follows=release" >> "$GITHUB_OUTPUT"
-
-      - name: Write and sign the channel
-        working-directory: deploy-state
-        env:
           CHANNEL: ${{ inputs.environment }}
-          RELEASE: ${{ steps.release.outputs.release }}
-          FOLLOWS: ${{ steps.release.outputs.follows }}
-          OWNER: ${{ github.repository_owner }}
-          GH_TOKEN: ${{ github.token }}
+          RELEASE: ${{ inputs.release }}
+          COMMIT: ${{ inputs.commit }}
           ALLOW_ROLLBACK: ${{ inputs.allow-rollback || false }}
           FREEZE: ${{ inputs.freeze || false }}
-        run: |
-          set -euo pipefail
-          channel=$(echo "$CHANNEL" | tr '[:upper:]' '[:lower:]')
-          mkdir -p channels
-          if [ "$FOLLOWS" = commit ]; then
-            # Commit deployments carry verified image digests in the signed channel.
-            node "$GITHUB_WORKSPACE/scripts/commit-image-lock.ts" \
-              "$RELEASE" "$OWNER" "$GITHUB_WORKSPACE/.promotion-inventory/security/release-images.json" \
-              > images.json
-            jq -n --arg commit "$RELEASE" --slurpfile images images.json \
-              --argjson allowRollback "$ALLOW_ROLLBACK" --argjson freeze "$FREEZE" \
-              '{commit: $commit, images: $images[0], allowRollback: $allowRollback, freeze: $freeze}' \
-              > "channels/${channel}.json"
-            rm -f images.json
-          else
-            jq -n --arg release "$RELEASE" --argjson allowRollback "$ALLOW_ROLLBACK" \
-              --argjson freeze "$FREEZE" \
-              '{release: $release, allowRollback: $allowRollback, freeze: $freeze}' \
-              > "channels/${channel}.json"
-          fi
-          cosign sign-blob --yes \
-            --bundle "channels/${channel}.json.sigstore.json" \
-            "channels/${channel}.json"
-          echo "CHANNEL_FILE=channels/${channel}.json" >> "$GITHUB_ENV"
+          HOSTNAME: ${{ vars.APP_HOSTNAME }}
+        run: node scripts/resolve-promotion.ts
+
+      - name: Sign the channel
+        working-directory: deploy-state
+        env:
+          CHANNEL_FILE: ${{ steps.release.outputs.channel }}
+        run: cosign sign-blob --yes --bundle "${CHANNEL_FILE}.sigstore.json" "$CHANNEL_FILE"
 
       - name: Publish the channel
         working-directory: deploy-state
         env:
           GH_TOKEN: ${{ github.token }}
+          CHANNEL_FILE: ${{ steps.release.outputs.channel }}
           RELEASE: ${{ steps.release.outputs.release }}
         run: |
           node ../scripts/commit-via-api.ts \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -527,24 +527,19 @@ jobs:
     permissions:
       contents: read
     steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: ./.github/actions/setup-toolchain
+        with:
+          install: "none"
+
       - name: Wait for staging to be running this commit
         env:
           GH_TOKEN: ${{ github.token }}
           COMMIT: ${{ needs.release.outputs.sha }}
-        run: |
-          set -euo pipefail
-          deadline=$(( SECONDS + 1500 ))
-          while [ "$SECONDS" -lt "$deadline" ]; do
-            channel=$(gh api "repos/$GITHUB_REPOSITORY/contents/channels/staging.json?ref=deploy-state" \
-              --jq '.content' 2>/dev/null | base64 -d 2>/dev/null || echo '{}')
-            [ "$(jq -r '.commit // empty' <<< "$channel")" = "$COMMIT" ] && {
-              echo "staging is on $COMMIT"; exit 0; }
-            [ "$(jq -r '.freeze // false' <<< "$channel")" = true ] && {
-              echo "::error::staging is frozen, so this release has not been rehearsed there"; exit 1; }
-            sleep 20
-          done
-          echo "::error::staging did not reach ${COMMIT} — production is not offered an unrehearsed release"
-          exit 1
+        run: node scripts/await-staging.ts
 
   deploy-production:
     needs: [release, awaiting-staging]

--- a/docs/contributor/ci-cd.mdx
+++ b/docs/contributor/ci-cd.mdx
@@ -389,6 +389,13 @@ the browser E2E suite and the application-server image download that artifact an
 from the same JAR. The unit, architecture and integration suites are the exception: they produce
 nothing that ships, so they compile from source in `Test` and do not wait for packaging.
 
+An image a pull request did not change is not rebuilt either: `Tag unchanged images` verifies the
+digest an earlier run published and re-tags it to this run's head SHA. It is aliased from the
+nearest commit the default branch contains, found by walking up the chain of bases — a layer of a
+stacked pull request is based on another branch's head, which published nothing — and a run that
+reaches no such commit builds every image itself. `detect-changes` resolves that commit once, with
+`scripts/resolve-alias-base.ts`, and hands it to the image jobs as `alias_base`.
+
 ## Parallelism and concurrency
 
 - `Quality` legs and `Test` suites start from source; `Build` gates start when `App Server: Package`

--- a/scripts/automatic-promotion.ts
+++ b/scripts/automatic-promotion.ts
@@ -1,9 +1,9 @@
-import { appendFile, readFile } from "node:fs/promises";
+import { appendFile } from "node:fs/promises";
 
 import { requiredEnv } from "./lib/env.ts";
-import { asRecord, asString, parseJson } from "./lib/json.ts";
-import { output } from "./lib/process.ts";
-import { parseChannel, type Channel } from "./reconcile-deployment.ts";
+import { compareStatus } from "./lib/github.ts";
+import { readJsonFile } from "./lib/json.ts";
+import { isCommit, parseChannel, type Channel } from "./reconcile-deployment.ts";
 
 /** Called under the promotion concurrency lock, against its freshly checked-out channel. */
 export async function automaticPromotion(
@@ -11,8 +11,7 @@ export async function automaticPromotion(
 	commit: string,
 	compare: (base: string, head: string) => Promise<string>,
 ): Promise<boolean> {
-	if (!/^[0-9a-f]{40}$/.test(commit))
-		throw new Error("automatic promotion requires a full commit SHA");
+	if (!isCommit(commit)) throw new Error("automatic promotion requires a full commit SHA");
 	if (channel.freeze) return false;
 	const status = await compare(channel.release, commit);
 	if (status === "ahead") return true;
@@ -25,17 +24,9 @@ if (import.meta.main) {
 	if (channel !== "Staging") throw new Error("automatic promotion is only supported for Staging");
 	const commit = requiredEnv(process.env, "COMMIT");
 	const repository = requiredEnv(process.env, "GITHUB_REPOSITORY");
-	const current = parseChannel(
-		parseJson(await readFile("deploy-state/channels/staging.json", "utf8")),
-	);
-	const apply = await automaticPromotion(current, commit, async (base, head) =>
-		asString(
-			asRecord(
-				parseJson(await output("gh", ["api", `repos/${repository}/compare/${base}...${head}`])),
-				"comparison",
-			).status,
-			"comparison status",
-		),
+	const current = parseChannel(await readJsonFile("deploy-state/channels/staging.json"));
+	const apply = await automaticPromotion(current, commit, (base, head) =>
+		compareStatus(repository, base, head),
 	);
 	console.log(
 		apply

--- a/scripts/await-staging.test.ts
+++ b/scripts/await-staging.test.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { awaitStaging } from "./await-staging.ts";
+
+const commit = "a".repeat(40);
+const images = { HEPHAESTUS_IMAGE_WEBAPP: `ghcr.io/o/webapp@sha256:${"1".repeat(64)}` };
+const channel = (fields: Record<string, unknown>): string =>
+	JSON.stringify({ commit, images, ...fields });
+const answers = (...replies: (string | Error)[]): (() => Promise<string>) => {
+	const queue = [...replies];
+	return () => {
+		const reply = queue.shift();
+		if (reply === undefined) throw new Error("staging was polled once too often");
+		return reply instanceof Error ? Promise.reject(reply) : Promise.resolve(reply);
+	};
+};
+const patient = new AbortController().signal;
+
+await test("returns once staging's channel names the commit", async () => {
+	await awaitStaging(commit, answers(channel({})), patient, 0);
+});
+
+await test("keeps polling while staging is on an older build or a release", async () => {
+	await awaitStaging(
+		commit,
+		answers(
+			channel({ commit: "b".repeat(40) }),
+			JSON.stringify({ release: "v1.2.3" }),
+			channel({}),
+		),
+		patient,
+		0,
+	);
+});
+
+await test("a channel the API could not serve is retried, not decided on", async () => {
+	await awaitStaging(commit, answers(new Error("HTTP 502"), channel({})), patient, 0);
+});
+
+await test("a frozen channel and an unreadable channel fail closed at once", async () => {
+	await assert.rejects(
+		awaitStaging(commit, answers(channel({ commit: "b".repeat(40), freeze: true })), patient, 0),
+		/frozen/,
+	);
+	await assert.rejects(awaitStaging(commit, answers("{"), patient, 0), SyntaxError);
+	await assert.rejects(
+		awaitStaging(commit, answers(JSON.stringify({ release: "main" })), patient, 0),
+		/immutable vX\.Y\.Z/,
+	);
+});
+
+await test("gives up at the deadline", async () => {
+	const older = channel({ commit: "b".repeat(40) });
+	await assert.rejects(
+		awaitStaging(commit, () => Promise.resolve(older), AbortSignal.timeout(30), 5),
+		/did not reach/,
+	);
+});

--- a/scripts/await-staging.ts
+++ b/scripts/await-staging.ts
@@ -1,0 +1,57 @@
+/**
+ * Waits until staging's channel names the commit a release was cut from, so production is never
+ * offered a release staging has not rehearsed. A channel that cannot be read is retried, because
+ * the API answered nothing to decide on; a channel that does not parse, or is frozen, fails at once.
+ */
+import { setTimeout as sleep } from "node:timers/promises";
+
+import { requiredEnv } from "./lib/env.ts";
+import { parseJson } from "./lib/json.ts";
+import { output } from "./lib/process.ts";
+import { parseChannel } from "./reconcile-deployment.ts";
+
+export async function awaitStaging(
+	commit: string,
+	readChannel: () => Promise<string>,
+	signal: AbortSignal,
+	pollMilliseconds = 20_000,
+): Promise<void> {
+	while (!signal.aborted) {
+		let contents: string | undefined;
+		try {
+			contents = await readChannel();
+		} catch (error) {
+			console.error(`staging's channel could not be read: ${String(error)}`);
+		}
+		if (contents !== undefined) {
+			const channel = parseChannel(parseJson(contents));
+			if (channel.release === commit) return;
+			if (channel.freeze)
+				throw new Error("staging is frozen, so this release has not been rehearsed there");
+		}
+		await sleep(pollMilliseconds, undefined, { signal }).catch(() => {});
+	}
+	throw new Error(
+		`staging did not reach ${commit} — production is not offered an unrehearsed release`,
+	);
+}
+
+if (import.meta.main) {
+	const commit = requiredEnv(process.env, "COMMIT");
+	const repository = requiredEnv(process.env, "GITHUB_REPOSITORY");
+	await awaitStaging(
+		commit,
+		async () =>
+			Buffer.from(
+				await output("gh", [
+					"api",
+					`repos/${repository}/contents/channels/staging.json?ref=deploy-state`,
+					"--jq",
+					".content",
+				]),
+				"base64",
+			).toString("utf8"),
+		AbortSignal.timeout(25 * 60 * 1000),
+	);
+	console.log(`staging is on ${commit}`);
+}

--- a/scripts/ci-contract.test.ts
+++ b/scripts/ci-contract.test.ts
@@ -13,6 +13,7 @@ import { versionBranch } from "./dispatch-version-pr-ci.ts";
 import { asArray, asRecord, asString, isRecord } from "./lib/json.ts";
 import { commandsOf, loadTasks } from "./lib/task-graph.ts";
 import { planRelease, releaseOutputs } from "./plan-release.ts";
+import { resolveAliasBase } from "./resolve-alias-base.ts";
 import { planSubjects } from "./scan-main-images.ts";
 import { PLATFORMS, planUpstreamSubjects } from "./scan-upstream-images.ts";
 import { validateManifest } from "./verify-release-evidence.ts";
@@ -591,6 +592,65 @@ void describe("CI contract", () => {
 			reusable,
 			/inputs\.single-arch.*linux\/amd64.*ubuntu-24\.04.*linux\/arm64.*ubuntu-24\.04-arm/,
 		);
+	});
+
+	void test("a pull request based on an unmerged branch still reaches a Docker verdict", async () => {
+		const orchestrator = parseDocument(await readFile(".github/workflows/cicd.yml", "utf8"));
+		const detect = ["jobs", "detect-changes"];
+		const resolve = namedStep(
+			orchestrator,
+			detect,
+			"Resolve the commit unchanged images are aliased from",
+		);
+		assert.equal(resolve.get("run"), "node scripts/resolve-alias-base.ts");
+		assert.match(
+			String(orchestrator.getIn([...detect, "outputs", "alias-base"])),
+			/^\$\{\{ steps\.alias_base\.outputs\.commit }}$/,
+		);
+
+		// A layer's base is the head of an open pull request, which published no image of its own. The
+		// walk ends on the commit the default branch contains, and that is what the tagging job aliases.
+		const published = "a".repeat(40);
+		assert.equal(
+			await resolveAliasBase("b".repeat(40), "main", {
+				compare: (base) => Promise.resolve(base === published ? "ahead" : "diverged"),
+				baseOf: () => Promise.resolve(published),
+			}),
+			published,
+		);
+
+		const docker = parseDocument(await readFile(".github/workflows/ci-docker-build.yml", "utf8"));
+		const tagging = ["jobs", "tag-unchanged-images"];
+		assert.match(
+			String(orchestrator.getIn(["jobs", "Docker", "with", "alias_base"])),
+			/^\$\{\{ needs\.detect-changes\.outputs\.alias-base }}$/,
+		);
+		const shell = runScript(docker, tagging, "Verify and tag unchanged images");
+		assert.match(shell, /\$ALIAS_BASE/);
+		assert.doesNotMatch(shell, /BASE_SHA/);
+
+		// A run that reaches no published commit builds every image rather than failing to alias one,
+		// which leaves this job nothing to do and the Docker verdict green either way.
+		assert.match(
+			String(orchestrator.getIn([...detect, "outputs", "all-images"])),
+			/steps\.alias_base\.outputs\.commit == ''/,
+		);
+		for (const image of [
+			"webapp_changed",
+			"application_server_changed",
+			"agent_images_changed",
+			"postgres_image_changed",
+		]) {
+			assert.match(
+				String(orchestrator.getIn(["jobs", "Docker", "with", image])),
+				/all-images == 'true'/,
+				`${image} must be built when the run has nothing to alias`,
+			);
+			assert.match(
+				String(docker.getIn([...tagging, "if"])),
+				new RegExp(`inputs\\.${image} != 'true'`),
+			);
+		}
 	});
 
 	void test("builds fork pull-request images without registry writes", async () => {
@@ -1173,12 +1233,15 @@ void describe("CI contract", () => {
 		// publishes every release image itself, under every event, exactly as its dispatch run did.
 		const complete = String(workflow.getIn([...detection, "outputs", "all-images"]));
 		const completeShape =
-			/^\$\{\{ github\.event_name != '(\w+)' \|\| steps\.version_branch\.outputs\.version-branch == 'true' }}$/.exec(
+			/^\$\{\{ github\.event_name != '(\w+)' \|\| steps\.version_branch\.outputs\.version-branch == 'true' \|\| steps\.alias_base\.outputs\.commit == '' }}$/.exec(
 				complete,
 			);
 		assert.ok(completeShape, `this test cannot evaluate \`${complete}\``);
-		const buildsEveryImage = (event: string, onVersionBranch: boolean): boolean =>
-			event !== completeShape[1] || onVersionBranch;
+		const buildsEveryImage = (
+			event: string,
+			onVersionBranch: boolean,
+			nothingToAlias = false,
+		): boolean => event !== completeShape[1] || onVersionBranch || nothingToAlias;
 		for (const event of events)
 			assert.ok(
 				buildsEveryImage(event, true),
@@ -1188,6 +1251,9 @@ void describe("CI contract", () => {
 			events.map((event) => buildsEveryImage(event, false)),
 			[false, true, true, true],
 		);
+		// The other run with nothing to alias: a pull request whose chain of bases reaches no
+		// published commit builds the whole set rather than failing to alias one.
+		assert.ok(buildsEveryImage("pull_request", false, true));
 
 		// One home for that decision too: an input that selects an image reads it, and no input
 		// re-tests the event on its own. `server_changed` is in the list because the buildpacks image

--- a/scripts/commit-image-lock.ts
+++ b/scripts/commit-image-lock.ts
@@ -1,8 +1,8 @@
 /** Resolve commit-tagged images and verify their build provenance before channel signing. */
-import { readFile } from "node:fs/promises";
-
-import { asArray, asRecord, asString, asStringArray, parseJson } from "./lib/json.ts";
-import { CAPTURE_LIMIT_BYTES } from "./lib/process.ts";
+import { requiredEnv } from "./lib/env.ts";
+import { asArray, asRecord, asString, asStringArray, readJsonFile } from "./lib/json.ts";
+import { output, run } from "./lib/process.ts";
+import { isCommit } from "./reconcile-deployment.ts";
 
 export interface ImageInventory {
 	readonly images: readonly string[];
@@ -13,8 +13,7 @@ export interface ImageInventory {
 	}[];
 }
 
-const COMMIT_SHA = /^[0-9a-f]{40}$/;
-const DIGEST = /^sha256:[0-9a-f]{64}$/;
+export const DIGEST = /^sha256:[0-9a-f]{64}$/;
 
 export function environmentKey(image: string): string {
 	return `HEPHAESTUS_IMAGE_${image.toUpperCase().replaceAll("-", "_")}`;
@@ -41,7 +40,7 @@ export async function resolveImages(
 	owner: string,
 	resolve: (repository: string, commit: string) => Promise<string>,
 ): Promise<Record<string, string>> {
-	if (!COMMIT_SHA.test(commit)) throw new Error(`expected a full commit, got ${commit}`);
+	if (!isCommit(commit)) throw new Error(`expected a full commit, got ${commit}`);
 	const images: Record<string, string> = {};
 	for (const entry of inventory.upstream)
 		images[environmentKey(entry.name)] = `${entry.repository}@${entry.digest}`;
@@ -55,28 +54,24 @@ export async function resolveImages(
 }
 
 export async function readInventory(path: string): Promise<ImageInventory> {
-	return parseInventory(parseJson(await readFile(path, "utf8")));
+	return parseInventory(await readJsonFile(path));
 }
 
-async function resolveAndVerify(repository: string, commit: string): Promise<string> {
-	const { execFileSync } = await import("node:child_process");
-	const ghRepository = process.env.GITHUB_REPOSITORY;
-	if (!ghRepository) throw new Error("GITHUB_REPOSITORY is required to verify build provenance");
+export async function resolveAndVerify(repository: string, commit: string): Promise<string> {
+	const ghRepository = requiredEnv(process.env, "GITHUB_REPOSITORY");
 
-	const digest = execFileSync(
-		"docker",
-		[
+	const digest = (
+		await output("docker", [
 			"buildx",
 			"imagetools",
 			"inspect",
 			`${repository}:${commit}`,
 			"--format",
 			"{{.Manifest.Digest}}",
-		],
-		{ encoding: "utf8", maxBuffer: CAPTURE_LIMIT_BYTES },
+		])
 	).trim();
 
-	execFileSync(
+	await run(
 		"gh",
 		[
 			"attestation",
@@ -93,17 +88,7 @@ async function resolveAndVerify(repository: string, commit: string): Promise<str
 			"--predicate-type",
 			"https://slsa.dev/provenance/v1",
 		],
-		{ stdio: ["ignore", "ignore", "inherit"], maxBuffer: CAPTURE_LIMIT_BYTES },
+		{ stdin: "ignore", stdout: "ignore" },
 	);
 	return digest;
-}
-
-if (import.meta.main) {
-	const [commit, owner = "hephaestus-build", inventoryPath = "security/release-images.json"] =
-		process.argv.slice(2);
-	if (!commit) throw new Error("usage: commit-image-lock <commit> [owner] [inventory]");
-	// The inventory belongs to the commit being promoted; this file may be newer than it.
-	const inventory = await readInventory(inventoryPath);
-	const images = await resolveImages(inventory, commit, owner, resolveAndVerify);
-	process.stdout.write(`${JSON.stringify(images, null, 2)}\n`);
 }

--- a/scripts/lib/github.ts
+++ b/scripts/lib/github.ts
@@ -1,0 +1,17 @@
+import { asRecord, asString, parseJson } from "./json.ts";
+import { output } from "./process.ts";
+
+/** Where `head` stands relative to `base` on GitHub: identical, ahead, behind or diverged. */
+export async function compareStatus(
+	repository: string,
+	base: string,
+	head: string,
+): Promise<string> {
+	return asString(
+		asRecord(
+			parseJson(await output("gh", ["api", `repos/${repository}/compare/${base}...${head}`])),
+			"comparison",
+		).status,
+		"comparison status",
+	);
+}

--- a/scripts/prepare-host-smoke-env.ts
+++ b/scripts/prepare-host-smoke-env.ts
@@ -11,7 +11,7 @@ import { join } from "node:path";
 
 import { run } from "./lib/process.ts";
 
-const SELF_HOST = join(import.meta.dirname, "..", "docker", "self-host");
+export const SELF_HOST = join(import.meta.dirname, "..", "docker", "self-host");
 
 /**
  * Traefik routes a boot by `Host(APP_HOSTNAME)`, so the release smoke's ingress check reaches the

--- a/scripts/prepare-smoke-lock.test.ts
+++ b/scripts/prepare-smoke-lock.test.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { readInventory, resolveImages } from "./commit-image-lock.ts";
+import { bootedBuild, smokeLockImages } from "./prepare-smoke-lock.ts";
+
+const inventory = await readInventory(
+	fileURLToPath(new URL("../security/release-images.json", import.meta.url)),
+);
+const commit = "c".repeat(40);
+const applicationDigest = `sha256:${"1".repeat(64)}`;
+
+await test("a render sets every image a commit deploy would pin, to a name no registry serves", async () => {
+	const rendered = smokeLockImages(inventory);
+	const pinned = await resolveImages(inventory, commit, "o", () =>
+		Promise.resolve(applicationDigest),
+	);
+	assert.deepEqual(Object.keys(rendered).toSorted(), Object.keys(pinned).toSorted());
+	for (const [name, reference] of Object.entries(rendered))
+		assert.match(reference, /^example\.invalid\/[a-z-]+@sha256:0{64}$/, name);
+});
+
+await test("a boot runs this run's own application server and database beside the upstream pins", () => {
+	const booted = smokeLockImages(inventory, { commit, applicationDigest });
+	assert.equal(
+		booted.HEPHAESTUS_IMAGE_APPLICATION_SERVER,
+		`ghcr.io/hephaestus-build/application-server@${applicationDigest}`,
+	);
+	assert.equal(booted.HEPHAESTUS_IMAGE_POSTGRES, `ghcr.io/hephaestus-build/postgres:${commit}`);
+	for (const upstream of inventory.upstream)
+		if (upstream.name === "alpine" || upstream.name === "nats")
+			assert.equal(
+				booted[`HEPHAESTUS_IMAGE_${upstream.name.toUpperCase()}`],
+				`${upstream.repository}@${upstream.digest}`,
+			);
+	// The edge and the webapp are rendered but never started, so nothing has to exist for them.
+	for (const name of ["WEBAPP", "AGENT_PI", "NGINX", "TRAEFIK"])
+		assert.match(String(booted[`HEPHAESTUS_IMAGE_${name}`]), /^example\.invalid\//);
+});
+
+await test("a booted build is named whole or not at all", () => {
+	assert.equal(bootedBuild({}), undefined);
+	assert.deepEqual(bootedBuild({ HEAD_SHA: commit, APPLICATION_DIGEST: applicationDigest }), {
+		commit,
+		applicationDigest,
+	});
+	assert.throws(() => bootedBuild({ HEAD_SHA: commit }), /together/);
+	assert.throws(() => bootedBuild({ APPLICATION_DIGEST: applicationDigest }), /together/);
+	assert.throws(
+		() => bootedBuild({ HEAD_SHA: "main", APPLICATION_DIGEST: applicationDigest }),
+		/full commit SHA/,
+	);
+	assert.throws(
+		() => bootedBuild({ HEAD_SHA: commit, APPLICATION_DIGEST: "latest" }),
+		/invalid application image digest/,
+	);
+});

--- a/scripts/prepare-smoke-lock.ts
+++ b/scripts/prepare-smoke-lock.ts
@@ -1,0 +1,67 @@
+/**
+ * Writes `docker/self-host/smoke-lock.env`, the image lock CI renders and boots the supported
+ * installation with before any release exists. Every image the inventory names is set, because the
+ * Compose files refuse to render without one, and every image that never runs is a placeholder no
+ * registry serves.
+ *
+ * A job that boots the installation names the build it boots through `HEAD_SHA` and
+ * `APPLICATION_DIGEST`: the application server and PostgreSQL then come from that run's own images
+ * and the broker and volume initialiser from the upstream pins. A job that only renders sets neither.
+ */
+import { writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { DIGEST, environmentKey, readInventory, type ImageInventory } from "./commit-image-lock.ts";
+import { SELF_HOST } from "./prepare-host-smoke-env.ts";
+import { commitLockEnvironment, isCommit } from "./reconcile-deployment.ts";
+
+export interface Build {
+	commit: string;
+	applicationDigest: string;
+}
+
+/** The upstream images a boot starts: the broker, and the initialiser the application server waits for. */
+const BOOTED_UPSTREAM = new Set(["alpine", "nats"]);
+
+const placeholder = (image: string): string => `example.invalid/${image}@sha256:${"0".repeat(64)}`;
+
+export function smokeLockImages(
+	inventory: ImageInventory,
+	build?: Build,
+): Readonly<Record<string, string>> {
+	const images: Record<string, string> = {};
+	for (const image of inventory.images) images[environmentKey(image)] = placeholder(image);
+	for (const upstream of inventory.upstream)
+		images[environmentKey(upstream.name)] =
+			build && BOOTED_UPSTREAM.has(upstream.name)
+				? `${upstream.repository}@${upstream.digest}`
+				: placeholder(upstream.name);
+	if (build) {
+		images[environmentKey("application-server")] =
+			`ghcr.io/hephaestus-build/application-server@${build.applicationDigest}`;
+		images[environmentKey("postgres")] = `ghcr.io/hephaestus-build/postgres:${build.commit}`;
+	}
+	return images;
+}
+
+export function bootedBuild(environment: NodeJS.ProcessEnv): Build | undefined {
+	const { HEAD_SHA: commit, APPLICATION_DIGEST: applicationDigest } = environment;
+	if (!commit && !applicationDigest) return undefined;
+	if (!commit || !applicationDigest)
+		throw new Error("HEAD_SHA and APPLICATION_DIGEST name the booted build together");
+	if (!isCommit(commit)) throw new Error(`HEAD_SHA must be a full commit SHA, not '${commit}'`);
+	if (!DIGEST.test(applicationDigest))
+		throw new Error("Build returned an invalid application image digest");
+	return { commit, applicationDigest };
+}
+
+if (import.meta.main) {
+	const build = bootedBuild(process.env);
+	const inventory = await readInventory(
+		join(import.meta.dirname, "..", "security", "release-images.json"),
+	);
+	await writeFile(
+		join(SELF_HOST, "smoke-lock.env"),
+		commitLockEnvironment(build?.commit ?? "0".repeat(40), smokeLockImages(inventory, build)),
+	);
+}

--- a/scripts/reconcile-deployment.test.ts
+++ b/scripts/reconcile-deployment.test.ts
@@ -6,6 +6,7 @@ import { join } from "node:path";
 import { test } from "node:test";
 
 import { environmentForGitFixture, GIT_REPOSITORY_VARIABLES } from "./lib/git-environment.ts";
+import { parseJson } from "./lib/json.ts";
 import {
 	adoptTooling,
 	appliedCommit,
@@ -19,6 +20,7 @@ import {
 	parseStacks,
 	readApplied,
 	renderMetrics,
+	serializeChannel,
 	syncUnits,
 	unlockedImages,
 } from "./reconcile-deployment.ts";
@@ -232,6 +234,16 @@ await test("a commit channel names a whole commit, so it cannot be an abbreviati
 
 await test("a channel names a release or a commit, never both", () => {
 	assert.throws(() => parseChannel({ release: "v1.2.3", commit, images }), /must name one/);
+});
+
+await test("the channel the promotion writes is the channel the host reads back", () => {
+	for (const channel of [
+		parseChannel({ release: "v1.2.3", freeze: true }),
+		parseChannel({ commit, images, allowRollback: true }),
+	])
+		assert.deepEqual(parseChannel(parseJson(serializeChannel(channel))), channel);
+	assert.match(serializeChannel({ release: commit, images }), /"commit": "c{40}"/);
+	assert.doesNotMatch(serializeChannel({ release: "v1.2.3" }), /images/);
 });
 
 await test("a commit is applied even though it cannot be ordered against a release", () => {

--- a/scripts/reconcile-deployment.ts
+++ b/scripts/reconcile-deployment.ts
@@ -11,7 +11,8 @@ import {
 } from "node:fs/promises";
 import { join } from "node:path";
 
-import { asRecord, asString, parseJson } from "./lib/json.ts";
+import { requiredEnv } from "./lib/env.ts";
+import { asRecord, asString, parseJson, readJsonFile } from "./lib/json.ts";
 import { output, run, succeeds } from "./lib/process.ts";
 
 export type Stack = "proxy" | "core" | "app";
@@ -64,15 +65,19 @@ export type Decision =
 	| { action: "noop"; reason: string }
 	| { action: "refuse"; reason: string };
 
-const RELEASE_TAG = /^v(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)$/;
+export const RELEASE_TAG = /^v(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)$/;
 const CHANNEL_NAME = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 const COMMIT_SHA = /^[0-9a-f]{40}$/;
 const IMAGE_KEY = /^HEPHAESTUS_IMAGE_[A-Z0-9_]+$/;
 const IMAGE_DIGEST = /^[^\s@]+@sha256:[0-9a-f]{64}$/;
 
+export function isCommit(value: string): boolean {
+	return COMMIT_SHA.test(value);
+}
+
 /** What a channel may ask a host to run: a published release, or a commit of the default branch. */
 export function isTarget(value: string): boolean {
-	return RELEASE_TAG.test(value) || COMMIT_SHA.test(value);
+	return RELEASE_TAG.test(value) || isCommit(value);
 }
 
 function optionalBoolean(value: unknown, label: string): boolean {
@@ -99,7 +104,7 @@ export function parseChannel(value: unknown): Channel {
 		if (record.release !== undefined)
 			throw new Error("channel names both a release and a commit; it must name one");
 		const commit = asString(record.commit, "channel.commit");
-		if (!COMMIT_SHA.test(commit))
+		if (!isCommit(commit))
 			throw new Error(`channel.commit must be a full 40-character commit, not ${commit}`);
 		return { release: commit, images: parseImages(record.images), allowRollback, freeze };
 	}
@@ -108,6 +113,15 @@ export function parseChannel(value: unknown): Channel {
 	if (!RELEASE_TAG.test(release))
 		throw new Error(`channel.release must be an immutable vX.Y.Z tag, not ${release}`);
 	return { release, allowRollback, freeze };
+}
+
+/** The channel file the promotion signs, in the shape `parseChannel` reads back. */
+export function serializeChannel(channel: Channel): string {
+	const { release, images, allowRollback = false, freeze = false } = channel;
+	const record = images
+		? { commit: release, images, allowRollback, freeze }
+		: { release, allowRollback, freeze };
+	return `${JSON.stringify(record, null, "\t")}\n`;
 }
 
 /**
@@ -252,7 +266,7 @@ export function lockedReleaseCommit(lockEnv: string): string {
 		.split("\n")
 		.filter((line) => line.startsWith("HEPHAESTUS_RELEASE_COMMIT="))
 		.map((line) => line.slice(line.indexOf("=") + 1));
-	if (values.length !== 1 || !/^[a-f0-9]{40}$/.test(values[0] ?? ""))
+	if (values.length !== 1 || !isCommit(values[0] ?? ""))
 		throw new Error("release lock must contain one source commit");
 	return values[0] ?? "";
 }
@@ -283,12 +297,7 @@ interface HostConfig {
 }
 
 function hostConfig(environment: NodeJS.ProcessEnv): HostConfig {
-	const required = (name: string): string => {
-		const value = environment[name];
-		if (!value) throw new Error(`${name} must be set`);
-		return value;
-	};
-	const channel = required("HEPHAESTUS_CHANNEL");
+	const channel = requiredEnv(environment, "HEPHAESTUS_CHANNEL");
 	if (!CHANNEL_NAME.test(channel))
 		throw new Error("HEPHAESTUS_CHANNEL must contain lowercase letters, digits, and hyphens");
 	const stateDirectory = environment.STATE_DIRECTORY ?? "/var/lib/hephaestus";
@@ -304,13 +313,13 @@ function hostConfig(environment: NodeJS.ProcessEnv): HostConfig {
 		secretsDirectory: environment.HEPHAESTUS_SECRETS ?? "/etc/hephaestus",
 		metricsFile: environment.HEPHAESTUS_METRICS_FILE,
 		waitTimeoutSeconds,
-		promoteIdentity: required("HEPHAESTUS_PROMOTE_IDENTITY"),
+		promoteIdentity: requiredEnv(environment, "HEPHAESTUS_PROMOTE_IDENTITY"),
 	};
 }
 
 export async function readApplied(file: string): Promise<AppliedState | undefined> {
 	try {
-		const record = asRecord(parseJson(await readFile(file, "utf8")), "applied state");
+		const record = asRecord(await readJsonFile(file), "applied state");
 		const applied = {
 			release: asString(record.release, "applied.release"),
 			channelCommit: asString(record.channelCommit, "applied.channelCommit"),
@@ -319,7 +328,7 @@ export async function readApplied(file: string): Promise<AppliedState | undefine
 		};
 		if (!isTarget(applied.release))
 			throw new Error("applied.release must be a vX.Y.Z tag or a commit");
-		if (!/^[a-f0-9]{40}$/.test(applied.channelCommit))
+		if (!isCommit(applied.channelCommit))
 			throw new Error("applied.channelCommit must be a Git commit");
 		if (applied.commit !== undefined && !COMMIT_SHA.test(applied.commit))
 			throw new Error("applied.commit must be a Git commit");
@@ -330,8 +339,7 @@ export async function readApplied(file: string): Promise<AppliedState | undefine
 			throw new Error("applied.appliedAt must be an ISO timestamp");
 		return applied;
 	} catch (error) {
-		if (typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT")
-			return undefined;
+		if (error instanceof Error && "code" in error && error.code === "ENOENT") return undefined;
 		throw error;
 	}
 }

--- a/scripts/release-deployment-policy.test.ts
+++ b/scripts/release-deployment-policy.test.ts
@@ -11,6 +11,7 @@ import { parseStacks } from "./reconcile-deployment.ts";
 const release = readFileSync(".github/workflows/release.yml", "utf8");
 const deployment = readFileSync(".github/workflows/deploy-locked-compose.yml", "utf8");
 const promotion = readFileSync(".github/workflows/promote.yml", "utf8");
+const resolver = readFileSync("scripts/resolve-promotion.ts", "utf8");
 const reconciler = readFileSync("scripts/reconcile-deployment.ts", "utf8");
 const upgradeDrill = readFileSync("scripts/release-upgrade-test.ts", "utf8");
 
@@ -130,10 +131,21 @@ await test("verification identity is the release's own: run context now, the map
 	);
 });
 
-await test("promotion refuses a draft but reaches any published release, and the host verifies", () => {
-	assert.match(promotion, /--json isDraft --jq \.isDraft/);
+await test("every promotion decision is taken by the script that owns it", () => {
+	// Each decision below is proven by its own spec; what no spec can see is the workflow that
+	// stops calling it, or a step reading a channel file the resolver did not write.
+	assert.match(promotion, /^ +run: node scripts\/resolve-promotion\.ts$/m);
+	for (const consumer of ["Sign the channel", "Publish the channel"])
+		assert.match(
+			promotion,
+			new RegExp(
+				`name: ${consumer}\\n(?: +.*\\n)*? +CHANNEL_FILE: \\$\\{\\{ steps\\.release\\.outputs\\.channel \\}\\}`,
+			),
+			`${consumer} must sign and publish the file the resolver wrote`,
+		);
+	assert.match(release, /^ +run: node scripts\/await-staging\.ts$/m);
 	// Rollback must support releases predating immutable tags; the signed lock binds their digests.
-	assert.doesNotMatch(promotion, /isImmutable/);
+	assert.doesNotMatch(resolver, /isImmutable/);
 	// The verifier is the tooling this tick runs — resolved from the running script, which Node pins
 	// to the tree it loaded — never the release under review.
 	assert.match(reconciler, /join\(import\.meta\.dirname, "prepare-release-lock\.ts"\)/);

--- a/scripts/resolve-alias-base.test.ts
+++ b/scripts/resolve-alias-base.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { resolveAliasBase, type BaseChain } from "./resolve-alias-base.ts";
+
+const sha = (letter: string): string => letter.repeat(40);
+const main = sha("a");
+const layers = { [sha("c")]: sha("b"), [sha("b")]: main };
+const never = (what: string) => (): Promise<never> =>
+	Promise.reject(new Error(`${what} must not be consulted`));
+
+const chain = (
+	bases: Readonly<Record<string, string>>,
+	published: readonly string[],
+): BaseChain => ({
+	compare: (base) => Promise.resolve(published.includes(base) ? "ahead" : "diverged"),
+	baseOf: (commit) => Promise.resolve(bases[commit]),
+});
+
+await test("a pull request based on the default branch aliases from its own base", async () => {
+	assert.equal(
+		await resolveAliasBase(main, "main", {
+			compare: () => Promise.resolve("identical"),
+			baseOf: never("the base chain"),
+		}),
+		main,
+	);
+});
+
+await test("a layer of a stack aliases from the nearest commit the default branch contains", async () => {
+	assert.equal(await resolveAliasBase(sha("c"), "main", chain(layers, [main])), main);
+	assert.equal(await resolveAliasBase(sha("b"), "main", chain(layers, [main])), main);
+});
+
+await test("a layer stops at the first published base, not at the default branch", async () => {
+	assert.equal(await resolveAliasBase(sha("c"), "main", chain(layers, [sha("b"), main])), sha("b"));
+});
+
+await test("a chain that reaches nothing published leaves the run every image to build", async () => {
+	assert.equal(await resolveAliasBase(sha("c"), "main", chain(layers, [])), undefined);
+	assert.equal(
+		await resolveAliasBase(sha("c"), "main", chain({ [sha("c")]: sha("c") }, [])),
+		undefined,
+	);
+});

--- a/scripts/resolve-alias-base.ts
+++ b/scripts/resolve-alias-base.ts
@@ -1,0 +1,66 @@
+/**
+ * The commit whose published images a pull request aliases for every component its diff left alone.
+ *
+ * A pull request based on the default branch aliases from its own base, whose images that branch's
+ * own run published. A layer of a stacked pull request is based on another branch's head, which
+ * published nothing and belongs to no merged pull request, so the chain of bases is walked until a
+ * commit the default branch contains. A run that reaches none has nothing to alias and builds every
+ * image itself.
+ */
+import { appendFile } from "node:fs/promises";
+
+import { requiredEnv } from "./lib/env.ts";
+import { compareStatus } from "./lib/github.ts";
+import { asArray, asRecord, asString, parseJson } from "./lib/json.ts";
+import { output } from "./lib/process.ts";
+
+export interface BaseChain {
+	/** Where `head` stands relative to `base`, as GitHub's compare API reports it. */
+	compare: (base: string, head: string) => Promise<string>;
+	/** The base of the open pull request whose head is `commit`, when a pull request has that head. */
+	baseOf: (commit: string) => Promise<string | undefined>;
+}
+
+/** A stack deeper than this, or a chain of bases that loops, is given up on rather than followed. */
+const LAYER_LIMIT = 10;
+
+export async function resolveAliasBase(
+	base: string,
+	defaultBranch: string,
+	chain: BaseChain,
+): Promise<string | undefined> {
+	let commit: string | undefined = base;
+	for (let layer = 0; commit !== undefined && layer < LAYER_LIMIT; layer += 1) {
+		const status = await chain.compare(commit, defaultBranch);
+		if (status === "identical" || status === "ahead") return commit;
+		commit = await chain.baseOf(commit);
+	}
+	return undefined;
+}
+
+if (import.meta.main) {
+	const repository = requiredEnv(process.env, "GITHUB_REPOSITORY");
+	const commit = await resolveAliasBase(
+		requiredEnv(process.env, "BASE_SHA"),
+		requiredEnv(process.env, "DEFAULT_BRANCH"),
+		{
+			compare: (base, head) => compareStatus(repository, base, head),
+			// A commit the default branch does not contain answers with the open pull requests whose
+			// branches carry it; only the one it is the head of names the next base up.
+			baseOf: async (head) => {
+				const pulls = asArray(
+					parseJson(await output("gh", ["api", `repos/${repository}/commits/${head}/pulls`])),
+					"pull requests",
+				);
+				for (const [index, value] of pulls.entries()) {
+					const pull = asRecord(value, `pull requests[${index}]`);
+					const sha = asString(asRecord(pull.head, "pull request head").sha, "head.sha");
+					if (sha === head)
+						return asString(asRecord(pull.base, "pull request base").sha, "base.sha");
+				}
+				return undefined;
+			},
+		},
+	);
+	await appendFile(requiredEnv(process.env, "GITHUB_OUTPUT"), `commit=${commit ?? ""}\n`);
+}

--- a/scripts/resolve-promotion.test.ts
+++ b/scripts/resolve-promotion.test.ts
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { resolvePromotion, type PromotionSources } from "./resolve-promotion.ts";
+
+const commit = "a".repeat(40);
+const images = { HEPHAESTUS_IMAGE_WEBAPP: `ghcr.io/o/webapp@sha256:${"1".repeat(64)}` };
+const request = { allowRollback: false, freeze: false };
+const never = (what: string) => (): Promise<never> =>
+	Promise.reject(new Error(`${what} must not be consulted`));
+const sources: PromotionSources = {
+	compare: never("history"),
+	isDraft: never("the release"),
+	images: never("the registry"),
+};
+
+await test("a published release is promoted by tag and reported by version", async () => {
+	assert.deepEqual(
+		await resolvePromotion(
+			{ ...request, release: "v1.2.3", freeze: true },
+			{ ...sources, isDraft: () => Promise.resolve(false) },
+		),
+		{ channel: { release: "v1.2.3", allowRollback: false, freeze: true }, version: "1.2.3" },
+	);
+});
+
+await test("a draft or a mutable reference is never promoted", async () => {
+	await assert.rejects(
+		resolvePromotion(
+			{ ...request, release: "v1.2.3" },
+			{ ...sources, isDraft: () => Promise.resolve(true) },
+		),
+		/still a draft/,
+	);
+	for (const release of ["main", "v1.2", "v01.2.3", "v1.2.3-rc.1"])
+		await assert.rejects(resolvePromotion({ ...request, release }, sources), /immutable vX\.Y\.Z/);
+});
+
+await test("a commit of the default branch is promoted with the digests its build produced", async () => {
+	for (const status of ["identical", "ahead"]) {
+		const compared: string[] = [];
+		assert.deepEqual(
+			await resolvePromotion(
+				{ ...request, commit, allowRollback: true },
+				{
+					...sources,
+					compare: (base, head) => {
+						compared.push(`${base}...${head}`);
+						return Promise.resolve(status);
+					},
+					images: (at) => Promise.resolve(at === commit ? images : {}),
+				},
+			),
+			{ channel: { release: commit, images, allowRollback: true, freeze: false }, version: commit },
+		);
+		assert.deepEqual(compared, [`${commit}...main`]);
+	}
+});
+
+await test("a commit outside the default branch is refused before any image is resolved", async () => {
+	for (const status of ["behind", "diverged", "unexpected"])
+		await assert.rejects(
+			resolvePromotion(
+				{ ...request, commit },
+				{ ...sources, compare: () => Promise.resolve(status) },
+			),
+			/not on the default branch/,
+		);
+	await assert.rejects(
+		resolvePromotion(
+			{ ...request, commit },
+			{ ...sources, compare: () => Promise.reject(new Error("unavailable")) },
+		),
+		/unavailable/,
+	);
+});
+
+await test("a promotion names exactly one target, and a commit is named whole", async () => {
+	await assert.rejects(
+		resolvePromotion({ ...request, release: "v1.2.3", commit }, sources),
+		/not both/,
+	);
+	await assert.rejects(resolvePromotion(request, sources), /Name a release or a commit/);
+	for (const short of [commit.slice(0, 7), "main"])
+		await assert.rejects(
+			resolvePromotion({ ...request, commit: short }, sources),
+			/full commit SHA/,
+		);
+});

--- a/scripts/resolve-promotion.ts
+++ b/scripts/resolve-promotion.ts
@@ -1,0 +1,109 @@
+/**
+ * Resolves what a manual promotion moves an environment to and writes the channel that
+ * `promote.yml` signs and publishes: a published release by tag, or a commit of the default branch
+ * with the digests its build produced.
+ */
+import { appendFile, mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { readInventory, resolveAndVerify, resolveImages } from "./commit-image-lock.ts";
+import { requiredEnv } from "./lib/env.ts";
+import { compareStatus } from "./lib/github.ts";
+import { output } from "./lib/process.ts";
+import { isCommit, RELEASE_TAG, serializeChannel, type Channel } from "./reconcile-deployment.ts";
+
+export interface PromotionRequest {
+	release?: string;
+	commit?: string;
+	allowRollback: boolean;
+	freeze: boolean;
+}
+
+export interface PromotionSources {
+	/** Where `head` stands relative to `base`, as GitHub's compare API reports it. */
+	compare: (base: string, head: string) => Promise<string>;
+	isDraft: (release: string) => Promise<boolean>;
+	/** The digests a commit's build produced, verified against that commit's provenance. */
+	images: (commit: string) => Promise<Record<string, string>>;
+}
+
+export interface Promotion {
+	channel: Channel;
+	/** What the environment reports once it runs the channel: the version, or the commit. */
+	version: string;
+}
+
+export async function resolvePromotion(
+	request: PromotionRequest,
+	sources: PromotionSources,
+): Promise<Promotion> {
+	const { release, commit, allowRollback, freeze } = request;
+	if (commit !== undefined) {
+		if (release !== undefined) throw new Error("Name a release or a commit, not both");
+		if (!isCommit(commit)) throw new Error(`Follow a full commit SHA, not '${commit}'`);
+		// Dispatch permission must not authorize commits outside main.
+		const status = await sources.compare(commit, "main");
+		if (status !== "identical" && status !== "ahead")
+			throw new Error(`${commit} is not on the default branch`);
+		const images = await sources.images(commit);
+		return { channel: { release: commit, images, allowRollback, freeze }, version: commit };
+	}
+	if (release === undefined) throw new Error("Name a release or a commit");
+	if (!RELEASE_TAG.test(release))
+		throw new Error(`Promote an immutable vX.Y.Z release, not '${release}'`);
+	// The host binds the tag's source tree to the signed release lock before applying it.
+	if (await sources.isDraft(release)) throw new Error(`${release} is still a draft`);
+	return { channel: { release, allowRollback, freeze }, version: release.slice(1) };
+}
+
+if (import.meta.main) {
+	const repository = requiredEnv(process.env, "GITHUB_REPOSITORY");
+	const owner = repository.slice(0, repository.indexOf("/"));
+	const environment = requiredEnv(process.env, "CHANNEL");
+	const hostname = requiredEnv(process.env, "HOSTNAME");
+	const optional = (name: string): string | undefined => {
+		const value = process.env[name];
+		// A dispatch input left blank arrives as an empty string.
+		return value === "" ? undefined : value;
+	};
+	const { channel, version } = await resolvePromotion(
+		{
+			release: optional("RELEASE"),
+			commit: optional("COMMIT"),
+			allowRollback: process.env.ALLOW_ROLLBACK === "true",
+			freeze: process.env.FREEZE === "true",
+		},
+		{
+			compare: (base, head) => compareStatus(repository, base, head),
+			isDraft: async (release) =>
+				(
+					await output("gh", [
+						"release",
+						"view",
+						release,
+						"--repo",
+						repository,
+						"--json",
+						"isDraft",
+						"--jq",
+						".isDraft",
+					])
+				).trim() !== "false",
+			// The inventory belongs to the commit being promoted; this checkout's may be newer than it.
+			images: async (commit) =>
+				resolveImages(
+					await readInventory(".promotion-inventory/security/release-images.json"),
+					commit,
+					owner,
+					resolveAndVerify,
+				),
+		},
+	);
+	const file = `channels/${environment.toLowerCase()}.json`;
+	await mkdir(join("deploy-state", "channels"), { recursive: true });
+	await writeFile(join("deploy-state", file), serializeChannel(channel));
+	await appendFile(
+		requiredEnv(process.env, "GITHUB_OUTPUT"),
+		`environment_url=https://${hostname}\nchannel=${file}\nrelease=${channel.release}\nversion=${version}\n`,
+	);
+}


### PR DESCRIPTION
## What changed and why

Four decisions lived in workflow bash, where nothing can test them. `promote.yml` resolved what a
promotion moves an environment to and hand-built the channel JSON with `jq`; `cicd.yml` and
`ci-compose-validate.yml` each spelled the smoke image lock out again; `release.yml` polled staging
with a `|| echo '{}'` that read an unreadable channel and a malformed one as the same thing. Each is
now a script with a spec, and the shared helpers they had each re-implemented — required environment,
JSON reading, subprocess capture, the compare API, a full-commit check — come from one place. The
channel a promotion writes gains `serializeChannel` beside the `parseChannel` that reads it back, so
its shape has one home rather than a `jq -n` template and a validator that could drift apart.

The fourth decision is #1870. `Tag unchanged images` re-tags the digest an earlier run published for
every component a pull request did not change, and it looked that image up under the literal base
SHA. A layer of a stacked pull request is based on another branch's head, which published no image
and belongs to no merged pull request, so the alias found nothing and a required check failed for a
reason the diff had no part in. `detect-changes` now resolves the alias source once, by walking the
chain of bases until a commit the default branch contains, and hands it to the image jobs as
`alias_base`; a run that reaches no published commit has nothing to alias and builds every image
itself, through the `all-images` decision that already exists for the Version PR's branch.

Fixes #1870

## How to test

- `vp run check` — green, including `gate:contracts`, `gate:runner-contract` and `gate:tooling`.
- `node --test scripts/resolve-promotion.test.ts scripts/prepare-smoke-lock.test.ts scripts/await-staging.test.ts scripts/resolve-alias-base.test.ts` — 17 assertions over draft refusal, commits off the default branch, both promotion targets, the render/boot image split, fail-open on an unreadable channel and fail-closed on a frozen one, and the base-chain walk.
- `node --test scripts/ci-contract.test.ts scripts/release-deployment-policy.test.ts` — the workflow wiring: `promote.yml` runs the resolver, the sign and publish steps read the file it wrote, `release.yml` runs the staging wait, and a pull request based on an unmerged branch still reaches a Docker verdict.
- `actionlint` with `SHELLCHECK_OPTS=--severity=warning` and `zizmor --min-confidence medium` over `.github/` — both clean.
- The promotion, smoke-boot and staging-wait paths run only on GitHub; they were not exercised locally.

## Release impact

No changeset. Nothing under `server/`, `webapp/` or `docker/` changes: this is CI and repository
tooling only. `scripts/reconcile-deployment.ts` ships to hosts, and its edits are behaviour-neutral —
`requiredEnv`/`readJsonFile` swaps, an `isCommit` extraction, and a new `serializeChannel` that only
the promotion path calls.

## Notes for reviewers

- **Landing order.** `.github/workflows/**` is one lane. #1873 also writes `cicd.yml`; it conflicts
  with `main` today and has to rebase regardless, so this can land first and #1873 rebases, or the
  reverse. #1847 and #1851 write workflows this PR does not touch.
- This carries the `scripts/` half of the closed #1867. Its ADR 0042 restructure, the
  `deploy-staging.yml` deletion, the `vite.config.ts` and `check-toolchain.ts` helper sweep and the
  staging/production docs rewrite are not here; #1867's closing comment lists them.
- `resolve-promotion.test.ts` injects a source that rejects when consulted, so
  "a commit outside the default branch is refused before any image is resolved" fails if the
  registry call is ever hoisted above the compare.
- The walk stops at the first commit the default branch contains, so an ordinary pull request costs
  one compare call and a stack costs one per layer.
