### PR TITLE
fix(server): an observation summary names what the review found

### DIFF
--- a/.changeset/an-observation-summary-names-what-it-found.md
+++ b/.changeset/an-observation-summary-names-what-it-found.md
@@ -1,0 +1,7 @@
+---
+"hephaestus": patch
+---
+
+An observation on your practice page now names what the review saw. A summary of a single word, such
+as "Test", sat above the practice's own name and told you nothing about the work; a short phrase is
+recorded there instead.

--- a/server/application/src/main/resources/agent/pi-observation-normalize.ts
+++ b/server/application/src/main/resources/agent/pi-observation-normalize.ts
@@ -434,6 +434,13 @@ export function normalizeObservation(observation: unknown): NormalizedObservatio
 	const { presence, assessment, severity } = parseOutcome(outcome);
 	if (!practiceSlug) throw new Error("practiceSlug is required");
 	if (!title) throw new Error("summary is required");
+	// The summary is what the developer reads on their practice page, above the practice's own name and
+	// with no evidence beside it, so a single word there ("Test") names nothing the practice did not.
+	if (!/\S\s+\S/.test(title))
+		throw new Error(
+			"summary must say what was observed as a short phrase, not one word — e.g. " +
+				"'Debug print left in the request handler'",
+		);
 	if (!reasoning) throw new Error("evidenceRationale is required");
 	const externalEvidence: Record<string, unknown> = isRecord(observation.evidence)
 		? observation.evidence

--- a/server/application/src/main/resources/agent/pi-orchestrator.md
+++ b/server/application/src/main/resources/agent/pi-orchestrator.md
@@ -439,6 +439,8 @@ Use `report_observation` — it is the only output contract. The tool schema is 
 
 Each call contains `practiceSlug`, a neutral `summary`, one exact `outcome`, exact `evidence`, and an
 `evidenceRationale` that explains how the evidence warrants the outcome without advice or hidden chain-of-thought.
+The `summary` is read on the developer's practice page above the practice's own name and with no evidence beside
+it, so write a short phrase naming what you saw there, not the practice's name again.
 
 - A `BEHAVIOR_PRESENT_*` or `BEHAVIOR_ABSENT_*` outcome makes a semantic claim and carries its assessment and,
   for BAD, severity in one value. Target-behaviour absence is an assessed outcome, never a decline.

--- a/server/application/src/main/resources/agent/pi-runner.ts
+++ b/server/application/src/main/resources/agent/pi-runner.ts
@@ -433,7 +433,14 @@ const observationSchema = {
 	required: ["practiceSlug", "summary", "outcome", "evidence", "evidenceRationale"],
 	properties: {
 		practiceSlug: { type: "string", minLength: 1 },
-		summary: { type: "string", minLength: 1, maxLength: 120 },
+		summary: {
+			type: "string",
+			minLength: 1,
+			maxLength: 120,
+			description:
+				"A short phrase naming what you observed, such as 'Debug print left in the request handler'. " +
+				"Never a single word and never the practice's own name.",
+		},
 		outcome: {
 			type: "string",
 			enum: [

--- a/server/application/src/test/resources/agent/pi-observation-normalize.spec.ts
+++ b/server/application/src/test/resources/agent/pi-observation-normalize.spec.ts
@@ -198,6 +198,15 @@ void test("dedupe key uses the normalized hyphenated slug", () => {
 	assert.equal(a, b, "underscored and upper-hyphenated slugs must dedupe to the same key");
 });
 
+void test("a one-word summary is refused, because it names nothing on the practice page", () => {
+	assert.throws(() => normalizeObservation(baseObservation({ title: "Test" })), /short phrase/);
+	assert.throws(
+		() => normalizeObservation(baseObservation({ title: "  Duplication  " })),
+		/short phrase/,
+	);
+	assert.equal(normalizeObservation(baseObservation({ title: "No tests" })).summary, "No tests");
+});
+
 void test("genuinely invalid enum still rejected after normalization", () => {
 	const invalid = baseObservation();
 	invalid.outcome = "MAYBE";


### PR DESCRIPTION
## Problem

A staging review of the validation repository recorded this observation against "leaves the code clean with intent-revealing comments":

| field | value |
|---|---|
| summary | `Test` |
| evidence | a leftover `// T…` comment in `CacheManager.java` |

The finding is real, but the summary is what a developer reads on their practice page, listed under the practice's own name and with no evidence beside it. One word names nothing there.

## Fix

`report_observation` refuses a summary that is not at least a short phrase, and the error says what to write instead, so the reviewer rewrites it in the same turn rather than the record keeping the word. The orchestrator prompt asks for the phrase up front, with an example of the shape the page needs.

## Verification

`vp run test:agents` — 118 passing, including a new case for a one-word summary, a padded one-word summary, and a two-word summary that is accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZzUtPvAhEnBHsxqWTaRHn
