### PR TITLE
fix(server): a credential in a package named example is not sample code

### DIFF
--- a/.changeset/secrets-in-example-packages-are-reported-in-full.md
+++ b/.changeset/secrets-in-example-packages-are-reported-in-full.md
@@ -1,0 +1,9 @@
+---
+"hephaestus": patch
+---
+
+A hardcoded credential committed in a package named `example` or `sample` — the placeholder package
+most JVM projects are generated with — is no longer read as sample code. Those words counted as a
+directory of samples wherever they sat in a path, so a credential in ordinary application code was
+reduced to a minor suggestion, and a review with other suggestions to make could leave it out of the
+comment entirely. A credential in an `examples/` or `samples/` directory is still a minor suggestion.

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/handler/SecretDiffScanner.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/handler/SecretDiffScanner.java
@@ -79,9 +79,17 @@ final class SecretDiffScanner {
     /** Documentation example keys that are intentionally public. */
     private static final List<String> DOC_EXAMPLE_KEYS = List.of("AKIAIOSFODNN7EXAMPLE", "sk-test_example");
 
-    /** Paths whose hits are downgraded to non-blocking (test/example/doc fixtures). */
+    /**
+     * Paths whose hits are downgraded to non-blocking (test/example/doc fixtures). The singular
+     * {@code example}/{@code sample} counts only as the first segment: deeper in a path it names a
+     * package rather than a directory of samples, and {@code com/example} is the placeholder group every
+     * JVM project generator writes, so a credential in that tree is application code with a credential in
+     * it. The plural still matches at any depth, where it is a samples directory even when it sits inside
+     * a workspace package ({@code packages/sdk/examples/}).
+     */
     private static final Pattern LOW_SIGNAL_PATH =
-            Pattern.compile("(?i)(?:^|/)(?:tests?|spec|specs|fixtures?|__tests__|__mocks__|examples?|samples?|docs?)/"
+            Pattern.compile("(?i)(?:^|/)(?:tests?|spec|specs|fixtures?|__tests__|__mocks__|docs?|examples|samples)/"
+                    + "|^(?:example|sample)/"
                     + "|\\.(?:example|sample|md)$|(?:^|/)\\.env\\.example$");
 
     /**

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/handler/SecretDiffScannerTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/handler/SecretDiffScannerTest.java
@@ -230,5 +230,22 @@ class SecretDiffScannerTest extends BaseUnitTest {
             assertThat(scanner.isLowSignalPath("examples/demo.env")).isTrue();
             assertThat(scanner.isLowSignalPath("src/main/Weather.swift")).isFalse();
         }
+
+        @Test
+        void packageNamedExampleIsNotLowSignal() {
+            assertThat(scanner.isLowSignalPath("src/main/java/com/example/util/CacheManager.java"))
+                    .isFalse();
+            assertThat(scanner.isLowSignalPath("app/src/main/kotlin/com/sample/Api.kt"))
+                    .isFalse();
+        }
+
+        @Test
+        @DisplayName("a samples directory stays low-signal wherever it sits, including inside a package")
+        void samplesDirectoryIsLowSignalAtAnyDepth() {
+            assertThat(scanner.isLowSignalPath("packages/sdk/examples/quickstart.ts"))
+                    .isTrue();
+            assertThat(scanner.isLowSignalPath("e2e/samples/seed.json")).isTrue();
+            assertThat(scanner.isLowSignalPath("example/demo.env")).isTrue();
+        }
     }
 }


### PR DESCRIPTION
## Problem

Found while reviewing a staging run against the validation repository. A pull request that added a hardcoded AWS key, a Redis password and hardcoded database credentials produced three secret-scanner observations, all recorded MINOR, and the delivered review comment showed none of them. It ended with "4 more minor suggestions are not shown."

The scanner downgrades a hit whose path looks like a test, example or documentation location. Its pattern matched `example`/`sample` as a path segment anywhere, so `src/main/java/com/example/util/CacheManager.java` counted as a directory of samples. `com/example` is the placeholder package every JVM project generator writes, and plenty of shipped code lives under it.

The composer keeps every CRITICAL and MAJOR observation and caps the non-blocking tail, so the downgrade is what removed the credentials from the feedback: on a change with a handful of other suggestions the developer is told nothing about the committed key.

## Fix

`example` and `sample` count only as the first path segment, which is where a directory of samples actually lives. They are the two entries in that list that name packages and modules as often as they name sample directories; `tests/`, `spec/`, `fixtures/`, `__tests__/`, `__mocks__/` and `docs/` still match anywhere, and the `.example`/`.sample`/`.md` suffix rules are unchanged. A placeholder under a top-level `examples/` is still non-blocking.

## Verification

`SecretDiffScannerTest` gains a case for a JVM package named `example` and `sample`; the existing path-signal case still passes. Run with `./mvnw -pl application -am test -Dtest=SecretDiffScannerTest`.

## Noted, not fixed here

The scanner writes its remediation sentence itself so that "it must not wait on a composition stage that is entitled to withhold", but a low-signal secret observation is still subject to the improvement cap and can be dropped from the comment silently. Whether a credential finding should be exempt from that cap is a separate question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZzUtPvAhEnBHsxqWTaRHn
