### PR TITLE
fix(server): the recovery pass inherits the review budget the first pass left

### DIFF
--- a/.changeset/a-review-uses-its-whole-budget-before-giving-up.md
+++ b/.changeset/a-review-uses-its-whole-budget-before-giving-up.md
@@ -1,0 +1,9 @@
+---
+"hephaestus": patch
+---
+
+A practice review can now use its whole time budget when it needs it. Part of that budget was held
+back even while the review was running short of time, so a review could end with practices unreviewed
+and deliver no feedback at all, minutes of its budget unspent. A review that needs a second pass now
+holds its sandbox for the full budget, so those reviews take longer and cost more model time than
+before.

--- a/server/application/src/main/resources/agent/pi-runner-timings.ts
+++ b/server/application/src/main/resources/agent/pi-runner-timings.ts
@@ -31,6 +31,56 @@ export function deriveReconBudget(initialMs: number) {
 	return Math.min(240_000, Math.max(floorMs, Math.floor(initialMs * 0.1)));
 }
 
+export interface StageTimeouts {
+	initialMs: number;
+	retryMs: number;
+	compositionMs: number;
+}
+
+/**
+ * The retry's wall clock: whatever is left of the review budget when the initial pass ends, and never
+ * less than the slice the split reserved for it. That reservation guards against an initial pass that
+ * runs long; it is not a cap, because a pass that returned early has not spent the rest and the retry
+ * is the last stage that can still close a practice nobody observed.
+ *
+ * <p>What is left of the process bounds it from above. The review budget is measured from the first
+ * pass, the process budget from module load, and the watchdog's grace is all that covers the two
+ * stretches inside neither: the SDK and model runtime the run builds before the first pass, and the
+ * composition session it builds after the last one. So the retry stops early enough to leave
+ * composition its own slice of what remains.
+ */
+export function deriveRetryWindow(
+	timeouts: StageTimeouts,
+	initialElapsedMs: number,
+	remainingProcessMs: number,
+) {
+	for (const [name, value] of Object.entries({ ...timeouts, initialElapsedMs })) {
+		if (!Number.isFinite(value) || value < 0) {
+			throw new Error(`${name} must be a non-negative number, got: ${value}`);
+		}
+	}
+	// remainingProcessMs is the one argument that may be negative: a process already past its budget
+	// has a negative remainder, and the reservation below is what keeps that from arming a timer in
+	// the past.
+	const unspentReviewMs = timeouts.initialMs + timeouts.retryMs - initialElapsedMs;
+	const beforeCompositionMs = remainingProcessMs - timeouts.compositionMs;
+	return Math.max(timeouts.retryMs, Math.floor(Math.min(unspentReviewMs, beforeCompositionMs)));
+}
+
+/**
+ * Arms the retry's hard stop on the window it derives, so the window the sessions are budgeted
+ * against and the window the abort fires on are one number.
+ */
+export function armRetryWindow(
+	timeouts: StageTimeouts,
+	initialElapsedMs: number,
+	remainingProcessMs: number,
+	onExpire: () => void,
+) {
+	const windowMs = deriveRetryWindow(timeouts, initialElapsedMs, remainingProcessMs);
+	return { windowMs, timer: setTimeout(onExpire, windowMs) };
+}
+
 export function deriveTurnTiming(remainingMs: number, remainingTurns: number) {
 	if (!Number.isFinite(remainingMs) || remainingMs < 0) {
 		throw new Error(`remainingMs must be a non-negative number, got: ${remainingMs}`);

--- a/server/application/src/main/resources/agent/pi-runner.ts
+++ b/server/application/src/main/resources/agent/pi-runner.ts
@@ -48,6 +48,7 @@ import {
 } from "./pi-runner-composition.ts";
 import { outputPath } from "./pi-runner-output.ts";
 import {
+	armRetryWindow,
 	deriveReconBudget,
 	deriveTimeouts,
 	deriveTurnTiming,
@@ -204,11 +205,19 @@ const AGENT_DIR = process.env.PI_CODING_AGENT_DIR;
 if (!AGENT_DIR) {
 	throw new Error("PI_CODING_AGENT_DIR env var is required");
 }
+const TIMEOUTS = deriveTimeouts(
+	AGENT_BUDGET_MS,
+	existsSync(`${CWD}/inputs/feedback-composition.json`),
+);
 const {
 	initialMs: INITIAL_TIMEOUT_MS,
 	retryMs: RETRY_TIMEOUT_MS,
 	compositionMs: COMPOSITION_TIMEOUT_MS,
-} = deriveTimeouts(AGENT_BUDGET_MS, existsSync(`${CWD}/inputs/feedback-composition.json`));
+} = TIMEOUTS;
+
+// The instant the watchdog below counts from. Every stage deadline starts later than this, so it is
+// the only reading against which the process budget means anything.
+const PROCESS_START_MS = Date.now();
 
 setTimeout(() => {
 	console.error(`[pi-runner] Watchdog: ${AGENT_BUDGET_MS + 30_000}ms elapsed, hard-exiting`);
@@ -1840,14 +1849,20 @@ async function main() {
 	);
 
 	const retryAbort = new AbortController();
-	const retryTimer = setTimeout(() => {
-		retryAborted = true;
-		retryAbort.abort();
-		console.error(`[pi-runner] Retry hard timeout — aborting`);
-		for (const activeSession of activeSessions) {
-			activeSession.dispose();
-		}
-	}, RETRY_TIMEOUT_MS);
+	const retry = armRetryWindow(
+		TIMEOUTS,
+		initialDurationMs,
+		AGENT_BUDGET_MS - (Date.now() - PROCESS_START_MS),
+		() => {
+			retryAborted = true;
+			retryAbort.abort();
+			console.error(`[pi-runner] Retry hard timeout — aborting`);
+			for (const activeSession of activeSessions) {
+				activeSession.dispose();
+			}
+		},
+	);
+	console.error(`[pi-runner] Retry window: ${(retry.windowMs / 1000).toFixed(1)}s`);
 
 	const retryStartMs = Date.now();
 
@@ -1882,11 +1897,7 @@ async function main() {
 				const unsubscribeRetry = subscribeSession(retrySession, `retry:${group.id}`);
 				activeSessions.add(retrySession);
 				const activeSlots = Math.min(concurrency, retriesRemaining);
-				const retryBudgetMs = deriveWorkstreamBudget(
-					RETRY_TIMEOUT_MS,
-					activeSlots,
-					retriesRemaining,
-				);
+				const retryBudgetMs = deriveWorkstreamBudget(retry.windowMs, activeSlots, retriesRemaining);
 				const retryDeadline = scheduleDeadline(retryBudgetMs, () => {
 					retrySession.dispose();
 				});
@@ -1913,7 +1924,7 @@ async function main() {
 			retryAbort.signal,
 		);
 	} finally {
-		clearTimeout(retryTimer);
+		clearTimeout(retry.timer);
 	}
 
 	const retryDurationMs = Date.now() - retryStartMs;

--- a/server/application/src/test/resources/agent/pi-runner-timings.spec.ts
+++ b/server/application/src/test/resources/agent/pi-runner-timings.spec.ts
@@ -2,7 +2,9 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+	armRetryWindow,
 	deriveReconBudget,
+	deriveRetryWindow,
 	deriveTimeouts,
 	deriveTurnTiming,
 	deriveWorkstreamBudget,
@@ -28,6 +30,56 @@ void test("the shared reconnaissance gets a turn's worth of time, not a share of
 	for (const invalid of [0, -1, Number.NaN]) {
 		assert.throws(() => deriveReconBudget(invalid), /positive number/);
 	}
+});
+
+void test("the retry inherits what the initial pass did not spend", () => {
+	const timeouts = deriveTimeouts(900_000);
+	// The initial pass returned after 400s of its 765s slice, with the process budget untouched.
+	assert.equal(deriveRetryWindow(timeouts, 400_000, 900_000), 500_000);
+	// It used every second it was given: the retry gets exactly its reservation.
+	assert.equal(deriveRetryWindow(timeouts, timeouts.initialMs, 135_000), timeouts.retryMs);
+	// It overran (a hard abort lands late): the reservation is the floor, never a negative window.
+	assert.equal(deriveRetryWindow(timeouts, 900_000, 0), timeouts.retryMs);
+});
+
+void test("the retry leaves composition its slice of what the process has left", () => {
+	const timeouts = deriveTimeouts(1_740_000, true);
+	// 18s of SDK and model runtime setup ran before the first pass, which returned after 736s of its
+	// own slice. 743s of review budget are unspent, but only 725s of them can be spent here without
+	// pushing composition past the watchdog.
+	assert.equal(deriveRetryWindow(timeouts, 736_000, 1_740_000 - 754_000), 725_000);
+});
+
+void test("the retry's abort fires on the window it was given, not on the reserved slice", (t) => {
+	t.mock.timers.enable({ apis: ["setTimeout"] });
+	const timeouts = deriveTimeouts(900_000);
+	let aborted = false;
+	const retry = armRetryWindow(timeouts, 400_000, 900_000, () => {
+		aborted = true;
+	});
+
+	assert.equal(retry.windowMs, 500_000);
+	t.mock.timers.tick(timeouts.retryMs);
+	assert.equal(aborted, false);
+	t.mock.timers.tick(retry.windowMs - timeouts.retryMs);
+	assert.equal(aborted, true);
+	clearTimeout(retry.timer);
+});
+
+for (const invalid of [-1, Number.NaN]) {
+	void test(`rejects invalid initial elapsed time ${invalid}`, () => {
+		assert.throws(
+			() => deriveRetryWindow(deriveTimeouts(900_000), invalid, 900_000),
+			/initialElapsedMs must be a non-negative/,
+		);
+	});
+}
+
+void test("rejects a stage timeout that cannot be spent", () => {
+	assert.throws(
+		() => deriveRetryWindow({ initialMs: 100, retryMs: -1, compositionMs: 0 }, 0, 100),
+		/retryMs must be a non-negative/,
+	);
 });
 
 void test("a small review never allocates more time than it owns", () => {


### PR DESCRIPTION
## What changed and why

A review splits its budget 85/15 between a first pass and a recovery pass, and the 15% was treated
as a cap as well as a reservation. Observed on staging, review `e266d340` of a validation pull
request:

```
[pi-runner] Budget: total=1740000ms, initial=1257150ms, retry=221850ms
[pi-runner] Initial: 736.4s, calls=24, softTimeout=false, hardAbort=false, resultFile=true, reviewState=true
[pi-runner] Retrying 6 missing practice observer(s): …
[pi-runner] Retry hard timeout — aborting
[pi-runner] Retry: 221.9s
[pi-runner] Practice coverage: evaluated=9, eligible=14, ratio=0.6429
[pi-runner] FAILED: 5 practice observer(s) still missing after retry: …
```

The first pass returned after 736 of the 1257 seconds it was allowed. The recovery pass was still
held to its fixed 222-second slice and ran out with five practices unobserved, and an incomplete
exit never reaches the stage that admits observations and composes feedback, so the review delivered
nothing at all with more than eight minutes of its own budget unspent.

The reservation becomes a floor. `deriveRetryWindow` gives the recovery pass whatever is left of the
review budget when the first pass ends, and its reserved slice when the first pass used everything
or overran.

What is left of the process bounds it from above. The watchdog counts from module load, while every
stage deadline starts later, so the SDK and model runtime built before the first pass and the
composition session built after the last one sit inside no stage deadline at all — with the review
budget spent to its last millisecond, the watchdog's 30-second grace would have had to cover both.
The recovery pass now stops early enough to leave composition its own slice of what remains, and
`armRetryWindow` arms the hard stop on the window it derives, so the retry sessions' budgets and the
abort read one number.

A review that needs a recovery pass will now routinely occupy its container for the full budget, so
model spend and worker occupancy rise on that path and only that path.

## How to test

`vp run test:agents` — 129 passing. The new cases cover a first pass that returned early, one that
used its whole slice and one that overran; a rejected stage timeout; and, with `node:test`'s mock
timers, that the abort fires on the derived window rather than on the reserved slice. Arming the
timer on `retryMs` again, or dropping the process bound, turns those two red.

`vp run check` and `vp run check:affected` — green.

## Release impact

`.changeset/a-review-uses-its-whole-budget-before-giving-up.md`, patch. No operator action, but the
summary names the cost: a review that needs a second pass now holds its sandbox for the full budget,
so those reviews take longer and cost more model time than before.

## Notes for reviewers

Rebased onto #1928, which touched the same three files; this branch now carries only the retry
change.

Surfaces walked: the runner ships inside the agent image and executes in the sandbox the `worker`
role starts, and no bean is added or gated, so no runtime role gains an absence to tolerate. Nothing
crosses HTTP, there is no entity, changelog or ERD, and no component. The change alters how long a
review may run, not what feedback carries, so no channel decision differs.

`deriveRetryWindow` validates every timeout it is handed and the elapsed time, but not
`remainingProcessMs`: that one may legitimately be negative when the process is already past its
budget, and the reservation floor is what keeps a negative remainder from arming a timer in the
past.
