### PR TITLE
fix(server): practice reviews get a search tool the sandbox can run

### DIFF
--- a/.changeset/practice-reviews-can-search-the-work.md
+++ b/.changeset/practice-reviews-can-search-the-work.md
@@ -1,0 +1,7 @@
+---
+"hephaestus": patch
+---
+
+Practice reviews can search the reviewed work again. The search their sandbox offered relied on a
+program the sandbox does not allow to run, so every search failed and observers could only read
+files one at a time.

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/practice/PracticeRunnerProfile.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/practice/PracticeRunnerProfile.java
@@ -12,6 +12,7 @@ public final class PracticeRunnerProfile implements PiRunnerProfile {
     /** Imported by {@link #SCRIPT} with a relative specifier, so each must be staged beside it. */
     private static final List<String> SIDECARS = List.of(
             "pi-error-text.ts",
+            "pi-grep-tool.ts",
             "pi-observation-normalize.ts",
             "pi-practice-coverage.ts",
             "pi-runner-output.ts",

--- a/server/application/src/main/resources/agent/pi-grep-tool.ts
+++ b/server/application/src/main/resources/agent/pi-grep-tool.ts
@@ -25,10 +25,14 @@ export interface GrepDetails {
 }
 
 const DEFAULT_LIMIT = 100;
+const MAX_CONTEXT = 20;
 const MAX_FILE_BYTES = 2 * 1024 * 1024;
 const MAX_LINE_LENGTH = 240;
-/** Directories that hold runtime state rather than evidence. */
-const SKIPPED_DIRECTORIES = new Set(["node_modules", ".git", ".pi", ".sessions", "out", "work"]);
+const MAX_OUTPUT_BYTES = 50 * 1024;
+/** Never evidence, at any depth. */
+const SKIPPED_ANYWHERE = new Set(["node_modules", ".git"]);
+/** The sandbox's own state, which sits at the workspace root; a reviewed repository may use these names. */
+const SKIPPED_AT_ROOT = new Set([".pi", ".sessions", "out", "work"]);
 
 function globToRegExp(glob: string): RegExp {
 	let source = "";
@@ -58,7 +62,7 @@ function truncateLine(text: string): { text: string; wasTruncated: boolean } {
 		: { text, wasTruncated: false };
 }
 
-function listFiles(root: string, out: string[]): void {
+function listFiles(root: string, out: string[], atWorkspaceRoot: boolean): void {
 	let entries: import("node:fs").Dirent[];
 	try {
 		entries = readdirSync(root, { withFileTypes: true });
@@ -68,7 +72,9 @@ function listFiles(root: string, out: string[]): void {
 	entries.sort((a, b) => a.name.localeCompare(b.name));
 	for (const entry of entries) {
 		if (entry.isDirectory()) {
-			if (!SKIPPED_DIRECTORIES.has(entry.name)) listFiles(join(root, entry.name), out);
+			if (SKIPPED_ANYWHERE.has(entry.name)) continue;
+			if (atWorkspaceRoot && SKIPPED_AT_ROOT.has(entry.name)) continue;
+			listFiles(join(root, entry.name), out, false);
 		} else if (entry.isFile()) {
 			out.push(join(root, entry.name));
 		}
@@ -101,7 +107,8 @@ export function searchFiles(
 		};
 	}
 	const globMatcher = params.glob ? globToRegExp(params.glob) : null;
-	const context = params.context && params.context > 0 ? Math.floor(params.context) : 0;
+	const context =
+		params.context && params.context > 0 ? Math.min(MAX_CONTEXT, Math.floor(params.context)) : 0;
 	const limit = Math.max(1, params.limit ?? DEFAULT_LIMIT);
 
 	let rootStat: import("node:fs").Stats;
@@ -114,7 +121,7 @@ export function searchFiles(
 		};
 	}
 	const files: string[] = [];
-	if (rootStat.isDirectory()) listFiles(searchRoot, files);
+	if (rootStat.isDirectory()) listFiles(searchRoot, files, searchRoot === resolve(cwd));
 	else files.push(searchRoot);
 
 	const blocks: string[] = [];
@@ -170,7 +177,15 @@ export function searchFiles(
 			`[Output truncated at ${limit} matches; narrow the pattern, path or glob to see more]`,
 		);
 	if (linesTruncated) notes.push(`[Some lines were truncated at ${MAX_LINE_LENGTH} characters]`);
-	const text = blocks.length === 0 ? "No matches found" : [...blocks, ...notes].join("\n");
+	let body = blocks.join("\n");
+	if (body.length > MAX_OUTPUT_BYTES) {
+		body = body.slice(0, MAX_OUTPUT_BYTES);
+		notes.push(
+			`[Output truncated at ${MAX_OUTPUT_BYTES} characters; narrow the pattern, path or glob to see more]`,
+		);
+		truncated = true;
+	}
+	const text = blocks.length === 0 ? "No matches found" : [body, ...notes].join("\n");
 	return { text, details: { matches, truncated } };
 }
 
@@ -204,6 +219,7 @@ export function buildGrepTool(cwd: string) {
 	return defineTool({
 		name: "grep",
 		label: "Grep",
+		promptSnippet: "Search file contents for a pattern within the reviewed work",
 		description:
 			"Search file contents for a pattern. Returns matching lines with file paths and line numbers. " +
 			`Output is truncated to ${DEFAULT_LIMIT} matches by default; use limit, path or glob to narrow it.`,

--- a/server/application/src/main/resources/agent/pi-grep-tool.ts
+++ b/server/application/src/main/resources/agent/pi-grep-tool.ts
@@ -100,6 +100,17 @@ export function searchFiles(
 			details: { matches: 0, truncated: false },
 		};
 	}
+	// The skips apply to a search rooted inside them as much as to a walk reaching them.
+	const rootSegments = fromWorkspace === "" ? [] : fromWorkspace.split(sep);
+	const rootIsSkipped =
+		rootSegments.some((segment) => SKIPPED_ANYWHERE.has(segment)) ||
+		rootSegments.some((_, index) => SKIPPED_PATHS.has(rootSegments.slice(0, index + 1).join("/")));
+	if (rootIsSkipped) {
+		return {
+			text: `Path ${params.path} is the sandbox's own state, not the reviewed work; it is not searchable.`,
+			details: { matches: 0, truncated: false },
+		};
+	}
 	const flags = params.ignoreCase ? "i" : "";
 	const source = params.literal
 		? params.pattern.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")

--- a/server/application/src/main/resources/agent/pi-grep-tool.ts
+++ b/server/application/src/main/resources/agent/pi-grep-tool.ts
@@ -1,0 +1,244 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { basename, join, relative, resolve, sep } from "node:path";
+
+import { type AgentToolResult, defineTool } from "@earendil-works/pi-coding-agent";
+
+/**
+ * The search tool a review session gets instead of the SDK's `grep`, which spawns ripgrep and, when
+ * it cannot, downloads one; the sandbox allows neither a child process nor the network. This walks
+ * the workspace in-process with the same parameters and the same output shape as the SDK tool, so
+ * the orchestrator's instructions and the model's habits carry over unchanged.
+ */
+export interface GrepParams {
+	pattern: string;
+	path?: string;
+	glob?: string;
+	ignoreCase?: boolean;
+	literal?: boolean;
+	context?: number;
+	limit?: number;
+}
+
+export interface GrepDetails {
+	matches: number;
+	truncated: boolean;
+}
+
+const DEFAULT_LIMIT = 100;
+const MAX_FILE_BYTES = 2 * 1024 * 1024;
+const MAX_LINE_LENGTH = 240;
+/** Directories that hold runtime state rather than evidence. */
+const SKIPPED_DIRECTORIES = new Set(["node_modules", ".git", ".pi", ".sessions", "out", "work"]);
+
+function globToRegExp(glob: string): RegExp {
+	let source = "";
+	for (let i = 0; i < glob.length; i += 1) {
+		const c = glob.charAt(i);
+		if (c === "*") {
+			if (glob.charAt(i + 1) === "*") {
+				source += ".*";
+				i += 1;
+				if (glob.charAt(i + 1) === "/") i += 1;
+			} else {
+				source += "[^/]*";
+			}
+		} else if (c === "?") {
+			source += "[^/]";
+		} else {
+			source += c.replace(/[.+^${}()|[\]\\]/g, "\\$&");
+		}
+	}
+	// A glob without a slash matches a basename anywhere, as ripgrep's does.
+	return new RegExp(glob.includes("/") ? `^${source}$` : `(^|/)${source}$`);
+}
+
+function truncateLine(text: string): { text: string; wasTruncated: boolean } {
+	return text.length > MAX_LINE_LENGTH
+		? { text: `${text.slice(0, MAX_LINE_LENGTH)}…`, wasTruncated: true }
+		: { text, wasTruncated: false };
+}
+
+function listFiles(root: string, out: string[]): void {
+	let entries: import("node:fs").Dirent[];
+	try {
+		entries = readdirSync(root, { withFileTypes: true });
+	} catch {
+		return;
+	}
+	entries.sort((a, b) => a.name.localeCompare(b.name));
+	for (const entry of entries) {
+		if (entry.isDirectory()) {
+			if (!SKIPPED_DIRECTORIES.has(entry.name)) listFiles(join(root, entry.name), out);
+		} else if (entry.isFile()) {
+			out.push(join(root, entry.name));
+		}
+	}
+}
+
+/** Searches under `cwd` and returns the SDK grep tool's text output. Pure apart from reading files. */
+export function searchFiles(
+	cwd: string,
+	params: GrepParams,
+): { text: string; details: GrepDetails } {
+	const searchRoot = resolve(cwd, params.path ?? ".");
+	if (relative(cwd, searchRoot).startsWith("..")) {
+		return {
+			text: `Path ${params.path} is outside the workspace.`,
+			details: { matches: 0, truncated: false },
+		};
+	}
+	const flags = params.ignoreCase ? "i" : "";
+	const source = params.literal
+		? params.pattern.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+		: params.pattern;
+	let matcher: RegExp;
+	try {
+		matcher = new RegExp(source, flags);
+	} catch (error) {
+		return {
+			text: `Invalid pattern: ${error instanceof Error ? error.message : String(error)}`,
+			details: { matches: 0, truncated: false },
+		};
+	}
+	const globMatcher = params.glob ? globToRegExp(params.glob) : null;
+	const context = params.context && params.context > 0 ? Math.floor(params.context) : 0;
+	const limit = Math.max(1, params.limit ?? DEFAULT_LIMIT);
+
+	let rootStat: import("node:fs").Stats;
+	try {
+		rootStat = statSync(searchRoot);
+	} catch {
+		return {
+			text: `Path ${params.path ?? "."} does not exist.`,
+			details: { matches: 0, truncated: false },
+		};
+	}
+	const files: string[] = [];
+	if (rootStat.isDirectory()) listFiles(searchRoot, files);
+	else files.push(searchRoot);
+
+	const blocks: string[] = [];
+	let matches = 0;
+	let truncated = false;
+	let linesTruncated = false;
+	for (const file of files) {
+		if (matches >= limit) {
+			truncated = true;
+			break;
+		}
+		const relativePath = relative(searchRoot, file);
+		// A single-file search has no relative path; its name stands in, as ripgrep prints it.
+		const shown = relativePath === "" ? basename(file) : relativePath;
+		if (globMatcher && !globMatcher.test(shown.split(sep).join("/"))) continue;
+		let content: string;
+		try {
+			if (statSync(file).size > MAX_FILE_BYTES) continue;
+			const raw = readFileSync(file);
+			if (raw.includes(0)) continue;
+			content = raw.toString("utf8");
+		} catch {
+			continue;
+		}
+		const lines = content.split("\n");
+		// A file's final newline ends its last line; it does not start an empty one.
+		if (lines.at(-1) === "") lines.pop();
+		for (let index = 0; index < lines.length; index += 1) {
+			if (matches >= limit) {
+				truncated = true;
+				break;
+			}
+			const line = lines[index]?.replace(/\r/g, "") ?? "";
+			matcher.lastIndex = 0;
+			if (!matcher.test(line)) continue;
+			matches += 1;
+			const lineNumber = index + 1;
+			const start = context > 0 ? Math.max(1, lineNumber - context) : lineNumber;
+			const end = context > 0 ? Math.min(lines.length, lineNumber + context) : lineNumber;
+			for (let current = start; current <= end; current += 1) {
+				const { text, wasTruncated } = truncateLine(lines[current - 1]?.replace(/\r/g, "") ?? "");
+				if (wasTruncated) linesTruncated = true;
+				blocks.push(
+					current === lineNumber ? `${shown}:${current}: ${text}` : `${shown}-${current}- ${text}`,
+				);
+			}
+			if (context > 0) blocks.push("--");
+		}
+	}
+	const notes: string[] = [];
+	if (truncated)
+		notes.push(
+			`[Output truncated at ${limit} matches; narrow the pattern, path or glob to see more]`,
+		);
+	if (linesTruncated) notes.push(`[Some lines were truncated at ${MAX_LINE_LENGTH} characters]`);
+	const text = blocks.length === 0 ? "No matches found" : [...blocks, ...notes].join("\n");
+	return { text, details: { matches, truncated } };
+}
+
+/** The model's arguments arrive untyped; anything of the wrong shape is ignored rather than trusted. */
+export function readGrepParams(raw: unknown): GrepParams {
+	const record: Record<string, unknown> = typeof raw === "object" && raw !== null ? { ...raw } : {};
+	const string = (key: string) => {
+		const value = record[key];
+		return typeof value === "string" ? value : undefined;
+	};
+	const bool = (key: string) => {
+		const value = record[key];
+		return typeof value === "boolean" ? value : undefined;
+	};
+	const number = (key: string) => {
+		const value = record[key];
+		return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+	};
+	return {
+		pattern: string("pattern") ?? "",
+		path: string("path"),
+		glob: string("glob"),
+		ignoreCase: bool("ignoreCase"),
+		literal: bool("literal"),
+		context: number("context"),
+		limit: number("limit"),
+	};
+}
+
+export function buildGrepTool(cwd: string) {
+	return defineTool({
+		name: "grep",
+		label: "Grep",
+		description:
+			"Search file contents for a pattern. Returns matching lines with file paths and line numbers. " +
+			`Output is truncated to ${DEFAULT_LIMIT} matches by default; use limit, path or glob to narrow it.`,
+		parameters: {
+			type: "object",
+			additionalProperties: false,
+			required: ["pattern"],
+			properties: {
+				pattern: { type: "string", description: "Search pattern (regex or literal string)" },
+				path: {
+					type: "string",
+					description: "Directory or file to search (default: current directory)",
+				},
+				glob: {
+					type: "string",
+					description: "Filter files by glob pattern, e.g. '*.ts' or '**/*.spec.ts'",
+				},
+				ignoreCase: { type: "boolean", description: "Case-insensitive search (default: false)" },
+				literal: {
+					type: "boolean",
+					description: "Treat pattern as literal string instead of regex (default: false)",
+				},
+				context: {
+					type: "number",
+					description: "Number of lines to show before and after each match (default: 0)",
+				},
+				limit: {
+					type: "number",
+					description: `Maximum number of matches to return (default: ${DEFAULT_LIMIT})`,
+				},
+			},
+		},
+		execute: (_toolCallId, params): Promise<AgentToolResult<GrepDetails>> => {
+			const { text, details } = searchFiles(cwd, readGrepParams(params));
+			return Promise.resolve({ content: [{ type: "text", text }], details });
+		},
+	});
+}

--- a/server/application/src/main/resources/agent/pi-grep-tool.ts
+++ b/server/application/src/main/resources/agent/pi-grep-tool.ts
@@ -31,8 +31,11 @@ const MAX_LINE_LENGTH = 240;
 const MAX_OUTPUT_BYTES = 50 * 1024;
 /** Never evidence, at any depth. */
 const SKIPPED_ANYWHERE = new Set(["node_modules", ".git"]);
-/** The sandbox's own state, which sits at the workspace root; a reviewed repository may use these names. */
-const SKIPPED_AT_ROOT = new Set([".pi", ".sessions", "out", "work"]);
+/**
+ * The sandbox's own state, by its path from the workspace root; a reviewed repository may use these
+ * names. `work` itself stays searchable: the precompute summary the orchestrator points at lives there.
+ */
+const SKIPPED_PATHS = new Set([".pi", ".sessions", "out", "work/composition"]);
 
 function globToRegExp(glob: string): RegExp {
 	let source = "";
@@ -62,7 +65,8 @@ function truncateLine(text: string): { text: string; wasTruncated: boolean } {
 		: { text, wasTruncated: false };
 }
 
-function listFiles(root: string, out: string[], atWorkspaceRoot: boolean): void {
+function listFiles(cwd: string, root: string, out: string[], signal?: AbortSignal): void {
+	if (signal?.aborted) return;
 	let entries: import("node:fs").Dirent[];
 	try {
 		entries = readdirSync(root, { withFileTypes: true });
@@ -73,8 +77,9 @@ function listFiles(root: string, out: string[], atWorkspaceRoot: boolean): void 
 	for (const entry of entries) {
 		if (entry.isDirectory()) {
 			if (SKIPPED_ANYWHERE.has(entry.name)) continue;
-			if (atWorkspaceRoot && SKIPPED_AT_ROOT.has(entry.name)) continue;
-			listFiles(join(root, entry.name), out, false);
+			const child = join(root, entry.name);
+			if (SKIPPED_PATHS.has(relative(cwd, child).split(sep).join("/"))) continue;
+			listFiles(cwd, child, out, signal);
 		} else if (entry.isFile()) {
 			out.push(join(root, entry.name));
 		}
@@ -85,9 +90,11 @@ function listFiles(root: string, out: string[], atWorkspaceRoot: boolean): void 
 export function searchFiles(
 	cwd: string,
 	params: GrepParams,
+	signal?: AbortSignal,
 ): { text: string; details: GrepDetails } {
 	const searchRoot = resolve(cwd, params.path ?? ".");
-	if (relative(cwd, searchRoot).startsWith("..")) {
+	const fromWorkspace = relative(cwd, searchRoot);
+	if (fromWorkspace === ".." || fromWorkspace.startsWith(`..${sep}`)) {
 		return {
 			text: `Path ${params.path} is outside the workspace.`,
 			details: { matches: 0, truncated: false },
@@ -121,14 +128,19 @@ export function searchFiles(
 		};
 	}
 	const files: string[] = [];
-	if (rootStat.isDirectory()) listFiles(searchRoot, files, searchRoot === resolve(cwd));
+	if (rootStat.isDirectory()) listFiles(resolve(cwd), searchRoot, files, signal);
 	else files.push(searchRoot);
 
 	const blocks: string[] = [];
 	let matches = 0;
 	let truncated = false;
 	let linesTruncated = false;
+	let aborted = signal?.aborted ?? false;
 	for (const file of files) {
+		if (signal?.aborted) {
+			aborted = true;
+			break;
+		}
 		if (matches >= limit) {
 			truncated = true;
 			break;
@@ -172,6 +184,7 @@ export function searchFiles(
 		}
 	}
 	const notes: string[] = [];
+	if (aborted) notes.push("[Search stopped: the session's time is up]");
 	if (truncated)
 		notes.push(
 			`[Output truncated at ${limit} matches; narrow the pattern, path or glob to see more]`,
@@ -185,7 +198,7 @@ export function searchFiles(
 		);
 		truncated = true;
 	}
-	const text = blocks.length === 0 ? "No matches found" : [body, ...notes].join("\n");
+	const text = [blocks.length === 0 ? "No matches found" : body, ...notes].join("\n");
 	return { text, details: { matches, truncated } };
 }
 
@@ -252,8 +265,8 @@ export function buildGrepTool(cwd: string) {
 				},
 			},
 		},
-		execute: (_toolCallId, params): Promise<AgentToolResult<GrepDetails>> => {
-			const { text, details } = searchFiles(cwd, readGrepParams(params));
+		execute: (_toolCallId, params, signal): Promise<AgentToolResult<GrepDetails>> => {
+			const { text, details } = searchFiles(cwd, readGrepParams(params), signal);
 			return Promise.resolve({ content: [{ type: "text", text }], details });
 		},
 	});

--- a/server/application/src/main/resources/agent/pi-runner.ts
+++ b/server/application/src/main/resources/agent/pi-runner.ts
@@ -14,6 +14,7 @@ import {
 } from "@earendil-works/pi-coding-agent";
 
 import { errorText } from "./pi-error-text.ts";
+import { buildGrepTool } from "./pi-grep-tool.ts";
 import {
 	citationMatchesArtifact,
 	dedupeKeyForObservation,
@@ -172,7 +173,9 @@ function isAdmittedObservation(value: unknown): value is AdmittedObservation {
 
 // Overridable so a harness with no /workspace can drive the runner. Production never sets it.
 const WORKSPACE_ROOT = "/workspace";
-const EVIDENCE_TOOLS = ["read", "grep"] as const;
+// The SDK's grep spawns ripgrep, which the sandbox forbids; the runner's own search tool takes its
+// place in every session, with the same name, parameters and output.
+const EVIDENCE_TOOLS = ["read"] as const;
 const CWD = process.env.PI_RUNNER_CWD ?? WORKSPACE_ROOT;
 const OUTPUT = `${CWD}/out`;
 const RESULT_PATH = outputPath(OUTPUT, "result.json");
@@ -1575,6 +1578,7 @@ async function main() {
 	// the model is ever called. Nothing project-local is wanted here anyway: every resource this run
 	// uses is injected by the runner, never discovered from the checkout.
 	const settingsManager = SettingsManager.create(CWD, AGENT_DIR, { projectTrusted: false });
+	const grepTool = buildGrepTool(CWD);
 	// The only instructions a session carries beyond its prompt are the orchestrator the server staged
 	// in the agent dir. The SDK's own context-file discovery would climb from the working directory
 	// to `/` looking for AGENTS.md and die on the first ancestor the allowlist forbids, and it would
@@ -1657,8 +1661,8 @@ async function main() {
 			await createAgentSession({
 				cwd: CWD,
 				agentDir: AGENT_DIR,
-				tools: ["read", "grep", "report_feedback", "report_summary"],
-				customTools: [feedbackTool, buildSummaryTool()],
+				tools: ["read", "report_feedback", "report_summary"],
+				customTools: [grepTool, feedbackTool, buildSummaryTool()],
 				sessionManager: SessionManager.inMemory(),
 				settingsManager,
 				resourceLoader: await loadResources(),
@@ -1735,7 +1739,7 @@ async function main() {
 			cwd: CWD,
 			agentDir: AGENT_DIR,
 			tools: [...EVIDENCE_TOOLS],
-			customTools: [],
+			customTools: [grepTool],
 			sessionManager: manager,
 			settingsManager,
 			resourceLoader: await loadResources(),
@@ -1796,7 +1800,7 @@ async function main() {
 					cwd: CWD,
 					agentDir: AGENT_DIR,
 					tools: [...EVIDENCE_TOOLS, "report_observation"],
-					customTools: [scopedTool],
+					customTools: [grepTool, scopedTool],
 					sessionManager: manager,
 					settingsManager,
 					resourceLoader: await loadResources(),
@@ -1927,7 +1931,7 @@ async function main() {
 					cwd: CWD,
 					agentDir: AGENT_DIR,
 					tools: [...EVIDENCE_TOOLS, "report_observation"],
-					customTools: [retryTool],
+					customTools: [grepTool, retryTool],
 					sessionManager: priorSessionFile
 						? SessionManager.open(priorSessionFile, sessionDir)
 						: SessionManager.inMemory(),

--- a/server/application/src/main/resources/agent/pi-runner.ts
+++ b/server/application/src/main/resources/agent/pi-runner.ts
@@ -174,8 +174,9 @@ function isAdmittedObservation(value: unknown): value is AdmittedObservation {
 // Overridable so a harness with no /workspace can drive the runner. Production never sets it.
 const WORKSPACE_ROOT = "/workspace";
 // The SDK's grep spawns ripgrep, which the sandbox forbids; the runner's own search tool takes its
-// place in every session, with the same name, parameters and output.
-const EVIDENCE_TOOLS = ["read"] as const;
+// place in every session under the same name. "grep" stays listed: the SDK filters custom tools
+// through this list too, and a listed custom definition replaces the built-in of that name.
+const EVIDENCE_TOOLS = ["read", "grep"] as const;
 const CWD = process.env.PI_RUNNER_CWD ?? WORKSPACE_ROOT;
 const OUTPUT = `${CWD}/out`;
 const RESULT_PATH = outputPath(OUTPUT, "result.json");
@@ -1661,7 +1662,7 @@ async function main() {
 			await createAgentSession({
 				cwd: CWD,
 				agentDir: AGENT_DIR,
-				tools: ["read", "report_feedback", "report_summary"],
+				tools: ["read", "grep", "report_feedback", "report_summary"],
 				customTools: [grepTool, feedbackTool, buildSummaryTool()],
 				sessionManager: SessionManager.inMemory(),
 				settingsManager,

--- a/server/application/src/test/resources/agent/pi-grep-tool-registration.spec.ts
+++ b/server/application/src/test/resources/agent/pi-grep-tool-registration.spec.ts
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+	createAgentSession,
+	DefaultResourceLoader,
+	ModelRuntime,
+	SessionManager,
+	SettingsManager,
+} from "@earendil-works/pi-coding-agent";
+
+import { buildGrepTool } from "../../../main/resources/agent/pi-grep-tool.ts";
+
+/**
+ * The SDK filters custom tools through the same allowlist as its built-ins, so a session gets the
+ * runner's grep only when "grep" is listed, and then the custom definition replaces the built-in
+ * under that name. Both halves are what the runner relies on.
+ */
+void test("the runner's grep replaces the SDK's in a session opened the way the runner opens one", async () => {
+	const cwd = mkdtempSync(join(tmpdir(), "grep-registration-"));
+	const agentDir = join(cwd, ".pi");
+	mkdirSync(agentDir, { recursive: true });
+	for (const file of ["settings.json", "auth.json", "models.json"])
+		writeFileSync(join(agentDir, file), "{}\n");
+	const settingsManager = SettingsManager.create(cwd, agentDir, { projectTrusted: false });
+	const resourceLoader = new DefaultResourceLoader({
+		cwd,
+		agentDir,
+		settingsManager,
+		noContextFiles: true,
+		agentsFilesOverride: () => ({ agentsFiles: [] }),
+	});
+	await resourceLoader.reload();
+	const modelRuntime = await ModelRuntime.create({
+		authPath: join(agentDir, "auth.json"),
+		modelsPath: join(agentDir, "models.json"),
+		allowModelNetwork: false,
+	});
+	process.env.GREP_REGISTRATION_TOKEN = "unused";
+	modelRuntime.registerProvider("registration", {
+		name: "registration",
+		baseUrl: "http://127.0.0.1:9/v1",
+		apiKey: "$GREP_REGISTRATION_TOKEN",
+		authHeader: true,
+		api: "openai-completions",
+		models: [
+			{
+				id: "model",
+				name: "model",
+				reasoning: false,
+				input: ["text"],
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+				contextWindow: 1000,
+				maxTokens: 100,
+			},
+		],
+	});
+	const grepTool = buildGrepTool(cwd);
+	const { session } = await createAgentSession({
+		cwd,
+		agentDir,
+		tools: ["read", "grep"],
+		customTools: [grepTool],
+		sessionManager: SessionManager.inMemory(cwd),
+		settingsManager,
+		resourceLoader,
+		modelRuntime,
+		model: modelRuntime.getModel("registration", "model"),
+	});
+	try {
+		assert.ok(session.getActiveToolNames().includes("grep"));
+		const grep = session.getAllTools().find((tool) => tool.name === "grep");
+		assert.equal(grep?.description, grepTool.description);
+	} finally {
+		session.dispose();
+	}
+});

--- a/server/application/src/test/resources/agent/pi-grep-tool-registration.spec.ts
+++ b/server/application/src/test/resources/agent/pi-grep-tool-registration.spec.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -76,5 +76,6 @@ void test("the runner's grep replaces the SDK's in a session opened the way the 
 		assert.equal(grep?.description, grepTool.description);
 	} finally {
 		session.dispose();
+		rmSync(cwd, { recursive: true, force: true });
 	}
 });

--- a/server/application/src/test/resources/agent/pi-grep-tool.spec.ts
+++ b/server/application/src/test/resources/agent/pi-grep-tool.spec.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -12,6 +12,10 @@ function workspace(): string {
 	mkdirSync(join(root, "inputs", "sources", "scm", "repo", "src"), { recursive: true });
 	mkdirSync(join(root, ".sessions"), { recursive: true });
 	mkdirSync(join(root, "inputs", "sources", "scm", "repo", "work"), { recursive: true });
+	mkdirSync(join(root, "work", "precompute-out"), { recursive: true });
+	mkdirSync(join(root, "work", "composition"), { recursive: true });
+	writeFileSync(join(root, "work", "precompute-out", "summary.md"), "API_KEY appears in a hint\n");
+	writeFileSync(join(root, "work", "composition", "observations.json"), '{"summary":"API_KEY"}\n');
 	writeFileSync(
 		join(root, "inputs", "sources", "scm", "repo", "work", "queue.py"),
 		"API_KEY = load()\n",
@@ -41,8 +45,10 @@ void test("matches carry the SDK grep tool's path:line: shape and skip runtime s
 		"inputs/sources/scm/repo/src/app.py:2:     return API_KEY",
 		// A reviewed repository's own `work` directory is evidence; only the sandbox's root-level one is not.
 		"inputs/sources/scm/repo/work/queue.py:1: API_KEY = load()",
+		// The precompute summary the orchestrator points at is evidence; the runner's composition state is not.
+		"work/precompute-out/summary.md:1: API_KEY appears in a hint",
 	]);
-	assert.deepEqual(details, { matches: 4, truncated: false });
+	assert.deepEqual(details, { matches: 5, truncated: false });
 });
 
 void test("path, glob, literal, ignoreCase and context narrow and widen the output as the SDK tool's do", () => {
@@ -114,4 +120,15 @@ void test("context is clamped and the output has a size ceiling", () => {
 	assert.ok(capped.text.length < 52 * 1024);
 	assert.match(capped.text, /truncated at 51200 characters/);
 	assert.equal(capped.details.truncated, true);
+});
+
+void test("an aborted session stops the walk with a note, and temp workspaces are removed", () => {
+	const root = workspace();
+	const controller = new AbortController();
+	controller.abort();
+	const { text, details } = searchFiles(root, { pattern: "API_KEY" }, controller.signal);
+	assert.equal(details.matches, 0);
+	assert.match(text, /Search stopped/);
+	assert.match(searchFiles(root, { pattern: "x", path: "..foo" }).text, /does not exist/);
+	rmSync(root, { recursive: true, force: true });
 });

--- a/server/application/src/test/resources/agent/pi-grep-tool.spec.ts
+++ b/server/application/src/test/resources/agent/pi-grep-tool.spec.ts
@@ -11,6 +11,11 @@ function workspace(): string {
 	mkdirSync(join(root, "inputs", "context"), { recursive: true });
 	mkdirSync(join(root, "inputs", "sources", "scm", "repo", "src"), { recursive: true });
 	mkdirSync(join(root, ".sessions"), { recursive: true });
+	mkdirSync(join(root, "inputs", "sources", "scm", "repo", "work"), { recursive: true });
+	writeFileSync(
+		join(root, "inputs", "sources", "scm", "repo", "work", "queue.py"),
+		"API_KEY = load()\n",
+	);
 	writeFileSync(
 		join(root, "inputs", "context", "diff.patch"),
 		"+API_KEY = 'sk-live'\n context\n+print(API_KEY)\n",
@@ -34,20 +39,22 @@ void test("matches carry the SDK grep tool's path:line: shape and skip runtime s
 		"inputs/context/diff.patch:1: +API_KEY = 'sk-live'",
 		"inputs/context/diff.patch:3: +print(API_KEY)",
 		"inputs/sources/scm/repo/src/app.py:2:     return API_KEY",
+		// A reviewed repository's own `work` directory is evidence; only the sandbox's root-level one is not.
+		"inputs/sources/scm/repo/work/queue.py:1: API_KEY = load()",
 	]);
-	assert.deepEqual(details, { matches: 3, truncated: false });
+	assert.deepEqual(details, { matches: 4, truncated: false });
 });
 
 void test("path, glob, literal, ignoreCase and context narrow and widen the output as the SDK tool's do", () => {
 	const root = workspace();
-	assert.equal(
+	assert.deepEqual(
 		searchFiles(root, {
 			pattern: "api_key",
 			ignoreCase: true,
 			path: "inputs/sources",
 			glob: "*.py",
-		}).text,
-		"scm/repo/src/app.py:2:     return API_KEY",
+		}).text.split("\n"),
+		["scm/repo/src/app.py:2:     return API_KEY", "scm/repo/work/queue.py:1: API_KEY = load()"],
 	);
 	assert.equal(
 		searchFiles(root, {
@@ -88,4 +95,23 @@ void test("arguments of the wrong shape are dropped rather than trusted", () => 
 		limit: undefined,
 	});
 	assert.equal(readGrepParams(null).pattern, "");
+});
+
+void test("context is clamped and the output has a size ceiling", () => {
+	const root = workspace();
+	const wide = searchFiles(root, {
+		pattern: "print",
+		path: "inputs/context/diff.patch",
+		context: 500,
+	});
+	assert.equal(wide.text.split("\n").length, 4);
+	mkdirSync(join(root, "inputs", "big"), { recursive: true });
+	writeFileSync(
+		join(root, "inputs", "big", "log.txt"),
+		Array.from({ length: 400 }, (_, i) => `match ${i} ${"x".repeat(200)}`).join("\n"),
+	);
+	const capped = searchFiles(root, { pattern: "match", path: "inputs/big", limit: 400 });
+	assert.ok(capped.text.length < 52 * 1024);
+	assert.match(capped.text, /truncated at 51200 characters/);
+	assert.equal(capped.details.truncated, true);
 });

--- a/server/application/src/test/resources/agent/pi-grep-tool.spec.ts
+++ b/server/application/src/test/resources/agent/pi-grep-tool.spec.ts
@@ -14,6 +14,17 @@ function workspace(): string {
 	mkdirSync(join(root, "inputs", "sources", "scm", "repo", "work"), { recursive: true });
 	mkdirSync(join(root, "work", "precompute-out"), { recursive: true });
 	mkdirSync(join(root, "work", "composition"), { recursive: true });
+	mkdirSync(join(root, "out"), { recursive: true });
+	mkdirSync(join(root, ".pi"), { recursive: true });
+	mkdirSync(join(root, "inputs", "sources", "scm", "repo", "node_modules", "dep"), {
+		recursive: true,
+	});
+	writeFileSync(join(root, "out", "result.json"), '{"API_KEY": 1}\n');
+	writeFileSync(join(root, ".pi", "settings.json"), '{"API_KEY": 1}\n');
+	writeFileSync(
+		join(root, "inputs", "sources", "scm", "repo", "node_modules", "dep", "index.js"),
+		"API_KEY\n",
+	);
 	writeFileSync(join(root, "work", "precompute-out", "summary.md"), "API_KEY appears in a hint\n");
 	writeFileSync(join(root, "work", "composition", "observations.json"), '{"summary":"API_KEY"}\n');
 	writeFileSync(
@@ -131,4 +142,19 @@ void test("an aborted session stops the walk with a note, and temp workspaces ar
 	assert.match(text, /Search stopped/);
 	assert.match(searchFiles(root, { pattern: "x", path: "..foo" }).text, /does not exist/);
 	rmSync(root, { recursive: true, force: true });
+});
+
+void test("the sandbox's own state is not searchable even when named as the path", () => {
+	const root = workspace();
+	for (const path of [
+		".sessions",
+		".pi",
+		"out",
+		"work/composition",
+		".sessions/s.jsonl",
+		"inputs/sources/scm/repo/node_modules",
+	]) {
+		assert.match(searchFiles(root, { pattern: "API_KEY", path }).text, /not searchable/, path);
+	}
+	assert.match(searchFiles(root, { pattern: "API_KEY", path: "work" }).text, /precompute-out/);
 });

--- a/server/application/src/test/resources/agent/pi-grep-tool.spec.ts
+++ b/server/application/src/test/resources/agent/pi-grep-tool.spec.ts
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import { readGrepParams, searchFiles } from "../../../main/resources/agent/pi-grep-tool.ts";
+
+function workspace(): string {
+	const root = mkdtempSync(join(tmpdir(), "grep-tool-"));
+	mkdirSync(join(root, "inputs", "context"), { recursive: true });
+	mkdirSync(join(root, "inputs", "sources", "scm", "repo", "src"), { recursive: true });
+	mkdirSync(join(root, ".sessions"), { recursive: true });
+	writeFileSync(
+		join(root, "inputs", "context", "diff.patch"),
+		"+API_KEY = 'sk-live'\n context\n+print(API_KEY)\n",
+	);
+	writeFileSync(
+		join(root, "inputs", "sources", "scm", "repo", "src", "app.py"),
+		"def main():\n    return API_KEY\n",
+	);
+	writeFileSync(
+		join(root, "inputs", "sources", "scm", "repo", "src", "blob.bin"),
+		Buffer.from([0, 65, 80, 73, 95, 75, 69, 89]),
+	);
+	writeFileSync(join(root, ".sessions", "s.jsonl"), '{"text":"API_KEY"}\n');
+	return root;
+}
+
+void test("matches carry the SDK grep tool's path:line: shape and skip runtime state and binaries", () => {
+	const root = workspace();
+	const { text, details } = searchFiles(root, { pattern: "API_KEY" });
+	assert.deepEqual(text.split("\n"), [
+		"inputs/context/diff.patch:1: +API_KEY = 'sk-live'",
+		"inputs/context/diff.patch:3: +print(API_KEY)",
+		"inputs/sources/scm/repo/src/app.py:2:     return API_KEY",
+	]);
+	assert.deepEqual(details, { matches: 3, truncated: false });
+});
+
+void test("path, glob, literal, ignoreCase and context narrow and widen the output as the SDK tool's do", () => {
+	const root = workspace();
+	assert.equal(
+		searchFiles(root, {
+			pattern: "api_key",
+			ignoreCase: true,
+			path: "inputs/sources",
+			glob: "*.py",
+		}).text,
+		"scm/repo/src/app.py:2:     return API_KEY",
+	);
+	assert.equal(
+		searchFiles(root, {
+			pattern: "API_KEY = 'sk-live'",
+			literal: true,
+			glob: "**/*.patch",
+		}).text.split("\n").length,
+		1,
+	);
+	assert.deepEqual(
+		searchFiles(root, {
+			pattern: "print",
+			path: "inputs/context/diff.patch",
+			context: 1,
+		}).text.split("\n"),
+		["diff.patch-2-  context", "diff.patch:3: +print(API_KEY)", "--"],
+	);
+});
+
+void test("a limit truncates with a note, an invalid pattern and a path outside the workspace are answered, not thrown", () => {
+	const root = workspace();
+	const limited = searchFiles(root, { pattern: "API_KEY", limit: 1 });
+	assert.equal(limited.details.truncated, true);
+	assert.match(limited.text, /truncated at 1 matches/);
+	assert.match(searchFiles(root, { pattern: "(" }).text, /^Invalid pattern/);
+	assert.match(searchFiles(root, { pattern: "x", path: "../.." }).text, /outside the workspace/);
+	assert.equal(searchFiles(root, { pattern: "nothing-here" }).text, "No matches found");
+});
+
+void test("arguments of the wrong shape are dropped rather than trusted", () => {
+	assert.deepEqual(readGrepParams({ pattern: "x", limit: "5", ignoreCase: 1, path: 3 }), {
+		pattern: "x",
+		path: undefined,
+		glob: undefined,
+		ignoreCase: undefined,
+		literal: undefined,
+		context: undefined,
+		limit: undefined,
+	});
+	assert.equal(readGrepParams(null).pattern, "");
+});


### PR DESCRIPTION
## Problem

The SDK's `grep` tool spawns ripgrep and, when it cannot, downloads one; the review sandbox allows neither a child process nor the network, so every search an observer made failed and evidence was found by reading files one at a time or not at all (#1900).

## Fix

The runner ships its own search tool with the SDK tool's name, parameters and output shape, walking the workspace in-process with bounded results (100 matches by default, 2 MB per file, 240 characters per line, 50 KB of output, context clamped at 20 lines) and stopping when the session's time is up. It skips the sandbox's own state by path (`.pi`, `.sessions`, `out`, `work/composition`) and `node_modules`/`.git` at any depth, so a reviewed repository's own directories of those names and the precompute summary stay searchable. "grep" stays in the session's tool list because the SDK filters custom tools through that list and a listed custom definition replaces the built-in of the same name; the mentor runner exposes no filesystem tools and is unchanged.

## Verification

- `pi-grep-tool-registration.spec.ts` opens a session the way the runner does and proves the custom tool is the registered `grep`.
- `pi-grep-tool.spec.ts` covers the output shape, path/glob/literal/ignoreCase/context, the skips, the limits and caps, an aborted session, an invalid pattern and a path outside the workspace.
- `tsconfig.agents.json` type-check and oxlint; `RunnerProfileSidecarTest` and `PiRuntimeFactoryTest` for the staged sidecar.
- After merge: the validation sweep on staging shows observers searching successfully.

Closes #1900.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZzUtPvAhEnBHsxqWTaRHn