### PR TITLE
ci: a merge group runs only the jobs its changes need

### DIFF
--- a/.github/actions/postgres-image/action.yml
+++ b/.github/actions/postgres-image/action.yml
@@ -1,0 +1,39 @@
+name: Resolve the PostgreSQL image
+description: >-
+  Makes the PostgreSQL image the database legs run available under a local tag, by pulling the one
+  published for a commit or by building the same Dockerfile.
+inputs:
+  base-sha:
+    description: >-
+      The commit whose published image to reuse. A run resolves the commit it is a diff from, which
+      is the caller's to know.
+    required: true
+  image-changed:
+    description: >-
+      Whether this run changed the image's own inputs, in which case the published one is stale and
+      the Dockerfile is built instead.
+    required: false
+    default: "false"
+  tag:
+    description: The local tag the resolved image is made available under.
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Resolve the PostgreSQL image
+      shell: bash
+      env:
+        BASE_SHA: ${{ inputs.base-sha }}
+        IMAGE_CHANGED: ${{ inputs.image-changed }}
+        TAG: ${{ inputs.tag }}
+      # A published image is a pull rather than an install of pg_partman over the same base, so it
+      # is worth reaching for; the base commit's own run may not have finished publishing it yet,
+      # and a run whose diff reaches no published commit at all has nothing to pull.
+      run: |
+        set -euo pipefail
+        source="ghcr.io/hephaestus-build/postgres:$BASE_SHA"
+        if [ "$IMAGE_CHANGED" = "true" ] || ! docker pull "$source"; then
+          docker build -t "$TAG" docker/postgres
+        else
+          docker tag "$source" "$TAG"
+        fi

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -41,6 +41,10 @@ on:
         required: false
         type: string
         default: "false"
+      postgres_base_sha:
+        description: "Commit whose published PostgreSQL image the database legs reuse"
+        required: true
+        type: string
       server_image_changed:
         description: "Whether the application-server image inputs changed"
         required: false
@@ -140,20 +144,17 @@ jobs:
             echo "| API specs sync | :x: Out of sync | \`vp run generate:api\` |" >> $GITHUB_STEP_SUMMARY
             exit 1
           fi
+      - uses: ./.github/actions/postgres-image
+        if: always()
+        with:
+          base-sha: ${{ inputs.postgres_base_sha }}
+          image-changed: ${{ inputs.postgres_image_changed }}
+          tag: hephaestus-postgres:ci
       - name: Migration chain, schema drift and ERD
         id: schema
         continue-on-error: true
         if: always()
-        env:
-          INPUTS_POSTGRES_IMAGE_CHANGED: ${{ inputs.postgres_image_changed }}
         run: |
-          # The base image may still be publishing; build the same Dockerfile as fallback.
-          if [[ "${INPUTS_POSTGRES_IMAGE_CHANGED}" == "true" ]] ||
-            ! docker pull ghcr.io/hephaestus-build/postgres:${{ github.event.pull_request.base.sha || github.sha }}; then
-            docker build -t hephaestus-postgres:ci docker/postgres
-          else
-            docker tag ghcr.io/hephaestus-build/postgres:${{ github.event.pull_request.base.sha || github.sha }} hephaestus-postgres:ci
-          fi
           docker run -d --name postgres-db \
             -e POSTGRES_DB=hephaestus -e POSTGRES_PASSWORD=root -e POSTGRES_USER=root \
             -p 5432:5432 hephaestus-postgres:ci
@@ -221,17 +222,13 @@ jobs:
       - uses: ./.github/actions/restore-server-build
         with:
           artifact: ${{ env.SERVER_BUILD_ARTIFACT }}
+      - uses: ./.github/actions/postgres-image
+        with:
+          base-sha: ${{ inputs.postgres_base_sha }}
+          image-changed: ${{ inputs.postgres_image_changed }}
+          tag: hephaestus-postgres:ci
       - name: Run database contract tests and the major-upgrade drill
-        env:
-          INPUTS_POSTGRES_IMAGE_CHANGED: ${{ inputs.postgres_image_changed }}
         run: |
-          # The base image may still be publishing; build the same Dockerfile as fallback.
-          if [[ "${INPUTS_POSTGRES_IMAGE_CHANGED}" == "true" ]] ||
-            ! docker pull ghcr.io/hephaestus-build/postgres:${{ github.event.pull_request.base.sha || github.sha }}; then
-            docker build -t hephaestus-postgres:ci docker/postgres
-          else
-            docker tag ghcr.io/hephaestus-build/postgres:${{ github.event.pull_request.base.sha || github.sha }} hephaestus-postgres:ci
-          fi
           docker run -d --name postgres-db \
             -e POSTGRES_DB=hephaestus -e POSTGRES_PASSWORD=root -e POSTGRES_USER=root \
             -p 5432:5432 hephaestus-postgres:ci
@@ -280,15 +277,14 @@ jobs:
         with:
           name: ${{ env.SERVER_BUILD_ARTIFACT }}
           path: server
+      # `server/compose.yaml` resolves the database by the `dev` tag, so that is the name it needs.
+      - uses: ./.github/actions/postgres-image
+        with:
+          base-sha: ${{ inputs.postgres_base_sha }}
+          image-changed: ${{ inputs.postgres_image_changed }}
+          tag: ghcr.io/hephaestus-build/postgres:dev
       - name: Run end-to-end tests against the built server
         run: |
-          # The base image may still be publishing; build the same Dockerfile as fallback.
-          if [[ "${INPUTS_POSTGRES_IMAGE_CHANGED}" == "true" ]] ||
-            ! docker pull ghcr.io/hephaestus-build/postgres:${{ github.event.pull_request.base.sha || github.sha }}; then
-            docker build -t ghcr.io/hephaestus-build/postgres:dev docker/postgres
-          else
-            docker tag ghcr.io/hephaestus-build/postgres:${{ github.event.pull_request.base.sha || github.sha }} ghcr.io/hephaestus-build/postgres:dev
-          fi
           docker compose -f server/compose.yaml up -d --wait --no-build postgres
           cleanup() {
             if [[ -n "${SERVER_PID:-}" ]]; then
@@ -319,8 +315,6 @@ jobs:
           docker compose -f server/compose.yaml exec -T postgres \
             psql -v ON_ERROR_STOP=1 -U root -d hephaestus < webapp/e2e/seed.sql
           timeout --kill-after=30s 10m vp run --filter webapp test:e2e
-        env:
-          INPUTS_POSTGRES_IMAGE_CHANGED: ${{ inputs.postgres_image_changed }}
       - name: Upload diagnostics
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -14,9 +14,11 @@ on:
   merge_group:
 
 # A dispatch never shares a group with a push on the same ref: the Version PR is validated by
-# dispatch while `main` is validated by push, and a push produces the images a release promotes, so
-# it is the one run that must never be cancelled by another. A pull request or a dispatch validates
-# a branch that is still moving, where the newest run is the only one whose answer is wanted.
+# dispatch while `main` is validated by push. A pending push run is replaced by the next merge
+# rather than held; `queue: max` would hold every one, which is not wanted, because only main's tip
+# is deployed and `plan-release.ts` re-cuts a consumed version from a later commit. A pull request
+# or a dispatch validates a branch that is still moving, where the newest run is the only one whose
+# answer is wanted.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' }}
@@ -62,7 +64,13 @@ jobs:
       # Aliasing an unchanged image falls back to main's own push run, which has published nothing
       # yet when the Version PR head is written, so that branch builds the whole set itself; so does
       # a pull request whose chain of bases reaches no published commit at all.
-      all-images: ${{ github.event_name != 'pull_request' || steps.version_branch.outputs.version-branch == 'true' || steps.alias_base.outputs.commit == '' }}
+      all-images: ${{ steps.alias_base.outputs.commit == '' || steps.version_branch.outputs.version-branch == 'true' }}
+      # A push and a dispatch validate a commit whole; a pull request and a merge group are each a
+      # diff, which paths-filter reads for a group from `merge_group.base_sha..head_sha` without
+      # being told.
+      unfiltered: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
+      publishable: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+      previews: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
       # A skipped duplicate would skip the image builds the release evidence preflight needs, and
       # the gate refuses to pass the Version PR without one.
       should_skip: ${{ steps.skip_check.outputs.should_skip == 'true' && steps.version_branch.outputs.version-branch != 'true' }}
@@ -107,17 +115,22 @@ jobs:
           [ "$current" = "$previous" ] || changed=true
           echo "changed=$changed" >> "$GITHUB_OUTPUT"
 
-      - if: github.event_name == 'pull_request'
+      - if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
         uses: ./.github/actions/setup-toolchain
         with:
           install: "none"
 
+      # An unresolved base already means "build every image", and the script writes its output only
+      # once it has one, so a failed `gh api` call takes the safe answer. Failing the step instead
+      # would fail a merge group's run, which drops its pull requests from the queue without failing
+      # a check on them.
       - name: Resolve the commit unchanged images are aliased from
         id: alias_base
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: node scripts/resolve-alias-base.ts
 
@@ -266,6 +279,7 @@ jobs:
               - '.github/actions/setup-caches/**'
               - '.github/actions/setup-browsers/**'
               - '.github/actions/restore-server-build/**'
+              - '.github/actions/postgres-image/**'
             test-config:
               - '.github/workflows/cicd.yml'
               - '.java-version'
@@ -311,6 +325,8 @@ jobs:
               - '!webapp/src/**/*.stories.*'
               - '!webapp/src/test/**'
 
+  # `Actionlint` is a required context, and a required context that skips still satisfies the
+  # ruleset — docs/contributor/ci-cd.mdx § Merge policy says why.
   workflow-lint:
     name: "Actionlint"
     timeout-minutes: 10
@@ -320,7 +336,7 @@ jobs:
       (github.event_name != 'push' || needs.detect-changes.outputs.version-bump == 'true') &&
       needs.detect-changes.outputs.should_skip != 'true' && (
         needs.detect-changes.outputs.ci-config == 'true' ||
-        github.event_name != 'pull_request'
+        needs.detect-changes.outputs.unfiltered == 'true'
       )
     permissions:
       checks: write
@@ -338,6 +354,7 @@ jobs:
           filter_mode: nofilter
           reporter: github-check
 
+  # A required context as well; the note above `workflow-lint` says why filtering one is safe.
   zizmor:
     name: "Zizmor"
     timeout-minutes: 10
@@ -345,7 +362,7 @@ jobs:
     needs: [detect-changes]
     if: |
       (github.event_name != 'push' || needs.detect-changes.outputs.version-bump == 'true') &&
-      (github.event_name != 'pull_request' || needs.detect-changes.outputs.ci-config == 'true')
+      (needs.detect-changes.outputs.unfiltered == 'true' || needs.detect-changes.outputs.ci-config == 'true')
     permissions:
       contents: read
       security-events: write
@@ -373,7 +390,7 @@ jobs:
       needs.detect-changes.outputs.should_skip != 'true' && (
         needs.detect-changes.outputs.any-code == 'true' ||
         needs.detect-changes.outputs.quality-config == 'true' ||
-        github.event_name != 'pull_request'
+        needs.detect-changes.outputs.unfiltered == 'true'
       )
     secrets:
       CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
@@ -385,10 +402,10 @@ jobs:
       statuses: write
     with:
       should_skip: ${{ needs.detect-changes.outputs.should_skip }}
-      webapp_changed: ${{ (needs.detect-changes.outputs.webapp == 'true' || needs.detect-changes.outputs.quality-config == 'true' || github.event_name != 'pull_request') && 'true' || 'false' }}
-      application_server_changed: ${{ (needs.detect-changes.outputs.application-server == 'true' || needs.detect-changes.outputs.quality-config == 'true' || github.event_name != 'pull_request') && 'true' || 'false' }}
-      tooling_changed: ${{ (needs.detect-changes.outputs.tooling == 'true' || needs.detect-changes.outputs.quality-config == 'true' || github.event_name != 'pull_request') && 'true' || 'false' }}
-      pmd_canary: ${{ (needs.detect-changes.outputs.pmd-canary == 'true' || github.event_name != 'pull_request') && 'true' || 'false' }}
+      webapp_changed: ${{ (needs.detect-changes.outputs.webapp == 'true' || needs.detect-changes.outputs.quality-config == 'true' || needs.detect-changes.outputs.unfiltered == 'true') && 'true' || 'false' }}
+      application_server_changed: ${{ (needs.detect-changes.outputs.application-server == 'true' || needs.detect-changes.outputs.quality-config == 'true' || needs.detect-changes.outputs.unfiltered == 'true') && 'true' || 'false' }}
+      tooling_changed: ${{ (needs.detect-changes.outputs.tooling == 'true' || needs.detect-changes.outputs.quality-config == 'true' || needs.detect-changes.outputs.unfiltered == 'true') && 'true' || 'false' }}
+      pmd_canary: ${{ (needs.detect-changes.outputs.pmd-canary == 'true' || needs.detect-changes.outputs.unfiltered == 'true') && 'true' || 'false' }}
 
   # Same-repository pull requests run Build regardless of paths: previews need the application
   # image at the head SHA on every push.
@@ -397,8 +414,8 @@ jobs:
     needs: [detect-changes]
     if: |
       needs.detect-changes.outputs.should_skip != 'true' && (
-        github.event_name != 'pull_request' ||
-        github.event.pull_request.head.repo.full_name == github.repository ||
+        needs.detect-changes.outputs.unfiltered == 'true' ||
+        needs.detect-changes.outputs.previews == 'true' ||
         needs.detect-changes.outputs.any-code == 'true' ||
         needs.detect-changes.outputs.build-config == 'true'
       )
@@ -410,12 +427,13 @@ jobs:
       attestations: write
     with:
       should_skip: ${{ needs.detect-changes.outputs.should_skip }}
-      publish: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+      publish: ${{ needs.detect-changes.outputs.publishable == 'true' }}
       single_arch: ${{ needs.detect-changes.outputs.single-arch }}
+      postgres_base_sha: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.sha }}
       server_changed: ${{ (needs.detect-changes.outputs.application-server == 'true' || needs.detect-changes.outputs.e2e == 'true' || needs.detect-changes.outputs.postgres-image == 'true' || needs.detect-changes.outputs.build-config == 'true' || needs.detect-changes.outputs.application-server-image == 'true' || needs.detect-changes.outputs.supported-host-smoke == 'true' || needs.detect-changes.outputs.all-images == 'true') && 'true' || 'false' }}
-      contracts_changed: ${{ (github.event_name != 'push' || needs.detect-changes.outputs.version-bump == 'true') && (needs.detect-changes.outputs.application-server == 'true' || needs.detect-changes.outputs.postgres-image == 'true' || needs.detect-changes.outputs.build-config == 'true' || github.event_name != 'pull_request') && 'true' || 'false' }}
-      e2e_changed: ${{ (github.event_name != 'push' || needs.detect-changes.outputs.version-bump == 'true') && (needs.detect-changes.outputs.e2e == 'true' || github.event_name != 'pull_request') && 'true' || 'false' }}
-      postgres_image_changed: ${{ (needs.detect-changes.outputs.postgres-image == 'true' || github.event_name != 'pull_request') && 'true' || 'false' }}
+      contracts_changed: ${{ (github.event_name != 'push' || needs.detect-changes.outputs.version-bump == 'true') && (needs.detect-changes.outputs.application-server == 'true' || needs.detect-changes.outputs.postgres-image == 'true' || needs.detect-changes.outputs.build-config == 'true' || needs.detect-changes.outputs.unfiltered == 'true') && 'true' || 'false' }}
+      e2e_changed: ${{ (github.event_name != 'push' || needs.detect-changes.outputs.version-bump == 'true') && (needs.detect-changes.outputs.e2e == 'true' || needs.detect-changes.outputs.unfiltered == 'true') && 'true' || 'false' }}
+      postgres_image_changed: ${{ (needs.detect-changes.outputs.postgres-image == 'true' || needs.detect-changes.outputs.unfiltered == 'true') && 'true' || 'false' }}
       server_image_changed: ${{ (needs.detect-changes.outputs.application-server-image == 'true' || needs.detect-changes.outputs.supported-host-smoke == 'true' || needs.detect-changes.outputs.all-images == 'true') && 'true' || 'false' }}
 
   Security:
@@ -427,14 +445,14 @@ jobs:
         needs.detect-changes.outputs.any-code == 'true' ||
         needs.detect-changes.outputs.security-config == 'true' ||
         needs.detect-changes.outputs.release-images == 'true' ||
-        github.event_name != 'pull_request'
+        needs.detect-changes.outputs.unfiltered == 'true'
       )
     permissions:
       contents: read
       security-events: write
     with:
       should_skip: ${{ needs.detect-changes.outputs.should_skip }}
-      release_images_changed: ${{ (needs.detect-changes.outputs.release-images == 'true' || github.event_name != 'pull_request') && 'true' || 'false' }}
+      release_images_changed: ${{ (needs.detect-changes.outputs.release-images == 'true' || needs.detect-changes.outputs.unfiltered == 'true') && 'true' || 'false' }}
 
   Test:
     uses: ./.github/workflows/ci-tests.yml
@@ -444,14 +462,14 @@ jobs:
       needs.detect-changes.outputs.should_skip != 'true' && (
         needs.detect-changes.outputs.application-server == 'true' ||
         needs.detect-changes.outputs.test-config == 'true' ||
-        github.event_name != 'pull_request'
+        needs.detect-changes.outputs.unfiltered == 'true'
       )
     permissions:
       contents: read
       checks: write
     with:
       should_skip: ${{ needs.detect-changes.outputs.should_skip }}
-      application_server_changed: ${{ (needs.detect-changes.outputs.application-server == 'true' || needs.detect-changes.outputs.test-config == 'true' || github.event_name != 'pull_request') && 'true' || 'false' }}
+      application_server_changed: ${{ (needs.detect-changes.outputs.application-server == 'true' || needs.detect-changes.outputs.test-config == 'true' || needs.detect-changes.outputs.unfiltered == 'true') && 'true' || 'false' }}
 
   Changesets:
     if: github.event_name == 'pull_request'
@@ -474,12 +492,12 @@ jobs:
       SENTRY_PROJECT: ${{ github.event_name == 'push' && secrets.SENTRY_PROJECT || '' }}
     needs: [detect-changes]
     # Same-repository previews require every image at the PR head tag; unchanged images are aliased
-    # here and the application image is built by Build. Forks cannot preview, so their image builds
-    # remain path-filtered.
+    # here and the application image is built by Build. A fork and a merge group have no preview, so
+    # their image builds stay path-filtered.
     if: |
       needs.detect-changes.outputs.should_skip != 'true' && (
-        github.event_name != 'pull_request' ||
-        github.event.pull_request.head.repo.full_name == github.repository ||
+        needs.detect-changes.outputs.unfiltered == 'true' ||
+        needs.detect-changes.outputs.previews == 'true' ||
         needs.detect-changes.outputs.any-code == 'true' ||
         needs.detect-changes.outputs.ci-config == 'true'
       )
@@ -490,7 +508,7 @@ jobs:
       attestations: write
     with:
       should_skip: ${{ needs.detect-changes.outputs.should_skip }}
-      publish: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+      publish: ${{ needs.detect-changes.outputs.publishable == 'true' }}
       single_arch: ${{ needs.detect-changes.outputs.single-arch }}
       webapp_changed: ${{ (needs.detect-changes.outputs.webapp-image == 'true' || needs.detect-changes.outputs.docker-config == 'true' || needs.detect-changes.outputs.all-images == 'true') && 'true' || 'false' }}
       application_server_changed: ${{ (needs.detect-changes.outputs.application-server-image == 'true' || needs.detect-changes.outputs.supported-host-smoke == 'true' || needs.detect-changes.outputs.all-images == 'true') && 'true' || 'false' }}
@@ -506,8 +524,7 @@ jobs:
     # A fork pull request builds its images without publishing them, so there is nothing to pull
     # and no boot to check; the release path exercises a fork's install path once it is on `main`.
     if: >-
-      github.event_name == 'pull_request' &&
-      github.event.pull_request.head.repo.full_name == github.repository &&
+      needs.detect-changes.outputs.previews == 'true' &&
       needs.detect-changes.outputs.should_skip != 'true' &&
       needs.detect-changes.outputs.supported-host-smoke == 'true'
     runs-on: ubuntu-24.04

--- a/docs/contributor/ci-cd.mdx
+++ b/docs/contributor/ci-cd.mdx
@@ -82,6 +82,22 @@ workflows run again for the merge group, which includes the current base and que
 the pull request. Each required context is bound to the GitHub Actions integration rather than
 accepting a same-named external status.
 
+A merge group is a diff, so it selects its jobs from the paths it touches —
+[Path filters](#path-filters). It has no preview, so `Build` and `Docker` are filtered there too.
+`any-code` is the union of the source filters and reaches `docs/**` through the tooling filter, so a
+documentation-only group still starts `Quality`, `Security`, `Build` and `Docker` even where the
+jobs inside them skip. To find out why a leg did not run, read the `CI Status Gate` summary, which
+lists every leg including the skipped ones, and the `Detect changes` log, which records the filters
+the diff matched.
+
+A required context may be filtered because a ruleset accepts a skipped check as satisfied; the check
+still reports `skipped`, not `success`. A workflow that never triggers reports nothing at all, and a
+required context left pending blocks the queue for good — `merge_group` supports no `paths:` filter
+in any case, so the filtering lives in each job's `if`. The queue builds up to
+`max_entries_to_build: 3` groups speculatively, a repository-ruleset field rather than a file here,
+and each group costs a whole `CI/CD` run, so a job added to `cicd.yml` is paid for once per group in
+flight.
+
 A failed merge group drops its pull requests from the queue without failing any check on them, so
 CI updates a comment on the pull request named by the merge group's head ref with the run link. It
 does not requeue automatically: the result does not say whether the failure was transient or
@@ -378,8 +394,11 @@ action directly rather than checking out the repository only to reach a wrapper.
 
 ## Path filters
 
-`detect-changes` in `cicd.yml` selects legs from the changed paths. Same-repository pull requests run
-`Build` and `Docker` regardless of paths, because previews need every image at the head SHA.
+`detect-changes` in `cicd.yml` selects legs from the changed paths on the two events that are a
+diff: a pull request against its base, and a merge group against `merge_group.base_sha..head_sha`. A
+push to `main` and a dispatch validate a whole commit and run every leg, which `detect-changes`
+publishes as `unfiltered`. Same-repository pull requests also run `Build` and `Docker` regardless of
+paths, because previews need every image at the head SHA; no other event has a preview.
 
 | Selects | Paths |
 | --- | --- |
@@ -460,9 +479,10 @@ reaches no such commit builds every image itself. `detect-changes` resolves that
   so the matrix value never appears in a `run:` script. `fail-fast: false` lets both shards report,
   and `CI Status Gate` requires the aggregate `Test` result. Locally the tier runs whole.
 - Pull requests and merge groups build `linux/amd64`; pushes to `main`, and every run on the Version
-  PR's branch, build both architectures. A pull request also builds only the images its diff touched
-  and aliases the rest, while the Version PR's branch builds all of them. `detect-changes` decides
-  both once, as `single-arch` and `all-images`, and hands them to every image build in the run.
+  PR's branch, build both architectures. A pull request and a merge group each also build only the
+  images their own diff touched and alias the rest, while the Version PR's branch builds all of
+  them. `detect-changes` decides both once, as `single-arch` and `all-images`, and hands them to
+  every image build in the run.
 - The `Quality` matrix uses `fail-fast: false`; the image matrix in `reusable-docker-build.yml` uses
   `fail-fast: true`.
 - Pull-request runs cancel superseded runs; `release.yml` never cancels.

--- a/scripts/ci-contract.test.ts
+++ b/scripts/ci-contract.test.ts
@@ -678,6 +678,49 @@ void describe("CI contract", () => {
 		assert.match(reporter, /core\.setFailed/);
 	});
 
+	void test("a merge group selects its jobs by the paths its own diff touches", async () => {
+		const source = await readFile(".github/workflows/cicd.yml", "utf8");
+		const workflow = parseDocument(source);
+
+		// `!= 'pull_request'` reads every other event as "run everything", so it opts each new event
+		// into the whole workflow. The ban cannot cover `detect-changes`, which holds the two outputs
+		// that do test the event, so the decision every filtered job reads is pinned on its own.
+		assert.doesNotMatch(
+			source.replace(job(source, "detect-changes"), ""),
+			/github\.event_name != 'pull_request'/,
+		);
+		assert.match(
+			String(workflow.getIn(["jobs", "detect-changes", "outputs", "unfiltered"])),
+			/^\$\{\{ github\.event_name == 'push' \|\| github\.event_name == 'workflow_dispatch' }}$/,
+		);
+
+		// Asserted on the condition, not the whole job: a `with:` input the condition never reads
+		// must not satisfy it.
+		for (const name of [
+			"workflow-lint",
+			"zizmor",
+			"Quality",
+			"Build",
+			"Security",
+			"Test",
+			"Docker",
+		])
+			assert.match(
+				String(workflow.getIn(["jobs", name, "if"])),
+				/needs\.detect-changes\.outputs\.unfiltered == 'true'/,
+				`${name} does not read the path-selection decision`,
+			);
+
+		assert.doesNotMatch(
+			String(workflow.getIn(["jobs", "detect-changes", "outputs", "all-images"])),
+			/event_name/,
+		);
+		// The caller owns which commit a run is a diff from; `ci-build.yml` derives nothing from
+		// the event.
+		const build = await readFile(".github/workflows/ci-build.yml", "utf8");
+		assert.doesNotMatch(build, /github\.event\.pull_request\.base\.sha/);
+	});
+
 	void test("decides an image's architectures once, for every image the run builds", async () => {
 		const source = await readFile(".github/workflows/cicd.yml", "utf8");
 		const caller = job(source, "Docker");
@@ -785,10 +828,14 @@ void describe("CI contract", () => {
 		const orchestrator = parseDocument(await readFile(".github/workflows/cicd.yml", "utf8"));
 		// One decision, taken where the run can see whose repository the head branch is on. A fork's
 		// GITHUB_TOKEN is read-only, so a publishing build there fails on its first write.
+		assert.match(
+			String(orchestrator.getIn(["jobs", "detect-changes", "outputs", "publishable"])),
+			/^\$\{\{ github\.event_name != 'pull_request' \|\| github\.event\.pull_request\.head\.repo\.full_name == github\.repository }}$/,
+		);
 		for (const caller of ["Build", "Docker"])
 			assert.match(
 				String(orchestrator.getIn(["jobs", caller, "with", "publish"])),
-				/^\$\{\{ github\.event_name != 'pull_request' \|\| github\.event\.pull_request\.head\.repo\.full_name == github\.repository }}$/,
+				/^\$\{\{ needs\.detect-changes\.outputs\.publishable == 'true' }}$/,
 			);
 
 		const reusable = parseDocument(
@@ -907,8 +954,11 @@ void describe("CI contract", () => {
 		const orchestrator = parseDocument(source);
 		const condition = String(orchestrator.getIn(["jobs", "Supported-host-smoke", "if"]));
 		// A fork publishes no images, so there is nothing for this job to pull.
-		assert.match(condition, /github\.event_name == 'pull_request'/);
-		assert.match(condition, /head\.repo\.full_name == github\.repository/);
+		assert.match(condition, /needs\.detect-changes\.outputs\.previews == 'true'/);
+		assert.match(
+			String(orchestrator.getIn(["jobs", "detect-changes", "outputs", "previews"])),
+			/github\.event_name == 'pull_request' && github\.event\.pull_request\.head\.repo\.full_name == github\.repository/,
+		);
 		assert.match(condition, /needs\.detect-changes\.outputs\.supported-host-smoke == 'true'/);
 
 		const smoke = job(source, "Supported-host-smoke");
@@ -1360,24 +1410,39 @@ void describe("CI contract", () => {
 		// wrote this head and has published nothing yet when the alias runs. So the version branch
 		// publishes every release image itself, under every event, exactly as its dispatch run did.
 		const complete = String(workflow.getIn([...detection, "outputs", "all-images"]));
-		const completeShape =
-			/^\$\{\{ github\.event_name != '(\w+)' \|\| steps\.version_branch\.outputs\.version-branch == 'true' \|\| steps\.alias_base\.outputs\.commit == '' }}$/.exec(
-				complete,
-			);
-		assert.ok(completeShape, `this test cannot evaluate \`${complete}\``);
+		assert.match(
+			complete,
+			/^\$\{\{ steps\.alias_base\.outputs\.commit == '' \|\| steps\.version_branch\.outputs\.version-branch == 'true' }}$/,
+		);
+		// A run builds every image when it resolved no commit to alias from, so which events can
+		// resolve one is read from the resolver's own condition rather than restated here.
+		const steps = workflow.getIn([...detection, "steps"]);
+		assert.ok(isSeq(steps));
+		const resolver = steps.items.find(
+			(candidate) => isMap(candidate) && candidate.get("id") === "alias_base",
+		);
+		assert.ok(isMap(resolver));
+		// The resolver calls the API, and a merge group's failed run drops its pull requests from the
+		// queue without failing a check on them. An unresolved base is already the safe answer.
+		assert.equal(resolver.get("continue-on-error"), true);
+		const resolves = String(resolver.get("if"));
+		const aliasing = [...resolves.matchAll(/github\.event_name == '(\w+)'/g)].map((match) =>
+			String(match[1]),
+		);
+		assert.equal(aliasing.length, 2, `this test cannot evaluate \`${resolves}\``);
 		const buildsEveryImage = (
 			event: string,
 			onVersionBranch: boolean,
 			nothingToAlias = false,
-		): boolean => event !== completeShape[1] || onVersionBranch || nothingToAlias;
+		): boolean => !aliasing.includes(event) || nothingToAlias || onVersionBranch;
 		for (const event of events)
 			assert.ok(
 				buildsEveryImage(event, true),
 				`a ${event} run on the Version PR's branch must publish every release image itself`,
 			);
 		assert.deepEqual(
-			events.map((event) => buildsEveryImage(event, false)),
-			[false, true, true, true],
+			Object.fromEntries(events.map((event) => [event, buildsEveryImage(event, false)])),
+			{ pull_request: false, merge_group: false, workflow_dispatch: true, push: true },
 		);
 		// The other run with nothing to alias: a pull request whose chain of bases reaches no
 		// published commit builds the whole set rather than failing to alias one.

--- a/scripts/resolve-alias-base.ts
+++ b/scripts/resolve-alias-base.ts
@@ -1,11 +1,11 @@
 /**
- * The commit whose published images a pull request aliases for every component its diff left alone.
+ * The commit whose published images a run aliases for every component its diff left alone.
  *
- * A pull request based on the default branch aliases from its own base, whose images that branch's
- * own run published. A layer of a stacked pull request is based on another branch's head, which
- * published nothing and belongs to no merged pull request, so the chain of bases is walked until a
- * commit the default branch contains. A run that reaches none has nothing to alias and builds every
- * image itself.
+ * A run based on the default branch aliases from its own base, whose images that branch's own run
+ * published. A layer of a stacked pull request is based on another branch's head, which published
+ * nothing and belongs to no merged pull request, so the chain of bases is walked until a commit the
+ * default branch contains. A run that reaches none has nothing to alias and builds every image
+ * itself.
  */
 import { appendFile } from "node:fs/promises";
 


### PR DESCRIPTION
## What changed and why

Every job condition in `cicd.yml` decided whether to run by asking `github.event_name != 'pull_request'`. That reads *every other* event as "run everything", so a merge group ran the entire workflow — and the queue builds several groups speculatively, each one a full `CI/CD` run. Merge-queue throughput is the symptom in #1908.

The filter outputs were already right. `dorny/paths-filter` has read a merge group's diff from `merge_group.base_sha..head_sha` since v4.0.1 and the repository pins v4.0.3; nothing consumed the result. So this is mostly a deletion: `detect-changes` names the decision once as `unfiltered`, and each job now asks whether *its own inputs* changed instead of naming an event. Eighteen copies of the event test become three named outputs.

Two consequences follow from the same idea:

- A merge group now resolves a commit to alias unchanged images from, so it stops rebuilding an image set that no preview, deployment or release ever resolves. The existing contract test *every image a consumer resolves is one the build published for that event* is what establishes that nothing reads them. That resolve is best-effort: a failed `gh api` call leaves the base empty, which already means "build every image", rather than failing a group's run and dropping its pull requests from the queue without failing a check on them.
- The database legs are told which commit's PostgreSQL image to reuse, instead of deriving it from the event in three places. While doing that, the three duplicated resolve-or-build blocks moved into `.github/actions/postgres-image`, which gives their shared fallback one home.

One clause is unrelated: the `concurrency` comment said a push run "must never be cancelled by another", which was misleading — a *pending* push run is replaced by the next arrival regardless. It now records why `queue: max` was rejected instead.

Part of #1908.

## How to test

```bash
vp run check                                     # complete local quality gate
node --test scripts/ci-contract.test.ts          # 55 pass
SHELLCHECK_OPTS="--severity=warning" actionlint  # no output
```

The guard is mutation-tested — each of these must fail a test, so please undo them after trying:

- put `github.event_name != 'pull_request'` back into any job condition in `cicd.yml`
- redefine `detect-changes`' `unfiltered` output as `github.event_name != 'pull_request'`
- drop `continue-on-error` from the `alias_base` step
- point a `base-sha:` in `ci-build.yml` at `github.event.pull_request.base.sha`
- drop `merge_group` from the `alias_base` step condition

**The behaviour itself cannot be proven locally.** It needs a real merge group. Queueing a documentation-only pull request should skip `Test`, `Actionlint` and `Zizmor`, skip every job inside `Build` and `Docker`, still run `Quality / Tooling and Docs`, `Compose` and `CI Status Gate` — and still merge, which is what confirms a skipped required context satisfies the ruleset. `docs/**` is inside the `tooling` filter, which is why the docs leg is on the expected-to-run side.

## Release impact

No changeset. The diff touches `.github/`, `docs/` and `scripts/` only, and `verify-changesets` scopes the requirement to `server/`, `webapp/` and `docker/`. Nothing shipped to an operator or a user changes.

## Notes for reviewers

Start at `detect-changes` in `.github/workflows/cicd.yml`; everything else follows from the three outputs it gains.

**Landing order.** #1851 writes `.github/workflows/**` too, so it shares the lane `docs/contributor/ai-agent-workflow.mdx` defines. The file sets are disjoint, but this one goes first — it is self-contained and it lowers the per-group cost every queued pull request behind it pays — and #1851 rebases onto it and lands last.

Things worth your judgement rather than mine:

- **This is safe only because a skipped job satisfies a required check.** `Actionlint` and `Zizmor` are two of the three required contexts and are now filtered on a merge group. GitHub reports such a job as `skipped`, and the ruleset accepts that as satisfied. A workflow that never *triggers* reports nothing at all and would wedge the queue — which is why the filtering lives in each job's `if` and not in a `paths:` trigger.
- **Speculative groups may keep building every image.** GitHub does not document what `merge_group.base_sha` is for a group built on another group's head. If it is not a commit `main` contains, `resolve-alias-base.ts` resolves nothing and that group builds every image, exactly as it does today. The job-selection win does not depend on this; the image win may only apply to the first group.
- **One behaviour change to note.** Extracting the composite action moved the image resolve out from under `continue-on-error`. A failed resolve now fails at its own step instead of being reported as schema drift. No run that previously passed can now fail, because the schema step needs that database.
- **`max_entries_to_build` is unchanged.** #1908 also suggests lowering it. After this change the per-group job set is much smaller, so it may no longer be the right lever — and `min_entries_to_merge` with a wait, which batches several pull requests into one run, is probably a better one. Both are ruleset settings, so they are yours to make.
- **A pre-existing gap I did not fix.** The `security-config` path filter selects none of the three local actions `ci-security-scan.yml` uses, so editing `download-trivy-db` does not re-run the Security leg on a pull request. The other three filters are complete. It is a separate concern and changes which jobs run on security changes, so it deserves its own pull request.
- **#1908's CodeQL bullet is deliberately left open.** I built the language filtering and then removed it: selecting `javascript-typescript` needs a hand-maintained extension list, and mine missed `**/*.html`, which would have silently skipped analysis of `webapp/index.html`. Weakening a security control to save two jobs is the wrong trade, and it wants its own pull request that derives the extensions rather than listing them.

The Storybook browser suite fails in my sandbox with a browser-startup error and zero tests executed; the diff touches no webapp input, and CI owns that suite.
