### PR TITLE
fix(ci): every integration test runs on a pull request

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -59,10 +59,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # Surefire's `test` parameter replaces `includes`, so only the second shard's exclusion —
+          # never an inclusion of its own — keeps the two selectors complementary over every class
+          # the unsharded tier scans. scripts/ci-contract.test.ts proves the partition.
           - shard: providers
             tests: "de/tum/cit/aet/hephaestus/integration/**"
           - shard: application
-            tests: "**/*Test,!de/tum/cit/aet/hephaestus/integration/**"
+            tests: "!de/tum/cit/aet/hephaestus/integration/**"
     permissions:
       contents: read
       checks: write
@@ -79,16 +82,10 @@ jobs:
           os: ${{ runner.os }}
       - name: Run integration tests
         env:
-          # Read by vite.config.ts when it loads: the selector reaches Maven without a matrix value
-          # ever appearing in a run: script, which is what the workflow linter forbids.
+          # vite.config.ts reads this at load, so no matrix value ever reaches a run: script — which
+          # the workflow linter forbids.
           HEPHAESTUS_INTEGRATION_TESTS: ${{ matrix.tests }}
         run: vp run test:server:integration
-      - name: Refuse a shard that ran nothing
-        # A selector that drifts away from every class would otherwise pass green with zero tests.
-        run: |
-          count=$(grep -ho '<testcase ' server/application/target/surefire-reports/TEST-*.xml | wc -l)
-          echo "testcases=$count"
-          test "$count" -gt 0
       - name: Upload test results
         if: always()
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0

--- a/docs/contributor/ci-cd.mdx
+++ b/docs/contributor/ci-cd.mdx
@@ -430,12 +430,16 @@ reaches no such commit builds every image itself. `detect-changes` resolves that
 - `Quality` legs and `Test` suites start from source; `Build` gates start when `App Server: Package`
   uploads its artifact.
 - `App Server: Integration` runs two matrix shards: `providers` selects the `integration` package
-  and `application` its complement. Both keep the `integration` tag filter and run in their own JVM
-  and Testcontainers database; a new package belongs to one shard by construction. The shard's
-  selector reaches Maven through `HEPHAESTUS_INTEGRATION_TESTS`, which `vite.config.ts` reads when
-  it loads, so the matrix value never appears in a `run:` script; a shard that ran zero test cases
-  fails its job, so a selector that drifts cannot pass green. `fail-fast: false` lets both shards report, and
-  `CI Status Gate` requires the aggregate `Test` result. Locally the tier runs whole.
+  and `application` excludes it. Both keep the `integration` tag filter and run in their own JVM and
+  Testcontainers database. The split is by package boundary rather than by size, so the tier's wall
+  time is the larger `application` shard's. Because
+  Surefire's `-Dtest` replaces its include patterns, only `application`'s pure exclusion keeps the
+  two selectors complementary over every class the unsharded run scans; an inclusion of its own
+  would drop whatever it failed to name. `scripts/ci-contract.test.ts` proves the partition against
+  the test sources, so a selector that drifts fails `check` rather than passing green. The selector
+  reaches Maven through `HEPHAESTUS_INTEGRATION_TESTS`, which `vite.config.ts` reads when it loads,
+  so the matrix value never appears in a `run:` script. `fail-fast: false` lets both shards report,
+  and `CI Status Gate` requires the aggregate `Test` result. Locally the tier runs whole.
 - Pull requests and merge groups build `linux/amd64`; pushes to `main`, and every run on the Version
   PR's branch, build both architectures. A pull request also builds only the images its diff touched
   and aliases the rest, while the Version PR's branch builds all of them. `detect-changes` decides

--- a/scripts/ci-contract.test.ts
+++ b/scripts/ci-contract.test.ts
@@ -107,6 +107,46 @@ function escapeRegExp(value: string): string {
 }
 
 /**
+ * Whether a Surefire `-Dtest` value selects one test class, named by its path under the test root
+ * without the extension.
+ *
+ * The value replaces the `includes` and `excludes` parameters outright, and a pattern prefixed with
+ * `!` is an exclusion — so a value carrying only exclusions leaves no inclusion pattern, and every
+ * class Surefire scans is a candidate until an exclusion removes it. That is what lets one shard
+ * select a package and the other select its complement without either restating the four default
+ * include patterns.
+ * https://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#test
+ */
+function surefireSelects(selector: string, testClass: string): boolean {
+	const patterns = selector.split(",").map((pattern) => pattern.trim());
+	const matches = (pattern: string) => surefirePattern(pattern.replace(/^!/, "")).test(testClass);
+	const included = patterns.filter((pattern) => !pattern.startsWith("!"));
+	const excluded = patterns.filter((pattern) => pattern.startsWith("!"));
+	return (included.length === 0 || included.some(matches)) && !excluded.some(matches);
+}
+
+/** Surefire's glob dialect: `**` crosses directories, `*` and `?` stay inside one segment. */
+function surefirePattern(pattern: string): RegExp {
+	const unqualified = pattern.replace(/\.(?:java|class)$/, "");
+	const qualified = unqualified.includes("/") ? unqualified : `**/${unqualified}`;
+	const body = qualified.replaceAll(/\*\*\/|\*\*|\*|\?|[^*?]+/g, (token) => {
+		switch (token) {
+			case "**/":
+				return "(?:[^/]+/)*";
+			case "**":
+				return ".*";
+			case "*":
+				return "[^/]*";
+			case "?":
+				return "[^/]";
+			default:
+				return escapeRegExp(token);
+		}
+	});
+	return new RegExp(`^${body}$`);
+}
+
+/**
  * Every repository script a given entry point loads, transitively — its static relative imports,
  * plus any sibling script it names as a string, which is how the scanners reach the policy
  * evaluator (they spawn it rather than importing it, so that its exit status is the verdict).
@@ -392,32 +432,83 @@ void describe("CI contract", () => {
 		assert.deepEqual(used, accepted, "Every accepted cache type is requested by a workflow");
 	});
 
-	void test("partitions integration tests without duplicating tiers or bypassing the status gate", async () => {
-		const source = await readFile(".github/workflows/ci-tests.yml", "utf8");
-		const integration = job(source, "server-integration");
-		assert.match(integration, /fail-fast: false/);
-		const selectors = [...integration.matchAll(/tests: "([^"\n]+)"/g)].map((match) => match[1]);
-		assert.deepEqual(selectors, [
-			"de/tum/cit/aet/hephaestus/integration/**",
-			"**/*Test,!de/tum/cit/aet/hephaestus/integration/**",
+	void test("every class the integration tier can run belongs to exactly one shard", async () => {
+		const workflow = parseDocument(await readFile(".github/workflows/ci-tests.yml", "utf8"));
+		const matrix = workflow.getIn(["jobs", "server-integration", "strategy", "matrix"]);
+		assert.ok(isMap(matrix), "server-integration runs no matrix");
+		const selectors = matrixValues(matrix, "tests");
+		assert.equal(selectors.length, 2, "The tier is sharded in two");
+		for (const selector of selectors)
+			assert.doesNotMatch(
+				selector,
+				/[%#]/,
+				`${selector}: a regex or method selector is outside what surefireSelects models`,
+			);
+
+		// The tier the shards must cover is what Surefire runs when nothing narrows it: the four
+		// default include patterns, filtered by the integration tag. A probe for each pattern, in and
+		// out of the sharded package, keeps the tier's current naming from deciding the verdict — a
+		// class dropped by both shards is invisible in CI and runs locally, so the shape has to be
+		// safe for the name nobody has written yet.
+		const testRoot = "server/application/src/test/java/";
+		const sources = await posixGlob(`${testRoot}**/*.java`);
+		assert.ok(sources.length > 0, `No test sources under ${testRoot}`);
+		const probes = ["TestFoo", "FooTest", "FooTests", "FooTestCase"].flatMap((name) => [
+			`de/tum/cit/aet/hephaestus/integration/github/${name}`,
+			`de/tum/cit/aet/hephaestus/practice/${name}`,
 		]);
-		// The matrix value reaches Maven through the config's environment read, never through a run: script.
-		assert.match(integration, /HEPHAESTUS_INTEGRATION_TESTS: \$\{\{ matrix.tests \}\}/);
-		assert.doesNotMatch(integration, /run: vp run test:server:integration "-D/);
-		// A shard whose reports carry no test case fails on that fact, not on a step name.
+		const defaultIncludes = [
+			"**/Test*.java",
+			"**/*Test.java",
+			"**/*Tests.java",
+			"**/*TestCase.java",
+		];
+		const tier = [
+			...sources.map((file) => file.slice(testRoot.length).replace(/\.java$/, "")),
+			...probes,
+		].filter((candidate) =>
+			defaultIncludes.some((pattern) => surefirePattern(pattern).test(candidate)),
+		);
+		assert.ok(tier.length > probes.length, "The tier is more than its probes");
+
+		const shards = selectors.map(
+			(selector) => new Set(tier.filter((candidate) => surefireSelects(selector, candidate))),
+		);
+		for (const [index, shard] of shards.entries())
+			assert.notEqual(shard.size, 0, `${selectors[index]} selects no class at all`);
+		assert.deepEqual(
+			tier.filter((candidate) => !shards.some((shard) => shard.has(candidate))),
+			[],
+			"Classes the pull request would never run",
+		);
+		assert.deepEqual(
+			tier.filter((candidate) => shards.every((shard) => shard.has(candidate))),
+			[],
+			"Classes both shards would run",
+		);
+	});
+
+	void test("runs the integration tier once, under the status gate, off an untemplated command", async () => {
+		const source = await readFile(".github/workflows/ci-tests.yml", "utf8");
+		const workflow = parseDocument(source);
+		const integration = job(source, "server-integration");
+		assert.match(integration, /fail-fast: false/, "One failing shard must not hide the other");
+		const jobPath = ["jobs", "server-integration"];
+		const run = namedStep(workflow, jobPath, "Run integration tests");
+		const environment = run.get("env");
+		assert.ok(isMap(environment));
 		assert.match(
-			integration,
-			/grep -ho '<testcase ' server\/application\/target\/surefire-reports\/TEST-\*\.xml \| wc -l/,
+			String(environment.get("HEPHAESTUS_INTEGRATION_TESTS")),
+			/matrix\.tests/,
+			"The shard's selector reaches the task as an environment value",
 		);
-		assert.match(integration, /test "\$count" -gt 0/);
-		const guardStart = integration.indexOf("Refuse a shard");
-		const guardEnd = integration.indexOf("- name:", guardStart);
 		assert.doesNotMatch(
-			integration.slice(guardStart, guardEnd === -1 ? undefined : guardEnd),
-			/if: always\(\)/,
+			runScript(workflow, jobPath, "Run integration tests"),
+			/\$\{\{/,
+			"The selector reaches Maven through the environment, never through a run: script",
 		);
-		assert.match(integration, /Test Results - App Server Integration \(\$\{\{ matrix.shard \}\}\)/);
 		assert.equal((source.match(/run: vp run test:server:integration/g) ?? []).length, 1);
+		assert.match(integration, /Test Results - App Server Integration \(\$\{\{ matrix.shard \}\}\)/);
 		const tasks = await readFile("vite.config.ts", "utf8");
 		assert.match(tasks, /HEPHAESTUS_INTEGRATION_TESTS/);
 		assert.match(

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -269,7 +269,7 @@ export default defineConfig({
 			// CI runs the tier as shards. The selector is decided here, at config load, so the workflow
 			// passes a matrix value through the environment rather than into a command; locally the
 			// whole tier runs. failIfNoSpecifiedTests=false is for the generated-clients module, which
-			// has no tests for any selector; a shard that runs nothing is caught by the workflow instead.
+			// has no tests for any selector.
 			"test:server:integration": run(
 				`${mvnw} -pl application -am package -Dspring-boot.repackage.skip=true -Dsurefire.includedGroups=integration${integrationShard} -Dparallel=none --batch-mode`,
 			),


### PR DESCRIPTION
## What changed and why

Sharding the integration tier gave the `application` shard the selector
`**/*Test,!de/tum/cit/aet/hephaestus/integration/**`. Surefire's `test` parameter
[replaces the `includes` parameter](https://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#test)
("This parameter overrides the parameter `includes`, `excludes`"), and
[`includes`](https://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#includes)
otherwise defaults to `**/Test*.java`, `**/*Test.java`, `**/*Tests.java`, `**/*TestCase.java`.
That one inclusion pattern therefore stood in for all four: a class named `FooTests`, `TestFoo` or
`FooTestCase` carrying `@Tag("integration")` would have run on `main` and in
`vp run test:server:integration` locally, and been skipped silently on every pull request. Nothing
is dropped today — the tier holds no such name — so this was latent, and latent in the direction
that shows no signal.

The shard now carries only the exclusion, `!de/tum/cit/aet/hephaestus/integration/**`. The same
page documents `!` as an exclusion prefix; with no inclusion pattern left, every class Surefire
scans is a candidate until an exclusion removes it, so the two selectors are complements over the
whole tier for any naming convention anyone writes next.

The `Refuse a shard that ran nothing` step went with it. Its comment claimed to catch a selector
that drifts, but a threshold of zero cannot: the `application` shard runs over a hundred classes,
and a selector that dropped all but one of them still passed. What replaces it is a contract test
that applies Surefire's selection rules to the server's test sources plus a probe for each of the
four default patterns inside and outside the sharded package, and fails when a class belongs to no
shard or to both. It runs in `check`, so the drift is caught before CI rather than by it.

The two assertions the same test used to make — a pinned copy of both selector strings, and
`doesNotMatch(integration, /run: vp run test:server:integration "-D/)`, which no plausible edit
could ever produce — are gone. The assertions that carry real facts stay: the tier is invoked once,
the status gate still reaches it through the aggregate `Test` result, `fail-fast: false` holds, and
the selector reaches Maven as an environment value rather than through a `run:` script.

Part of #1608.

## How to test

```bash
vp run check:affected          # green
vp run check                   # green
actionlint .github/workflows/ci-tests.yml                  # 0 findings
zizmor --min-confidence medium .github/workflows/ci-tests.yml  # 0 findings (v1.29.0, as CI pins)
```

The partition test was proved against the defect rather than only against the fix: restoring
`**/*Test,!de/tum/cit/aet/hephaestus/integration/**` makes it fail, naming the probes it drops —

```
AssertionError: Classes the pull request would never run
+   'de/tum/cit/aet/hephaestus/practice/TestFoo',
+   'de/tum/cit/aet/hephaestus/practice/FooTests',
+   'de/tum/cit/aet/hephaestus/practice/FooTestCase'
```

The timing this PR is measured on is the run on this branch. The shape it replaces took 8m46s
unsharded; the `providers` shard reported 5m32s on #1905 and the split is by package boundary, not
by size, so the tier's wall time is the larger `application` shard's — which `docs/contributor/ci-cd.mdx`
now says.

## Release impact

No changeset: nothing under `server/`, `webapp/` or `docker/` changes, so no shipped behaviour does.

## Notes for reviewers

`scripts/ci-contract.test.ts` carries a small model of Surefire's `-Dtest` semantics rather than
pinning the selector strings. It refuses any selector shape it does not model (`%regex[…]`, `#method`),
so a selector it cannot judge fails the test instead of passing it silently.

`.github/workflows/**` is a contended lane: #1851 holds `cd-docs.yml`, `cd-docs-teardown.yml` and
`ci-quality-gates.yml`, none of them this file, and it conflicts with `main` on its own. No open
pull request writes `ci-tests.yml`, `vite.config.ts` or `scripts/ci-contract.test.ts`.

Best place to start: the matrix in `.github/workflows/ci-tests.yml`, then `surefireSelects` in
`scripts/ci-contract.test.ts`.
