### PR TITLE
fix(integration): recovering an unreadable credential guards the row it clears

### DIFF
--- a/.changeset/guarded-app-credential-recovery.md
+++ b/.changeset/guarded-app-credential-recovery.md
@@ -1,0 +1,7 @@
+---
+"hephaestus": patch
+---
+
+An integration whose stored token cannot be read now tells a workspace administrator to store a replacement personal access token, instead of naming an API surface the console has no form for.
+
+The credential key rotation runbook's statement for clearing a quarantined GitHub App credential now matches the key version and quarantine time you listed, so it cannot null out a credential that was reconnected between the listing and the statement.

--- a/docs/admin/credential-key-rotation.mdx
+++ b/docs/admin/credential-key-rotation.mdx
@@ -56,30 +56,6 @@ Stop if the result contains an unexpected version.
 
 ## Failure recovery
 
-### A credential the running key cannot read
-
-Outside rotation, Hephaestus attempts to record the same mark when a request needs a stored
-credential that the configured keys cannot decrypt, and later reads repeat the attempt — after a key was changed, or a host was set up with a new key over
-an existing database. The request answers `409 Conflict` with a problem detail that names the
-connection and says what clears it, instead of a bare server error, and the workspace's integration
-pages show the connection with a notice saying the stored token cannot be read. A GitHub App
-connection runs on its installation and the app's own key, not on the blob it stores, so it is never
-reported this way; its blob can still be quarantined by rotation, and the listing below shows it with
-the operation that clears it. Two ways out:
-
-- Restore the key the credential was written with, if it was changed by mistake; the next read
-  succeeds and attempts to clear the mark the same way, so later reads repeat that too.
-- Replace the credential: re-enter the token, or reconnect the integration. Writing a new credential
-  clears the mark.
-
-A credential written under a key *version* the server is not configured with at all is a different
-case: the read is refused as a configuration fault and, as long as the ciphertext is well-formed, the
-row is not marked, because the fix is to configure that key, never to touch the row.
-
-The listing above finds every quarantined row, whether or not the connection runs on it;
-`credentials_rotation_failed_at` holds the time the credential was first found unreadable, and is
-reset when it reads again or is rewritten.
-
 Before rotation starts, restore the previous configuration. After any row is re-encrypted, retain both
 keys and roll forward. The rotation job quarantines a row it cannot decrypt, continues with later rows,
 logs the connection, workspace and integration kind, and increments
@@ -95,10 +71,15 @@ WHERE credentials_rotation_failed_at IS NOT NULL
 ORDER BY credentials_rotation_failed_at, id;
 ```
 
+The listing finds every quarantined row, whether or not the connection runs on the credential it
+holds; `mode` tells those two apart. `credentials_rotation_failed_at` holds the time the credential
+was first found unreadable, and is reset when it reads again or is rewritten, so each value the
+listing prints describes the row only as long as nothing rewrites it.
+
 A key version that has no key configured at all stops rotation instead of quarantining anything: the
-job fails the batch with an error naming that version, marks no well-formed row, and resumes on its own once you
-configure the key. While this is happening `pending` stops falling and `undecryptable` stays flat;
-find the affected rows with
+job fails the batch with an error naming that version, marks no row whose ciphertext is well-formed,
+and resumes on its own once you configure the key. While this is happening `pending` stops falling
+and `undecryptable` stays flat; find the affected rows with
 `SELECT id, workspace_id, kind FROM connection WHERE credentials_key_version = <version>`.
 
 Key material that is configured but wrong cannot be told apart from a corrupt ciphertext, so it
@@ -118,13 +99,22 @@ Re-enable rotation only after the update is applied.
 
 If the ciphertext is corrupt or its key is permanently unavailable, replace the credential. For Slack
 and Outline, disconnect the integration in workspace administration and connect it again. For a
-GitHub or GitLab personal access token, submit the new token to the workspace token endpoint
-(`PATCH /api/workspaces/{slug}/token`); the admin console has no form for it yet. Writing a
-replacement clears the marker. A quarantined GitHub App row (`mode` = `GITHUB_APP` in the listing) has nothing to
-replace, since nothing runs on its blob: clear the blob itself, which takes the row out of rotation
-until the app is connected again through the connect flow, which writes a fresh one. The guard on the mode keeps a mistyped id from
-destroying a live token, and the version bump keeps a concurrently loaded row from writing the old
-blob back:
+GitHub or GitLab personal access token, submit the replacement as a workspace administrator to
+`PATCH /api/workspaces/{workspaceSlug}/token`. Writing a replacement clears the marker. Confirm the
+provider request succeeds and rerun the verification query before removing the prior key. Never clear
+the marker repeatedly without correcting the credential: that recreates a retry loop and alert noise.
+
+### A quarantined GitHub App row
+
+A row whose `mode` is `GITHUB_APP` has nothing to replace, since nothing runs on its blob: clear the
+blob itself, which takes the row out of rotation until the app is connected again through the connect
+flow, which writes a fresh one.
+
+Copy the key version and the quarantine timestamp from the listing into the statement. Connecting the
+app again rewrites the blob and clears the marker, so a row that was reconnected between your listing
+and this statement no longer matches these values and is left alone; without them the statement would
+null out the credential the reconnect had just written. The version bump keeps a concurrently loaded
+row from writing the old blob back.
 
 ```sql
 UPDATE connection
@@ -136,9 +126,28 @@ SET credentials_encrypted = NULL,
     updated_at = now()
 WHERE id = <app connection id>
   AND config ->> 'type' = 'GITHUB_APP'
+  AND credentials_key_version = <credentials_key_version from the listing>
+  AND credentials_rotation_failed_at = '<credentials_rotation_failed_at from the listing>'
 RETURNING id, workspace_id;
 ```
 
-Confirm the
-provider request succeeds and rerun the verification query before removing the prior key. Never clear
-the marker repeatedly without correcting the credential: that recreates a retry loop and alert noise.
+If it returns no row, the connection changed after you listed it. List it again and read the new row
+before deciding whether it still needs clearing.
+
+### A credential the running key cannot read
+
+Outside rotation, Hephaestus attempts to record the same mark when a request needs a stored credential
+that the configured keys cannot decrypt, and later reads repeat the attempt — after a key was changed,
+or a host was set up with a new key over an existing database. The request answers `409 Conflict` with
+a problem detail that names the connection and says what clears it, instead of a bare server error,
+and the workspace's integration pages show the connection with a notice saying the stored token cannot
+be read. A GitHub App connection runs on its installation and the app's own key, not on the blob it
+stores, so it is never reported this way. Two ways out:
+
+- Restore the key the credential was written with, if it was changed by mistake; the next read
+  succeeds and attempts to clear the mark the same way, so later reads repeat that too.
+- Replace the credential, by the same doors as above. Writing a new credential clears the mark.
+
+A credential written under a key *version* the server is not configured with at all is a different
+case: the read is refused as a configuration fault and, as long as the ciphertext is well-formed, the
+row is not marked, because the fix is to configure that key, never to touch the row.

--- a/webapp/src/components/admin/integrations/ConnectionStateNotice.tsx
+++ b/webapp/src/components/admin/integrations/ConnectionStateNotice.tsx
@@ -94,7 +94,7 @@ export function ConnectionStateNotice({
 					<KeyRoundIcon />
 					<AlertTitle>The stored token can't be read</AlertTitle>
 					<AlertDescription>
-						{`${displayName}'s stored token can't be read with this server's current keys — after a key change, or a database restored under another key — so nothing that needs it can run. ${credentialRecovery}, or restore the key it was written with if that was changed by mistake.`}
+						{`${displayName}'s stored token can't be read with this server's current keys — usually after a key change, or a database restored under another key — so nothing that needs it can run. ${credentialRecovery}, or restore the key it was written with if that was changed by mistake.`}
 					</AlertDescription>
 				</Alert>
 			)}

--- a/webapp/src/routes/_authenticated/w/$workspaceSlug/admin/integrations/scm.tsx
+++ b/webapp/src/routes/_authenticated/w/$workspaceSlug/admin/integrations/scm.tsx
@@ -220,7 +220,7 @@ function ScmIntegrationPage() {
 				<ConnectionStateNotice
 					connectionState={entry.connectionState}
 					credentialsUnreadableSince={entry.credentialsUnreadableSince}
-					credentialRecovery="Replace it by submitting a new personal access token to the workspace token endpoint, which the console has no form for yet"
+					credentialRecovery="Replace it by storing a new personal access token for this workspace"
 					displayName={label}
 				/>
 			)}


### PR DESCRIPTION
## Problem

Two things #1881 shipped are wrong for the operator and the admin reading them.

The key-rotation runbook's statement for clearing a quarantined GitHub App credential matches on the
connection id and `config ->> 'type' = 'GITHUB_APP'`. Neither of those changes when the app is
connected again, and the connect flow rewrites `credentials_encrypted` on the same row. An operator
who lists the quarantined rows, is interrupted, and pastes the statement afterwards therefore nulls
out the credential the reconnect had just written, and the workspace's App installation identity is
gone until someone reconnects again. The prose above it claimed "the guard on the mode keeps a
mistyped id from destroying a live token", which the `WHERE` never provided — a mistyped id belonging
to another App row matches just as happily.

The same section also reads out of order: a paragraph beginning "The listing above" sits before the
only listing, and the new subsection was inserted into the middle of the rotation narrative, so
"Before rotation starts, restore the previous configuration" reads as advice about the
unreadable-credential case.

On the source-control integration page, the unreadable-token notice tells a workspace administrator
to submit a token "to the workspace token endpoint, which the console has no form for yet" — shipped
copy that names an API surface instead of an action and documents a missing feature. The runbook
stated the same gap a second time.

## Fix

- The App-blob statement also matches `credentials_key_version` and `credentials_rotation_failed_at`
  as the listing printed them. Connecting the app again rewrites the blob and clears the marker
  (`Connection#setCredentials`), so a reconnected row no longer matches and is left alone. The prose
  says what the guard actually protects, and what an empty `RETURNING` means.
- `## Failure recovery` runs in order: the rotation narrative and its listing, then the paragraph
  describing the listing, then `### A quarantined GitHub App row` and
  `### A credential the running key cannot read` as their own subsections.
- The notice says "Replace it by storing a new personal access token for this workspace". The
  endpoint keeps one home, in `docs/admin/`, where the path is corrected to `{workspaceSlug}` to
  match the spec.
- The notice's causal clause is softened to "usually after a key change, or a database restored under
  another key": a credential is marked on any decryption failure, which includes a truncated or
  tampered row, and stating a cause the product cannot know is a wrong claim about someone's setup.
- Wrapping and a stranded fragment left by the previous edit are repaired, and "marks no well-formed
  row" is rewritten as "marks no row whose ciphertext is well-formed".

## Verification

- `vp run format` — clean.
- `vp run check:affected` — resolved to the full local quality gate; passed.
- `vp run docs:lint` — 0 errors over 121 files.
- `vp run test:webapp` — 168 passed.
- No story or test asserts either changed string (`ConnectionStateNotice.stories.tsx` matches on the
  alert title and on the default `credentialRecovery`, neither of which moved). The browser story
  suite is CI's.

Part of #1860. Bullet 2 of its *Done when* stays open for a GitHub or GitLab personal access token:
the console shows the state and names the action, but has no form to re-enter the token, and this PR
does not add one.