### PR TITLE
docs: the instruction files state each fact once and match the code

### DIFF
--- a/.agents/skills/land-pr/SKILL.md
+++ b/.agents/skills/land-pr/SKILL.md
@@ -42,7 +42,8 @@ vp run format
 vp run check
 ```
 
-`check` is the complete local quality gate: every gate in the `quality` group in `vite.config.ts`.config.ts`, and every one also runs in CI. CI additionally runs service tests, builds, images,
+`check` is the complete local quality gate: every gate in the `quality` group in `vite.config.ts`,
+and every one also runs in CI. CI additionally runs service tests, builds, images,
 security checks, and workflow-specific gates. Formatting must never be the reason a remote build
 fails.
 

--- a/.claude/skills/land-pr/SKILL.md
+++ b/.claude/skills/land-pr/SKILL.md
@@ -42,7 +42,8 @@ vp run format
 vp run check
 ```
 
-`check` is the complete local quality gate: every gate in the `quality` group in `vite.config.ts`.config.ts`, and every one also runs in CI. CI additionally runs service tests, builds, images,
+`check` is the complete local quality gate: every gate in the `quality` group in `vite.config.ts`,
+and every one also runs in CI. CI additionally runs service tests, builds, images,
 security checks, and workflow-specific gates. Formatting must never be the reason a remote build
 fails.
 

--- a/.claude/skills/storybook-components/RUBRIC.md
+++ b/.claude/skills/storybook-components/RUBRIC.md
@@ -182,7 +182,7 @@ propose work here.
 Nearly every file carries `tags: ["autodocs"]`, so a JSDoc block above `meta` or above an exported story
 **is** the component's documentation page.
 
-- **D** — Prose restating the story's name (`/** Moving an area's worth in one action */` above `BulkSet`),
+- **D** — Prose restating the story's name (`/** Moving a group's worth in one action */` above `BulkSet`),
   or explaining how the assertion reaches the DOM — that belongs in a `//` inside the play function.
 - **C** — Accurate description of what the story shows.
 - **B** — Records something the reader cannot derive from the code below it: a rejected alternative, a trap,

--- a/.claude/skills/storybook-components/rules/story-titles.md
+++ b/.claude/skills/storybook-components/rules/story-titles.md
@@ -23,7 +23,7 @@ Two conventions live side by side, and which one applies is a property of the co
   `Instance admin/…` for the `isAppAdmin`-guarded `webapp/src/routes/_authenticated/admin.*`. Never a
   bare `Admin/…` — the reader cannot tell which console it is. A presentational component **both**
   consoles render belongs to neither: file it under `Shared/…`, as
-  `Shared/Practice catalog/Area visual picker` does.
+  `Shared/Practice catalog/Group visual picker` does.
 
 - **A leaf and a folder must not share a name.** If `Foo` gains children, the leaf becomes `Foo/Overview`.
 

--- a/.claude/skills/storybook-components/traps.md
+++ b/.claude/skills/storybook-components/traps.md
@@ -18,37 +18,22 @@ animation routinely. Any settle helper must `.catch()` the rejection and treat i
 
 ## 3. A hook suppression aimed at the `useEffect` line suppresses nothing
 
-`react/set-state-in-effect` reports on the **`setState` call inside the effect body**, not on the
-`useEffect` line. So the obvious placement — a `disable-next-line` above the effect — points at the
-`useEffect`: the diagnostic still fires, and the directive is additionally reported as
-`Unused oxlint-disable directive` because `options.reportUnusedDisableDirectives` is `error` in the
-repo-root `.oxlintrc.json`. The build fails complaining about the directive while the diagnostic you
-meant to silence is still there. Put the directive above the reported line, or fix the effect.
-
-One `setState` in an effect usually trips **two** rules at once — `react/set-state-in-effect` and
-`react/no-deriving-state-in-effects` — so a directive naming one leaves the other reporting on the
-same line and looks like the suppression failed. Name both, or fix the effect.
-
-Naming `react/rules-of-hooks` instead is the dangerous spelling: oxlint routes the hook rules through
-that one name, so a directive naming it **anywhere in a component body** silences every hook
-diagnostic in that component, whichever line it sits above. A sibling component in the same file keeps
-reporting, so the file does not look disabled. The directive is itself reported unused, so the build
-fails — but it fails about the directive, and the diagnostics it swallowed are simply gone.
+`webapp/AGENTS.md` § Linting owns this: the two effect rules report on the `setState` line inside the
+effect, one `setState` usually trips both, and a directive naming `react/rules-of-hooks` silences
+every hook diagnostic in the component while the build fails about the directive instead.
 
 ## 4. One story's MSW handlers answer for the whole Docs page
 
-Autodocs mounts every story of a file into **one** document, and `msw-storybook-addon` installs on a
-single global worker — so the last story's handlers serve every story on that page. One error story
-silently breaks its siblings' Docs page while every isolated story, and therefore every test and every
-snapshot, stays green; the symptom is a Docs page that renders every sibling as the error state. A
-story file installs no handlers at all, and `scripts/check-presentational-components.ts` enforces it.
+`webapp/AGENTS.md` § Container/presentation split owns this: a story file installs no handlers at
+all, and `scripts/check-presentational-components.ts` enforces it. The symptom is a Docs page that
+renders every sibling as the error state while every isolated story stays green.
 
-## 5. `test:storybook` does not run the README-export check — CI does, right after
+## 5. `test:storybook` does not run the brand-asset check — CI does, right after
 
-`.github/workflows/ci-quality-gates.yml` runs the webapp package's `export:assets` immediately after
-`test:storybook`, and fails the job if `docs/images/readme` is dirty afterwards. So the storybook job can go red
-having printed a clean pass line. If a change moves or renames a story that exports a README asset,
-run `vp run --filter webapp export:assets` and commit the result.
+The `Webapp: Stories` job runs the webapp package's `export:assets` immediately after
+`test:storybook` and fails if any exported asset is dirty afterwards, so the job can go red having
+printed a clean pass line. If a change moves or renames a story that exports an asset, run
+`vp run --filter webapp export:assets` and commit the result; `/fix-ci` lists the paths.
 
 ## 6. A hand-rolled stateful wrapper swallows the spy in `meta.args`
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,9 +155,8 @@ for byte and `gate:instructions` fails when a half drifts. Copy a skill nowhere 
 - Test observable behaviour. A story proves what a component renders from its props and installs
   no network; a route test owns the wire contract. Do not assert callback wiring or mirror the
   implementation.
-- Backend behaviour changes ship with focused tests in the right tier (`server/AGENTS.md` § Test
-  tiers). Integration tests share a database with earlier tests: assert on the row you created,
-  never on a count.
+- Backend behaviour changes ship with focused tests in the right tier, asserting on the rows they
+  created (`server/AGENTS.md` § Test tiers).
 - Before pushing, `vp run format` then `vp run check`; the pre-push hook runs `check` again.
   `vp run verify` adds the credential-free builds and suites before review. CI owns images,
   browser and live-service suites — `docs/contributor/local-verification.mdx`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ To ensure a transparent and trustworthy environment, we have established differe
 
 ### Signed Commits
 
-A commit pushed to a branch in this repository is signed, and its commit email is an address verified on your GitHub account; a push carrying an unsigned commit is refused. A pull request from a fork needs none of this — the commit that lands on `main` is created and signed by GitHub.
+A commit pushed to a branch in this repository is signed, and its commit email resolves to the GitHub account that opened the pull request, so set `git config user.email` to an address verified on your account before you commit; a push carrying an unsigned commit is refused. A pull request from a fork needs none of this — the commit that lands on `main` is created and signed by GitHub.
 
 Sign with the SSH key you already push with — [GitHub accepts an authentication key a second time as a signing key](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification):
 
@@ -45,8 +45,6 @@ git rebase --exec 'git commit --amend --no-edit -S' origin/main
 ```
 
 ### Compliance
-
-Every commit on a pull request must be authored by an email address that resolves to the GitHub account that opened it, so set `git config user.email` accordingly before you commit.
 
 Contributions that do not adhere to these guidelines will be rejected. We align with [GitHub Acceptable Use Policies](https://docs.github.com/en/site-policy/acceptable-use-policies).
 
@@ -199,4 +197,4 @@ If your pull request is still in progress, please open it as a **Draft Pull Requ
   - Think of it as completing the sentence: "If applied, this commit will ..."
   - ✅ "fix authentication bug" → "If applied, this commit will fix authentication bug"
   - ❌ "fixed authentication bug" or "fixes authentication bug"
-- Keep the entire title under 72 characters when possible
+- Keep the entire title to at most 100 characters; commitlint rejects a longer one

--- a/README.md
+++ b/README.md
@@ -112,12 +112,9 @@ The feedback is advisory: it does not approve a change for merge or grade anyone
 
 ## Contributing
 
-Contributions are welcome. Hephaestus is a research project and
-[@FelixTJDietrich](https://github.com/FelixTJDietrich) is its core maintainer, so issues and pull
-requests are triaged on a best-effort basis; security reports get priority.
-[CONTRIBUTING.md](./CONTRIBUTING.md) explains how to set up the project, propose a change, run the
-quality checks, and open a pull request. Participation in the project is governed by the
-[Code of Conduct](./CODE_OF_CONDUCT.md).
+Contributions are welcome. [CONTRIBUTING.md](./CONTRIBUTING.md) explains how to set up the project,
+propose a change, run the quality checks and open a pull request, and what to expect from triage.
+Participation in the project is governed by the [Code of Conduct](./CODE_OF_CONDUCT.md).
 
 ## Project origins
 

--- a/server/AGENTS.md
+++ b/server/AGENTS.md
@@ -10,18 +10,14 @@ are not here: write code that reads like the file you are editing.
 
 ## Local development loop
 
-`vp run dev` from the repo root launches `mprocs` with server and webapp in separate panes and brings up
-the Postgres container. For plain terminals: `vp run dev:server` and `vp run dev:webapp`.
-
 - **No devtools.** Hot reload is JVM HotSwap via the IDE — IntelliJ's Spring Boot run config with
   *Update Classes and Resources* on save. Method-body edits reload; signature changes, new methods and
   `@Configuration` edits need a full restart
   ([ref](https://docs.spring.io/spring-boot/how-to/hotswapping.html)).
 - **`ddl-auto: validate`** locally — Liquibase owns DDL. If the validator fails on boot your DB has
   drifted: `vp run dev:reset`.
-- **`BufferingApplicationStartup`** is wired in `Application.main()`. With `app.profiles=local`,
-  `GET /actuator/startup` returns the timeline; `StartupBudgetIntegrationTest` catches per-step
-  regressions in CI.
+- **`BufferingApplicationStartup`** is wired in `Application.main()`; `StartupBudgetIntegrationTest`
+  reads its timeline and fails on a slow step. `/actuator/startup` is not exposed.
 
 ## Build traps
 
@@ -123,7 +119,7 @@ or on "the only" result, and never write cleanup that another test depends on ha
 
 - Workspace-scoped controllers carry `@WorkspaceScopedController` and take a `WorkspaceContext`.
   Authorization is declared, never assumed: `@RequireAtLeastWorkspaceAdmin`, `@RequireWorkspaceOwner`,
-  `@RequireMentorAccess`, `@PreAuthorize("hasAuthority('app_admin')")` for instance-admin routes.
+  `@PreAuthorize("hasAuthority('app_admin')")` for instance-admin routes.
   Anything reachable while impersonating goes through `ImpersonationGuard`. Admin mutations declare
   `@Audited` or `@AuditExempt` — an ArchUnit rule enforces it.
 - Express lifecycle transitions as HTTP methods (`PATCH /workspaces/{slug}/status`), not RPC verbs.
@@ -153,10 +149,12 @@ Procedure: `docs/contributor/database-migration.mdx`. What the drift gate reads 
 
 ## Webhook receiver
 
-`integration/core/webhook/`. Pure verifier and builder classes (HMAC, GitLab token, subject builders,
-dedup id) sit beside the Spring-backed controllers, the JetStream publisher and the stream bootstrap —
-all gated together on `RuntimeRole.WEBHOOK_PROPERTY`. Configuration binds to `hephaestus.webhook.*`
-through `core.webhook.WebhookProperties`, shared with auto-registration in `workspace/GitLabWebhookService`.
+`integration/core/webhook/` is the receive-side substrate: one `POST /webhooks/{kind}` entry point
+resolves the kind through `IntegrationKindRouting` and hands it to `WebhookIngestPipeline`, which
+selects that adapter's `WebhookSignatureVerifier` and `SubjectKeyDeriver` and publishes the verified
+envelope to JetStream, all gated on `RuntimeRole.WEBHOOK_PROPERTY`. Configuration binds to `hephaestus.webhook.*` through
+`core.webhook.WebhookProperties`, shared with auto-registration in
+`integration/scm/gitlab/workspace/GitLabWebhookService`.
 
 - **Production runs it in its own `webhook-server` container** — the same image as `application-server`
   with `SPRING_PROFILES_ACTIVE=prod,webhook` — so an app-server deploy does not interrupt reception.

--- a/webapp/AGENTS.md
+++ b/webapp/AGENTS.md
@@ -16,6 +16,7 @@ already tells you are not here.
 | Lint + format | `vp run check:webapp` — does **not** type-check; that is the separate leg above |
 | Tests | `vp run test:webapp` |
 | Storybook | `vp run --filter webapp storybook:dev` |
+| Story tests | `vp run --filter webapp test:storybook` |
 
 ## Ask first
 
@@ -60,8 +61,7 @@ derives URL segments from the filenames there and the router owns that naming.
 
 **oxlint lints, oxfmt formats.** `.oxlintrc.json` is the whole rule set, every rule it turns off
 carries the reason beside it, and every restriction states itself at the call site when it fires. None
-of that is repeated here, and the repo-root `AGENTS.md` § Lint and format scopes explains why `lint`
-is spelled `cd .. && oxlint webapp`. What follows is what no diagnostic will ever tell you.
+of that is repeated here. What follows is what no diagnostic will ever tell you.
 
 - **Suppress with `// oxlint-disable-next-line <rule> -- <why>`**, above the line the diagnostic
   points at, spelling the rule the way the **diagnostic** prints it — `plugin(rule)` becomes
@@ -306,10 +306,9 @@ an assertion out of a story into a route test is exactly how this bites.
 ## Type checking
 
 **A dot-directory is invisible to a `**/*` include.** `tsconfig.json`'s `**/*.ts` does not match
-`.storybook/`, so a file there is type-checked only if something names the directory explicitly —
-which `.storybook/**/*.tsx` does, and nothing does for `.ts`. So `preview.tsx` is checked while
-`main.ts`, `manager.ts` and `vitest.setup.ts` are not. Confirm with
-`tsc -p webapp/tsconfig.json --listFiles` before assuming a config file is covered.
+`.storybook/`, which is why the directory is named explicitly in `include`; a new dot-directory
+needs its own entry. Confirm with `tsc -p webapp/tsconfig.json --listFiles` before assuming a config
+file is covered.
 
 ## Generated files
 
@@ -440,8 +439,7 @@ sets it on the Playwright context so play functions are deterministic. Every `mo
 therefore the branch under test, and no story can assert travel distance, an easing curve or a peek
 width: those are exactly the values reduced motion zeroes. A motion regression has to be pinned on
 something reduced motion leaves alone — the presence of `data-starting-style`, an attribute's
-sequence over frames, or the class list itself. Three separate drawer bugs shipped green through this
-suite before that was written down.
+sequence over frames, or the class list itself.
 
 **A drawer that mounts already open never animates in.** Base UI's `useTransitionStatus` seeds
 `mounted` from `open`, so `open && !mounted` — the branch that sets `starting` — cannot run on the
@@ -458,26 +456,17 @@ page throws the reader back to the top.
 
 ## Vocabulary
 
-`docs/contributor/practice-feedback-language.md` is normative. The rulings this branch settled:
-
-| Concept | The word | Not |
-|---|---|---|
-| What an instance offers | **catalog** / instance catalog | library |
-| Availability to workspaces | **include / exclude** | offer, retire |
-| A grouping of practices | **group**, at every layer — copy, code, types and the API alike | area, section |
-| A practice with no group | **Unassigned** | No area, Not in an area, Belong to no area |
-| Inputs and criteria | **review rules** | review behavior, detection config |
-
-Prefer dropping the class noun where the thing's own name is already on screen: "No practices here",
-not "No practices in this area".
+`docs/contributor/practice-feedback-language.md` is normative, and a word it retires is retired in
+code, types and story titles as well as in copy. Prefer dropping the class noun where the thing's own
+name is already on screen: "No practices here", not "No practices in this group".
 
 ## Status vocabularies
 
 Every enum a practice surface renders goes in `components/practice-vocabulary/` as `StatusDefs` and
 renders through `StatusBadge`. The icon is required and unique within its enum because badge variants
 collapse, and colour alone fails WCAG 2.2 SC 1.4.1. **Nothing else may hold words, a colour or an
-icon for an enum value** — a bare `<Badge>` next to a registry badge reads as the same family and is
-how a *setting* came to look identical to a *provenance state*.
+icon for an enum value** — a bare `<Badge>` next to a registry badge reads as the same family, so a
+*setting* becomes indistinguishable from a *provenance state*.
 
 A registry entry that would be identical for every value is not information. Say what to do about it
 in a sentence instead.

--- a/webapp/README.md
+++ b/webapp/README.md
@@ -3,22 +3,11 @@
 The React 19 SPA: TanStack Router and Query, Tailwind 4, shadcn primitives over Base UI, Vitest and
 Storybook for tests, oxlint and oxfmt for lint and format, Vite for the build.
 
-**Read [`AGENTS.md`](./AGENTS.md) before changing anything here.** It is the gotchas — the rules a
-look at the tree does not tell you, several of which fail the build if you guess: never hand-write a
-`queryKey`, never call `fetch` under `src/**`, never read the clock during render, never edit
-`src/components/ui/` in passing, and never import the query layer from a component.
-
-| Task | Command |
-|------|---------|
-| Dev server | `vp run dev:webapp` — port 4200 |
-| Type check | `vp run typecheck:webapp` |
-| Lint and format | `vp run check:webapp` — does **not** type-check |
-| Unit tests | `vp run test:webapp` |
-| Storybook | `vp run --filter webapp storybook:dev` |
-| Story tests | `vp run --filter webapp test:storybook` |
+**Read [`AGENTS.md`](./AGENTS.md) before changing anything here.** It has the commands and the
+gotchas — the rules a look at the tree does not tell you, several of which fail the build if you
+guess: never hand-write a `queryKey`, never call `fetch` under `src/**`, never read the clock during
+render, never edit `src/components/ui/` in passing, and never import the query layer from a
+component.
 
 The repository-wide gates are `vp run check` before pushing and `vp run verify` before requesting
 review; the root [`AGENTS.md`](../AGENTS.md) lists what each one covers.
-
-Component and story conventions live in the `storybook-components` skill
-(`.claude/skills/storybook-components/`), which ships the rubric a webapp diff is graded against.


### PR DESCRIPTION
## What changed and why

The instruction files an agent reads before it edits anything described a repository that has moved
on, and two of the errors were traps in the file whose job is to list traps.

- `server/AGENTS.md` sent a reader to `GET /actuator/startup`, which the exposed set does not
  include, and listed `@RequireMentorAccess`, which exists nowhere. Its webhook paragraph named
  `IntegrationKindRouting` as the thing that selects an adapter's verifier; routing resolves the
  kind and `WebhookIngestPipeline` selects the verifier.
- `webapp/AGENTS.md` said `.ts` files under `.storybook/` are unchecked. `tsconfig.json` names
  `.storybook/**/*.ts` in `include`, so they are.
- `CONTRIBUTING.md` asked for titles under 72 characters where commitlint permits 100, and stated the
  commit-email rule in two sections.
- The `land-pr` skill had a line corrupted mid-sentence in both mirrors.
- The storybook skill's traps 3 and 4 restated what `webapp/AGENTS.md` § Linting and
  § Container/presentation split already own in full, and trap 5 named the README export check where
  the job checks seven brand-asset paths.

Each is corrected against the source, or reduced to a pointer at the file that owns the fact. The
`webapp/README.md` command table goes the same way: `webapp/AGENTS.md` § Commands is its one home,
and it gains the `test:storybook` row it was missing.

## How to test

- `vp run check` — green, including `gate:instructions`, which proves the four Codex-mirrored skills
  are byte-identical to their `.claude/` halves.
- Each corrected claim checked against the tree: `application.yml`'s `management.endpoints` include
  list, a repository-wide grep for `@RequireMentorAccess`, `webapp/tsconfig.json:2`,
  `commitlint.config.ts:137`, `webapp/package.json:15`, and the `Webapp: Stories` job's
  `BRAND_ASSETS` array in `ci-quality-gates.yml`.

## Release impact

No changeset. No file under `server/`, `webapp/` or `docker/` outside in-tree documentation.

## Notes for reviewers

- Every deletion here either corrects a false statement or points at a section that holds the fact in
  full; the two the reviewer should check are `traps.md` § 3 against `webapp/AGENTS.md` § Linting and
  `traps.md` § 4 against § Container/presentation split.
- This carries the instruction-file half of the closed #1868. The published-guide half is #1894; the file
  sets are disjoint, so the two can land in either order.
