### PR TITLE
fix(server): a worker accepts the hub's heartbeat instead of warning about it

### DIFF
--- a/.changeset/worker-log-stays-quiet-on-heartbeats.md
+++ b/.changeset/worker-log-stays-quiet-on-heartbeats.md
@@ -1,0 +1,7 @@
+---
+"hephaestus": patch
+---
+
+A worker's log no longer fills with warnings about the heartbeats its own hub sends. The hub answers
+every capacity report with a heartbeat to keep an idle control channel alive, and the worker was
+reporting each one as a protocol violation, roughly three warnings a minute per worker.

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/runtime/worker/WorkerControlClient.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/runtime/worker/WorkerControlClient.java
@@ -203,7 +203,8 @@ public class WorkerControlClient {
         }
     }
 
-    private void handleInbound(WorkerControlFrame frame) {
+    /** Package-private: the inbound frame decision is the unit under test. */
+    void handleInbound(WorkerControlFrame frame) {
         try {
             switch (frame) {
                 case WorkerWelcome welcome -> {
@@ -225,8 +226,10 @@ public class WorkerControlClient {
                     forceReconnect("server-requested:" + r.reason());
                 }
                 case CancelJob c -> handleCancelJob(c);
-                // Hub never originates these — log once and ignore (protocol violation by the hub).
-                case Heartbeat h -> warnSourceMismatch(h);
+                // Empty on purpose. Arrival is the whole signal — see Heartbeat — and the transport
+                // stamped lastInboundAt before dispatch, so there is nothing left to do here.
+                case Heartbeat ignored -> {}
+                // The hub never originates these — log and ignore (protocol violation by the hub).
                 case WorkerHello h -> warnSourceMismatch(h);
                 case CapacityReport r -> warnSourceMismatch(r);
             }

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/runtime/worker/protocol/Heartbeat.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/runtime/worker/protocol/Heartbeat.java
@@ -1,7 +1,10 @@
 package de.tum.cit.aet.hephaestus.core.runtime.worker.protocol;
 
 /**
- * Liveness frame. Independent from WebSocket-level ping/pong: the {@code draining} flag is what
- * the hub uses to drop the worker from dispatch rotation before SIGTERM finishes the drain wait.
+ * Liveness frame, sent in both directions. Independent from WebSocket-level ping/pong.
+ * {@code draining} is meaningful worker → hub only: it is what the hub uses to drop the worker from
+ * dispatch rotation before SIGTERM finishes the drain wait. The hub answers every capacity report
+ * with a non-draining heartbeat, and that echo is what keeps an idle channel inside the worker's
+ * silence deadline.
  */
 public record Heartbeat(boolean draining) implements WorkerControlFrame {}

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/runtime/worker/WorkerControlClientInboundTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/runtime/worker/WorkerControlClientInboundTest.java
@@ -1,0 +1,81 @@
+package de.tum.cit.aet.hephaestus.agent.runtime.worker;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import de.tum.cit.aet.hephaestus.agent.runtime.worker.testing.WorkerPropertiesFixtures;
+import de.tum.cit.aet.hephaestus.core.runtime.worker.protocol.CapacityReport;
+import de.tum.cit.aet.hephaestus.core.runtime.worker.protocol.FrameCodec;
+import de.tum.cit.aet.hephaestus.core.runtime.worker.protocol.Heartbeat;
+import de.tum.cit.aet.hephaestus.core.runtime.worker.protocol.WorkerHello;
+import de.tum.cit.aet.hephaestus.testconfig.BaseUnitTest;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.List;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * The hub answers every capacity report with a heartbeat, so on an idle channel the worker receives
+ * one every reporting interval. That echo is the traffic the silence deadline waits for and must not
+ * read as a protocol violation.
+ */
+class WorkerControlClientInboundTest extends BaseUnitTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final WorkerControlClient client = new WorkerControlClient(
+            WorkerPropertiesFixtures.minimal("2", "1"),
+            new FrameCodec(objectMapper),
+            objectMapper,
+            new SimpleMeterRegistry());
+
+    private ListAppender<ILoggingEvent> appender;
+    private Logger logger;
+    private @Nullable Level originalLevel;
+
+    @BeforeEach
+    void attachAppender() {
+        logger = (Logger) LoggerFactory.getLogger(WorkerControlClient.class);
+        originalLevel = logger.getLevel();
+        // Pin the level so "no warning" is a fact about the code and not about the ambient setup.
+        logger.setLevel(Level.DEBUG);
+        appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+    }
+
+    @AfterEach
+    void detachAppender() {
+        logger.detachAppender(appender);
+        logger.setLevel(originalLevel);
+    }
+
+    @Test
+    void acceptsHubHeartbeatWithoutWarning() {
+        client.handleInbound(new Heartbeat(false));
+
+        assertThat(warnings()).isEmpty();
+    }
+
+    @Test
+    void reportsEachFrameOnlyAWorkerSends() {
+        client.handleInbound(new CapacityReport(2, 0, 1, 0, 2, 1));
+        client.handleInbound(new WorkerHello("w", List.of(1), "0.0-test"));
+
+        assertThat(warnings()).hasSize(2);
+    }
+
+    /** Anything below WARN is noise the worker is free to add or drop; the report is the contract. */
+    private List<String> warnings() {
+        return appender.list.stream()
+                .filter(event -> event.getLevel().isGreaterOrEqual(Level.WARN))
+                .map(ILoggingEvent::getFormattedMessage)
+                .toList();
+    }
+}


### PR DESCRIPTION
## What changed and why

Every worker writes `Unexpected worker-source frame from hub: Heartbeat` at WARN roughly three times
a minute. Staging's worker log is almost entirely this line.

The hub deliberately echoes a non-draining `Heartbeat` for every `CapacityReport` it receives
(`WorkerControlWebSocketHandler`), because on an otherwise idle channel that echo is the only inbound
traffic and the worker reconnects after three heartbeat intervals of silence. The worker's inbound
switch, however, classed `Heartbeat` as a frame only a worker originates and warned on each one. A
real protocol violation would have been invisible in that noise.

`Heartbeat` is a frame both sides send: worker to hub it carries `draining`, hub to worker it is a
keepalive. The worker now accepts it (the transport stamps `lastInboundAt` before dispatch, so there
is nothing else to do), and still reports a `CapacityReport` or `WorkerHello` arriving from the hub.
The record's javadoc says which direction means what.

## How to test

`WorkerControlClientInboundTest` covers both branches: a hub heartbeat logs nothing, a hub-sent
capacity report or hello logs one warning each.

```
cd server && MANAGEMENT_PORT=0 SERVER_PORT=0 ./mvnw -f application/pom.xml -Dtest=WorkerControlClientInboundTest test --batch-mode
```

## Release impact

`.changeset/worker-log-stays-quiet-on-heartbeats.md` (patch). No operator action.

## Notes for reviewers

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Workers no longer log warnings when receiving valid heartbeat messages from the hub.
  - Reduces unnecessary heartbeat-related warning logs during normal operation.

- **Documentation**
  - Clarified heartbeat behavior, including bidirectional liveness checks, draining status, and heartbeat responses.

- **Tests**
  - Added coverage verifying that hub heartbeats are handled quietly while unexpected worker-originated frames continue to be reported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->