### PR TITLE
fix(server): rebuild a repository checkout whose remote configuration broke

### DIFF
--- a/.changeset/rebuild-unusable-checkout.md
+++ b/.changeset/rebuild-unusable-checkout.md
@@ -1,0 +1,5 @@
+---
+"hephaestus": patch
+---
+
+A repository checkout whose remote configuration became unusable is rebuilt on the next sync; a repository that no longer exists upstream is reported, not rebuilt.

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/domain/workdir/GitRepositoryManager.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/domain/workdir/GitRepositoryManager.java
@@ -5,6 +5,7 @@ import java.io.BufferedOutputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -22,6 +23,7 @@ import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.api.errors.InvalidRemoteException;
 import org.eclipse.jgit.diff.DiffEntry;
 import org.eclipse.jgit.diff.DiffFormatter;
 import org.eclipse.jgit.diff.Edit;
@@ -44,6 +46,7 @@ import org.eclipse.jgit.util.FileUtils;
 import org.eclipse.jgit.util.io.DisabledOutputStream;
 import org.jspecify.annotations.Nullable;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.core.NestedExceptionUtils;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -184,7 +187,27 @@ public class GitRepositoryManager {
                     log.warn("Repository origin changed; rebuilding checkout: repoId={}", repositoryId);
                     cloneRepository(repoPath, cloneUrl, token);
                 } else {
-                    fetchRepository(repoPath, token);
+                    try {
+                        fetchRepository(repoPath, token);
+                    } catch (InvalidRemoteException e) {
+                        // JGit reports two faults as "invalid remote": the checkout's own remote
+                        // configuration does not parse (a URISyntaxException cause), which only a rebuild
+                        // fixes, or the remote answered that the repository is not there, which a rebuild
+                        // would only turn into a lost cache; a transport or authentication failure is a
+                        // different exception and stays visible.
+                        if (!(NestedExceptionUtils.getMostSpecificCause(e) instanceof URISyntaxException)) {
+                            log.error(
+                                    "Repository not found upstream; keeping checkout: repoId={}, error={}",
+                                    repositoryId,
+                                    e.getMessage(),
+                                    e);
+                            throw new GitOperationException("Repository not found upstream: " + repositoryId, e);
+                        }
+                        log.warn(
+                                "Repository remote configuration does not parse; rebuilding checkout: repoId={}",
+                                repositoryId);
+                        cloneRepository(repoPath, cloneUrl, token);
+                    }
                 }
                 return repoPath;
             } catch (GitAPIException | IOException e) {
@@ -194,10 +217,15 @@ public class GitRepositoryManager {
         });
     }
 
+    /**
+     * Whether the checkout's origin is exactly the clone URL. JGit fetches from the first {@code url}
+     * value of a remote but reads the last one back, so a stale value left ahead of the current URL
+     * is an origin change, not a match.
+     */
     private static boolean hasOrigin(Path repoPath, String cloneUrl) throws IOException {
         try (Git git = Git.open(repoPath.toFile())) {
-            String configuredUrl = git.getRepository().getConfig().getString("remote", "origin", "url");
-            return cloneUrl.equals(configuredUrl);
+            String[] configuredUrls = git.getRepository().getConfig().getStringList("remote", "origin", "url");
+            return configuredUrls.length == 1 && cloneUrl.equals(configuredUrls[0]);
         }
     }
 

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/scm/domain/workdir/GitRepositoryManagerTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/scm/domain/workdir/GitRepositoryManagerTest.java
@@ -8,6 +8,7 @@ import de.tum.cit.aet.hephaestus.integration.core.fabric.FabricLayout;
 import de.tum.cit.aet.hephaestus.testconfig.BaseUnitTest;
 import de.tum.cit.aet.hephaestus.testconfig.GitTestFixtures;
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -16,8 +17,11 @@ import java.util.List;
 import java.util.Map;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.api.errors.InvalidRemoteException;
+import org.eclipse.jgit.errors.NoRemoteRepositoryException;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.PersonIdent;
+import org.eclipse.jgit.util.FileUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -230,6 +234,102 @@ class GitRepositoryManagerTest extends BaseUnitTest {
                             .isEqualTo(replacementPath.toUri().toString());
                 }
             }
+        }
+
+        @Test
+        void shouldRebuildCheckoutWhenStaleOriginUrlPrecedesCurrentOne() throws Exception {
+            manager = createManager(true);
+            try (Git sourceGit = createSourceRepo()) {
+                String cloneUrl = sourceRepoPath.toUri().toString();
+                Path repoPath = manager.ensureRepository(1L, cloneUrl, null);
+
+                // JGit reads the last value back as the configured URL but fetches from the first,
+                // which is not a repository. Dropping the fetch refspec instead only yields "Nothing
+                // to fetch".
+                try (Git clone = Git.open(repoPath.toFile())) {
+                    var config = clone.getRepository().getConfig();
+                    config.setStringList(
+                            "remote",
+                            "origin",
+                            "url",
+                            List.of(tempDir.resolve("missing").toUri().toString(), cloneUrl));
+                    config.save();
+                    assertThatThrownBy(() -> clone.fetch().setRemote("origin").call())
+                            .isInstanceOf(InvalidRemoteException.class);
+                }
+
+                Path result = manager.ensureRepository(1L, cloneUrl, null);
+
+                assertThat(result).isEqualTo(repoPath);
+                try (Git clone = Git.open(result.toFile())) {
+                    assertThat(clone.getRepository().getConfig().getStringList("remote", "origin", "url"))
+                            .containsExactly(cloneUrl);
+                }
+
+                Files.writeString(sourceRepoPath.resolve("file2.txt"), "content");
+                sourceGit.add().addFilepattern("file2.txt").call();
+                String newSha = commit(sourceGit, "Second commit");
+
+                manager.ensureRepository(1L, cloneUrl, null);
+
+                assertThat(manager.commitExists(1L, newSha)).isTrue();
+            }
+        }
+
+        @Test
+        void shouldRebuildCheckoutWhenRemoteConfigurationDoesNotParse() throws Exception {
+            manager = createManager(true);
+            try (Git sourceGit = createSourceRepo()) {
+                String cloneUrl = sourceRepoPath.toUri().toString();
+                Path repoPath = manager.ensureRepository(1L, cloneUrl, null);
+
+                // An empty pushurl, as a partially written config leaves behind: JGit parses every URL
+                // of the remote before fetching and rejects the empty one.
+                try (Git clone = Git.open(repoPath.toFile())) {
+                    var config = clone.getRepository().getConfig();
+                    config.setString("remote", "origin", "pushurl", "");
+                    config.save();
+                    assertThatThrownBy(() -> clone.fetch().setRemote("origin").call())
+                            .isInstanceOf(InvalidRemoteException.class)
+                            .hasRootCauseInstanceOf(URISyntaxException.class);
+                }
+
+                Path result = manager.ensureRepository(1L, cloneUrl, null);
+
+                assertThat(result).isEqualTo(repoPath);
+                try (Git clone = Git.open(result.toFile())) {
+                    assertThat(clone.getRepository().getConfig().getString("remote", "origin", "pushurl"))
+                            .isNull();
+                }
+
+                Files.writeString(sourceRepoPath.resolve("file2.txt"), "content");
+                sourceGit.add().addFilepattern("file2.txt").call();
+                String newSha = commit(sourceGit, "Second commit");
+
+                manager.ensureRepository(1L, cloneUrl, null);
+
+                assertThat(manager.commitExists(1L, newSha)).isTrue();
+            }
+        }
+
+        @Test
+        void shouldKeepCheckoutWhenRepositoryIsGoneUpstream() throws Exception {
+            manager = createManager(true);
+            String cloneUrl = sourceRepoPath.toUri().toString();
+            String head;
+            try (Git sourceGit = createSourceRepo()) {
+                head = sourceGit.log().call().iterator().next().getName();
+            }
+            manager.ensureRepository(1L, cloneUrl, null);
+            FileUtils.delete(sourceRepoPath.toFile(), FileUtils.RECURSIVE);
+
+            assertThatThrownBy(() -> manager.ensureRepository(1L, cloneUrl, null))
+                    .isInstanceOf(GitRepositoryManager.GitOperationException.class)
+                    .hasMessageContaining("not found upstream")
+                    .hasRootCauseInstanceOf(NoRemoteRepositoryException.class);
+
+            assertThat(manager.isRepositoryCloned(1L)).isTrue();
+            assertThat(manager.commitExists(1L, head)).isTrue();
         }
     }
 


### PR DESCRIPTION
## Problem

On staging every sync of one repository logged `Failed to ensure repository: error=Invalid remote: origin` and its commit backfill never recovered. The checkout manager rebuilt a checkout only when its origin URL changed; a checkout whose remote configuration itself became unusable failed forever. JGit raises the same exception when the provider reports the repository not found, which is a different situation that must stay visible rather than trigger a rebuild (that is the staging case: the repository was deleted upstream, tracked in #1915).

## Fix

The origin check requires `remote.origin.url` to be exactly the clone URL (a stale value ahead of the current one made JGit read one and fetch from the other), so a multi-valued origin takes the existing rebuild path; a fetch that fails because the remote configuration does not parse rebuilds the checkout with a warning; a repository not found upstream keeps its checkout, is logged as such, and still fails the operation.

## Verification

- `GitRepositoryManagerTest`: three new cases, each first proving the raw JGit fetch fails with the expected cause on the corrupted checkout, then the rebuild (stale multi-valued url; unparsable `pushurl`) or the kept checkout (repository gone upstream).
- Architecture tier: `CodeQualityTest`, `TestTierTagCompletenessTest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZzUtPvAhEnBHsxqWTaRHn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Repository checkouts with invalid or unusable remote configuration are now automatically rebuilt during the next synchronization.
  * Checkouts are preserved when the upstream repository no longer exists, with a clear “not found upstream” error reported instead.
  * Remote configuration is validated more accurately when determining whether a checkout matches its expected source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->