### PR TITLE
fix(docker): the review sandbox ships and grants only what it needs

### DIFF
--- a/.changeset/agent-image-without-a-package-manager.md
+++ b/.changeset/agent-image-without-a-package-manager.md
@@ -1,0 +1,6 @@
+---
+"hephaestus": patch
+---
+
+The container that runs a practice review no longer carries a package manager, so nothing in it can
+install software while a review is running.

--- a/.changeset/practice-reviews-keep-their-sessions.md
+++ b/.changeset/practice-reviews-keep-their-sessions.md
@@ -2,6 +2,4 @@
 "hephaestus": patch
 ---
 
-Practice reviews and Heph conversations run to completion again. After the recent agent fixes every
-review still stopped at its first tool call, because the sandbox denied the review its own session
-files; the sandbox now prepares that directory before the review starts.
+Practice reviews and Heph conversations complete instead of stopping at their first tool call.

--- a/docker/agents/pi/Dockerfile
+++ b/docker/agents/pi/Dockerfile
@@ -36,9 +36,8 @@ RUN test -d /opt/pi-sdk/node_modules/@earendil-works/pi-coding-agent \
     mkdir -p /workspace && chown 1000:1000 /workspace
 
 RUN mkdir -p /tmp/abi-check && ln -sf /opt/pi-sdk/node_modules /tmp/abi-check/node_modules && \
-    cd /tmp/abi-check && \
-    printf 'const sdk = await import("@earendil-works/pi-coding-agent");\nif (!sdk || typeof sdk !== "object") { throw new Error("Pi SDK import yielded no module namespace"); }\nconsole.log("pi sdk exports:", Object.keys(sdk).length);\n' > check.ts && \
-    node --permission --allow-fs-read=/tmp/abi-check --allow-fs-read=/opt/pi-sdk check.ts && \
+    printf 'const sdk = await import("@earendil-works/pi-coding-agent");\nif (!sdk || typeof sdk !== "object") { throw new Error("Pi SDK import yielded no module namespace"); }\nconsole.log("pi sdk exports:", Object.keys(sdk).length);\n' > /tmp/abi-check/check.ts && \
+    node --permission --allow-fs-read=/tmp/abi-check --allow-fs-read=/opt/pi-sdk /tmp/abi-check/check.ts && \
     mkdir -p /tmp/abi-check/work/nested /tmp/abi-check/agent /tmp/abi-check/home && \
     printf 'SENTINEL-ORCHESTRATOR\n' > /tmp/abi-check/agent/AGENTS.md && \
     printf '{}\n' > /tmp/abi-check/agent/settings.json && \
@@ -71,8 +70,8 @@ RUN mkdir -p /tmp/abi-check && ln -sf /opt/pi-sdk/node_modules /tmp/abi-check/no
       'const modelRuntime = await ModelRuntime.create({ authPath: `${agentDir}/auth.json`, modelsPath: `${agentDir}/models.json`, allowModelNetwork: false });' \
       'modelRuntime.registerProvider("gate", { name: "gate", baseUrl: "http://127.0.0.1:9/v1", apiKey: "$GATE_TOKEN", authHeader: true, api: "openai-completions", models: [{ id: "model", name: "model", reasoning: false, input: ["text"], cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, contextWindow: 1000, maxTokens: 100 }] });' \
       'if (!(await modelRuntime.checkAuth("gate"))) { throw new Error("the credential of the gate provider did not resolve"); }' \
-      > runner-path-check.ts && \
-    HOME=/tmp/abi-check/home GATE_TOKEN=gate node --permission --allow-fs-read=/tmp/abi-check --allow-fs-read=/opt/pi-sdk --allow-fs-write=/tmp/abi-check/agent runner-path-check.ts && \
+      > /tmp/abi-check/runner-path-check.ts && \
+    HOME=/tmp/abi-check/home GATE_TOKEN=gate node --permission --allow-fs-read=/tmp/abi-check --allow-fs-read=/opt/pi-sdk --allow-fs-write=/tmp/abi-check/agent /tmp/abi-check/runner-path-check.ts && \
     ! node --permission --allow-fs-read=/tmp/abi-check --allow-fs-read=/opt/pi-sdk \
       -e 'require("node:fs").readFileSync("/etc/passwd")' 2>/dev/null && \
     # A write grant on a directory absent at startup covers its mkdir but nothing inside it; the
@@ -85,8 +84,8 @@ RUN mkdir -p /tmp/abi-check && ln -sf /opt/pi-sdk/node_modules /tmp/abi-check/no
       'let denied = false;' \
       'try { fs.writeFileSync(`${dir}/x`, "1"); } catch (error) { denied = error.code === "ERR_ACCESS_DENIED"; }' \
       'if (!denied) { throw new Error("a write inside a directory granted before it existed was allowed; revisit the pre-creation in PiRuntimeFactory"); }' \
-      > absent-grant-check.cjs && \
-    node --permission --allow-fs-read=/tmp/abi-check --allow-fs-write=/tmp/abi-check/absent absent-grant-check.cjs /tmp/abi-check/absent && \
+      > /tmp/abi-check/absent-grant-check.cjs && \
+    node --permission --allow-fs-read=/tmp/abi-check --allow-fs-write=/tmp/abi-check/absent /tmp/abi-check/absent-grant-check.cjs /tmp/abi-check/absent && \
     ! node --permission --allow-fs-read=/tmp/abi-check --allow-fs-read=/opt/pi-sdk \
       -e 'require("node:child_process").spawnSync("true")' 2>/dev/null && \
     rm -rf /tmp/abi-check
@@ -103,18 +102,21 @@ ENV GIT_PAGER=cat
 ENV GIT_TERMINAL_PROMPT=0
 ENV LANG=C.UTF-8
 
-RUN rm -rf /usr/local/lib/node_modules/npm /usr/local/lib/node_modules/corepack \
+# The base image installs Yarn as a tree under /opt that /usr/local/bin only links to, so removing
+# the links alone leaves a runnable package manager behind — which is why the check below reads the
+# filesystem rather than the PATH.
+RUN rm -rf /usr/local/lib/node_modules/npm /usr/local/lib/node_modules/corepack /opt/yarn-* \
         /usr/local/bin/npm /usr/local/bin/npx /usr/local/bin/corepack \
         /usr/local/bin/yarn /usr/local/bin/yarnpkg /usr/local/bin/pnpm /usr/local/bin/pnpx && \
     set -eu; \
     node --version; \
-    # `!` exempts a command from errexit and only the last iteration's status would escape the
-    # loop, so each hit must fail explicitly.
-    for manager in npm npx corepack yarn yarnpkg pnpm pnpx; do \
-        if command -v "$manager" >/dev/null 2>&1; then \
-            echo "FATAL: '$manager' resolves to $(command -v "$manager"); this image must carry no package manager." >&2; exit 1; \
-        fi; \
-    done
+    found=$(find / -xdev -path /proc -prune -o -path /sys -prune -o \
+        \( -name npm -o -name npx -o -name corepack -o -name yarn -o -name yarnpkg -o -name pnpm -o -name pnpx \) -print); \
+    if [ -n "$found" ]; then \
+        echo "FATAL: this image must carry no package manager, and ships:" >&2; \
+        echo "$found" >&2; \
+        exit 1; \
+    fi
 
 LABEL hephaestus.agent.runtime-contract=2
 LABEL hephaestus.agent.node-version=${NODE_VERSION}

--- a/docs/contributor/agent/workspace-abi.mdx
+++ b/docs/contributor/agent/workspace-abi.mdx
@@ -35,13 +35,15 @@ vs writable is decided by *where* a file lives, not by convention. Three top-lev
 ├── work/                            # AGENT + PRECOMPUTE SCRATCH. Never collected back into SQL.
 │   ├── precompute/                  #   Per-practice precompute scripts (TypeScript, run on Node).
 │   ├── precompute-out/              #   Precompute runtime output (logs, structured hints).
-│   └── analysis/practices/          #   Per-practice analysis output (holds the .gitkeep marker).
+│   ├── analysis/practices/          #   Per-practice analysis output (holds the .gitkeep marker).
+│   └── composition/                 #   observations.json — the admitted observations feedback is composed from.
 ├── out/                             # THE ONLY collected directory — result.json, review-state.json,
 │                                    #   usage.json, runner-debug.json, watchdog-killed.json
 ├── task.json                        # TaskEnvelope<…> — runtime contract between handler and runner.
 ├── .pi/                             # Pi SDK agent dir — $PI_CODING_AGENT_DIR resolves here.
 │   ├── AGENTS.md                    #   Orchestrator instructions
 │   └── settings.json                #   Pi SDK config (provider, model, compaction)
+├── .sessions/                       # Pi SDK session JSONL, one file per session.
 ├── pi-provider.json                 # Provider/model routing for the runner.
 ├── pi-provider.ts                   # Provider/model helper imported by both runners.
 ├── pi-error-text.ts                 # Shared error-message helper.

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/runtime/PiRunnerProfile.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/runtime/PiRunnerProfile.java
@@ -2,6 +2,7 @@ package de.tum.cit.aet.hephaestus.agent.runtime;
 
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 /**
  * Per-runner-kind strategy. Each adapter owns its implementation in the adjacent domain package
@@ -9,34 +10,44 @@ import java.util.Map;
  * they MUST NOT capture spec-level state (provider, credentials, baseUrl).
  */
 public interface PiRunnerProfile {
-    /** Directories the runner may write, each created before Node starts; the grants below say why. */
-    List<String> WRITABLE_DIRECTORIES = List.of(
-            "/workspace/.pi",
-            "/workspace/.sessions",
-            "/workspace/work/composition",
-            "/workspace/out",
-            "/home/agent/.local/tmp");
+    /** Node's temporary directory in the agent image, which {@link PiRuntimeFactory} sets {@code TMPDIR} to. */
+    String AGENT_TMPDIR = "/home/agent/.local/tmp";
 
-    List<String> BASE_RUNTIME_FLAGS = List.of(
-            "--max-old-space-size=256",
-            "--permission",
-            "--allow-fs-read=/workspace",
-            "--allow-fs-read=/opt/pi-sdk",
-            // The SDK looks for user-level skills under $HOME (/home/agent in the image) on every
-            // session; that directory holds nothing, and a read the permission model denies is a
-            // thrown error, not an absence, so it must be readable.
-            "--allow-fs-read=/home/agent",
-            // Every path granted for writing exists before Node starts: a grant is resolved at startup,
-            // and a directory created afterwards accepts mkdir and then denies every write inside it.
-            // WRITABLE_DIRECTORIES is that list, and PiRuntimeFactory creates it.
-            // The SDK takes a lock directory beside settings.json and auth.json and keeps a models store
-            // in the agent dir; without this every session dies at its first model turn.
-            "--allow-fs-write=/workspace/.pi",
-            "--allow-fs-write=/workspace/.sessions",
-            // The runner writes the admitted observations it composes from, and Node's temp dir.
-            "--allow-fs-write=/workspace/work/composition",
-            "--allow-fs-write=/home/agent/.local/tmp",
-            "--allow-fs-write=/workspace/out");
+    /**
+     * Directories the runner may write.
+     *
+     * <p>A write grant is resolved when Node starts, so a directory created afterwards accepts its own
+     * {@code mkdir} and then denies every write inside it. {@link PiRuntimeFactory} therefore creates
+     * all of these before the runner starts, and {@link #BASE_RUNTIME_FLAGS} grants exactly these, so
+     * neither half can name a path the other does not.
+     *
+     * <p>{@code PracticePiAdapter} builds the precompute invocation with a grant and a pre-creation of
+     * its own, outside this list.
+     */
+    List<String> WRITABLE_DIRECTORIES = List.of(
+            // The SDK takes a lock directory beside settings.json and auth.json and keeps a models
+            // store in the agent dir; without this every session dies at its first model turn.
+            SandboxLayout.PI_AGENT_DIR,
+            // The SDK writes one JSONL file per session, from the session's first message on.
+            SandboxLayout.WORKSPACE_ROOT + "/" + SandboxLayout.SESSIONS_DIR,
+            // pi-runner.ts writes work/composition/observations.json, the admitted observations it
+            // composes feedback from.
+            SandboxLayout.WORKSPACE_ROOT + "/" + SandboxLayout.WORK_PREFIX + "composition",
+            SandboxLayout.OUTPUT_PATH,
+            AGENT_TMPDIR);
+
+    List<String> BASE_RUNTIME_FLAGS = Stream.concat(
+                    Stream.of(
+                            "--max-old-space-size=256",
+                            "--permission",
+                            "--allow-fs-read=" + SandboxLayout.WORKSPACE_ROOT,
+                            "--allow-fs-read=/opt/pi-sdk",
+                            // The SDK looks for user-level skills under $HOME (/home/agent in the image) on
+                            // every session; that directory holds nothing, and a read the permission model
+                            // denies is a thrown error, not an absence, so it must be readable.
+                            "--allow-fs-read=/home/agent"),
+                    WRITABLE_DIRECTORIES.stream().map(directory -> "--allow-fs-write=" + directory))
+            .toList();
     /** Runner script filename under {@code resources/agent/}. */
     String runnerScript();
 

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/runtime/PiRuntimeFactory.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/runtime/PiRuntimeFactory.java
@@ -82,7 +82,7 @@ public class PiRuntimeFactory {
 
         env.put("HOME", "/home/agent");
         env.put("XDG_CONFIG_HOME", "/home/agent/.config");
-        env.put("TMPDIR", "/home/agent/.local/tmp");
+        env.put("TMPDIR", PiRunnerProfile.AGENT_TMPDIR);
         env.put("PI_CODING_AGENT_DIR", SandboxLayout.PI_AGENT_DIR);
 
         String workspaceRoot = SandboxLayout.WORKSPACE_ROOT;

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/runtime/PiRuntimeFactoryTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/runtime/PiRuntimeFactoryTest.java
@@ -6,7 +6,9 @@ import de.tum.cit.aet.hephaestus.agent.mentor.MentorRunnerProfile;
 import de.tum.cit.aet.hephaestus.agent.practice.PracticeRunnerProfile;
 import de.tum.cit.aet.hephaestus.testconfig.BaseUnitTest;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -309,17 +311,32 @@ class PiRuntimeFactoryTest extends BaseUnitTest {
             assertThat(body.substring(sliceStart, nodeIdx)).isBlank();
         }
 
-        /** A write grant is resolved when Node starts, so every granted directory is created first. */
+        /**
+         * A write grant is resolved when Node starts, so a directory the command grants but does not
+         * create first accepts its own {@code mkdir} and denies every write inside it.
+         */
         @Test
-        void shouldCreateEveryWritableDirectoryBeforeNodeStarts() {
-            String body = factory.build(spec(PRACTICE)).command().get(2);
-            int mkdir = body.indexOf("mkdir -p ");
-            int node = body.indexOf("node ");
-            assertThat(mkdir).isNotNegative();
-            assertThat(node).isGreaterThan(mkdir);
-            for (String directory : PiRunnerProfile.WRITABLE_DIRECTORIES) {
-                assertThat(body.substring(mkdir, node)).contains(" " + directory + " ");
-                assertThat(body).contains("--allow-fs-write=" + directory);
+        void shouldCreateEveryDirectoryTheRunnerIsGrantedBeforeNodeStarts() {
+            for (PiRunnerProfile profile : List.of(PRACTICE, MENTOR)) {
+                String body = factory.build(spec(profile)).command().get(2);
+                // The precompute step runs its own `node` first, with a grant of its own.
+                int runner = body.lastIndexOf("node ");
+                int mkdir = body.indexOf("mkdir -p ");
+                assertThat(mkdir).isNotNegative();
+                assertThat(runner).isGreaterThan(mkdir);
+
+                String staging = body.substring(mkdir, runner);
+                List<String> granted = Pattern.compile("--allow-fs-write=(\\S+)")
+                        .matcher(body.substring(runner))
+                        .results()
+                        .map(match -> match.group(1))
+                        .toList();
+                assertThat(granted).isNotEmpty();
+                for (String directory : granted) {
+                    assertThat(staging)
+                            .as("%s creates %s before node starts", profile.runnerScript(), directory)
+                            .contains(" " + directory + " ");
+                }
             }
         }
 


### PR DESCRIPTION
## What changed and why

Two places decide what a practice review may do inside its sandbox, and neither said what it meant.

**The image shipped a package manager it declares it does not carry.** `docker/agents/pi/Dockerfile`
removes npm, npx, corepack, yarn, yarnpkg, pnpm and pnpx from `/usr/local/bin` and then asserts that
none of them resolves on the `PATH`. But the Node base image installs Yarn as a tree under
`/opt/yarn-v1.22.22` that `/usr/local/bin` only links to, so removing the links left the tree, and the
check — which asked the `PATH` — reported a clean image. Building the image and looking proves it:

```
$ docker run --rm --user 0:0 --entrypoint /bin/sh agent-pi -c '/opt/yarn-v1.22.22/bin/yarn --version'
1.22.22
```

The tree now goes with the links, and the check reads the filesystem instead of the `PATH`, because a
package manager off the `PATH` is still one the image ships. Rebuilt, it finds nothing, and `/opt`
holds only `pi-sdk` and `precompute`.

**The write grants and the directories the sandbox creates were five literals each.** Every path in
`WRITABLE_DIRECTORIES` already had a home — `SandboxLayout.PI_AGENT_DIR`, `SESSIONS_DIR`, `WORK_PREFIX`,
`OUTPUT_PATH` — and the runner's temp directory was written twice, once as a `--allow-fs-write=` grant
and once as `TMPDIR`, with nothing linking them: editing one would silently stop covering Node's temp
directory, which is the failure the grants exist to prevent. The grants are now derived from the one
list the sandbox command creates, and `TMPDIR` reads the same constant.

**The test read one source from both ends.** It walked `WRITABLE_DIRECTORIES` and checked the command
mentioned each — the same list the command is built from — so a `--allow-fs-write=` flag added to a
runner profile without a matching directory passed. It now parses the grants out of the rendered
command and asserts each names a directory the command creates first, for both runner profiles.

Part of #1378.

## How to test

```bash
vp run check                                            # green
vp run check:affected                                   # green
cd server && MANAGEMENT_PORT=0 SERVER_PORT=0 ./mvnw -f application/pom.xml \
  -Dtest='PiRuntimeFactoryTest,SandboxLayoutSyncTest' -Dsurefire.includedGroups=unit test --batch-mode
# Tests run: 26, Failures: 0, Errors: 0

docker build -f docker/agents/pi/Dockerfile -t agent-pi docker/agents
docker run --rm --entrypoint /bin/ls agent-pi -A /opt      # pi-sdk  precompute
docker run --rm --entrypoint /bin/ls agent-pi -A /tmp /    # no build-gate scratch anywhere
```

Both changes were proved against the defect, not only against the fix. The package-manager check run
against the image built from `main` fails on the two files it should:

```
FATAL: this image must carry no package manager, and ships:
/opt/yarn-v1.22.22/bin/yarnpkg
/opt/yarn-v1.22.22/bin/yarn
```

Adding `--allow-fs-write=/workspace/nope` to a runner profile fails the unit test:

```
PiRuntimeFactoryTest.shouldCreateEveryDirectoryTheRunnerIsGrantedBeforeNodeStarts
  [pi-mentor-runner.ts creates /workspace/nope before node starts]
```

## Release impact

`.changeset/agent-image-without-a-package-manager.md`, `patch` — no operator action; the image is
rebuilt and repulled like any other release. `.changeset/practice-reviews-keep-their-sessions.md`,
already on `main` and unreleased, is rewritten: its summary pointed at "the recent agent fixes",
which no operator can resolve, and then described the code rather than the symptom.

## Notes for reviewers

The two write grants the sandbox gained with the session directory — `work/composition` and
`/home/agent/.local/tmp` — are kept and now say why in the list itself: the runner writes
`work/composition/observations.json`, and `TMPDIR` points into `/home/agent/.local/tmp`. Neither was
granted before, so both were denied. `docs/contributor/agent/workspace-abi.mdx` was missing both
`work/composition/` and `.sessions/` from its layout; they are in the tree now.

`PracticePiAdapter` builds the precompute invocation with a grant and a pre-creation of its own,
outside this list. That is stated where the list is, rather than folded into it: the two invocations
have different lifetimes and the precompute grant carries a trailing wildcard the runner's do not.

Reviewed for #1907's follow-up. Its review also reported that the ABI gate's scripts ship at `/` in
the released image; they do not — line 39's `cd /tmp/abi-check` put them inside the directory the gate
removes, and the build above shows a clean `/`. The scripts now name their directory where they are
written, so nothing depends on a `cd` thirty lines earlier, but that is clarity, not a fix.
