### PR TITLE
fix(docker): clear staging provider credentials from preview clones

### DIFF
--- a/.changeset/preview-provider-credentials.md
+++ b/.changeset/preview-provider-credentials.md
@@ -1,0 +1,5 @@
+---
+---
+
+Repository infrastructure only: the preview seed policy now clears staging's provider credentials.
+Previews are this repository's own pull-request stacks, not part of a Hephaestus release.

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -164,6 +164,10 @@ jobs:
               # gate:env validates these deployment inputs against application.yml.
               - 'docker/compose.app.yaml'
               - 'docker/compose.core.yaml'
+              # PreviewSeedPolicyIntegrationTest runs this file's clone policy against the migrated
+              # schema; a preview cannot rehearse it, because the controller refuses to deploy a
+              # head that changes docker/preview/.
+              - 'docker/preview/compose.app.yaml'
               - '!server/**/AGENTS.md'
               - '!server/**/CLAUDE.md'
             tooling:

--- a/docker/preview/README.md
+++ b/docker/preview/README.md
@@ -32,6 +32,11 @@ hold, each enforced before Coolify is asked to deploy:
   (`login_provider`, `jwt_signing_key`, `issued_jwt`) is dropped so the preview signs its own tokens.
   The seed loader verifies that against the database and refuses to mark the preview seeded
   otherwise, so a policy that silently did not apply leaves the preview un-booted rather than live.
+- Staging's provider credentials do not survive the clone either: the instance and workspace AI
+  catalog keys are cleared and those connections disabled, every integration connection loses its
+  credential bundle and the webhook signing secret its config carries, and the job tokens staging
+  minted for its own review jobs are replaced. The same verification covers all of them, so a
+  preview that would hold something able to act as staging never boots.
 - The application server reads staging's JetStream, so a preview sees the events a shared GitHub App
   delivers there. Its durable is named per deploy, so previews never compete for one consumer, and
   it expires 72h after the preview stops reading — a preview is deleted, not shut down, so it never

--- a/docker/preview/compose.app.yaml
+++ b/docker/preview/compose.app.yaml
@@ -77,6 +77,7 @@ services:
       - -c
       - |
         set -eu
+        trap 'rm -f /tmp/seed.dump' EXIT
 
         APP_FQDN="$${SERVICE_FQDN_APPSERVER:-$${SERVICE_FQDN_WEBAPP:-}}"
         if ! echo "$$APP_FQDN" | grep -Eq "^pr[0-9]+"; then
@@ -175,6 +176,28 @@ services:
         DELETE FROM issued_jwt;
         DELETE FROM jwt_signing_key;
         DELETE FROM login_provider;
+
+        -- 3. Forget provider secrets; catalogs, integrations and their state stay as they were, so the
+        --    preview looks like staging without holding anything that can act as staging.
+        UPDATE llm_connection SET api_key = NULL, enabled = FALSE, updated_at = NOW()
+         WHERE api_key IS NOT NULL OR enabled;
+        UPDATE workspace_llm_connection SET api_key = NULL, enabled = FALSE, updated_at = NOW()
+         WHERE api_key IS NOT NULL OR enabled;
+        UPDATE connection
+           SET credentials_encrypted = NULL,
+               credentials_alg = NULL,
+               credentials_key_version = NULL,
+               credentials_rotation_failed_at = NULL,
+               -- the Outline signing secret lives in the config document, not in the credential bundle
+               config = config - 'webhookSecret',
+               updated_at = NOW()
+         WHERE credentials_encrypted IS NOT NULL OR credentials_alg IS NOT NULL
+            OR credentials_key_version IS NOT NULL OR credentials_rotation_failed_at IS NOT NULL
+            OR config ? 'webhookSecret';
+        -- A job token is a credential staging minted; the jobs are cancelled or finished, so the
+        -- token has nothing left to authorise. The column is unique, hence a marker per row.
+        UPDATE agent_job SET job_token = 'cleared-by-preview-clone:' || id, job_token_hash = NULL
+         WHERE job_token NOT LIKE 'cleared-by-preview-clone:%';
         SQL
 
         # Every statement above succeeds when it matches nothing, so the marker is earned by
@@ -191,7 +214,15 @@ services:
                + (SELECT count(*) FROM sync_job WHERE status IN ('PENDING', 'RUNNING'))
                + (SELECT count(*) FROM login_provider)
                + (SELECT count(*) FROM jwt_signing_key)
-               + (SELECT count(*) FROM issued_jwt)")
+               + (SELECT count(*) FROM issued_jwt)
+               + (SELECT count(*) FROM llm_connection WHERE api_key IS NOT NULL OR enabled)
+               + (SELECT count(*) FROM workspace_llm_connection WHERE api_key IS NOT NULL OR enabled)
+               + (SELECT count(*) FROM connection
+                   WHERE credentials_encrypted IS NOT NULL OR credentials_alg IS NOT NULL
+                      OR credentials_key_version IS NOT NULL OR credentials_rotation_failed_at IS NOT NULL
+                      OR config ? 'webhookSecret')
+               + (SELECT count(*) FROM agent_job
+                   WHERE job_token NOT LIKE 'cleared-by-preview-clone:%' OR job_token_hash IS NOT NULL)")
         if [ "$$LIVE" != "0" ]; then
           echo "Preview policy did not take effect ($$LIVE rows still live); refusing to mark this preview seeded"
           exit 1

--- a/docs/contributor/ci-cd.mdx
+++ b/docs/contributor/ci-cd.mdx
@@ -254,6 +254,25 @@ Preview controllers run only for pull requests targeting `main`; this keeps priv
 `pull_request_target` workflows anchored to the protected branch. A stacked layer becomes eligible
 after it is retargeted to `main`.
 
+### What a preview keeps from staging
+
+Accounts, workspaces, reviewed work, observations, feedback and the AI catalogs' metadata are all
+there to read, model prices, grants and bindings included, and each connection keeps the state it
+had on staging. What the clone is stripped of, and what the seed loader verifies before it lets the
+preview boot, is
+[`docker/preview/README.md` § Security boundary](https://github.com/ls1intum/Hephaestus/blob/main/docker/preview/README.md#security-boundary).
+
+None of staging's provider credentials are among what it keeps, so a preview reaches no model and no
+provider on staging's account. To give one AI access, add a **preview-only provider key** through
+the preview's own AI models administration and enable that connection; instance and workspace
+connections both work, and a preview talking to a different endpoint gets a connection of its own.
+There is no provider-key environment variable and no fallback to staging's key, and enabling a
+connection does not switch practice review execution on.
+
+Seeding happens once per preview, so a preview seeded before this policy was installed still holds
+what the policy now clears. **Recreate it, including its private database volume** — a normal
+redeploy preserves an already-seeded database — and configure its AI access again afterwards.
+
 ### When the comment says nothing deployed
 
 | Comment says | What to do |

--- a/scripts/check-preview-stack.test.ts
+++ b/scripts/check-preview-stack.test.ts
@@ -3,6 +3,7 @@ import { describe, test } from "node:test";
 
 import {
 	findEnvDrift,
+	findSeedPolicyGaps,
 	findStaleOmissions,
 	findViolations,
 	REQUIRED_SWITCHES,
@@ -242,6 +243,60 @@ void describe("preview drift from the reference stack", () => {
 
 	void test("stays quiet for a variable recorded as deliberately omitted", () => {
 		assert.deepEqual(findEnvDrift(reference("      SANDBOX_CPUS: 2"), preview), []);
+	});
+});
+
+void describe("preview seed policy", () => {
+	const seedLoader = (policy: string, counted: string[]) =>
+		[
+			"        psql -h target -v ON_ERROR_STOP=1 <<'SQL'",
+			policy,
+			"        SQL",
+			"",
+			'        LIVE=$$(psql -h target -tAX -v ON_ERROR_STOP=1 -c "',
+			`          SELECT ${counted.map((table) => `(SELECT count(*) FROM ${table})`).join(" + ")}")`,
+			'        if [ "$$LIVE" != "0" ]; then exit 1; fi',
+		].join("\n");
+
+	void test("passes when the policy clears exactly what the verification counts", () => {
+		const stack = seedLoader(
+			"        UPDATE llm_connection SET api_key = NULL;\n        DELETE FROM issued_jwt;",
+			["llm_connection", "issued_jwt"],
+		);
+
+		assert.deepEqual(findSeedPolicyGaps(stack), []);
+	});
+
+	void test("names a credential store the policy clears and nothing counts", () => {
+		const stack = seedLoader(
+			"        UPDATE llm_connection SET api_key = NULL;\n        UPDATE workspace_llm_connection SET api_key = NULL;",
+			["llm_connection"],
+		);
+
+		assert.deepEqual(findSeedPolicyGaps(stack), [
+			"the policy changes workspace_llm_connection but the verification query never counts it",
+		]);
+	});
+
+	void test("names a store the verification counts and the policy never clears", () => {
+		const stack = seedLoader("        UPDATE llm_connection SET api_key = NULL;", [
+			"llm_connection",
+			"connection",
+		]);
+
+		assert.deepEqual(findSeedPolicyGaps(stack), [
+			"the verification query counts connection but the policy never changes it",
+		]);
+	});
+
+	void test("refuses a seed loader that applies or verifies nothing", () => {
+		assert.deepEqual(findSeedPolicyGaps("services:\n  seed-loader:\n"), [
+			"the seed loader applies no SQL policy",
+		]);
+		assert.deepEqual(
+			findSeedPolicyGaps("        psql <<'SQL'\n        DELETE FROM issued_jwt;\n        SQL\n"),
+			["the seed loader marks a clone seeded without verifying its policy"],
+		);
 	});
 });
 

--- a/scripts/check-preview-stack.ts
+++ b/scripts/check-preview-stack.ts
@@ -1,5 +1,6 @@
 /**
- * Asserts that the preview stack cannot leave its sandbox.
+ * Asserts that the preview stack cannot leave its sandbox, and that the seed policy which strips
+ * staging out of a clone verifies every store it touches.
  *
  * Coolify re-reads docker/preview/compose.app.yaml from the commit it deploys, so a pull request's
  * own copy of that file defines its stack. The preview controller refuses to deploy a head that
@@ -110,6 +111,42 @@ export function findStaleOmissions(referenceText: string): string[] {
 		.map(
 			(key) => `${key} is recorded as deliberately omitted but ${REFERENCE_FILE} no longer sets it`,
 		);
+}
+
+/** The heredoc the seed loader pipes into psql, and the query that decides whether it took effect. */
+const SEED_POLICY = /<<'SQL'\n([\s\S]*?)\n[ \t]*SQL\n/;
+const SEED_VERIFICATION = /LIVE=\$\$\(psql[^\n]*-c "([\s\S]*?)"\)/;
+const CHANGED_TABLE = /\b(?:UPDATE|DELETE FROM)[\s\n]+([a-z_]+)/g;
+const COUNTED_TABLE = /\bFROM[\s\n]+([a-z_]+)/g;
+
+function tablesIn(sql: string, pattern: RegExp): Set<string> {
+	return new Set([...sql.matchAll(pattern)].flatMap((match) => match[1] ?? []));
+}
+
+/**
+ * A clone of staging earns its seed marker by being counted, not by psql's exit status — every
+ * statement in the policy succeeds when it matches nothing. The policy and the count are written far
+ * apart in the same shell block, so a store the policy clears and the count forgets turns a policy
+ * that silently did not apply into a live preview holding staging's secrets, and a store the count
+ * watches and the policy never clears leaves every preview un-booted.
+ */
+export function findSeedPolicyGaps(previewText: string): string[] {
+	const policy = SEED_POLICY.exec(previewText)?.[1];
+	if (policy === undefined) return ["the seed loader applies no SQL policy"];
+	const verification = SEED_VERIFICATION.exec(previewText)?.[1];
+	if (verification === undefined) {
+		return ["the seed loader marks a clone seeded without verifying its policy"];
+	}
+	const changed = tablesIn(policy, CHANGED_TABLE);
+	const counted = tablesIn(verification, COUNTED_TABLE);
+	return [
+		...[...changed.difference(counted)]
+			.toSorted()
+			.map((table) => `the policy changes ${table} but the verification query never counts it`),
+		...[...counted.difference(changed)]
+			.toSorted()
+			.map((table) => `the verification query counts ${table} but the policy never changes it`),
+	];
 }
 
 /** Only has to let Compose interpolate; Coolify supplies the real values per pull request. */
@@ -289,12 +326,12 @@ export function renderStack(): unknown {
 
 if (import.meta.main) {
 	try {
-		const drift = findEnvDrift(
-			readFileSync(REFERENCE_FILE, "utf8"),
-			readFileSync(COMPOSE_FILE, "utf8"),
-		);
+		const previewText = readFileSync(COMPOSE_FILE, "utf8");
+		const drift = findEnvDrift(readFileSync(REFERENCE_FILE, "utf8"), previewText);
 		for (const problem of drift) console.error(`error: ${problem}`);
-		if (drift.length > 0) process.exitCode = 1;
+		const gaps = findSeedPolicyGaps(previewText);
+		for (const gap of gaps) console.error(`error: ${COMPOSE_FILE}: ${gap}`);
+		if (drift.length + gaps.length > 0) process.exitCode = 1;
 
 		const stack = renderStack();
 		if (stack === undefined) {

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/schema/ObservationAssessmentBackfillIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/schema/ObservationAssessmentBackfillIntegrationTest.java
@@ -1,11 +1,10 @@
 package de.tum.cit.aet.hephaestus.integration.schema;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import de.tum.cit.aet.hephaestus.testconfig.PostgreSQLTestContainer;
 import de.tum.cit.aet.hephaestus.testconfig.PostgreSQLTestContainer.TestDatabase;
-import java.util.HashMap;
+import de.tum.cit.aet.hephaestus.testconfig.SchemaRowSeeder;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -26,6 +25,7 @@ class ObservationAssessmentBackfillIntegrationTest {
 
     private final JdbcTemplate jdbcTemplate = new JdbcTemplate(
             new SingleConnectionDataSource(DATABASE.jdbcUrl(), DATABASE.username(), DATABASE.password(), true));
+    private final SchemaRowSeeder seeder = new SchemaRowSeeder(jdbcTemplate);
 
     /**
      * The four backfill UPDATE statements, copied VERBATIM from changeSet {@code 1781092589259-60}
@@ -71,8 +71,9 @@ class ObservationAssessmentBackfillIntegrationTest {
 
         long desirablePracticeId = 9_000_001L;
         long undesirablePracticeId = 9_000_002L;
-        insertRow("practice", Map.of("id", desirablePracticeId, "slug", "backfill-desirable", "polarity", "DESIRABLE"));
-        insertRow(
+        seeder.insert(
+                "practice", Map.of("id", desirablePracticeId, "slug", "backfill-desirable", "polarity", "DESIRABLE"));
+        seeder.insert(
                 "practice",
                 Map.of("id", undesirablePracticeId, "slug", "backfill-undesirable", "polarity", "UNDESIRABLE"));
 
@@ -134,80 +135,13 @@ class ObservationAssessmentBackfillIntegrationTest {
         // dummy filler can't know that, so pin a valid value explicitly.
         overrides.put("artifact_kind", "scm.pull_request");
         // assessment intentionally omitted -> NULL (the pre-backfill state).
-        insertRow("observation", overrides);
+        seeder.insert("observation", overrides);
         return id;
-    }
-
-    /**
-     * Generic insert that satisfies the table's full NOT-NULL surface: every NOT-NULL column without
-     * a default and not supplied in {@code overrides} is filled with a type-appropriate dummy. FK
-     * targets are not seeded — this runs under {@code session_replication_role = replica}. Keeps the
-     * seed resilient to schema evolution (new NOT-NULL columns won't break this test).
-     */
-    private void insertRow(String table, Map<String, ?> overrides) {
-        List<Map<String, @Nullable Object>> columns = jdbcTemplate.queryForList(
-                "SELECT column_name, data_type, is_nullable, column_default " + "FROM information_schema.columns "
-                        + "WHERE table_schema = 'public' AND table_name = ?",
-                table);
-
-        Map<String, Object> values = new LinkedHashMap<>(overrides);
-        Map<String, String> dataTypes = new HashMap<>();
-        for (Map<String, Object> col : columns) {
-            String name = (String) col.get("column_name");
-            String dataType = (String) col.get("data_type");
-            assertNotNull(name);
-            assertNotNull(dataType);
-            dataTypes.put(name, dataType);
-            if (values.containsKey(name)) {
-                continue;
-            }
-            boolean nullable = "YES".equals(col.get("is_nullable"));
-            boolean hasDefault = col.get("column_default") != null;
-            if (nullable || hasDefault) {
-                continue; // leave to NULL / DB default
-            }
-            values.put(name, dummyFor(dataType, name));
-        }
-
-        String cols = String.join(", ", values.keySet());
-        String placeholders = String.join(
-                ", ",
-                values.keySet().stream()
-                        .map(name -> switch (required(dataTypes.get(name))) {
-                            case "json" -> "?::json";
-                            case "jsonb" -> "?::jsonb";
-                            default -> "?";
-                        })
-                        .toList());
-        jdbcTemplate.update(
-                "INSERT INTO " + table + " (" + cols + ") VALUES (" + placeholders + ")",
-                values.values().toArray());
-    }
-
-    /** Type-appropriate dummy for a NOT-NULL column the test does not otherwise care about. */
-    private Object dummyFor(String dataType, String columnName) {
-        return switch (dataType) {
-            case "uuid" -> UUID.randomUUID();
-            case "bigint", "integer", "smallint" -> 1L;
-            case "real", "double precision", "numeric" -> 0.0;
-            case "boolean" -> Boolean.FALSE;
-            case "jsonb", "json" -> "{}";
-            case "timestamp with time zone", "timestamp without time zone" ->
-                java.sql.Timestamp.from(java.time.Instant.now());
-            // character varying / text: keep it unique so any UNIQUE NOT-NULL column (e.g.
-            // observation.occurrence_key) doesn't collide across the seeded rows.
-            default -> "seed-" + columnName + "-" + UUID.randomUUID();
-        };
     }
 
     private @Nullable String assessmentOf(UUID observationId) {
         return jdbcTemplate.queryForObject(
                 "SELECT assessment FROM observation WHERE id = ?", String.class, observationId);
-    }
-
-    private static <T> T required(@org.jspecify.annotations.Nullable T value) {
-        assertNotNull(value);
-        return value;
     }
 
     private boolean columnExists(String table, String column) {

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/schema/PreviewSeedPolicyIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/schema/PreviewSeedPolicyIntegrationTest.java
@@ -1,0 +1,244 @@
+package de.tum.cit.aet.hephaestus.integration.schema;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import de.tum.cit.aet.hephaestus.testconfig.PostgreSQLTestContainer;
+import de.tum.cit.aet.hephaestus.testconfig.PostgreSQLTestContainer.TestDatabase;
+import de.tum.cit.aet.hephaestus.testconfig.SchemaRowSeeder;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.SingleConnectionDataSource;
+
+/**
+ * Runs the preview clone policy of {@code docker/preview/compose.app.yaml} against the migrated
+ * production schema.
+ *
+ * <p>The statements are read from the file a preview deploys, and they run against the schema
+ * Liquibase produces. A copy of either here would pass while the deployed statement failed on a
+ * column type or a constraint it does not carry, and the preview controller refuses to deploy a head
+ * that changes {@code docker/preview/}, so no preview can rehearse the policy before it lands.
+ *
+ * <p>{@code scripts/check-preview-stack.ts} owns the other half: that the policy and the query
+ * verifying it agree on which stores a clone has to be stripped of.
+ */
+@Tag("database")
+class PreviewSeedPolicyIntegrationTest {
+
+    private static final Path COMPOSE = Path.of("../../docker/preview/compose.app.yaml");
+    private static final Pattern POLICY = Pattern.compile("<<'SQL'\n(.*?)\n[ \t]*SQL\n", Pattern.DOTALL);
+    private static final Pattern VERIFICATION =
+            Pattern.compile("LIVE=\\$\\$\\(psql[^\n]*-c \"(.*?)\"\\)", Pattern.DOTALL);
+    private static final Pattern UPDATED_TABLE = Pattern.compile("\\bUPDATE\\s+([a-z_]+)");
+    private static final Pattern EMPTIED_TABLE = Pattern.compile("\\bDELETE FROM\\s+([a-z_]+)");
+    private static final String MARKER_PREFIX = "cleared-by-preview-clone:";
+
+    private static final TestDatabase DATABASE =
+            PostgreSQLTestContainer.createMigratedDatabase("hephaestus_preview_seed_policy");
+
+    private final JdbcTemplate jdbcTemplate = new JdbcTemplate(
+            new SingleConnectionDataSource(DATABASE.jdbcUrl(), DATABASE.username(), DATABASE.password(), true));
+    private final SchemaRowSeeder seeder = new SchemaRowSeeder(jdbcTemplate);
+
+    @Test
+    void shouldClearEveryColumnOfTheSchemaThatCanHoldAStagingSecret() {
+        Map<String, String> updates = new HashMap<>();
+        Set<String> emptied = new HashSet<>();
+        for (String statement : read(POLICY).split(";")) {
+            Matcher updated = UPDATED_TABLE.matcher(statement);
+            if (updated.find()) {
+                updates.merge(updated.group(1), statement, String::concat);
+            }
+            Matcher deleted = EMPTIED_TABLE.matcher(statement);
+            if (deleted.find()) {
+                emptied.add(deleted.group(1));
+            }
+        }
+
+        // A secret is stored as text or bytes; the same words on a numeric column count LLM tokens.
+        List<String> uncleared = jdbcTemplate.queryForList("""
+                        SELECT table_name, column_name FROM information_schema.columns
+                         WHERE table_schema = 'public'
+                           AND data_type IN ('text', 'character varying', 'bytea')
+                           AND (column_name LIKE '%api_key%' OR column_name LIKE '%credential%'
+                             OR column_name LIKE '%token%' OR column_name LIKE '%secret%'
+                             OR column_name LIKE '%password%')""").stream()
+                .filter(column -> {
+                    String table = String.valueOf(column.get("table_name"));
+                    return !emptied.contains(table)
+                            && !updates.getOrDefault(table, "").contains(String.valueOf(column.get("column_name")));
+                })
+                .map(column -> column.get("table_name") + "." + column.get("column_name"))
+                .toList();
+
+        assertThat(uncleared)
+                .as(
+                        "a column that can hold a secret staging minted must be written by the clone policy in %s,"
+                                + " or live in a table the policy empties",
+                        COMPOSE)
+                .isEmpty();
+    }
+
+    @Test
+    void shouldStripStagingCredentialsAndKeepConnectionMetadataWhenACloneIsSeeded() {
+        // Foreign keys are not seeded, and the marker per agent_job row is what the UNIQUE index on
+        // job_token forces the policy to compute rather than write as one literal.
+        jdbcTemplate.execute("SET session_replication_role = 'replica'");
+        long workspaceId = 9_100_001L;
+        long instanceCatalogId = 9_100_002L;
+        long workspaceCatalogId = 9_100_003L;
+        long gitHubConnectionId = 9_100_004L;
+        long outlineConnectionId = 9_100_005L;
+        UUID jobId = UUID.randomUUID();
+
+        seeder.insert(
+                "llm_connection",
+                Map.of(
+                        "id",
+                        instanceCatalogId,
+                        "api_protocol",
+                        "openai-completions",
+                        "api_key",
+                        "staging-instance-key",
+                        "enabled",
+                        true));
+        seeder.insert(
+                "workspace_llm_connection",
+                Map.of(
+                        "id",
+                        workspaceCatalogId,
+                        "workspace_id",
+                        workspaceId,
+                        "api_protocol",
+                        "openai-completions",
+                        "api_key",
+                        "staging-workspace-key",
+                        "enabled",
+                        true));
+        seedConnection(gitHubConnectionId, workspaceId, "GITHUB", "{\"type\": \"GITHUB\"}");
+        seedConnection(
+                outlineConnectionId,
+                workspaceId,
+                "OUTLINE",
+                "{\"type\": \"OUTLINE\", \"webhookSecret\": \"staging-signing-secret\"}");
+        seeder.insert(
+                "agent_job",
+                Map.of(
+                        "id", jobId,
+                        "workspace_id", workspaceId,
+                        "status", "COMPLETED",
+                        "practice_trigger_mode", "AUTO",
+                        "job_token", "staging-minted-token",
+                        "job_token_hash", "staging-token-hash"));
+        jdbcTemplate.execute("SET session_replication_role = 'origin'");
+
+        applyPolicy();
+
+        assertThat(scalar("SELECT api_key FROM llm_connection WHERE id = " + instanceCatalogId))
+                .isNull();
+        assertThat(scalar("SELECT enabled::text FROM llm_connection WHERE id = " + instanceCatalogId))
+                .isEqualTo("false");
+        assertThat(scalar("SELECT api_key FROM workspace_llm_connection WHERE id = " + workspaceCatalogId))
+                .isNull();
+        assertThat(scalar("SELECT enabled::text FROM workspace_llm_connection WHERE id = " + workspaceCatalogId))
+                .isEqualTo("false");
+
+        for (long connectionId : List.of(gitHubConnectionId, outlineConnectionId)) {
+            assertThat(scalar("SELECT credentials_encrypted::text FROM connection WHERE id = " + connectionId))
+                    .isNull();
+            assertThat(scalar("SELECT credentials_alg FROM connection WHERE id = " + connectionId))
+                    .isNull();
+            assertThat(scalar("SELECT credentials_key_version::text FROM connection WHERE id = " + connectionId))
+                    .isNull();
+            assertThat(scalar("SELECT state FROM connection WHERE id = " + connectionId))
+                    .as("a clone keeps each connection's state; only what can act as staging goes")
+                    .isEqualTo("ACTIVE");
+        }
+        assertThat(scalar("SELECT config ->> 'webhookSecret' FROM connection WHERE id = " + outlineConnectionId))
+                .isNull();
+        assertThat(scalar("SELECT config ->> 'type' FROM connection WHERE id = " + outlineConnectionId))
+                .isEqualTo("OUTLINE");
+
+        String marker = scalar("SELECT job_token FROM agent_job WHERE id = '" + jobId + "'");
+        assertThat(marker).isEqualTo(MARKER_PREFIX + jobId);
+        assertThat(scalar("SELECT job_token_hash FROM agent_job WHERE id = '" + jobId + "'"))
+                .isNull();
+        assertThat(residualCredentials())
+                .as("the seed marker is earned by counting, so nothing the policy touches may be left")
+                .isZero();
+
+        applyPolicy();
+        assertThat(scalar("SELECT job_token FROM agent_job WHERE id = '" + jobId + "'"))
+                .as("a second pass rewrites no marker, so a redeployed seed loader is a no-op")
+                .isEqualTo(marker);
+        assertThat(residualCredentials()).isZero();
+
+        jdbcTemplate.execute(
+                "UPDATE llm_connection SET api_key = 'restored-after-the-policy' WHERE id = " + instanceCatalogId);
+        assertThat(residualCredentials())
+                .as("a credential the policy did not reach leaves the preview un-booted rather than live")
+                .isPositive();
+    }
+
+    private void seedConnection(long id, long workspaceId, String kind, String config) {
+        seeder.insert(
+                "connection",
+                Map.of(
+                        "id",
+                        id,
+                        "workspace_id",
+                        workspaceId,
+                        "kind",
+                        kind,
+                        "state",
+                        "ACTIVE",
+                        "config",
+                        config,
+                        "credentials_encrypted",
+                        new byte[] {1, 2, 3},
+                        "credentials_alg",
+                        "AES-GCM",
+                        "credentials_key_version",
+                        1));
+    }
+
+    private void applyPolicy() {
+        jdbcTemplate.execute(read(POLICY));
+    }
+
+    private long residualCredentials() {
+        Long live = jdbcTemplate.queryForObject(read(VERIFICATION), Long.class);
+        return live == null ? -1 : live;
+    }
+
+    private @Nullable String scalar(String sql) {
+        return jdbcTemplate.queryForObject(sql, String.class);
+    }
+
+    private static String read(Pattern block) {
+        String compose;
+        try {
+            compose = Files.readString(COMPOSE);
+        } catch (IOException exception) {
+            throw new UncheckedIOException("Cannot read " + COMPOSE, exception);
+        }
+        Matcher matcher = block.matcher(compose);
+        assertThat(matcher.find())
+                .as("%s must contain the seed loader block matching %s", COMPOSE, block)
+                .isTrue();
+        return matcher.group(1);
+    }
+}

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/testconfig/SchemaRowSeeder.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/testconfig/SchemaRowSeeder.java
@@ -1,0 +1,81 @@
+package de.tum.cit.aet.hephaestus.testconfig;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.jspecify.annotations.Nullable;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * Inserts a row into a physical table by asking the database what the table requires: every NOT NULL
+ * column without a default that the caller did not supply is filled with a type-appropriate dummy,
+ * sized to the column. A schema test seeding through this keeps working when a table it does not
+ * care about gains a column.
+ *
+ * <p>Foreign keys are not resolved, so callers seed under {@code session_replication_role =
+ * 'replica'} — the Testcontainers role is a superuser and may set it.
+ */
+public final class SchemaRowSeeder {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public SchemaRowSeeder(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    public void insert(String table, Map<String, ?> overrides) {
+        List<Map<String, @Nullable Object>> columns = jdbcTemplate.queryForList(
+                "SELECT column_name, data_type, is_nullable, column_default, character_maximum_length "
+                        + "FROM information_schema.columns WHERE table_schema = 'public' AND table_name = ?",
+                table);
+
+        Map<String, Object> values = new LinkedHashMap<>(overrides);
+        Map<String, String> dataTypes = new HashMap<>();
+        for (Map<String, @Nullable Object> column : columns) {
+            String name = String.valueOf(column.get("column_name"));
+            String dataType = String.valueOf(column.get("data_type"));
+            dataTypes.put(name, dataType);
+            boolean supplied = values.containsKey(name);
+            boolean optional = "YES".equals(column.get("is_nullable")) || column.get("column_default") != null;
+            if (supplied || optional) {
+                continue;
+            }
+            values.put(name, dummyFor(dataType, name, (Integer) column.get("character_maximum_length")));
+        }
+
+        String placeholders = values.keySet().stream()
+                .map(name -> switch (dataTypes.getOrDefault(name, "")) {
+                    case "json" -> "?::json";
+                    case "jsonb" -> "?::jsonb";
+                    default -> "?";
+                })
+                .reduce((left, right) -> left + ", " + right)
+                .orElseThrow(() -> new IllegalArgumentException("Nothing to insert into " + table));
+        jdbcTemplate.update(
+                "INSERT INTO " + table + " (" + String.join(", ", values.keySet()) + ") VALUES (" + placeholders + ")",
+                values.values().toArray());
+    }
+
+    /** Type-appropriate dummy for a NOT NULL column the caller does not otherwise care about. */
+    private static Object dummyFor(String dataType, String columnName, @Nullable Integer maximumLength) {
+        return switch (dataType) {
+            case "uuid" -> UUID.randomUUID();
+            case "bigint", "integer", "smallint" -> 1L;
+            case "real", "double precision", "numeric" -> 0.0;
+            case "boolean" -> Boolean.FALSE;
+            case "jsonb", "json" -> "{}";
+            case "timestamp with time zone", "timestamp without time zone" ->
+                java.sql.Timestamp.from(java.time.Instant.now());
+            // Unique, so a UNIQUE NOT NULL column does not collide across seeded rows, and within the
+            // column's own width, so a narrow VARCHAR does not reject the filler.
+            default -> {
+                String readable = "seed-" + columnName + "-" + UUID.randomUUID();
+                yield maximumLength == null || maximumLength >= readable.length()
+                        ? readable
+                        : UUID.randomUUID().toString().replace("-", "").substring(0, Math.min(32, maximumLength));
+            }
+        };
+    }
+}


### PR DESCRIPTION
## What changed and why

A preview environment clones staging's database and then silences its review triggers and drops the
instance identity, but left the encrypted provider credentials in place: every preview held a copy of
staging's AI connection keys and integration tokens at rest, readable with staging's credential key.

The clone policy now clears the API keys of both AI catalogs and disables those connections, clears
each integration connection's credential bundle and the webhook signing secret its config carries,
and replaces the job tokens staging minted for jobs that are already cancelled or finished. Each
connection keeps the state it had, so a preview still looks like staging without holding anything
that can act as staging. The query the seed marker is earned by counts every one of those stores, so
a policy that silently did not apply leaves the preview un-booted rather than live.

`docker/preview/README.md` § Security boundary owns what a clone is stripped of. The new
*What a preview keeps from staging* section of `docs/contributor/ci-cd.mdx` points at it and carries
only what is not there: what a preview keeps to read, how to give one AI access of its own, and the
instruction to recreate previews seeded before this policy. #1889 asked for that page under
`docs/admin/`, which is for operators of a self-hosted install; previews are this repository's own
infrastructure and are not part of one, so it landed under `docs/contributor/` instead.

Part of #1889.

## How to test

- `vp run gate:preview-stack` — renders the preview stack, and now also fails when the clone policy
  and the query verifying it disagree on which stores a clone is stripped of.
- `cd server && MANAGEMENT_PORT=0 SERVER_PORT=0 ./mvnw -f application/pom.xml -Dtest=PreviewSeedPolicyIntegrationTest -Dsurefire.includedGroups=database test --batch-mode`
  — runs the compose file's own statements against the Liquibase-migrated schema: every column of
  that schema which can hold a secret is written by the policy, the seeded rows lose their
  credentials and keep their metadata and state, a second pass changes nothing, and a credential
  restored afterwards makes the verification non-zero.
- `vp run check` and `vp run test:server:architecture` are green.

Both database tests fail on the defect they target: dropping the `llm_connection` clause from the
policy turns them red.

## Release impact

`.changeset/preview-provider-credentials.md` stays an empty changeset. `docker/preview/` is this
repository's own pull-request infrastructure rather than shipped product, so there is no release note
and nothing for a self-hoster to do. Maintainers recreate previews seeded before this change,
including their private database volumes; `docs/contributor/ci-cd.mdx` says so.

## Notes for reviewers

- The preview controller refuses to deploy a head that changes anything under `docker/preview/`, so
  this policy cannot be exercised on a preview before it lands. The database tier is the only proof
  available, which is why `docker/preview/compose.app.yaml` now reaches the `application-server`
  change filter.
- `SchemaRowSeeder` is `ObservationAssessmentBackfillIntegrationTest`'s private row filler moved into
  `testconfig` so both schema tests share it, rather than copied. It now sizes a filler to the
  column, which the narrow `VARCHAR`s on `agent_job` need.
