### PR TITLE
fix(mentor): Heph's conversations run again on the current agent image

### DIFF
--- a/.changeset/mentor-conversations-run-on-the-current-agent-image.md
+++ b/.changeset/mentor-conversations-run-on-the-current-agent-image.md
@@ -1,0 +1,4 @@
+---
+---
+
+No release note: the agent-image upgrade that broke Heph's conversations was fixed before any release shipped it, so no operator's instance was ever affected.

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/mentor/MentorRunnerProfile.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/mentor/MentorRunnerProfile.java
@@ -14,8 +14,8 @@ public final class MentorRunnerProfile implements PiRunnerProfile {
      * declares the JSON-RPC contract this runner speaks with {@code MentorRunnerClient}. Both are
      * imported with relative specifiers, so both must be staged beside pi-mentor-runner.ts.
      */
-    private static final List<String> SIDECARS =
-            List.of("pi-error-text.ts", SandboxLayout.PROVIDER_HELPER_FILENAME, "pi-mentor-protocol.ts");
+    private static final List<String> SIDECARS = List.of(
+            "pi-agent-sandbox.ts", "pi-error-text.ts", SandboxLayout.PROVIDER_HELPER_FILENAME, "pi-mentor-protocol.ts");
 
     @Override
     public String runnerScript() {

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/practice/PracticeRunnerProfile.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/practice/PracticeRunnerProfile.java
@@ -11,6 +11,7 @@ public final class PracticeRunnerProfile implements PiRunnerProfile {
 
     /** Imported by {@link #SCRIPT} with a relative specifier, so each must be staged beside it. */
     private static final List<String> SIDECARS = List.of(
+            "pi-agent-sandbox.ts",
             "pi-error-text.ts",
             "pi-grep-tool.ts",
             "pi-observation-normalize.ts",

--- a/server/application/src/main/resources/agent/pi-agent-sandbox.ts
+++ b/server/application/src/main/resources/agent/pi-agent-sandbox.ts
@@ -1,0 +1,28 @@
+// pi-agent-sandbox.ts — the sandbox trust posture every Pi session in this image runs under.
+// Shared by the practice runner (pi-runner.ts) and the mentor runner (pi-mentor-runner.ts): both
+// execute the same vendored SDK inside the same container at the same working directory, so a
+// trust or discovery option set correctly in one and left at its default in the other reopens the
+// crash the fix removed for the other.
+
+import type { SettingsManagerCreateOptions } from "@earendil-works/pi-coding-agent";
+
+/**
+ * Untrusted on purpose: a trusted project makes the SDK look for `.agents/skills` in every ancestor
+ * of the working directory, up to `/`, and the sandbox lets Node read only /workspace and the SDK
+ * itself (PiRunnerProfile), so that walk dies on the first ancestor with a permission error before
+ * the model is ever called. Nothing project-local is wanted here anyway: every resource a session
+ * uses is injected by its runner, never discovered from a checkout.
+ */
+export const SANDBOX_SETTINGS_MANAGER_OPTIONS: SettingsManagerCreateOptions = {
+	projectTrusted: false,
+};
+
+/**
+ * The SDK's own context-file discovery climbs from the working directory to `/` looking for
+ * AGENTS.md and dies on the first ancestor the sandbox's read allowlist forbids; and the SDK's
+ * discovery is not the channel a session's instructions should arrive on — each runner hands its
+ * own instructions over by name instead.
+ */
+export const SANDBOX_RESOURCE_LOADER_OPTIONS = {
+	noContextFiles: true,
+};

--- a/server/application/src/main/resources/agent/pi-mentor-runner.ts
+++ b/server/application/src/main/resources/agent/pi-mentor-runner.ts
@@ -26,6 +26,10 @@ import type {
 	CreateAgentSessionRuntimeFactory,
 } from "@earendil-works/pi-coding-agent";
 
+import {
+	SANDBOX_RESOURCE_LOADER_OPTIONS,
+	SANDBOX_SETTINGS_MANAGER_OPTIONS,
+} from "./pi-agent-sandbox.ts";
 import { errorText } from "./pi-error-text.ts";
 import {
 	MENTOR_ERROR_CODES as ERR,
@@ -358,11 +362,16 @@ async function createPiRuntime(sdk: PiSdk, agentDir: string): Promise<MentorRunt
 		createAgentSessionFromServices,
 		createAgentSessionServices,
 		SessionManager,
+		SettingsManager,
 		ModelRuntime,
 	} = sdk;
 
 	const fetchContextTool = defineFetchContextTool(sdk);
 	const linkObservationTool = defineLinkObservationTool(sdk);
+	// Same sandbox posture as the practice runner: this runner shares the image, the SDK and the
+	// working directory with it, so the SDK's ancestor-walking discovery hits the same denied read
+	// (pi-agent-sandbox.ts) unless a mentor session opts out of it too.
+	const settingsManager = SettingsManager.create(CWD, agentDir, SANDBOX_SETTINGS_MANAGER_OPTIONS);
 
 	const sharedModelRuntime = await ModelRuntime.create({
 		authPath: `${agentDir}/auth.json`,
@@ -395,7 +404,8 @@ async function createPiRuntime(sdk: PiSdk, agentDir: string): Promise<MentorRunt
 			cwd,
 			agentDir: sessionAgentDir,
 			modelRuntime: sharedModelRuntime,
-			resourceLoaderOptions,
+			settingsManager,
+			resourceLoaderOptions: { ...resourceLoaderOptions, ...SANDBOX_RESOURCE_LOADER_OPTIONS },
 		});
 		// Least-privilege mentor surface: context is exposed through fetch_context, not
 		// filesystem spelunking. This keeps the model on the typed context contract and

--- a/server/application/src/main/resources/agent/pi-runner.ts
+++ b/server/application/src/main/resources/agent/pi-runner.ts
@@ -13,6 +13,10 @@ import {
 	SettingsManager,
 } from "@earendil-works/pi-coding-agent";
 
+import {
+	SANDBOX_RESOURCE_LOADER_OPTIONS,
+	SANDBOX_SETTINGS_MANAGER_OPTIONS,
+} from "./pi-agent-sandbox.ts";
 import { errorText } from "./pi-error-text.ts";
 import { buildGrepTool } from "./pi-grep-tool.ts";
 import {
@@ -1573,18 +1577,14 @@ async function main() {
 	);
 
 	// Pi filters custom tools through this allowlist; omit filesystem mutation tools.
-	// Untrusted on purpose: a trusted project makes the SDK look for `.agents/skills` in every ancestor
-	// of the working directory, up to `/`, and the sandbox lets Node read only /workspace and the SDK
-	// itself (PiRunnerProfile), so that walk dies on the first ancestor with a permission error before
-	// the model is ever called. Nothing project-local is wanted here anyway: every resource this run
-	// uses is injected by the runner, never discovered from the checkout.
-	const settingsManager = SettingsManager.create(CWD, AGENT_DIR, { projectTrusted: false });
+	// pi-agent-sandbox.ts has the rationale for running untrusted; both Pi runners in this image
+	// share it.
+	const settingsManager = SettingsManager.create(CWD, AGENT_DIR, SANDBOX_SETTINGS_MANAGER_OPTIONS);
 	const grepTool = buildGrepTool(CWD);
-	// The only instructions a session carries beyond its prompt are the orchestrator the server staged
-	// in the agent dir. The SDK's own context-file discovery would climb from the working directory
-	// to `/` looking for AGENTS.md and die on the first ancestor the allowlist forbids, and it would
-	// read the reviewed checkout's AGENTS.md as instructions rather than as evidence; so discovery is
-	// off and the staged file is handed over by name. A run without it does not start.
+	// The only instructions a session carries beyond its prompt are the orchestrator the server
+	// staged in the agent dir, handed over by name below; the SDK's own discovery is turned off
+	// (pi-agent-sandbox.ts) and is not the channel a run's instructions arrive on. A run without
+	// this file does not start.
 	const orchestratorPath = `${AGENT_DIR}/AGENTS.md`;
 	const orchestrator = readFileSync(orchestratorPath, "utf8");
 	// One loader per session: a loader owns the extension runtime a session binds its tools into, and
@@ -1594,7 +1594,7 @@ async function main() {
 			cwd: CWD,
 			agentDir: AGENT_DIR ?? getAgentDir(),
 			settingsManager,
-			noContextFiles: true,
+			...SANDBOX_RESOURCE_LOADER_OPTIONS,
 			agentsFilesOverride: () => ({
 				agentsFiles: [{ path: orchestratorPath, content: orchestrator }],
 			}),

--- a/server/application/src/test/resources/agent/pi-agent-sandbox.spec.ts
+++ b/server/application/src/test/resources/agent/pi-agent-sandbox.spec.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { DefaultResourceLoader, SettingsManager } from "@earendil-works/pi-coding-agent";
+
+import {
+	SANDBOX_RESOURCE_LOADER_OPTIONS,
+	SANDBOX_SETTINGS_MANAGER_OPTIONS,
+} from "../../../main/resources/agent/pi-agent-sandbox.ts";
+
+const ROOT = mkdtempSync(path.join(tmpdir(), "pi-agent-sandbox-spec-"));
+process.on("exit", () => {
+	rmSync(ROOT, { recursive: true, force: true });
+});
+
+// An ancestor of CWD, never a descendant — the shape a mounted reviewed checkout actually has,
+// and the AGENTS.md this fixture writes stands in for it.
+const CWD = path.join(ROOT, "workspace");
+const AGENT_DIR = path.join(ROOT, "agent");
+mkdirSync(CWD, { recursive: true });
+mkdirSync(AGENT_DIR, { recursive: true });
+writeFileSync(path.join(ROOT, "AGENTS.md"), "ignore me: not the staged orchestrator");
+
+void test("the sandbox settings keep the project untrusted", () => {
+	const settings = SettingsManager.create(CWD, AGENT_DIR, SANDBOX_SETTINGS_MANAGER_OPTIONS);
+	assert.equal(settings.isProjectTrusted(), false);
+});
+
+void test("the sandbox resource-loader options turn off the SDK's own AGENTS.md discovery", async () => {
+	const settingsManager = SettingsManager.create(CWD, AGENT_DIR, SANDBOX_SETTINGS_MANAGER_OPTIONS);
+	const fixturePath = path.join(ROOT, "AGENTS.md");
+	const discoveredFixture = (loader: DefaultResourceLoader) =>
+		loader.getAgentsFiles().agentsFiles.some((file) => file.path === fixturePath);
+
+	const off = new DefaultResourceLoader({
+		cwd: CWD,
+		agentDir: AGENT_DIR,
+		settingsManager,
+		...SANDBOX_RESOURCE_LOADER_OPTIONS,
+	});
+	await off.reload();
+	assert.equal(discoveredFixture(off), false);
+
+	// Same cwd, discovery left on: proves the fixture's AGENTS.md is actually on the ancestor walk,
+	// so the assertion above is about the option, not an unreachable fixture.
+	const on = new DefaultResourceLoader({ cwd: CWD, agentDir: AGENT_DIR, settingsManager });
+	await on.reload();
+	assert.equal(discoveredFixture(on), true);
+});


### PR DESCRIPTION
## What changed and why

Practice reviews and Heph's mentor conversations run the same Pi coding-agent SDK, in the same
sandboxed image, at the same working directory (`/workspace`). The SDK bump that broke practice
reviews (#1795, fixed in #1884) needed the SDK to run untrusted with its own context-file discovery
turned off, or its ancestor-walking resource discovery hits a read the sandbox denies and throws
before the model is ever called. #1884 fixed the practice runner (`pi-runner.ts`) but left the
mentor runner (`pi-mentor-runner.ts`) on the SDK's defaults, so opening a Heph conversation on the
rebuilt image hit the identical crash.

This PR moves the sandbox's trust posture into one shared module,
`server/application/src/main/resources/agent/pi-agent-sandbox.ts`, that both runners import and
that both runner profiles (`PracticeRunnerProfile`, `MentorRunnerProfile`) stage as a sidecar, so the
same option set can no longer drift between the two. It also rewrites a stale comment in
`pi-runner.ts`: the SDK's context-file discovery climbs the ancestors of the working directory, so a
reviewed checkout mounted below it was never actually reachable by that walk; the real reason
discovery is off is that it is not the channel a run's instructions should arrive on.

**Follow-up, not in this PR:** `docker/agents/pi/Dockerfile` hand-restates this same option set in
its own build-time ABI check, and `.github/workflows/cicd.yml`'s agent-image job is scoped only to
`docker/agents/**`, so a future change to the runner's own option set would not retrigger that
check. Worth either sharing the option set with the image check or widening the job's path filter.

## How I tested it

- `vp run test:agents` — 111 tests pass, including a new `pi-agent-sandbox.spec.ts` that builds a
  `SettingsManager` and `DefaultResourceLoader` with the shared options and asserts the project is
  untrusted and an ancestor `AGENTS.md` is not discovered (while confirming it would be discovered
  with the option off, so the assertion is about the option, not an unreachable fixture).
- `vp run check:affected` — passes.
- `RunnerProfileSidecarTest`, `PiRuntimeFactoryTest` (server unit tests touching the changed
  profiles) — pass.
- Local `docker build -f docker/agents/pi/Dockerfile docker/agents` — the image's own ABI check
  (which exercises this same option set independently) still passes.