### PR TITLE
refactor(server): record credential readability on the shared task executor

### DIFF
--- a/.changeset/credential-readability-executor.md
+++ b/.changeset/credential-readability-executor.md
@@ -1,0 +1,7 @@
+---
+---
+
+No release note: nothing an operator runs or an instance serves changes. The record of whether a
+stored credential could be read moves from a hand-rolled thread pool onto the shared task-executor
+configuration, which already owns pool sizing and orderly shutdown for every other background lane,
+and four leftovers in the same feature are tidied.

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/config/CredentialReadabilityExecutor.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/config/CredentialReadabilityExecutor.java
@@ -1,0 +1,15 @@
+package de.tum.cit.aet.hephaestus.config;
+
+/**
+ * Name of the executor every record of a stored credential's readability is written from.
+ *
+ * <p>A constant rather than a literal at the injection point, for the same reason as
+ * {@link FeedbackLaneExecutor}: a typo in a qualifier is not an error, it silently resolves to the
+ * default executor and undoes the isolation the pool exists to provide.
+ */
+public final class CredentialReadabilityExecutor {
+
+    public static final String BEAN_NAME = "credentialReadabilityExecutor";
+
+    private CredentialReadabilityExecutor() {}
+}

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/config/SpringAsyncConfig.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/config/SpringAsyncConfig.java
@@ -2,6 +2,7 @@ package de.tum.cit.aet.hephaestus.config;
 
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadPoolExecutor;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.task.TaskExecutionAutoConfiguration;
 import org.springframework.context.annotation.Bean;
@@ -74,6 +75,32 @@ public class SpringAsyncConfig implements AsyncConfigurer {
         // EntityManagerFactory closes.
         executor.setWaitForTasksToCompleteOnShutdown(true);
         executor.setAwaitTerminationSeconds(30);
+        return executor;
+    }
+
+    /**
+     * The lane every record of a stored credential's readability is written on.
+     *
+     * <p>One worker and a shallow queue that discards: the record is best effort, a later read of the
+     * same credential makes it again, and a stalled database must not turn a burst of failing reads
+     * into retained work or into a second pooled connection per caller. Off {@link
+     * #applicationTaskExecutor} so it neither queues behind the activity listeners a provider sync
+     * fans out nor competes with them for the same 500-deep queue.
+     *
+     * <p>Waits only briefly on shutdown, so a record already in flight lands before the
+     * EntityManagerFactory closes while a stalled one is abandoned like any other.
+     */
+    @Bean(name = CredentialReadabilityExecutor.BEAN_NAME)
+    public AsyncTaskExecutor credentialReadabilityExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(1);
+        executor.setMaxPoolSize(1);
+        executor.setQueueCapacity(64);
+        executor.setThreadNamePrefix("credential-readability-");
+        executor.setRejectedExecutionHandler(new ThreadPoolExecutor.DiscardPolicy());
+        executor.setTaskDecorator(new ContextPropagatingTaskDecorator());
+        executor.setWaitForTasksToCompleteOnShutdown(true);
+        executor.setAwaitTerminationSeconds(2);
         return executor;
     }
 

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/core/connection/ConnectionRepository.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/core/connection/ConnectionRepository.java
@@ -133,9 +133,9 @@ public interface ConnectionRepository extends JpaRepository<Connection, Long> {
      * Records that exactly this ciphertext could not be read, and only once: a credential replaced
      * since the failed read has a different ciphertext and is left alone. The record advances the
      * version, so an entity loaded before it and flushed after it fails its optimistic check instead
-     * of silently writing the stale value back. It never waits on the target row: one another transaction holds
-     * locked, as disconnect does while it revokes the credential it just read, is skipped and the
-     * record is left for a later read.
+     * of silently writing the stale value back. It never waits on the target row: a row another
+     * transaction holds locked — as disconnect does while it revokes the credential it just read — is
+     * skipped, and the record is left for a later read.
      */
     @Modifying
     @Query(value = """

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/core/connection/CredentialReader.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/core/connection/CredentialReader.java
@@ -1,18 +1,16 @@
 package de.tum.cit.aet.hephaestus.integration.core.connection;
 
+import de.tum.cit.aet.hephaestus.config.CredentialReadabilityExecutor;
 import de.tum.cit.aet.hephaestus.core.security.EncryptionException;
 import de.tum.cit.aet.hephaestus.core.security.MissingCredentialKeyException;
 import de.tum.cit.aet.hephaestus.integration.core.spi.ApiCredentialProvider.CredentialBundle;
-import jakarta.annotation.PreDestroy;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.Optional;
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.core.task.TaskExecutor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionDefinition;
@@ -31,50 +29,34 @@ import org.springframework.transaction.support.TransactionTemplate;
  * restoring the key it was written with changes any of them.
  *
  * <p>The record is written by a conditional update bound to the exact ciphertext that failed, so a
- * credential replaced between the failed read and the write is never marked, and it is written by a
- * worker of the reader's own, never on the caller's thread, so a burst of failing reads never holds
- * two pooled connections each and a stalled database never delays the answer. It skips a row another transaction holds locked rather than waiting, and
- * a failure to write it is logged; neither ever replaces the answer.
+ * credential replaced between the failed read and the write is never marked, and it is handed to
+ * {@link CredentialReadabilityExecutor} rather than run on the caller's thread, so a burst of failing
+ * reads never holds two pooled connections each and a stalled database never delays the answer. It
+ * skips a row another transaction holds locked rather than waiting, and a failure to write it is
+ * logged; neither ever replaces the answer.
  */
 @Service
 public class CredentialReader {
 
     private static final Logger log = LoggerFactory.getLogger(CredentialReader.class);
 
-    /** The thread every record is written from. */
-    static final String RECORDER_THREAD = "credential-readability";
-
     private final ConnectionRepository connectionRepository;
     private final CredentialBundleConverter converter;
     private final TransactionTemplate markTransaction;
+    private final TaskExecutor recorder;
     private final Clock clock;
-    /**
-     * One worker and a small queue: a record that finds the queue full, or arrives after shutdown, is
-     * dropped, because a later read of the same credential makes the same record again and a stalled
-     * database must not turn every failing read into retained work.
-     */
-    private final ExecutorService recorder = new ThreadPoolExecutor(
-            1,
-            1,
-            0L,
-            TimeUnit.MILLISECONDS,
-            new ArrayBlockingQueue<>(64),
-            runnable -> {
-                Thread thread = new Thread(runnable, RECORDER_THREAD);
-                thread.setDaemon(true);
-                return thread;
-            },
-            new ThreadPoolExecutor.DiscardPolicy());
 
     public CredentialReader(
             ConnectionRepository connectionRepository,
             CredentialBundleConverter converter,
             PlatformTransactionManager transactionManager,
+            @Qualifier(CredentialReadabilityExecutor.BEAN_NAME) TaskExecutor recorder,
             Clock clock) {
         this.connectionRepository = connectionRepository;
         this.converter = converter;
         this.markTransaction = new TransactionTemplate(transactionManager);
         this.markTransaction.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+        this.recorder = recorder;
         this.clock = clock;
     }
 
@@ -101,12 +83,7 @@ public class CredentialReader {
         }
     }
 
-    /**
-     * Hands the record's update to the recorder, which runs it in a transaction of its own on one
-     * connection at a time. Never on the caller's thread: inside a transaction the caller's connection
-     * stays checked out until the transaction is fully cleaned up, and a stalled database must not
-     * delay the answer the caller already has. The record is best effort; a later read repeats it.
-     */
+    /** Runs the update in a transaction of its own, and logs rather than replaces the caller's answer. */
     private void record(Runnable update) {
         recorder.execute(() -> {
             try {
@@ -115,20 +92,5 @@ public class CredentialReader {
                 log.warn("Could not record the readability of a stored credential", e);
             }
         });
-    }
-
-    @PreDestroy
-    void shutdown() {
-        recorder.shutdown();
-        try {
-            // Briefly, so a record already in flight lands before the data source goes; a stalled one
-            // is abandoned like any other.
-            if (!recorder.awaitTermination(2, TimeUnit.SECONDS)) {
-                recorder.shutdownNow();
-            }
-        } catch (InterruptedException e) {
-            recorder.shutdownNow();
-            Thread.currentThread().interrupt();
-        }
     }
 }

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/core/connection/CredentialUnreadableException.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/core/connection/CredentialUnreadableException.java
@@ -1,6 +1,7 @@
 package de.tum.cit.aet.hephaestus.integration.core.connection;
 
 import de.tum.cit.aet.hephaestus.integration.core.spi.IntegrationKind;
+import java.util.Locale;
 
 /**
  * A stored credential exists but cannot be decrypted with the keys this server runs with. That is a
@@ -15,7 +16,7 @@ public class CredentialUnreadableException extends RuntimeException {
 
     public CredentialUnreadableException(long connectionId, IntegrationKind kind, Throwable cause) {
         super(
-                "The stored " + kind.name().toLowerCase(java.util.Locale.ROOT) + " credential of connection "
+                "The stored " + kind.name().toLowerCase(Locale.ROOT) + " credential of connection "
                         + connectionId
                         + " cannot be read with the server's current encryption keys. Replace the credential, or restore the"
                         + " key it was written with if that was changed by mistake.",

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/core/connection/api/CredentialUnreadableProblemAdvice.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/core/connection/api/CredentialUnreadableProblemAdvice.java
@@ -2,8 +2,6 @@ package de.tum.cit.aet.hephaestus.integration.core.connection.api;
 
 import de.tum.cit.aet.hephaestus.integration.core.connection.ConnectionModeConflictException;
 import de.tum.cit.aet.hephaestus.integration.core.connection.CredentialUnreadableException;
-import org.springframework.core.Ordered;
-import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -13,10 +11,11 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
  * An unreadable credential, or a write the connection's mode cannot take, is a state of the
  * connection, so the answer names it and what clears it; nothing here is a fault of the request or of
  * the server's ability to serve it. Lives beside the connection API rather than in the core advice,
- * which must not depend on integration types.
+ * which must not depend on integration types. Unordered: {@code GlobalControllerAdvice} sits at
+ * {@code LOWEST_PRECEDENCE}, so these handlers already win over its catch-all without outranking a
+ * future advice more specific than they are.
  */
 @RestControllerAdvice
-@Order(Ordered.HIGHEST_PRECEDENCE)
 public class CredentialUnreadableProblemAdvice {
 
     @ExceptionHandler(CredentialUnreadableException.class)

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/github/lifecycle/GithubLifecycleListener.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/github/lifecycle/GithubLifecycleListener.java
@@ -322,7 +322,7 @@ public class GithubLifecycleListener implements IntegrationLifecycleListener {
                                 .map(b -> b.token() != null && !b.token().isBlank())
                                 .orElse(false);
 
-                if (isPatWorkspace && hasPatToken) {
+                if (hasPatToken) {
                     log.info(
                             "Skipped GitHub App installation linking, PAT workspace has stored token: workspaceId={}, accountLogin={}, installationId={}",
                             existingByLogin.getId(),

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/core/connection/ConnectionPurgeContributorTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/core/connection/ConnectionPurgeContributorTest.java
@@ -17,6 +17,7 @@ import de.tum.cit.aet.hephaestus.integration.core.spi.IntegrationRef;
 import de.tum.cit.aet.hephaestus.integration.core.spi.IntegrationState;
 import de.tum.cit.aet.hephaestus.integration.core.sync.SyncJobService;
 import de.tum.cit.aet.hephaestus.testconfig.BaseUnitTest;
+import de.tum.cit.aet.hephaestus.testconfig.CredentialReaders;
 import de.tum.cit.aet.hephaestus.workspace.Workspace;
 import de.tum.cit.aet.hephaestus.workspace.spi.WorkspacePurgeBlockedException;
 import java.lang.reflect.Field;
@@ -67,11 +68,7 @@ class ConnectionPurgeContributorTest extends BaseUnitTest {
                 eventPublisher,
                 syncJobService,
                 transactionManager,
-                new CredentialReader(
-                        org.mockito.Mockito.mock(ConnectionRepository.class),
-                        credentialConverter,
-                        org.mockito.Mockito.mock(org.springframework.transaction.PlatformTransactionManager.class),
-                        java.time.Clock.systemUTC()));
+                CredentialReaders.forTests(credentialConverter));
         Mockito.lenient().when(connectionRepository.save(any(Connection.class))).thenAnswer(inv -> inv.getArgument(0));
         Mockito.lenient().when(transactionManager.getTransaction(any())).thenReturn(new SimpleTransactionStatus());
         Mockito.lenient().when(connectionStrategy.kind()).thenReturn(IntegrationKind.GITHUB);

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/core/connection/ConnectionServiceTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/core/connection/ConnectionServiceTest.java
@@ -20,6 +20,7 @@ import de.tum.cit.aet.hephaestus.testconfig.BaseUnitTest;
 import de.tum.cit.aet.hephaestus.testconfig.TestEntities;
 import de.tum.cit.aet.hephaestus.workspace.Workspace;
 import java.lang.reflect.Field;
+import java.time.Clock;
 import java.time.Instant;
 import java.util.Optional;
 import java.util.Set;
@@ -33,6 +34,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.core.task.SyncTaskExecutor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.dao.QueryTimeoutException;
 import org.springframework.transaction.PlatformTransactionManager;
@@ -86,7 +88,11 @@ class ConnectionServiceTest extends BaseUnitTest {
                 syncJobService,
                 transactionManager,
                 new CredentialReader(
-                        connectionRepository, credentialConverter, transactionManager, java.time.Clock.systemUTC()));
+                        connectionRepository,
+                        credentialConverter,
+                        transactionManager,
+                        new SyncTaskExecutor(),
+                        Clock.systemUTC()));
         // Default: the connection is free. Only the disconnect fence ever asks.
         Mockito.lenient()
                 .when(syncJobService.requestCancelForTeardown(anyLong()))

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/core/connection/CredentialReaderTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/core/connection/CredentialReaderTest.java
@@ -4,10 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -22,26 +20,17 @@ import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.springframework.core.task.SyncTaskExecutor;
+import org.springframework.core.task.TaskExecutor;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.support.SimpleTransactionStatus;
 
 @Tag("unit")
 class CredentialReaderTest extends BaseUnitTest {
-
-    private final List<CredentialReader> readers = new ArrayList<>();
-
-    @AfterEach
-    void shutDownReaders() {
-        readers.forEach(CredentialReader::shutdown);
-    }
 
     private static final String KEY_A = "0123456789abcdef0123456789abcdef";
     private static final String KEY_B = "ABCDEFabcdef0123ABCDEFabcdef0123";
@@ -65,33 +54,30 @@ class CredentialReaderTest extends BaseUnitTest {
         ReflectionTestUtils.setField(connection, "id", 55L);
     }
 
-    @Test
-    void shouldRecordOffTheCallersThread() throws InterruptedException {
-        CredentialBundleConverter writer = new CredentialBundleConverter(KEY_A, "dev");
-        connection.setCredentials(TOKEN, writer);
-        CredentialBundleConverter reader = new CredentialBundleConverter(KEY_B, "dev");
-        AtomicReference<String> recordedOn = new AtomicReference<>();
-        CountDownLatch recorded = new CountDownLatch(1);
-        doAnswer(invocation -> {
-                    recordedOn.set(Thread.currentThread().getName());
-                    recorded.countDown();
-                    return 1;
-                })
-                .when(connectionRepository)
-                .markCredentialsUnreadable(any(), any(), any(), any());
-
-        assertThatThrownBy(() -> readerWith(reader).credentialsOf(connection))
-                .isInstanceOf(CredentialUnreadableException.class);
-
-        assertThat(recorded.await(2, TimeUnit.SECONDS)).isTrue();
-        assertThat(recordedOn.get()).isEqualTo(CredentialReader.RECORDER_THREAD);
+    /** Runs each record where the assertion can see it; the pool that runs it in production is wiring. */
+    private CredentialReader readerWith(CredentialBundleConverter converter) {
+        return readerWith(converter, new SyncTaskExecutor());
     }
 
-    private CredentialReader readerWith(CredentialBundleConverter converter) {
-        CredentialReader reader = new CredentialReader(
-                connectionRepository, converter, transactionManager, Clock.fixed(NOW, ZoneOffset.UTC));
-        readers.add(reader);
-        return reader;
+    private CredentialReader readerWith(CredentialBundleConverter converter, TaskExecutor recorder) {
+        return new CredentialReader(
+                connectionRepository, converter, transactionManager, recorder, Clock.fixed(NOW, ZoneOffset.UTC));
+    }
+
+    @Test
+    void shouldHandTheRecordToItsExecutorRatherThanRunItInline() {
+        connection.setCredentials(TOKEN, new CredentialBundleConverter(KEY_A, "dev"));
+        List<Runnable> handedOver = new ArrayList<>();
+
+        assertThatThrownBy(() -> readerWith(new CredentialBundleConverter(KEY_B, "dev"), handedOver::add)
+                        .credentialsOf(connection))
+                .isInstanceOf(CredentialUnreadableException.class);
+
+        // The caller has its answer before anything is written, so a stalled database cannot delay it.
+        verify(connectionRepository, never()).markCredentialsUnreadable(any(), any(), any(), any());
+        handedOver.forEach(Runnable::run);
+        verify(connectionRepository)
+                .markCredentialsUnreadable(eq(55L), eq(7L), eq(connection.getCredentialsEncrypted()), eq(NOW));
     }
 
     @Test
@@ -117,8 +103,8 @@ class CredentialReaderTest extends BaseUnitTest {
                 })
                 .hasMessageContaining("connection 55")
                 .hasMessageContaining("Replace the credential");
-        // The record arrives from the recorder, bound to the ciphertext that failed.
-        verify(connectionRepository, timeout(2000))
+        // Bound to the ciphertext that failed, so a credential replaced since is left alone.
+        verify(connectionRepository)
                 .markCredentialsUnreadable(eq(55L), eq(7L), eq(connection.getCredentialsEncrypted()), eq(NOW));
     }
 
@@ -129,8 +115,7 @@ class CredentialReaderTest extends BaseUnitTest {
         connection.markCredentialRotationFailed(NOW.minusSeconds(60));
 
         assertThat(readerWith(converter).credentialsOf(connection)).contains(TOKEN);
-        verify(connectionRepository, timeout(2000))
-                .markCredentialsReadable(eq(55L), eq(7L), eq(connection.getCredentialsEncrypted()));
+        verify(connectionRepository).markCredentialsReadable(eq(55L), eq(7L), eq(connection.getCredentialsEncrypted()));
     }
 
     @Test

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/scm/github/credentials/GithubCredentialProviderTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/scm/github/credentials/GithubCredentialProviderTest.java
@@ -6,10 +6,8 @@ import static org.mockito.Mockito.when;
 
 import de.tum.cit.aet.hephaestus.integration.core.connection.Connection;
 import de.tum.cit.aet.hephaestus.integration.core.connection.ConnectionConfig;
-import de.tum.cit.aet.hephaestus.integration.core.connection.ConnectionRepository;
 import de.tum.cit.aet.hephaestus.integration.core.connection.ConnectionService;
 import de.tum.cit.aet.hephaestus.integration.core.connection.CredentialBundleConverter;
-import de.tum.cit.aet.hephaestus.integration.core.connection.CredentialReader;
 import de.tum.cit.aet.hephaestus.integration.core.spi.ApiCredentialProvider.BearerToken;
 import de.tum.cit.aet.hephaestus.integration.core.spi.ApiCredentialProvider.CredentialBundle;
 import de.tum.cit.aet.hephaestus.integration.core.spi.ApiCredentialProvider.InstallationCredential;
@@ -18,6 +16,7 @@ import de.tum.cit.aet.hephaestus.integration.core.spi.IntegrationRef;
 import de.tum.cit.aet.hephaestus.integration.core.spi.IntegrationState;
 import de.tum.cit.aet.hephaestus.integration.scm.github.app.GitHubAppTokenService;
 import de.tum.cit.aet.hephaestus.testconfig.BaseUnitTest;
+import de.tum.cit.aet.hephaestus.testconfig.CredentialReaders;
 import de.tum.cit.aet.hephaestus.workspace.Workspace;
 import java.util.Optional;
 import java.util.Set;
@@ -48,14 +47,8 @@ class GithubCredentialProviderTest extends BaseUnitTest {
         MockitoAnnotations.openMocks(this);
         converter = new CredentialBundleConverter("0123456789abcdef0123456789abcdef", "dev");
         lenient().when(appTokenService.getConfiguredAppId()).thenReturn(42L);
-        provider = new GithubCredentialProvider(
-                connectionService,
-                new CredentialReader(
-                        org.mockito.Mockito.mock(ConnectionRepository.class),
-                        converter,
-                        org.mockito.Mockito.mock(org.springframework.transaction.PlatformTransactionManager.class),
-                        java.time.Clock.systemUTC()),
-                appTokenService);
+        provider =
+                new GithubCredentialProvider(connectionService, CredentialReaders.forTests(converter), appTokenService);
     }
 
     @Test

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/scm/gitlab/credentials/GitlabCredentialProviderTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/scm/gitlab/credentials/GitlabCredentialProviderTest.java
@@ -5,16 +5,15 @@ import static org.mockito.Mockito.when;
 
 import de.tum.cit.aet.hephaestus.integration.core.connection.Connection;
 import de.tum.cit.aet.hephaestus.integration.core.connection.ConnectionConfig;
-import de.tum.cit.aet.hephaestus.integration.core.connection.ConnectionRepository;
 import de.tum.cit.aet.hephaestus.integration.core.connection.ConnectionService;
 import de.tum.cit.aet.hephaestus.integration.core.connection.CredentialBundleConverter;
-import de.tum.cit.aet.hephaestus.integration.core.connection.CredentialReader;
 import de.tum.cit.aet.hephaestus.integration.core.spi.ApiCredentialProvider.BearerToken;
 import de.tum.cit.aet.hephaestus.integration.core.spi.ApiCredentialProvider.CredentialBundle;
 import de.tum.cit.aet.hephaestus.integration.core.spi.IntegrationKind;
 import de.tum.cit.aet.hephaestus.integration.core.spi.IntegrationRef;
 import de.tum.cit.aet.hephaestus.integration.core.spi.IntegrationState;
 import de.tum.cit.aet.hephaestus.testconfig.BaseUnitTest;
+import de.tum.cit.aet.hephaestus.testconfig.CredentialReaders;
 import de.tum.cit.aet.hephaestus.workspace.Workspace;
 import java.util.Optional;
 import java.util.Set;
@@ -36,13 +35,7 @@ class GitlabCredentialProviderTest extends BaseUnitTest {
     void setUp() {
         MockitoAnnotations.openMocks(this);
         converter = new CredentialBundleConverter("0123456789abcdef0123456789abcdef", "dev");
-        provider = new GitlabCredentialProvider(
-                connectionService,
-                new CredentialReader(
-                        org.mockito.Mockito.mock(ConnectionRepository.class),
-                        converter,
-                        org.mockito.Mockito.mock(org.springframework.transaction.PlatformTransactionManager.class),
-                        java.time.Clock.systemUTC()));
+        provider = new GitlabCredentialProvider(connectionService, CredentialReaders.forTests(converter));
     }
 
     @Test

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/slack/credentials/SlackCredentialProviderTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/slack/credentials/SlackCredentialProviderTest.java
@@ -5,16 +5,15 @@ import static org.mockito.Mockito.when;
 
 import de.tum.cit.aet.hephaestus.integration.core.connection.Connection;
 import de.tum.cit.aet.hephaestus.integration.core.connection.ConnectionConfig;
-import de.tum.cit.aet.hephaestus.integration.core.connection.ConnectionRepository;
 import de.tum.cit.aet.hephaestus.integration.core.connection.ConnectionService;
 import de.tum.cit.aet.hephaestus.integration.core.connection.CredentialBundleConverter;
-import de.tum.cit.aet.hephaestus.integration.core.connection.CredentialReader;
 import de.tum.cit.aet.hephaestus.integration.core.spi.ApiCredentialProvider.BearerToken;
 import de.tum.cit.aet.hephaestus.integration.core.spi.ApiCredentialProvider.CredentialBundle;
 import de.tum.cit.aet.hephaestus.integration.core.spi.IntegrationKind;
 import de.tum.cit.aet.hephaestus.integration.core.spi.IntegrationRef;
 import de.tum.cit.aet.hephaestus.integration.core.spi.IntegrationState;
 import de.tum.cit.aet.hephaestus.testconfig.BaseUnitTest;
+import de.tum.cit.aet.hephaestus.testconfig.CredentialReaders;
 import de.tum.cit.aet.hephaestus.workspace.Workspace;
 import java.util.Optional;
 import java.util.Set;
@@ -35,13 +34,7 @@ class SlackCredentialProviderTest extends BaseUnitTest {
     void setUp() {
         MockitoAnnotations.openMocks(this);
         converter = new CredentialBundleConverter("0123456789abcdef0123456789abcdef", "dev");
-        provider = new SlackCredentialProvider(
-                connectionService,
-                new CredentialReader(
-                        org.mockito.Mockito.mock(ConnectionRepository.class),
-                        converter,
-                        org.mockito.Mockito.mock(org.springframework.transaction.PlatformTransactionManager.class),
-                        java.time.Clock.systemUTC()));
+        provider = new SlackCredentialProvider(connectionService, CredentialReaders.forTests(converter));
     }
 
     @Test

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/slack/messaging/SlackMessageServiceLiveTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/slack/messaging/SlackMessageServiceLiveTest.java
@@ -10,15 +10,14 @@ import static org.mockito.Mockito.when;
 
 import de.tum.cit.aet.hephaestus.integration.core.connection.Connection;
 import de.tum.cit.aet.hephaestus.integration.core.connection.ConnectionConfig;
-import de.tum.cit.aet.hephaestus.integration.core.connection.ConnectionRepository;
 import de.tum.cit.aet.hephaestus.integration.core.connection.ConnectionService;
 import de.tum.cit.aet.hephaestus.integration.core.connection.CredentialBundleConverter;
-import de.tum.cit.aet.hephaestus.integration.core.connection.CredentialReader;
 import de.tum.cit.aet.hephaestus.integration.core.egress.OutboundEgressGuard;
 import de.tum.cit.aet.hephaestus.integration.core.spi.ApiCredentialProvider.BearerToken;
 import de.tum.cit.aet.hephaestus.integration.core.spi.IntegrationKind;
 import de.tum.cit.aet.hephaestus.integration.core.spi.IntegrationState;
 import de.tum.cit.aet.hephaestus.integration.slack.credentials.SlackCredentialProvider;
+import de.tum.cit.aet.hephaestus.testconfig.CredentialReaders;
 import de.tum.cit.aet.hephaestus.workspace.Workspace;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.Optional;
@@ -67,13 +66,8 @@ class SlackMessageServiceLiveTest {
         ConnectionService connectionService = mock(ConnectionService.class);
         when(connectionService.findActive(workspaceId, IntegrationKind.SLACK)).thenReturn(Optional.of(connection));
 
-        SlackCredentialProvider credentialProvider = new SlackCredentialProvider(
-                connectionService,
-                new CredentialReader(
-                        org.mockito.Mockito.mock(ConnectionRepository.class),
-                        converter,
-                        org.mockito.Mockito.mock(org.springframework.transaction.PlatformTransactionManager.class),
-                        java.time.Clock.systemUTC()));
+        SlackCredentialProvider credentialProvider =
+                new SlackCredentialProvider(connectionService, CredentialReaders.forTests(converter));
         SlackMessageService service = new SlackMessageService(
                 credentialProvider,
                 new SlackRateLimitTracker(new SimpleMeterRegistry()),

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/testconfig/CredentialReaders.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/testconfig/CredentialReaders.java
@@ -1,0 +1,32 @@
+package de.tum.cit.aet.hephaestus.testconfig;
+
+import static org.mockito.Mockito.mock;
+
+import de.tum.cit.aet.hephaestus.integration.core.connection.ConnectionRepository;
+import de.tum.cit.aet.hephaestus.integration.core.connection.CredentialBundleConverter;
+import de.tum.cit.aet.hephaestus.integration.core.connection.CredentialReader;
+import java.time.Clock;
+import org.springframework.core.task.SyncTaskExecutor;
+import org.springframework.transaction.PlatformTransactionManager;
+
+/**
+ * Readers for unit tests of the callers that decrypt through one — the credential providers, the
+ * connection services — rather than of the reader itself.
+ */
+public final class CredentialReaders {
+
+    private CredentialReaders() {}
+
+    /**
+     * A reader whose records go nowhere: the repository is a mock, so no statement needs stubbing, and
+     * the executor runs on the calling thread, so nothing is left in flight when the test ends.
+     */
+    public static CredentialReader forTests(CredentialBundleConverter converter) {
+        return new CredentialReader(
+                mock(ConnectionRepository.class),
+                converter,
+                mock(PlatformTransactionManager.class),
+                new SyncTaskExecutor(),
+                Clock.systemUTC());
+    }
+}

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/testconfig/TestAsyncConfiguration.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/testconfig/TestAsyncConfiguration.java
@@ -1,5 +1,6 @@
 package de.tum.cit.aet.hephaestus.testconfig;
 
+import de.tum.cit.aet.hephaestus.config.CredentialReadabilityExecutor;
 import de.tum.cit.aet.hephaestus.config.FeedbackLaneExecutor;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
@@ -91,6 +92,15 @@ public class TestAsyncConfiguration implements AsyncConfigurer {
      */
     @Bean(name = FeedbackLaneExecutor.BEAN_NAME)
     public AsyncTaskExecutor feedbackLaneExecutor() {
+        return syncExecutor;
+    }
+
+    /**
+     * The credential readability lane, synchronous here like every other. Must exist by name for the
+     * same reason as {@link #feedbackLaneExecutor()}: the qualifier resolves against the bean factory.
+     */
+    @Bean(name = CredentialReadabilityExecutor.BEAN_NAME)
+    public AsyncTaskExecutor credentialReadabilityExecutor() {
         return syncExecutor;
     }
 


### PR DESCRIPTION
## Problem

`CredentialReader`, added by #1881, writes the record of whether a stored credential could be read on
a pool it builds itself: a `ThreadPoolExecutor(1, 1, 0, MS, ArrayBlockingQueue(64), <custom
ThreadFactory>, DiscardPolicy)` plus a `@PreDestroy` that calls `shutdown()`, `awaitTermination(2s)`
and `shutdownNow()`. Every one of those is a property of Spring's `ThreadPoolTaskExecutor`, which also
implements `DisposableBean`, and `SpringAsyncConfig` already declares two lanes of exactly this shape
(`feedbackLaneExecutor`, `syncJobExecutor`) for the same reason — a bounded pool of its own so a burst
neither starves the web tier of connections nor queues behind the activity listeners a sync fans out.

Because the pool was private to the reader, five unit tests had to build one to get a reader at all,
each repeating the same six fully-qualified lines, and the tests that assert the record had to reach
for `verify(..., timeout(2000))` against it.

## Fix

- `credentialReadabilityExecutor` is a `ThreadPoolTaskExecutor` `@Bean` in `SpringAsyncConfig`:
  `setCorePoolSize(1)`, `setQueueCapacity(64)`, `setThreadNamePrefix`,
  `setRejectedExecutionHandler(DiscardPolicy)`, `setWaitForTasksToCompleteOnShutdown(true)` and
  `setAwaitTerminationSeconds(2)` — the same knobs, from the framework
  (<https://docs.spring.io/spring-boot/reference/features/task-execution-and-scheduling.html>). The
  `@PreDestroy` block goes away with it. `TestAsyncConfiguration` supplies the name synchronously, as
  it must for a qualifier and as it already does for the feedback lane.
- `CredentialReader` takes a `TaskExecutor` — the narrowest type it uses — behind a
  `CredentialReadabilityExecutor.BEAN_NAME` qualifier, following `FeedbackLaneExecutor`'s reasoning
  that a mistyped qualifier is not an error but a silent fall back to the default pool.
- `CredentialReaderTest` gives the reader a `SyncTaskExecutor`, so every record assertion is
  deterministic and no longer waits on a pool. The one guarantee that was really about deferral —
  the caller gets its answer before anything is written — is now asserted directly, by handing the
  reader an executor that collects the task instead of running it.
- `CredentialReaders.forTests(converter)` replaces the five inline constructions.

Four review leftovers in the same feature, none of them behaviour:

- `ConnectionRepository#markCredentialsUnreadable`'s javadoc had lost a noun ("one another
  transaction holds locked … is skipped").
- `GithubLifecycleListener`'s `if (isPatWorkspace && hasPatToken)` — `hasPatToken` is already
  `isPatWorkspace && …`.
- `CredentialUnreadableException` inlined `java.util.Locale.ROOT` in a file with an import block.
- `CredentialUnreadableProblemAdvice` was `@Order(Ordered.HIGHEST_PRECEDENCE)`; `GlobalControllerAdvice`
  is `LOWEST_PRECEDENCE`, so unordered already wins, without outranking a future advice more specific
  than this one.

## Verification

- `vp run format`, then `vp run check` — the complete local quality gate, exit 0 (PMD, architecture
  and Modulith verification, formatting, repository policy).
- `vp run test:server:unit` — full unit and architecture tier green, coverage checks met.
- `MANAGEMENT_PORT=0 SERVER_PORT=0 ./mvnw -f application/pom.xml -Dtest=CredentialReaderTest,ConnectionServiceTest,ConnectionPurgeContributorTest,GithubCredentialProviderTest,GitlabCredentialProviderTest,SlackCredentialProviderTest,CredentialRotationServiceTest,ConnectionTest,WorkspaceSettingsServiceTest,SpringAsyncConfigTest test` — 58 tests, 0 failures.
- `MANAGEMENT_PORT=0 SERVER_PORT=0 ./mvnw … -Dsurefire.includedGroups=integration -Dtest=CredentialReaderIntegrationTest,CredentialRotationServiceIntegrationTest,ConnectionDisconnectRevokeIsolationIntegrationTest,ConnectionConfigJsonRoundTripIntegrationTest` — 15 tests, 0 failures. The context boots with the new bean in the `test` profile, which is what proves the qualifier resolves in every runtime role.

Surfaces: no wire contract, no schema, no channel and no UI change; the bean is unconditional, as the
reader must be, since the webhook role reads a token too. Changeset is empty and says why.

Part of #1860.