### PR TITLE
fix(server): the review sandbox creates its session directory before the runner starts

### DIFF
--- a/.changeset/practice-reviews-keep-their-sessions.md
+++ b/.changeset/practice-reviews-keep-their-sessions.md
@@ -1,0 +1,7 @@
+---
+"hephaestus": patch
+---
+
+Practice reviews and Heph conversations run to completion again. After the recent agent fixes every
+review still stopped at its first tool call, because the sandbox denied the review its own session
+files; the sandbox now prepares that directory before the review starts.

--- a/docker/agents/pi/Dockerfile
+++ b/docker/agents/pi/Dockerfile
@@ -78,8 +78,15 @@ RUN mkdir -p /tmp/abi-check && ln -sf /opt/pi-sdk/node_modules /tmp/abi-check/no
     # A write grant on a directory absent at startup covers its mkdir but nothing inside it; the
     # server therefore creates every writable directory before Node starts, and this build fails
     # the day Node changes that, so the pre-creation can be revisited rather than cargo-culted.
-    ! node --permission --allow-fs-read=/tmp/abi-check --allow-fs-write=/tmp/abi-check/absent \
-      -e 'const fs = require("node:fs"); fs.mkdirSync("/tmp/abi-check/absent"); fs.writeFileSync("/tmp/abi-check/absent/x", "1")' 2>/dev/null && \
+    printf '%s\n' \
+      'const fs = require("node:fs");' \
+      'const dir = process.argv[2];' \
+      'fs.mkdirSync(dir);' \
+      'let denied = false;' \
+      'try { fs.writeFileSync(`${dir}/x`, "1"); } catch (error) { denied = error.code === "ERR_ACCESS_DENIED"; }' \
+      'if (!denied) { throw new Error("a write inside a directory granted before it existed was allowed; revisit the pre-creation in PiRuntimeFactory"); }' \
+      > absent-grant-check.cjs && \
+    node --permission --allow-fs-read=/tmp/abi-check --allow-fs-write=/tmp/abi-check/absent absent-grant-check.cjs /tmp/abi-check/absent && \
     ! node --permission --allow-fs-read=/tmp/abi-check --allow-fs-read=/opt/pi-sdk \
       -e 'require("node:child_process").spawnSync("true")' 2>/dev/null && \
     rm -rf /tmp/abi-check

--- a/docker/agents/pi/Dockerfile
+++ b/docker/agents/pi/Dockerfile
@@ -75,6 +75,11 @@ RUN mkdir -p /tmp/abi-check && ln -sf /opt/pi-sdk/node_modules /tmp/abi-check/no
     HOME=/tmp/abi-check/home GATE_TOKEN=gate node --permission --allow-fs-read=/tmp/abi-check --allow-fs-read=/opt/pi-sdk --allow-fs-write=/tmp/abi-check/agent runner-path-check.ts && \
     ! node --permission --allow-fs-read=/tmp/abi-check --allow-fs-read=/opt/pi-sdk \
       -e 'require("node:fs").readFileSync("/etc/passwd")' 2>/dev/null && \
+    # A write grant on a directory absent at startup covers its mkdir but nothing inside it; the
+    # server therefore creates every writable directory before Node starts, and this build fails
+    # the day Node changes that, so the pre-creation can be revisited rather than cargo-culted.
+    ! node --permission --allow-fs-read=/tmp/abi-check --allow-fs-write=/tmp/abi-check/absent \
+      -e 'const fs = require("node:fs"); fs.mkdirSync("/tmp/abi-check/absent"); fs.writeFileSync("/tmp/abi-check/absent/x", "1")' 2>/dev/null && \
     ! node --permission --allow-fs-read=/tmp/abi-check --allow-fs-read=/opt/pi-sdk \
       -e 'require("node:child_process").spawnSync("true")' 2>/dev/null && \
     rm -rf /tmp/abi-check

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/runtime/PiRunnerProfile.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/runtime/PiRunnerProfile.java
@@ -21,6 +21,9 @@ public interface PiRunnerProfile {
             // The SDK takes a lock directory beside settings.json and auth.json and keeps a models store
             // in the agent dir; without this every session dies at its first model turn.
             "--allow-fs-write=/workspace/.pi",
+            // A write grant is resolved when Node starts: a directory that does not exist yet accepts
+            // mkdir and then denies every write inside it, so PiRuntimeFactory creates each of these
+            // before the process starts.
             "--allow-fs-write=/workspace/.sessions",
             "--allow-fs-write=/workspace/out");
     /** Runner script filename under {@code resources/agent/}. */

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/runtime/PiRunnerProfile.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/runtime/PiRunnerProfile.java
@@ -9,6 +9,14 @@ import java.util.Map;
  * they MUST NOT capture spec-level state (provider, credentials, baseUrl).
  */
 public interface PiRunnerProfile {
+    /** Directories the runner may write, each created before Node starts; the grants below say why. */
+    List<String> WRITABLE_DIRECTORIES = List.of(
+            "/workspace/.pi",
+            "/workspace/.sessions",
+            "/workspace/work/composition",
+            "/workspace/out",
+            "/home/agent/.local/tmp");
+
     List<String> BASE_RUNTIME_FLAGS = List.of(
             "--max-old-space-size=256",
             "--permission",
@@ -18,13 +26,16 @@ public interface PiRunnerProfile {
             // session; that directory holds nothing, and a read the permission model denies is a
             // thrown error, not an absence, so it must be readable.
             "--allow-fs-read=/home/agent",
+            // Every path granted for writing exists before Node starts: a grant is resolved at startup,
+            // and a directory created afterwards accepts mkdir and then denies every write inside it.
+            // WRITABLE_DIRECTORIES is that list, and PiRuntimeFactory creates it.
             // The SDK takes a lock directory beside settings.json and auth.json and keeps a models store
             // in the agent dir; without this every session dies at its first model turn.
             "--allow-fs-write=/workspace/.pi",
-            // A write grant is resolved when Node starts: a directory that does not exist yet accepts
-            // mkdir and then denies every write inside it, so PiRuntimeFactory creates each of these
-            // before the process starts.
             "--allow-fs-write=/workspace/.sessions",
+            // The runner writes the admitted observations it composes from, and Node's temp dir.
+            "--allow-fs-write=/workspace/work/composition",
+            "--allow-fs-write=/home/agent/.local/tmp",
             "--allow-fs-write=/workspace/out");
     /** Runner script filename under {@code resources/agent/}. */
     String runnerScript();

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/runtime/PiRuntimeFactory.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/runtime/PiRuntimeFactory.java
@@ -95,13 +95,9 @@ public class PiRuntimeFactory {
         if (precomputeStep == null || jobToken == null) {
             throw new IllegalStateException("validated Pi plan contains null fields");
         }
-        // Every directory the runner's Node process may write must exist before Node starts: the
-        // permission model resolves a grant at startup, and a directory created afterwards accepts
-        // mkdir but denies every write inside it (PiRunnerProfile). The session directory is the one
-        // the SDK would otherwise create itself, on the first message of the first session.
-        String command = "mkdir -p " + SandboxLayout.OUTPUT_PATH
-                + " " + workspaceRoot + "/" + SandboxLayout.SESSIONS_DIR
-                + " /home/agent/.config /home/agent/.local/tmp && "
+        // Every directory the runner may write exists before Node starts; PiRunnerProfile says why.
+        String command = "mkdir -p " + String.join(" ", PiRunnerProfile.WRITABLE_DIRECTORIES)
+                + " /home/agent/.config && "
                 +
                 // The runner imports the Pi SDK by bare specifier, which resolves from <workspace>/node_modules,
                 // so the SDK the image exposes at /opt/pi-sdk must be symlinked into place.

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/runtime/PiRuntimeFactory.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/runtime/PiRuntimeFactory.java
@@ -95,7 +95,12 @@ public class PiRuntimeFactory {
         if (precomputeStep == null || jobToken == null) {
             throw new IllegalStateException("validated Pi plan contains null fields");
         }
+        // Every directory the runner's Node process may write must exist before Node starts: the
+        // permission model resolves a grant at startup, and a directory created afterwards accepts
+        // mkdir but denies every write inside it (PiRunnerProfile). The session directory is the one
+        // the SDK would otherwise create itself, on the first message of the first session.
         String command = "mkdir -p " + SandboxLayout.OUTPUT_PATH
+                + " " + workspaceRoot + "/" + SandboxLayout.SESSIONS_DIR
                 + " /home/agent/.config /home/agent/.local/tmp && "
                 +
                 // The runner imports the Pi SDK by bare specifier, which resolves from <workspace>/node_modules,

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/runtime/SandboxLayout.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/runtime/SandboxLayout.java
@@ -134,7 +134,9 @@ public final class SandboxLayout {
     public static final String MENTOR_SYSTEM_PROMPT_PATH = "agent/mentor/system.md";
 
     /** Workspace-relative directory for restored Pi SDK session JSONL files (matches the mentor runner's {@code SESSIONS_DIR}). */
-    public static final String SESSIONS_DIR_PREFIX = ".sessions/";
+    public static final String SESSIONS_DIR = ".sessions";
+
+    public static final String SESSIONS_DIR_PREFIX = SESSIONS_DIR + "/";
 
     /** Exit code emitted by the Pi runner on envelope/image drift (unsupported {@code schemaVersion} or {@code kind}). */
     public static final int EXIT_ENVELOPE_MISMATCH = 42;

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/runtime/PiRuntimeFactoryTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/runtime/PiRuntimeFactoryTest.java
@@ -309,6 +309,20 @@ class PiRuntimeFactoryTest extends BaseUnitTest {
             assertThat(body.substring(sliceStart, nodeIdx)).isBlank();
         }
 
+        /** A write grant is resolved when Node starts, so every granted directory is created first. */
+        @Test
+        void shouldCreateEveryWritableDirectoryBeforeNodeStarts() {
+            String body = factory.build(spec(PRACTICE)).command().get(2);
+            int mkdir = body.indexOf("mkdir -p ");
+            int node = body.indexOf("node ");
+            assertThat(mkdir).isNotNegative();
+            assertThat(node).isGreaterThan(mkdir);
+            for (String directory : PiRunnerProfile.WRITABLE_DIRECTORIES) {
+                assertThat(body.substring(mkdir, node)).contains(" " + directory + " ");
+                assertThat(body).contains("--allow-fs-write=" + directory);
+            }
+        }
+
         @Test
         void mentorProfileContributesMentorFlags() {
             String body = factory.build(spec(MENTOR)).command().get(2);
@@ -323,8 +337,6 @@ class PiRuntimeFactoryTest extends BaseUnitTest {
                     .contains("--allow-fs-read=/workspace")
                     .contains("--allow-fs-read=/home/agent")
                     .contains("--allow-fs-write=/workspace/.pi")
-                    // Granted for writing, so it must exist before Node starts.
-                    .contains("mkdir -p /workspace/out /workspace/.sessions ")
                     .contains("--allow-fs-write=/workspace/out");
         }
 

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/runtime/PiRuntimeFactoryTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/runtime/PiRuntimeFactoryTest.java
@@ -323,6 +323,8 @@ class PiRuntimeFactoryTest extends BaseUnitTest {
                     .contains("--allow-fs-read=/workspace")
                     .contains("--allow-fs-read=/home/agent")
                     .contains("--allow-fs-write=/workspace/.pi")
+                    // Granted for writing, so it must exist before Node starts.
+                    .contains("mkdir -p /workspace/out /workspace/.sessions ")
                     .contains("--allow-fs-write=/workspace/out");
         }
 

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/runtime/SandboxLayoutSyncTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/runtime/SandboxLayoutSyncTest.java
@@ -82,7 +82,7 @@ class SandboxLayoutSyncTest extends BaseUnitTest {
 
         assertThat(body)
                 .as("mentor runner references SandboxLayout.SESSIONS_DIR_PREFIX dir name (.sessions)")
-                .contains("/" + SandboxLayout.SESSIONS_DIR_PREFIX.replaceFirst("/$", ""));
+                .contains("/" + SandboxLayout.SESSIONS_DIR);
 
         assertThat(body)
                 .as("mentor runner falls back to SandboxLayout.PI_AGENT_DIR when PI_CODING_AGENT_DIR is unset")


### PR DESCRIPTION
## Problem

With #1896 on staging, every observer reaches its model turn and issues tool calls, then dies with `Access to this API has been restricted. Use --allow-fs-write` (seven of seven jobs in today's validation sweep). The denied write is the session file: the runner grants `--allow-fs-write=/workspace/.sessions`, but Node resolves a grant when it starts, and the SDK creates that directory only on the first message of the first session. A directory created after startup accepts `mkdir` and denies every write inside it, reproduced locally with a two-line script.

## Fix

The sandbox command creates the session directory before Node starts, next to the output and home directories it already creates. The image gate asserts the Node behaviour that makes this necessary, so the pre-creation is revisited rather than cargo-culted if Node changes it. `PiRuntimeFactoryTest` pins the directory in the command.

## Verification

- Local replica of the new gate check: a write inside a granted-but-absent directory is denied.
- `PiRuntimeFactoryTest`, `PracticePiAdapterTest`.
- After merge: the validation sweep on staging (seven pull requests in `HephaestusTest/practice-validation`) must produce completed jobs with observations.

Not reviewed by Codex: both accounts are out of credits until 7 September.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZzUtPvAhEnBHsxqWTaRHn


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Practice reviews and Heph conversations now run to completion instead of stopping at the first tool call.
  - Reviews can now access their required session files during execution, improving reliability of practice review workflows.

- **Reliability**
  - Runtime startup now prepares required workspace and session directories before execution, preventing permission-related failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->