### PR TITLE
ci: the integration tier runs as two shards on a pull request

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -51,10 +51,18 @@ jobs:
           fail-on-error: false
 
   server-integration:
-    name: "App Server: Integration"
+    name: "App Server: Integration (${{ matrix.shard }})"
     if: inputs.should_skip != 'true' && inputs.application_server_changed == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - shard: providers
+            tests: "**/integration/**"
+          - shard: application
+            tests: "*,!**/integration/**"
     permissions:
       contents: read
       checks: write
@@ -70,12 +78,13 @@ jobs:
           cache-type: application-server-reactor
           os: ${{ runner.os }}
       - name: Run integration tests
-        run: vp run test:server:integration
+        # The generated-clients reactor module has no tests matching these selectors.
+        run: vp run test:server:integration "-Dtest=${{ matrix.tests }}" -Dsurefire.failIfNoSpecifiedTests=false
       - name: Upload test results
         if: always()
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
         with:
-          name: "Test Results - App Server Integration"
+          name: "Test Results - App Server Integration (${{ matrix.shard }})"
           path: "server/application/target/surefire-reports/TEST-*.xml"
           reporter: java-junit
           fail-on-error: false

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -60,9 +60,9 @@ jobs:
       matrix:
         include:
           - shard: providers
-            tests: "**/integration/**"
+            tests: "de/tum/cit/aet/hephaestus/integration/**"
           - shard: application
-            tests: "*,!**/integration/**"
+            tests: "**/*Test,!de/tum/cit/aet/hephaestus/integration/**"
     permissions:
       contents: read
       checks: write
@@ -78,8 +78,16 @@ jobs:
           cache-type: application-server-reactor
           os: ${{ runner.os }}
       - name: Run integration tests
-        # The generated-clients reactor module has no tests matching these selectors.
-        run: vp run test:server:integration "-Dtest=${{ matrix.tests }}" -Dsurefire.failIfNoSpecifiedTests=false
+        env:
+          # Read by vite.config.ts when it loads; vp forwards no arguments to a command.
+          HEPHAESTUS_INTEGRATION_TESTS: ${{ matrix.tests }}
+        run: vp run test:server:integration
+      - name: Refuse a shard that ran nothing
+        # A selector that drifts away from every class would otherwise pass green with zero tests.
+        run: |
+          count=$(grep -ho '<testcase ' server/application/target/surefire-reports/TEST-*.xml | wc -l)
+          echo "testcases=$count"
+          test "$count" -gt 0
       - name: Upload test results
         if: always()
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -79,7 +79,8 @@ jobs:
           os: ${{ runner.os }}
       - name: Run integration tests
         env:
-          # Read by vite.config.ts when it loads; vp forwards no arguments to a command.
+          # Read by vite.config.ts when it loads: the selector reaches Maven without a matrix value
+          # ever appearing in a run: script, which is what the workflow linter forbids.
           HEPHAESTUS_INTEGRATION_TESTS: ${{ matrix.tests }}
         run: vp run test:server:integration
       - name: Refuse a shard that ran nothing

--- a/docs/contributor/ci-cd.mdx
+++ b/docs/contributor/ci-cd.mdx
@@ -422,6 +422,13 @@ nothing that ships, so they compile from source in `Test` and do not wait for pa
 
 - `Quality` legs and `Test` suites start from source; `Build` gates start when `App Server: Package`
   uploads its artifact.
+- `App Server: Integration` runs two independent matrix shards: `providers` selects the
+  `integration/` package and `application` selects its complement. Both retain the `integration`
+  tag filter and run sequentially inside their own JVM and Testcontainers database. New packages
+  automatically belong to one shard; unit and architecture tests still run only in their own job.
+  Each shard compiles from source concurrently with packaging. `fail-fast: false` lets both finish
+  reporting, and `CI Status Gate` requires the aggregate `Test` result, covering both shards.
+  Local and weekly profile runs still execute the complete integration tier in one invocation.
 - Pull requests and merge groups build `linux/amd64`; pushes to `main`, and every run on the Version
   PR's branch, build both architectures. A pull request also builds only the images its diff touched
   and aliases the rest, while the Version PR's branch builds all of them. `detect-changes` decides

--- a/docs/contributor/ci-cd.mdx
+++ b/docs/contributor/ci-cd.mdx
@@ -422,13 +422,13 @@ nothing that ships, so they compile from source in `Test` and do not wait for pa
 
 - `Quality` legs and `Test` suites start from source; `Build` gates start when `App Server: Package`
   uploads its artifact.
-- `App Server: Integration` runs two independent matrix shards: `providers` selects the
-  `integration/` package and `application` selects its complement. Both retain the `integration`
-  tag filter and run sequentially inside their own JVM and Testcontainers database. New packages
-  automatically belong to one shard; unit and architecture tests still run only in their own job.
-  Each shard compiles from source concurrently with packaging. `fail-fast: false` lets both finish
-  reporting, and `CI Status Gate` requires the aggregate `Test` result, covering both shards.
-  Local and weekly profile runs still execute the complete integration tier in one invocation.
+- `App Server: Integration` runs two matrix shards: `providers` selects the `integration` package
+  and `application` its complement. Both keep the `integration` tag filter and run in their own JVM
+  and Testcontainers database; a new package belongs to one shard by construction. The shard's
+  selector reaches Maven through `HEPHAESTUS_INTEGRATION_TESTS`, which `vite.config.ts` reads when
+  it loads, since `vp run` forwards no arguments; a shard that ran zero test cases fails its job, so
+  a selector that drifts cannot pass green. `fail-fast: false` lets both shards report, and
+  `CI Status Gate` requires the aggregate `Test` result. Locally the tier runs whole.
 - Pull requests and merge groups build `linux/amd64`; pushes to `main`, and every run on the Version
   PR's branch, build both architectures. A pull request also builds only the images its diff touched
   and aliases the rest, while the Version PR's branch builds all of them. `detect-changes` decides

--- a/docs/contributor/ci-cd.mdx
+++ b/docs/contributor/ci-cd.mdx
@@ -426,8 +426,8 @@ nothing that ships, so they compile from source in `Test` and do not wait for pa
   and `application` its complement. Both keep the `integration` tag filter and run in their own JVM
   and Testcontainers database; a new package belongs to one shard by construction. The shard's
   selector reaches Maven through `HEPHAESTUS_INTEGRATION_TESTS`, which `vite.config.ts` reads when
-  it loads, since `vp run` forwards no arguments; a shard that ran zero test cases fails its job, so
-  a selector that drifts cannot pass green. `fail-fast: false` lets both shards report, and
+  it loads, so the matrix value never appears in a `run:` script; a shard that ran zero test cases
+  fails its job, so a selector that drifts cannot pass green. `fail-fast: false` lets both shards report, and
   `CI Status Gate` requires the aggregate `Test` result. Locally the tier runs whole.
 - Pull requests and merge groups build `linux/amd64`; pushes to `main`, and every run on the Version
   PR's branch, build both architectures. A pull request also builds only the images its diff touched

--- a/scripts/ci-contract.test.ts
+++ b/scripts/ci-contract.test.ts
@@ -400,10 +400,21 @@ void describe("CI contract", () => {
 			"de/tum/cit/aet/hephaestus/integration/**",
 			"**/*Test,!de/tum/cit/aet/hephaestus/integration/**",
 		]);
-		// vp forwards no arguments, so the selector reaches Maven through the config's environment read.
+		// The matrix value reaches Maven through the config's environment read, never through a run: script.
 		assert.match(integration, /HEPHAESTUS_INTEGRATION_TESTS: \$\{\{ matrix.tests \}\}/);
-		assert.doesNotMatch(integration, /test:server:integration "-D/);
-		assert.match(integration, /Refuse a shard that ran nothing/);
+		assert.doesNotMatch(integration, /run: vp run test:server:integration "-D/);
+		// A shard whose reports carry no test case fails on that fact, not on a step name.
+		assert.match(
+			integration,
+			/grep -ho '<testcase ' server\/application\/target\/surefire-reports\/TEST-\*\.xml \| wc -l/,
+		);
+		assert.match(integration, /test "\$count" -gt 0/);
+		const guardStart = integration.indexOf("Refuse a shard");
+		const guardEnd = integration.indexOf("- name:", guardStart);
+		assert.doesNotMatch(
+			integration.slice(guardStart, guardEnd === -1 ? undefined : guardEnd),
+			/if: always\(\)/,
+		);
 		assert.match(integration, /Test Results - App Server Integration \(\$\{\{ matrix.shard \}\}\)/);
 		assert.equal((source.match(/run: vp run test:server:integration/g) ?? []).length, 1);
 		const tasks = await readFile("vite.config.ts", "utf8");

--- a/scripts/ci-contract.test.ts
+++ b/scripts/ci-contract.test.ts
@@ -396,13 +396,22 @@ void describe("CI contract", () => {
 		const integration = job(source, "server-integration");
 		assert.match(integration, /fail-fast: false/);
 		const selectors = [...integration.matchAll(/tests: "([^"\n]+)"/g)].map((match) => match[1]);
-		assert.deepEqual(selectors, ["**/integration/**", "*,!**/integration/**"]);
-		assert.match(integration, /"-Dtest=\$\{\{ matrix.tests \}\}"/);
-		assert.match(integration, /-Dsurefire.failIfNoSpecifiedTests=false/);
+		assert.deepEqual(selectors, [
+			"de/tum/cit/aet/hephaestus/integration/**",
+			"**/*Test,!de/tum/cit/aet/hephaestus/integration/**",
+		]);
+		// vp forwards no arguments, so the selector reaches Maven through the config's environment read.
+		assert.match(integration, /HEPHAESTUS_INTEGRATION_TESTS: \$\{\{ matrix.tests \}\}/);
+		assert.doesNotMatch(integration, /test:server:integration "-D/);
+		assert.match(integration, /Refuse a shard that ran nothing/);
 		assert.match(integration, /Test Results - App Server Integration \(\$\{\{ matrix.shard \}\}\)/);
 		assert.equal((source.match(/run: vp run test:server:integration/g) ?? []).length, 1);
 		const tasks = await readFile("vite.config.ts", "utf8");
-		assert.match(tasks, /"test:server:integration": run\([\s\S]*?-Dsurefire.includedGroups=integration/);
+		assert.match(tasks, /HEPHAESTUS_INTEGRATION_TESTS/);
+		assert.match(
+			tasks,
+			/"test:server:integration": run\([\s\S]*?-Dsurefire.includedGroups=integration\$\{integrationShard\}/,
+		);
 		const orchestrator = await readFile(".github/workflows/cicd.yml", "utf8");
 		assert.match(job(orchestrator, "Test"), /uses: \.\/\.github\/workflows\/ci-tests.yml/);
 		assert.match(job(orchestrator, "all-ci-passed"), /needs\.Test\.result/);

--- a/scripts/ci-contract.test.ts
+++ b/scripts/ci-contract.test.ts
@@ -391,6 +391,23 @@ void describe("CI contract", () => {
 		assert.deepEqual(used, accepted, "Every accepted cache type is requested by a workflow");
 	});
 
+	void test("partitions integration tests without duplicating tiers or bypassing the status gate", async () => {
+		const source = await readFile(".github/workflows/ci-tests.yml", "utf8");
+		const integration = job(source, "server-integration");
+		assert.match(integration, /fail-fast: false/);
+		const selectors = [...integration.matchAll(/tests: "([^"\n]+)"/g)].map((match) => match[1]);
+		assert.deepEqual(selectors, ["**/integration/**", "*,!**/integration/**"]);
+		assert.match(integration, /"-Dtest=\$\{\{ matrix.tests \}\}"/);
+		assert.match(integration, /-Dsurefire.failIfNoSpecifiedTests=false/);
+		assert.match(integration, /Test Results - App Server Integration \(\$\{\{ matrix.shard \}\}\)/);
+		assert.equal((source.match(/run: vp run test:server:integration/g) ?? []).length, 1);
+		const tasks = await readFile("vite.config.ts", "utf8");
+		assert.match(tasks, /"test:server:integration": run\([\s\S]*?-Dsurefire.includedGroups=integration/);
+		const orchestrator = await readFile(".github/workflows/cicd.yml", "utf8");
+		assert.match(job(orchestrator, "Test"), /uses: \.\/\.github\/workflows\/ci-tests.yml/);
+		assert.match(job(orchestrator, "all-ci-passed"), /needs\.Test\.result/);
+	});
+
 	void test("packages the server once and runs every artifact gate against it", async () => {
 		const build = await readFile(".github/workflows/ci-build.yml", "utf8");
 		const packageJob = job(build, "server-package");

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -266,8 +266,10 @@ export default defineConfig({
 			"test:server:verification": run(
 				`${mvnw} -pl application -am package -Dspring-boot.repackage.skip=true -Parchitecture-tests -Dsurefire.includedGroups=unit,architecture -DskipCoverage=false --batch-mode`,
 			),
-			// CI runs the tier as shards. The selector is decided here, at config load, because a command
-			// never contains `$` and vp forwards no arguments; locally the whole tier runs.
+			// CI runs the tier as shards. The selector is decided here, at config load, so the workflow
+			// passes a matrix value through the environment rather than into a command; locally the
+			// whole tier runs. failIfNoSpecifiedTests=false is for the generated-clients module, which
+			// has no tests for any selector; a shard that runs nothing is caught by the workflow instead.
 			"test:server:integration": run(
 				`${mvnw} -pl application -am package -Dspring-boot.repackage.skip=true -Dsurefire.includedGroups=integration${integrationShard} -Dparallel=none --batch-mode`,
 			),

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -102,6 +102,10 @@ const docsLintInputs = [
 ];
 
 const mvnw = "node scripts/run-mvnw.ts";
+const integrationTests = process.env.HEPHAESTUS_INTEGRATION_TESTS ?? "";
+const integrationShard = integrationTests
+	? ` -Dtest=${integrationTests} -Dsurefire.failIfNoSpecifiedTests=false`
+	: "";
 
 // The gates, by the tree they judge. `quality` runs all of them; each CI job runs one tree's set.
 const policyGates = [
@@ -262,8 +266,10 @@ export default defineConfig({
 			"test:server:verification": run(
 				`${mvnw} -pl application -am package -Dspring-boot.repackage.skip=true -Parchitecture-tests -Dsurefire.includedGroups=unit,architecture -DskipCoverage=false --batch-mode`,
 			),
+			// CI runs the tier as shards. The selector is decided here, at config load, because a command
+			// never contains `$` and vp forwards no arguments; locally the whole tier runs.
 			"test:server:integration": run(
-				`${mvnw} -pl application -am package -Dspring-boot.repackage.skip=true -Dsurefire.includedGroups=integration -Dparallel=none --batch-mode`,
+				`${mvnw} -pl application -am package -Dspring-boot.repackage.skip=true -Dsurefire.includedGroups=integration${integrationShard} -Dparallel=none --batch-mode`,
 			),
 			"test:server:mutation": run("node scripts/run-security-mutations.ts"),
 			"test:postgres-upgrade": run("node scripts/postgres-major-upgrade-test.ts"),


### PR DESCRIPTION
## Problem

The App Server integration tier is the longest leaf of every pull-request run, about nine minutes median on a 25-minute critical path (#1902).

## Fix

The integration job becomes a two-shard matrix: `providers` selects the `integration/` package and `application` its complement, each in its own JVM and database, both still filtered by the `integration` tag and both still required by the status gate through the aggregate `Test` result. The CI contract test pins the selectors, the single task invocation and the gate wiring; `docs/contributor/ci-cd.mdx` describes the shape.

## Verification

- `scripts/ci-contract.test.ts` for the new contract.
- The before/after timing this PR should carry is the CI run on this branch itself; it is not measured locally.
- Implemented by Codex (`gpt-6-astra`) from the issue; reviewed and committed from its worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZzUtPvAhEnBHsxqWTaRHn