### PR TITLE
fix(server): a worker claims only what its sandbox pool can start

### DIFF
--- a/.changeset/a-worker-claims-only-what-its-sandbox-can-run.md
+++ b/.changeset/a-worker-claims-only-what-its-sandbox-can-run.md
@@ -1,0 +1,9 @@
+---
+"hephaestus": patch
+---
+
+A worker no longer claims practice reviews its sandbox cannot start. When a host allows fewer
+containers than the worker's review capacity, the worker could pick up a review, fail to start it and
+put it back, logging a warning each time; a queued review waited behind that churn instead of running.
+A claim interrupted by a database error no longer retires one of that worker's review slots until
+the next restart.

--- a/docs/admin/runtime-roles.mdx
+++ b/docs/admin/runtime-roles.mdx
@@ -177,6 +177,11 @@ host is noisy — and mind the name: the JVM binds
 (`docker/compose.app.yaml` translates them); set them on a K8s or systemd deployment and they are
 silently ignored.
 
+Review capacity is also capped by `SANDBOX_MAX_CONCURRENT`: a worker never claims more reviews at
+once than the host lets it start sandboxes for. The single-host self-hosted Compose file sets that to
+1, so raising review capacity there changes nothing until you raise the sandbox limit too — with the
+RAM to match (see the [Install guide](./install)).
+
 The app pod signs worker tokens from a key *ring*, not a single value:
 `hephaestus.worker.hub.token.keys[0].kid` + `.private-key` and
 `hephaestus.worker.hub.token.active-kid`. Indexed list binding has no single env-var form, so

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobExecutor.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobExecutor.java
@@ -429,23 +429,25 @@ public class AgentJobExecutor {
     }
 
     /**
-     * The sandbox executor's free slots are the hard bound: worker capacity and pool size are separate
-     * knobs, so a capacity larger than the pool must not claim jobs the pool would then reject.
+     * The sandbox pool's size is the hard bound: worker capacity and pool size are separate knobs, so a
+     * capacity larger than the pool must not claim jobs the pool would then reject. What occupies a slot
+     * is a job this worker holds, not a thread the pool reports busy: the pool hands a task straight to
+     * a thread, so between submit and that thread entering the task it reports the slot idle, and a
+     * claim made on that reading is rejected on submit and requeued for nothing.
      */
     int computeCapacity() {
-        int poolCapacity = capacityState
-                .map(cs -> Math.max(0, cs.reviewMax() - localRunningJobs.size()))
-                .orElse(agentProperties.claimBatchSize());
-        int bounded = Math.min(poolCapacity, agentProperties.claimBatchSize());
-        return Math.min(bounded, sandboxExecutorFreeCapacity());
+        int concurrency = Math.min(
+                capacityState.map(WorkerCapacityState::reviewMax).orElse(Integer.MAX_VALUE),
+                sandboxExecutorConcurrency());
+        int free = concurrency == Integer.MAX_VALUE
+                ? agentProperties.claimBatchSize()
+                : Math.max(0, concurrency - localRunningJobs.size());
+        return Math.min(free, agentProperties.claimBatchSize());
     }
 
     /** Only ever narrows {@link #computeCapacity()}: an unknown executor type imposes no bound. */
-    private int sandboxExecutorFreeCapacity() {
-        if (sandboxExecutor instanceof ThreadPoolTaskExecutor pool) {
-            return Math.max(0, pool.getMaxPoolSize() - pool.getActiveCount());
-        }
-        return Integer.MAX_VALUE;
+    private int sandboxExecutorConcurrency() {
+        return sandboxExecutor instanceof ThreadPoolTaskExecutor pool ? pool.getMaxPoolSize() : Integer.MAX_VALUE;
     }
 
     /**
@@ -484,6 +486,11 @@ public class AgentJobExecutor {
         if (!(attempt instanceof ClaimResult claim)) {
             return false;
         }
+        // Counted after the claim commits, never inside its transaction: a failed commit rolls the row
+        // back to QUEUED and no execution then runs to release the count. Since the count is the hard
+        // claim bound, one leaked entry would retire a slot for this worker's lifetime.
+        localRunningJobs.add(jobId);
+        capacityState.ifPresent(WorkerCapacityState::claimReview);
         dispatchExecution(jobId, claim);
         return true;
     }
@@ -1055,8 +1062,6 @@ public class AgentJobExecutor {
             job.setConfigSnapshot(snapshot.toJson(objectMapper));
             jobRepository.save(job);
 
-            localRunningJobs.add(jobId);
-            capacityState.ifPresent(WorkerCapacityState::claimReview);
             return new ClaimResult(job, snapshot);
         });
     }

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobExecutorTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobExecutorTest.java
@@ -1,5 +1,6 @@
 package de.tum.cit.aet.hephaestus.agent.job;
 
+import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -1599,6 +1600,18 @@ class AgentJobExecutorTest extends BaseUnitTest {
     @DisplayName("Poll loop capacity math")
     class PollLoopCapacity {
 
+        /**
+         * The jobs this worker holds are the claim bound, and the only seam that fills the set is a
+         * committed claim — more machinery than a capacity assertion needs.
+         */
+        private Set<UUID> heldJobs() throws Exception {
+            java.lang.reflect.Field field = AgentJobExecutor.class.getDeclaredField("localRunningJobs");
+            field.setAccessible(true);
+            @SuppressWarnings("unchecked")
+            Set<UUID> held = (Set<UUID>) requireNonNull(field.get(executor));
+            return held;
+        }
+
         @Test
         @DisplayName("no WorkerCapacityState (worker role config absent) falls back to claimBatchSize")
         void noCapacityStateFallsBackToClaimBatchSize() {
@@ -1634,10 +1647,7 @@ class AgentJobExecutorTest extends BaseUnitTest {
                     Optional.empty());
             // Mirror the two claimReview() calls above by populating localRunningJobs directly —
             // computeCapacity reads localRunningJobs.size(), not the capacity state's own counter.
-            java.lang.reflect.Field localRunningJobsField = AgentJobExecutor.class.getDeclaredField("localRunningJobs");
-            localRunningJobsField.setAccessible(true);
-            @SuppressWarnings("unchecked")
-            Set<UUID> localRunningJobs = (Set<UUID>) localRunningJobsField.get(executor);
+            Set<UUID> localRunningJobs = heldJobs();
             localRunningJobs.add(UUID.randomUUID());
             localRunningJobs.add(UUID.randomUUID());
 
@@ -1708,9 +1718,9 @@ class AgentJobExecutorTest extends BaseUnitTest {
         }
 
         @Test
-        @DisplayName("capacity is further bounded by the sandbox executor's actual free pool "
-                + "slots — reviewMax alone is not enough, it can exceed the pool size")
-        void capacityIsBoundedBySandboxExecutorFreeSlots() throws Exception {
+        @DisplayName("capacity is further bounded by the sandbox executor's pool size — reviewMax "
+                + "alone is not enough, it can exceed the pool size")
+        void capacityIsBoundedBySandboxExecutorPoolSize() throws Exception {
             org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor realPool =
                     new org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor();
             realPool.setCorePoolSize(1);
@@ -1750,6 +1760,60 @@ class AgentJobExecutorTest extends BaseUnitTest {
                 // Nothing active yet: bounded by the pool's max size (2), not reviewMax (10) or
                 // claimBatchSize (5, AGENT_PROPS's default).
                 assertThat(executor.computeCapacity()).isEqualTo(2);
+            } finally {
+                realPool.shutdown();
+            }
+        }
+
+        @Test
+        @DisplayName("a job this worker already holds occupies a pool slot, whether or not the pool "
+                + "thread has entered it yet")
+        void heldJobsOccupyPoolSlots() throws Exception {
+            org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor realPool =
+                    new org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor();
+            realPool.setCorePoolSize(1);
+            realPool.setMaxPoolSize(2);
+            realPool.setQueueCapacity(0);
+            realPool.initialize();
+            try {
+                de.tum.cit.aet.hephaestus.agent.runtime.worker.WorkerCapacityState capacityState =
+                        new de.tum.cit.aet.hephaestus.agent.runtime.worker.WorkerCapacityState(new WorkerProperties(
+                                "w",
+                                new WorkerProperties.Capacity("10", "1"),
+                                new WorkerProperties.Drain(Duration.ofMinutes(5)),
+                                new WorkerProperties.Heartbeat(Duration.ofSeconds(20)),
+                                new WorkerProperties.Control(
+                                        URI.create("ws://example"), "tok", Duration.ofSeconds(10))));
+
+                executor = new AgentJobExecutor(
+                        AGENT_PROPS,
+                        jobRepository,
+                        bindingRepository,
+                        handlerRegistry,
+                        practiceAgent,
+                        workerJwtIssuer,
+                        sandboxManager,
+                        realPool,
+                        transactionTemplate,
+                        objectMapper,
+                        meterRegistry,
+                        new PracticeReviewRefusalMetrics(meterRegistry),
+                        new AgentJobTelemetry(meterRegistry),
+                        usageRecorder,
+                        llmBudgetService,
+                        NO_LIVE_ADMISSION,
+                        Optional.of(capacityState),
+                        Optional.empty());
+
+                Set<UUID> localRunningJobs = heldJobs();
+
+                // The pool reports no busy thread; the jobs this worker holds are what fills it.
+                localRunningJobs.add(UUID.randomUUID());
+                assertThat(realPool.getActiveCount()).isZero();
+                assertThat(executor.computeCapacity()).isEqualTo(1);
+
+                localRunningJobs.add(UUID.randomUUID());
+                assertThat(executor.computeCapacity()).isZero();
             } finally {
                 realPool.shutdown();
             }


### PR DESCRIPTION
## Problem

Observed on staging while draining a sweep of practice reviews. The host allows one sandbox container (`SANDBOX_MAX_CONCURRENT=1`) and the worker's review capacity resolves to three on its four-CPU host, so the worker repeatedly claimed a second review and the pool refused it:

```
Sandbox executor rejected claimed job daf6294e-… (pool smaller than configured worker capacity?) — requeuing
```

The claim bound was meant to prevent exactly this, but it read `getActiveCount()`. The pool has `queueCapacity=0`, so a submitted task is handed straight to a thread; between the submit and that thread entering the task, the pool reports the slot idle. The worker then claims on that reading, the submit is rejected, and the row goes back to QUEUED. Each cycle costs a claim transaction, a requeue transaction and a warning, while the queued review waits.

## Fix

What occupies a sandbox slot is a job this worker holds, and the worker already tracks those exactly in `localRunningJobs`. The claim bound is now the pool's size minus the jobs held, alongside the existing review-capacity and batch-size bounds. The `RejectedExecutionException` handler stays as the safety net it always was.

## Verification

`./mvnw -pl application -am test -Dtest=AgentJobExecutorTest` — 63 passing. New case: with a pool of two, no busy thread and one job held, capacity is 1; with two held, 0. The existing capacity cases still pin the review-capacity and batch-size bounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZzUtPvAhEnBHsxqWTaRHn
