### PR TITLE
fix(scripts): a host following commits keeps its database up across applies

### DIFF
--- a/.changeset/database-stays-up-across-staging-applies.md
+++ b/.changeset/database-stays-up-across-staging-applies.md
@@ -1,0 +1,10 @@
+---
+"hephaestus": patch
+---
+
+A host that follows the default branch no longer restarts its database on every apply. The
+PostgreSQL image is rebuilt for every commit, so each apply used to bring the database container
+back up under a new image, dropping every connection for minutes, failing the practice reviews in
+flight and answering 503 meanwhile. The host now keeps the PostgreSQL image it runs until a commit
+changes what that image is built from; a release still applies exactly the images it was signed
+with.

--- a/docs/admin/pull-based-deployment.mdx
+++ b/docs/admin/pull-based-deployment.mdx
@@ -169,6 +169,17 @@ Re-promoting reapplies Compose configuration; it does not restore arbitrary cont
 The reconciler refuses a release checkout with modified tracked files.
 :::
 
+### What restarts the database
+
+An apply recreates a container whose image or Compose definition changed, and recreating PostgreSQL
+drops every connection to it for as long as the application services take to stop and come back.
+Every commit of the default branch rebuilds the PostgreSQL image, so on a host following commits the
+reconciler keeps the PostgreSQL image it already runs and applies the rest of the channel; the
+database restarts only when the commit changes what that image is built from (`docker/postgres/`),
+when the `postgres` service in `docker/compose.app.yaml` changes, or when the host has no record of
+the image it runs. A release is applied exactly as its signed lock names it, so a release that
+rebuilt the image restarts the database.
+
 ## Watching it
 
 Set `HEPHAESTUS_METRICS_FILE` to a `.prom` file in an existing node_exporter textfile collector

--- a/docs/decisions/0042-hosts-pull-their-own-releases.md
+++ b/docs/decisions/0042-hosts-pull-their-own-releases.md
@@ -104,6 +104,15 @@ it. Rootless Podman with Quadlet would close the remaining gap and is not attemp
 
 An operator must disable the timer before hand-patching a host, or the next tick reverts the fix.
 
+A host following commits does not move its database image on every apply. Every commit rebuilds the
+PostgreSQL image, so the channel pins a new digest for it each time and applying that would recreate
+the container and drop every connection to it; the host keeps the digest it last applied while
+`docker/postgres` is unchanged between the applied commit and the one being applied. That digest was
+named and signed by the channel that first applied it, so nothing runs that a channel signature never
+covered — but for that one image the `deploy-state` history records what a host was offered rather
+than what it runs, and the host's own lock under `release-locks/` is what says which. Releases are
+unaffected: a release is applied exactly as its signed lock names it.
+
 Preview environments are unaffected. They are ephemeral, per-pull-request, and managed by Coolify on
 the staging host; the reconciler owns only the Compose projects it is configured for, so the two
 manage disjoint resources.

--- a/scripts/reconcile-deployment.test.ts
+++ b/scripts/reconcile-deployment.test.ts
@@ -11,6 +11,8 @@ import {
 	adoptTooling,
 	appliedCommit,
 	carriesToolingLink,
+	carryPostgresImage,
+	commitImages,
 	commitLockEnvironment,
 	ensureReleaseTree,
 	decide,
@@ -273,6 +275,110 @@ await test("an environment following the branch reports the commit it runs", () 
 		rendered.indexOf("HEPHAESTUS_IMAGE_ALPINE") < rendered.indexOf("HEPHAESTUS_IMAGE_WEBAPP"),
 	);
 	assert.ok(rendered.endsWith("\n"));
+});
+
+await test("a host following commits moves its database only when the image's inputs did", () => {
+	// Every commit of the default branch rebuilds the PostgreSQL image, so two consecutive channels
+	// name two digests for it; Compose recreates a container whose image changed, and the database
+	// coming back means every connection pool and review in flight is lost.
+	const running = `ghcr.io/o/postgres@sha256:${"a".repeat(64)}`;
+	const rebuilt = `ghcr.io/o/postgres@sha256:${"b".repeat(64)}`;
+	const channel = { ...images, HEPHAESTUS_IMAGE_POSTGRES: rebuilt };
+	const appliedLock = commitLockEnvironment("d".repeat(40), {
+		...images,
+		HEPHAESTUS_IMAGE_POSTGRES: running,
+	});
+	const kept = carryPostgresImage(channel, appliedLock, false);
+	assert.deepEqual(kept, { ...images, HEPHAESTUS_IMAGE_POSTGRES: running });
+	// The lock the host then renders names what it keeps, so the app stack passes the lock guard
+	// with the same pin — and the same Compose configuration — as before.
+	assert.deepEqual(unlockedImages([running], commitLockEnvironment(commit, kept)), []);
+
+	// A change under the image's inputs is applied, and so is the channel's pin on a host that has
+	// no record of what it ran, or one whose record is not a digest.
+	assert.deepEqual(carryPostgresImage(channel, appliedLock, true), channel);
+	assert.deepEqual(carryPostgresImage(channel, undefined, false), channel);
+	assert.deepEqual(
+		carryPostgresImage(channel, "HEPHAESTUS_IMAGE_POSTGRES=ghcr.io/o/postgres:main\n", false),
+		channel,
+	);
+	assert.deepEqual(carryPostgresImage(images, appliedLock, false), images);
+	// A channel that moves the image to another repository is naming a different image.
+	assert.deepEqual(
+		carryPostgresImage(
+			{
+				...images,
+				HEPHAESTUS_IMAGE_POSTGRES: `ghcr.io/elsewhere/postgres@sha256:${"b".repeat(64)}`,
+			},
+			appliedLock,
+			false,
+		),
+		{ ...images, HEPHAESTUS_IMAGE_POSTGRES: `ghcr.io/elsewhere/postgres@sha256:${"b".repeat(64)}` },
+	);
+});
+
+await test("the database image is kept while git says its tree stands still", async () => {
+	const directory = await mkdtemp(join(tmpdir(), "reconcile-images-"));
+	try {
+		const checkout = join(directory, "checkout");
+		await mkdir(join(checkout, "docker", "postgres"), { recursive: true });
+		const git = (...args: string[]): string =>
+			execFileSync("git", args, {
+				cwd: checkout,
+				encoding: "utf8",
+				env: environmentForGitFixture(),
+			}).trim();
+		git("init", "--quiet", "--initial-branch=main");
+		git("config", "user.email", "host@example.invalid");
+		git("config", "user.name", "host");
+		const commitAll = (message: string): string => {
+			git("add", "--all");
+			git("commit", "--quiet", "-m", message);
+			return git("rev-parse", "HEAD");
+		};
+		const dockerfile = join(checkout, "docker", "postgres", "Dockerfile");
+		await writeFile(dockerfile, "FROM postgres:18\n");
+		await writeFile(join(checkout, "compose.yaml"), "services: {}\n");
+		const first = commitAll("first");
+		await writeFile(join(checkout, "compose.yaml"), "services: {app: {}}\n");
+		const unrelated = commitAll("a commit that leaves the image alone");
+		await writeFile(dockerfile, "FROM postgres:19\n");
+		const rebuild = commitAll("a commit that rebuilds the image");
+
+		const running = `ghcr.io/o/postgres@sha256:${"a".repeat(64)}`;
+		const channel = {
+			...images,
+			HEPHAESTUS_IMAGE_POSTGRES: `ghcr.io/o/postgres@sha256:${"b".repeat(64)}`,
+		};
+		const lockDirectory = join(directory, "release-locks");
+		await mkdir(lockDirectory);
+		await writeFile(
+			join(lockDirectory, `${first}.env`),
+			commitLockEnvironment(first, { ...images, HEPHAESTUS_IMAGE_POSTGRES: running }),
+		);
+		const ran = { release: first, channelCommit: "e".repeat(40), appliedAt: applied.appliedAt };
+
+		assert.deepEqual(await commitImages(checkout, lockDirectory, ran, unrelated, channel), {
+			...images,
+			HEPHAESTUS_IMAGE_POSTGRES: running,
+		});
+		// The image's tree moved, so the channel's pin is applied — and so it is when the host cannot
+		// order the two commits at all, or has never applied anything.
+		assert.deepEqual(await commitImages(checkout, lockDirectory, ran, rebuild, channel), channel);
+		assert.deepEqual(
+			await commitImages(checkout, lockDirectory, ran, "f".repeat(40), channel),
+			channel,
+		);
+		assert.deepEqual(
+			await commitImages(checkout, lockDirectory, undefined, unrelated, channel),
+			channel,
+		);
+		// A host whose lock for the applied release is gone has no record of what it runs.
+		await rm(join(lockDirectory, `${first}.env`));
+		assert.deepEqual(await commitImages(checkout, lockDirectory, ran, unrelated, channel), channel);
+	} finally {
+		await rm(directory, { recursive: true, force: true });
+	}
 });
 
 await test("a build that finishes late cannot put staging back on an older commit", () => {

--- a/scripts/reconcile-deployment.ts
+++ b/scripts/reconcile-deployment.ts
@@ -261,14 +261,49 @@ export function unlockedImages(rendered: readonly string[], lockEnv: string): st
 	return rendered.filter((image) => !locked.has(image));
 }
 
-export function lockedReleaseCommit(lockEnv: string): string {
-	const values = lockEnv
+function lockValues(lockEnv: string, key: string): string[] {
+	return lockEnv
 		.split("\n")
-		.filter((line) => line.startsWith("HEPHAESTUS_RELEASE_COMMIT="))
-		.map((line) => line.slice(line.indexOf("=") + 1));
+		.filter((line) => line.startsWith(`${key}=`))
+		.map((line) => line.slice(key.length + 1));
+}
+
+export function lockedReleaseCommit(lockEnv: string): string {
+	const values = lockValues(lockEnv, "HEPHAESTUS_RELEASE_COMMIT");
 	if (values.length !== 1 || !isCommit(values[0] ?? ""))
 		throw new Error("release lock must contain one source commit");
 	return values[0] ?? "";
+}
+
+const POSTGRES_IMAGE = "HEPHAESTUS_IMAGE_POSTGRES";
+
+/** The PostgreSQL image's build context and Dockerfile; CI's `postgres-image` filter is that tree. */
+export const POSTGRES_IMAGE_INPUTS = "docker/postgres";
+
+/**
+ * The images a commit channel runs on this host: the channel's, except that PostgreSQL stays at the
+ * pin the host last applied while the image's own inputs are unchanged.
+ *
+ * Every push to the default branch rebuilds the PostgreSQL image — `docker/postgres/Dockerfile` says
+ * why — so a commit channel names a new digest for it on every commit. Compose recreates a container
+ * whose image changed, and a recreated database drops every connection pool and kills the reviews in
+ * flight. A host following commits therefore moves PostgreSQL only when what it is built from moved.
+ * A release is applied as signed: its lock is the artifact its evidence describes, and a rebuilt
+ * image is part of it.
+ */
+export function carryPostgresImage(
+	images: Readonly<Record<string, string>>,
+	appliedLockEnv: string | undefined,
+	inputsChanged: boolean,
+): Readonly<Record<string, string>> {
+	const pinned = images[POSTGRES_IMAGE];
+	if (inputsChanged || appliedLockEnv === undefined || pinned === undefined) return images;
+	const [kept, ...rest] = lockValues(appliedLockEnv, POSTGRES_IMAGE);
+	if (kept === undefined || rest.length > 0 || !IMAGE_DIGEST.test(kept)) return images;
+	// The digest is kept, never the repository it sits in: a channel naming the image somewhere else
+	// is naming a different image rather than a rebuild of this one.
+	if (kept.slice(0, kept.indexOf("@")) !== pinned.slice(0, pinned.indexOf("@"))) return images;
+	return { ...images, [POSTGRES_IMAGE]: kept };
 }
 
 function isStack(name: string): name is Stack {
@@ -520,9 +555,14 @@ async function main(): Promise<void> {
 		// A commit channel carries its own digests, and the channel file they arrived in was
 		// signature-verified before this point, so there is no release to fetch or verify. The
 		// version the instance reports is the commit, which is what the environment is following.
-		await writeFile(lockFile, commitLockEnvironment(decision.release, channel.images), {
-			mode: 0o600,
-		});
+		const images = await commitImages(
+			config.checkout,
+			lockDirectory,
+			applied,
+			releaseCommit,
+			channel.images,
+		);
+		await writeFile(lockFile, commitLockEnvironment(decision.release, images), { mode: 0o600 });
 	} else {
 		// The verifier is the tooling this tick runs, never the release's own copy of it.
 		await run(
@@ -623,6 +663,38 @@ async function main(): Promise<void> {
 	console.log(`Applied ${decision.release} to ${config.stacks.join(", ")}`);
 	// Only now, with the release verified and running, does the host run that release's tooling.
 	await followTooling(config, releaseTree);
+}
+
+/**
+ * `carryPostgresImage` with what this host knows: the lock it wrote for the applied release, which
+ * is its own record of the pins it verified and ran, and git's word on whether the PostgreSQL
+ * image's inputs changed between the applied commit and the one being applied.
+ */
+export async function commitImages(
+	checkout: string,
+	lockDirectory: string,
+	applied: AppliedState | undefined,
+	releaseCommit: string,
+	images: Readonly<Record<string, string>>,
+): Promise<Readonly<Record<string, string>>> {
+	if (applied === undefined) return images;
+	const previous = appliedCommit(applied);
+	if (previous === undefined) return images;
+	let appliedLockEnv: string | undefined;
+	try {
+		appliedLockEnv = await readFile(join(lockDirectory, `${applied.release}.env`), "utf8");
+	} catch (error) {
+		if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) throw error;
+	}
+	// `--quiet` exits 0 only when nothing under the path differs. A commit the checkout does not have
+	// fails it too, and that reads as changed: when the host cannot tell, it runs what the channel
+	// names rather than keep an image on a guess.
+	const unchanged = await succeeds(
+		"git",
+		["diff", "--quiet", previous, releaseCommit, "--", POSTGRES_IMAGE_INPUTS],
+		{ cwd: checkout },
+	);
+	return carryPostgresImage(images, appliedLockEnv, !unchanged);
 }
 
 /**

--- a/scripts/release-deployment-policy.test.ts
+++ b/scripts/release-deployment-policy.test.ts
@@ -6,7 +6,7 @@ import { parseDocument } from "yaml";
 
 import { releaseSignerIdentity, releaseSignerRepository } from "./lib/release-signer.ts";
 import { SMOKE_HOSTNAME } from "./prepare-host-smoke-env.ts";
-import { parseStacks } from "./reconcile-deployment.ts";
+import { parseStacks, POSTGRES_IMAGE_INPUTS } from "./reconcile-deployment.ts";
 
 const release = readFileSync(".github/workflows/release.yml", "utf8");
 const deployment = readFileSync(".github/workflows/deploy-locked-compose.yml", "utf8");
@@ -152,6 +152,16 @@ await test("every promotion decision is taken by the script that owns it", () =>
 	assert.doesNotMatch(reconciler, /join\(releaseTree, "scripts\/prepare-release-lock\.ts"\)/);
 	// Run through the tooling link, argv[1] and import.meta.filename differ; only import.meta.main holds.
 	assert.match(reconciler, /^if \(import\.meta\.main\) \{/m);
+});
+
+await test("the reconciler and CI agree on what the PostgreSQL image is built from", () => {
+	// A host keeps its database image while this tree is unchanged, so the tree it watches has to be
+	// the one CI treats as the image's own inputs; widening the filter without widening the constant
+	// would leave a rebuilt image unapplied.
+	const cicd = readFileSync(".github/workflows/cicd.yml", "utf8");
+	const filter = /^ +postgres-image:\n((?: +- .*\n)+)/m.exec(cicd)?.[1];
+	assert.ok(filter, "detect-changes must declare the postgres-image filter");
+	assert.equal(filter.trim(), `- '${POSTGRES_IMAGE_INPUTS}/**'`);
 });
 
 await test("derives the canonical signer identity and refuses missing CI identity", () => {


### PR DESCRIPTION
## Problem

Closes #1882. On the pull-based staging host every apply recreated the PostgreSQL container: the application lost its connection pool for minutes, in-flight practice reviews died and were requeued, and the site answered 503 while the app services came back.

The postgres service's Compose configuration hash is stable across releases. What changes is the image: every push to `main` rebuilds the PostgreSQL image (its Dockerfile bakes the source commit into a layer so the OS upgrade cannot replay from cache), so every commit channel pins a new digest for it, and Compose recreates a container whose image changed.

## Fix

When a commit channel arrives, the reconciler keeps the PostgreSQL pin from the lock it wrote for the applied release, unless `git diff --quiet <applied> <target> -- docker/postgres` reports a change (or cannot tell), or the host has no usable record of what it runs. The rendered lock names the kept pin, so the lock guard and the Compose configuration agree with what actually runs. A `postgres` service change in `compose.app.yaml` still recreates the container; a `docker/postgres` change still applies the channel's new digest. Releases are applied exactly as signed.

`docs/admin/pull-based-deployment.mdx` gains "What restarts the database", and a policy test holds the input tree to CI's `postgres-image` filter.

## Verification

- `node --test scripts/reconcile-deployment.test.ts scripts/release-deployment-policy.test.ts` (new test proves the pin is kept across commits with unchanged inputs and applied on input change, a missing record, or a non-digest record, and that the rendered lock passes the guard)
- oxfmt, oxlint from the root, `tsc -p tsconfig.agents.json`, markdownlint on the changed page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZzUtPvAhEnBHsxqWTaRHn
