### PR TITLE
fix(server): a review no longer validates its own output as if a model wrote it

### DIFF
--- a/.changeset/a-successful-review-no-longer-logs-a-validation-failure.md
+++ b/.changeset/a-successful-review-no-longer-logs-a-validation-failure.md
@@ -1,0 +1,7 @@
+---
+"hephaestus": patch
+---
+
+A practice review that succeeds no longer logs a validation failure. Every review that recorded
+observations wrote one, so the first line an operator read when a review looked wrong pointed away
+from the real problem.

--- a/docs/contributor/agent/workspace-abi.mdx
+++ b/docs/contributor/agent/workspace-abi.mdx
@@ -123,7 +123,7 @@ worker filesystem.
 
 | Code | Meaning |
 |------|---------|
-| 0    | Success — `out/result.json` is complete, whether from the first attempt, the recovery retry, or reconstruction from persisted tool state |
+| 0    | Success — `out/result.json` is complete, from the first attempt or from the recovery retry |
 | 1    | No complete review output after the initial attempt *and* the recovery retry |
 | 2    | Fatal runner error — an unhandled rejection or uncaught exception. Debug and usage files are persisted first |
 | 3    | Watchdog hard-kill (budget + grace exceeded); writes `out/watchdog-killed.json` first |

--- a/server/application/src/main/resources/agent/pi-runner.ts
+++ b/server/application/src/main/resources/agent/pi-runner.ts
@@ -483,77 +483,12 @@ function persistReviewState() {
 	);
 }
 
-const OUTCOME_VALUES = observationSchema.properties.outcome.enum;
-
-/** Validates the model-authored wire shape before normalization. */
-function isValidObservation(candidate: unknown): boolean {
-	if (!isRecord(candidate)) return false;
-	if (typeof candidate.practiceSlug !== "string" || !candidate.practiceSlug.trim()) return false;
-	if (typeof candidate.summary !== "string" || !candidate.summary.trim()) return false;
-	if (typeof candidate.outcome !== "string") return false;
-	return OUTCOME_VALUES.some((outcome) => outcome === candidate.outcome);
-}
-
-interface ObservationsPayload {
-	observations: unknown[];
-}
-
-function isValidObservationsPayload(payload: unknown): payload is ObservationsPayload {
-	return (
-		isRecord(payload) &&
-		Array.isArray(payload.observations) &&
-		payload.observations.length > 0 &&
-		payload.observations.every(isValidObservation)
-	);
-}
-
-const CONTROL_CHARACTER_ESCAPES = new Map([
-	["\n", "\\n"],
-	["\r", "\\r"],
-	["\t", "\\t"],
-]);
-const LAST_CONTROL_CODE_POINT = 0x1f;
-const DELETE_CODE_POINT = 0x7f;
-
-function lenientJsonParse(text: string): unknown {
-	try {
-		return parseJson(text);
-	} catch {
-		// Retry after escaping raw control characters.
-	}
-	let cleaned = "";
-	for (const character of text) {
-		const codePoint = character.codePointAt(0) ?? 0;
-		if (codePoint > LAST_CONTROL_CODE_POINT && codePoint !== DELETE_CODE_POINT) {
-			cleaned += character;
-			continue;
-		}
-		cleaned += CONTROL_CHARACTER_ESCAPES.get(character) ?? "";
-	}
-	return parseJson(cleaned);
-}
-
-function checkResultFile(): boolean {
-	if (!existsSync(RESULT_PATH)) return false;
-	try {
-		const data = lenientJsonParse(readFileSync(RESULT_PATH, "utf8"));
-		if (!isValidObservationsPayload(data)) {
-			const observations = isRecord(data) ? jsonArray(data.observations) : [];
-			const validCount = observations.filter(isValidObservation).length;
-			console.error(
-				`[pi-runner] result.json validation failed: observations=${observations.length}, valid=${validCount}`,
-			);
-			return false;
-		}
-		const normalized = data.observations.map(normalizeAndValidateObservation);
-		writeFileSync(RESULT_PATH, JSON.stringify({ observations: normalized }, null, 2));
-		return true;
-	} catch (e) {
-		console.error(`[pi-runner] result.json parse error: ${errorText(e)}`);
-		return false;
-	}
-}
-
+/**
+ * Writes the collected result, and is the only thing that writes it: a review session is opened with
+ * `read`, `grep` and `report_observation` and no tool that writes a file, so an observation reaches
+ * this runner through the tool or not at all. What lands here is therefore already normalised and
+ * already validated, by the same call that recorded it.
+ */
 function maybeWriteResultFile(): boolean {
 	if (reviewState.observations.length === 0) return false;
 	writeFileSync(RESULT_PATH, JSON.stringify({ observations: reviewState.observations }, null, 2));
@@ -562,12 +497,6 @@ function maybeWriteResultFile(): boolean {
 
 function hasPersistedReviewState(): boolean {
 	return reviewState.observations.length > 0;
-}
-
-function resolveResultFile(): "agent" | "tool-state" | null {
-	if (checkResultFile()) return "agent";
-	if (maybeWriteResultFile()) return "tool-state";
-	return null;
 }
 
 function appendObservations(observations: unknown[]): {
@@ -1877,19 +1806,14 @@ async function main() {
 		`[pi-runner] Initial: ${(initialDurationMs / 1000).toFixed(1)}s, calls=${initialUsage.totalCalls}, softTimeout=${softTimeoutFired}, hardAbort=${hardAborted}, resultFile=${existsSync(RESULT_PATH)}, reviewState=${hasPersistedReviewState()}`,
 	);
 
-	const resultFileSource = resolveResultFile();
+	const resultFileWritten = maybeWriteResultFile();
 	const missingAfterInitial = missingPracticeSlugs(
 		allSlugs,
 		reviewState.observations.map((item) => item.practiceSlug),
 	);
 	if (missingAfterInitial.length === 0) logPracticeCoverage();
 
-	if (resultFileSource === "agent" && missingAfterInitial.length === 0) {
-		console.error(`[pi-runner] SUCCESS: result.json valid after initial run`);
-		await completeWithAdmittedComposition();
-		process.exit(0);
-	}
-	if (resultFileSource === "tool-state" && missingAfterInitial.length === 0) {
+	if (resultFileWritten && missingAfterInitial.length === 0) {
 		console.error(
 			`[pi-runner] SUCCESS: composed result.json from persisted tool state after initial run`,
 		);
@@ -2010,14 +1934,6 @@ async function main() {
 		process.exit(1);
 	}
 
-	if (checkResultFile()) {
-		console.error(`[pi-runner] SUCCESS: result.json valid after retry`);
-		await completeWithAdmittedComposition();
-		process.exit(0);
-	}
-
-	// As in resolveResultFile(): what maybeWriteResultFile() writes is already normalised and validated,
-	// and re-reading it through checkResultFile() could only reject a measurement already admitted.
 	if (maybeWriteResultFile()) {
 		console.error(
 			`[pi-runner] SUCCESS: composed result.json from persisted tool state after retry`,


### PR DESCRIPTION
## Problem

Every successful staging review logged this, and it was never true:

```
[pi-runner] Initial: 736.4s, calls=24, …, resultFile=true, reviewState=true
[pi-runner] result.json validation failed: observations=8, valid=0
```

The runner writes `out/result.json` from the observations the review recorded through `report_observation`, so its entries are normalised: presence, assessment, severity. The check that then ran over the file validates the shape a model would have written, which requires an `outcome` enum. It rejected every entry of a file the runner had just written, on every run that used the tool, which is every run. It is the first line that looks wrong in a transcript someone is reading because something else went wrong.

## Fix

The check exists for a `result.json` the model wrote itself, and the model cannot write one: a review session is opened with the tools to read, to search and to record an observation, and none that writes a file. The path is therefore removed rather than guarded, and with it the wire-shape validator, the lenient JSON parse that fed it, the two-source resolution and both of its success log lines. The runner composes the result from what it recorded, which is what happened on every run already.

`docs/contributor/agent/workspace-abi.mdx` drops the third source from the exit-code table, since there are now two.

## Verification

`vp run test:agents` — 117 passing. `typecheck:agents` and `lint:agents` clean. Net 92 lines removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZzUtPvAhEnBHsxqWTaRHn
