### PR TITLE
fix(server): a token on a GitHub App connection answers 409, not 500

### DIFF
--- a/.changeset/token-on-app-connection-is-a-conflict.md
+++ b/.changeset/token-on-app-connection-is-a-conflict.md
@@ -1,0 +1,5 @@
+---
+"hephaestus": patch
+---
+
+Writing a personal access token to a workspace whose GitHub connection is an App installation, or reading a credential the server's current keys cannot decrypt, now answers with the conflict that names the connection's state instead of an internal server error.

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/core/connection/api/CredentialUnreadableProblemAdvice.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/core/connection/api/CredentialUnreadableProblemAdvice.java
@@ -2,6 +2,8 @@ package de.tum.cit.aet.hephaestus.integration.core.connection.api;
 
 import de.tum.cit.aet.hephaestus.integration.core.connection.ConnectionModeConflictException;
 import de.tum.cit.aet.hephaestus.integration.core.connection.CredentialUnreadableException;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -11,11 +13,13 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
  * An unreadable credential, or a write the connection's mode cannot take, is a state of the
  * connection, so the answer names it and what clears it; nothing here is a fault of the request or of
  * the server's ability to serve it. Lives beside the connection API rather than in the core advice,
- * which must not depend on integration types. Unordered: {@code GlobalControllerAdvice} sits at
- * {@code LOWEST_PRECEDENCE}, so these handlers already win over its catch-all without outranking a
- * future advice more specific than they are.
+ * which must not depend on integration types. One step above {@code GlobalControllerAdvice}, which
+ * sits at {@code LOWEST_PRECEDENCE}: an advice without an order has that same value, and among equals
+ * the first registered wins, so its catch-all would answer 500 before these handlers were asked. Still
+ * below every other advice, so a future one more specific than these outranks them.
  */
 @RestControllerAdvice
+@Order(Ordered.LOWEST_PRECEDENCE - 1)
 public class CredentialUnreadableProblemAdvice {
 
     @ExceptionHandler(CredentialUnreadableException.class)

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/core/connection/CredentialReaderTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/core/connection/CredentialReaderTest.java
@@ -4,11 +4,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import de.tum.cit.aet.hephaestus.config.SpringAsyncConfig;
 import de.tum.cit.aet.hephaestus.core.security.MissingCredentialKeyException;
 import de.tum.cit.aet.hephaestus.integration.core.spi.ApiCredentialProvider.BearerToken;
 import de.tum.cit.aet.hephaestus.integration.core.spi.IntegrationKind;
@@ -20,11 +22,15 @@ import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.springframework.core.task.SyncTaskExecutor;
 import org.springframework.core.task.TaskExecutor;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.support.SimpleTransactionStatus;
@@ -78,6 +84,65 @@ class CredentialReaderTest extends BaseUnitTest {
         handedOver.forEach(Runnable::run);
         verify(connectionRepository)
                 .markCredentialsUnreadable(eq(55L), eq(7L), eq(connection.getCredentialsEncrypted()), eq(NOW));
+    }
+
+    /** The lane production writes the record on: one worker, a queue of 64, and a discard beyond that. */
+    private static ThreadPoolTaskExecutor productionRecorder() {
+        ThreadPoolTaskExecutor recorder =
+                (ThreadPoolTaskExecutor) new SpringAsyncConfig().credentialReadabilityExecutor();
+        recorder.initialize();
+        return recorder;
+    }
+
+    @Test
+    @Timeout(10)
+    void shouldStillAnswerAtOnceWhenTheRecorderIsStalledAndItsQueueIsFull() throws InterruptedException {
+        connection.setCredentials(TOKEN, new CredentialBundleConverter(KEY_A, "dev"));
+        CountDownLatch recording = new CountDownLatch(1);
+        CountDownLatch release = new CountDownLatch(1);
+        doAnswer(invocation -> {
+                    recording.countDown();
+                    release.await(10, TimeUnit.SECONDS);
+                    return 1;
+                })
+                .when(connectionRepository)
+                .markCredentialsUnreadable(any(), any(), any(), any());
+        ThreadPoolTaskExecutor recorder = productionRecorder();
+        try {
+            CredentialReader reader = readerWith(new CredentialBundleConverter(KEY_B, "dev"), recorder);
+            int queueCapacity = recorder.getQueueCapacity();
+
+            // The first record occupies the only worker until released; the next fill the queue.
+            assertThatThrownBy(() -> reader.credentialsOf(connection))
+                    .isExactlyInstanceOf(CredentialUnreadableException.class);
+            assertThat(recording.await(10, TimeUnit.SECONDS)).isTrue();
+            for (int i = 0; i < queueCapacity + 1; i++) {
+                assertThatThrownBy(() -> reader.credentialsOf(connection))
+                        .isExactlyInstanceOf(CredentialUnreadableException.class);
+            }
+
+            // The recorder is still stalled and its queue full: the answer neither waits nor changes.
+            assertThatThrownBy(() -> reader.credentialsOf(connection))
+                    .isExactlyInstanceOf(CredentialUnreadableException.class);
+            assertThat(recorder.getThreadPoolExecutor().getQueue()).hasSize(queueCapacity);
+            assertThat(release.getCount()).isEqualTo(1);
+        } finally {
+            release.countDown();
+            recorder.shutdown();
+        }
+    }
+
+    @Test
+    void shouldStillAnswerWithTheUnreadableCredentialWhenTheRecorderHasShutDown() {
+        connection.setCredentials(TOKEN, new CredentialBundleConverter(KEY_A, "dev"));
+        ThreadPoolTaskExecutor recorder = productionRecorder();
+        recorder.shutdown();
+
+        assertThatThrownBy(() -> readerWith(new CredentialBundleConverter(KEY_B, "dev"), recorder)
+                        .credentialsOf(connection))
+                .isExactlyInstanceOf(CredentialUnreadableException.class);
+        // A record submitted after shutdown is discarded, not run and not thrown.
+        verify(connectionRepository, never()).markCredentialsUnreadable(any(), any(), any(), any());
     }
 
     @Test

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/workspace/WorkspaceControllerIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/workspace/WorkspaceControllerIntegrationTest.java
@@ -22,6 +22,7 @@ import de.tum.cit.aet.hephaestus.workspace.dto.UpdateWorkspaceFeaturesRequestDTO
 import de.tum.cit.aet.hephaestus.workspace.dto.UpdateWorkspaceNotificationsRequestDTO;
 import de.tum.cit.aet.hephaestus.workspace.dto.UpdateWorkspaceScheduleRequestDTO;
 import de.tum.cit.aet.hephaestus.workspace.dto.UpdateWorkspaceStatusRequestDTO;
+import de.tum.cit.aet.hephaestus.workspace.dto.UpdateWorkspaceTokenRequestDTO;
 import de.tum.cit.aet.hephaestus.workspace.dto.WorkspaceDTO;
 import de.tum.cit.aet.hephaestus.workspace.dto.WorkspaceListItemDTO;
 import java.util.List;
@@ -418,6 +419,46 @@ class WorkspaceControllerIntegrationTest extends AbstractWorkspaceIntegrationTes
                         () -> new AssertionError("Expected ACTIVE Slack Connection on workspace " + workspace.getId()));
         assertThat(slackConfig.teamLabel()).isEqualTo("core-team");
         assertThat(slackConfig.notificationChannelId()).isEqualTo("C12345678");
+    }
+
+    @Test
+    @WithAdminUser
+    void updateTokenOnAGitHubAppConnectionReturnsConnectionModeConflictProblemDetail() {
+        User owner = persistUser("app-token-owner");
+        Workspace workspace = createWorkspace("app-token-space", "App Token", "app-token", AccountType.ORG, owner);
+        ensureAdminMembership(workspace);
+        seedGitHubAppConnection(workspace);
+
+        ProblemDetail problem = webTestClient
+                .patch()
+                .uri("/workspaces/{workspaceSlug}/token", workspace.getWorkspaceSlug())
+                .headers(TestAuthUtils.withCurrentUser())
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(new UpdateWorkspaceTokenRequestDTO("ghp_replacement_token_for_test"))
+                .exchange()
+                .expectStatus()
+                .isEqualTo(HttpStatus.CONFLICT)
+                .expectHeader()
+                .contentTypeCompatibleWith(MediaType.APPLICATION_PROBLEM_JSON)
+                .expectBody(ProblemDetail.class)
+                .returnResult()
+                .getResponseBody();
+
+        assertThat(problem).isNotNull();
+        assertThat(problem.getTitle()).isEqualTo("Connection mode conflict");
+        assertThat(problem.getDetail()).contains("App installation");
+    }
+
+    /** An App installation runs on no stored token; the install flow activates this row in production. */
+    private void seedGitHubAppConnection(Workspace workspace) {
+        Connection connection = new Connection(
+                workspace,
+                IntegrationKind.GITHUB,
+                "100",
+                new ConnectionConfig.GitHubAppConfig(100L, "app-token", null, Set.of()));
+        connection.setDisplayName("app-token");
+        connection.setState(IntegrationState.ACTIVE);
+        connectionRepository.save(connection);
     }
 
     private void seedSlackConnection(Workspace workspace) {


### PR DESCRIPTION
## Problem

Writing the route-level test #1890 asked for showed that the 409 for a token written to a GitHub App connection never left the server: `PATCH /workspaces/{slug}/token` answered 500. `CredentialUnreadableProblemAdvice` had no `@Order`, so it resolved to the same lowest precedence as `GlobalControllerAdvice`, and among equals Spring takes the first advice with any matching handler; the core catch-all is scanned first and won. The same applied to the unreadable-credential 409 from #1881, so both answers were generic server errors in production.

## Fix

The advice is ordered just above the catch-all and below every other advice, and its javadoc states the mechanism.

## Verification

- `WorkspaceControllerIntegrationTest.updateTokenOnAGitHubAppConnectionReturnsConnectionModeConflictProblemDetail`: seeds an ACTIVE GitHub App connection, PATCHes the token as an admin member, asserts 409 with title "Connection mode conflict"; it answered 500 before the fix.
- `CredentialReaderTest`: a stalled recorder with a full queue still answers the next read at once, and a read after the executor's shutdown still answers with nothing else thrown (the recorder now lives on the shared task executor from #1901, so the tests build that bean).
- Architecture tier: `TestTierTagCompletenessTest`, `NoMockingOwnedEntitiesTest`, `CodeQualityTest`.

Closes #1890.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZzUtPvAhEnBHsxqWTaRHn