### PR TITLE
chore(release): drop the release note for a regression no release shipped

### DIFF
--- a/.changeset/practice-reviews-run-on-the-current-agent-image.md
+++ b/.changeset/practice-reviews-run-on-the-current-agent-image.md
@@ -1,6 +1,4 @@
 ---
-"hephaestus": patch
 ---
 
-Practice reviews start again after upgrading the agent image. On the previous image every review
-stopped inside its sandbox before it had looked at the work.
+No release note: the agent-image upgrade that broke practice reviews was fixed before any release shipped it, so no operator's instance was ever affected.


### PR DESCRIPTION
## What changed and why

#1884's changeset said "practice reviews start again after upgrading the agent image", implying a
released image had stopped running practice reviews and this fix restores them. It didn't: the SDK
bump that introduced the defect (#1795) is not an ancestor of the last released tag, `v0.76.0`
(`git merge-base --is-ancestor <squash of #1795> v0.76.0` reports false). No released version ever
shipped the defect, so the note would tell an operator reading the changelog that their instance was
affected when it never was.

This replaces `.changeset/practice-reviews-run-on-the-current-agent-image.md` with the empty form
`.changeset/README.md` prescribes (`---\n---\n`), with one sentence recording why no release note is
needed.

## How I tested it

- `vp run gate:changesets` — passes.
- `pnpm exec changeset status --since origin/main --output …` piped into
  `node scripts/verify-changesets.ts` (the check CI runs against changed changeset files) — passes.