### PR TITLE
fix(server): a review clears the network its interrupted run left behind

### DIFF
--- a/.changeset/an-interrupted-review-can-run-again.md
+++ b/.changeset/an-interrupted-review-can-run-again.md
@@ -1,0 +1,9 @@
+---
+"hephaestus": patch
+---
+
+A practice review interrupted mid-run can start again. Restarting the application while reviews were
+running left each one's isolated network behind, and because a review's network is named after the
+review, every later attempt was refused for a name already in use. Those reviews spent every attempt
+they had on the same refusal and ended as failed without producing feedback. A review now clears the
+network its interrupted run left behind.

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/SandboxNetworkManager.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/SandboxNetworkManager.java
@@ -53,6 +53,7 @@ public class SandboxNetworkManager {
     public String createJobNetwork(UUID jobId, boolean allowInternet) {
         String networkName = NETWORK_PREFIX + jobId;
         boolean internal = !allowInternet;
+        removeLeftoverNetwork(networkName);
         String networkId = networkOps.createNetwork(networkName, internal);
         log.info("Created job network: name={}, internal={}, networkId={}", networkName, internal, networkId);
         return networkId;
@@ -79,6 +80,32 @@ public class SandboxNetworkManager {
         return ip;
     }
 
+    /**
+     * A network under this job's own name is left from an earlier run of this same job, and nothing
+     * else reclaims it: Docker refuses the duplicate name, and the reconciler spares a network whose
+     * job is still queued — which a job retrying on that very conflict is. An attempt that was
+     * requeued as orphaned can still be running on a worker whose heartbeat only lapsed, but that
+     * attempt is superseded already, and Docker refuses to remove a network a running container
+     * holds, so this fails loudly rather than pulling the network out from under it.
+     */
+    private void removeLeftoverNetwork(String networkName) {
+        List<DockerOperations.NetworkInfo> candidates;
+        try {
+            candidates = networkOps.listNetworksByName(networkName);
+        } catch (RuntimeException e) {
+            // A probe that cannot answer is not a leftover, and createNetwork still refuses a duplicate name.
+            log.debug("Could not check for a leftover network {}: {}", networkName, e.getMessage());
+            return;
+        }
+        for (DockerOperations.NetworkInfo leftover : candidates) {
+            if (!networkName.equals(leftover.name())) {
+                continue; // the daemon's name filter is not exact; only this exact name is ours to remove
+            }
+            log.warn("Removing the network an interrupted run left behind: name={}, id={}", networkName, leftover.id());
+            forceRemoveNetwork(leftover.id(), networkName);
+        }
+    }
+
     /** Disconnect the app-server from a job network. Idempotent — no-op if already disconnected. */
     public void disconnectAppServer(String networkId) {
         String containerId = resolveAppServerContainerId();
@@ -90,6 +117,23 @@ public class SandboxNetworkManager {
 
     /** Remove a job network. */
     public void removeNetwork(String networkId) {
+        networkOps.removeNetwork(networkId);
+    }
+
+    /**
+     * Remove a job network whose app-server connection may have outlived its run: Docker refuses to
+     * remove a network a container is still attached to, and a run that never cleaned up left the
+     * app-server on it. A disconnect that fails is not worth stopping for — the removal reports what
+     * the daemon actually refuses.
+     *
+     * @param name the network name, for the log line only
+     */
+    public void forceRemoveNetwork(String networkId, String name) {
+        try {
+            disconnectAppServer(networkId);
+        } catch (RuntimeException e) {
+            log.debug("Could not disconnect app-server from {}: {}", name, e.getMessage());
+        }
         networkOps.removeNetwork(networkId);
     }
 

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/SandboxReconciler.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/SandboxReconciler.java
@@ -229,18 +229,7 @@ public class SandboxReconciler {
                     UUID jobId = UUID.fromString(jobIdStr);
                     if (!activeJobIds.contains(jobId) && !inUse.contains(jobId)) {
                         log.warn("Removing orphaned network: id={}, name={}", network.id(), name);
-                        // Disconnect app-server before removing — Docker refuses to remove
-                        // networks with connected containers. Normal cleanup may have failed
-                        // to disconnect (the exact scenario reconciliation handles).
-                        try {
-                            networkManager.disconnectAppServer(network.id());
-                        } catch (Exception disconnectEx) {
-                            log.debug(
-                                    "Could not disconnect app-server from orphaned network {}: {}",
-                                    name,
-                                    disconnectEx.getMessage());
-                        }
-                        networkManager.removeNetwork(network.id());
+                        networkManager.forceRemoveNetwork(network.id(), name);
                         orphanedNetworks.increment();
                     }
                 } catch (IllegalArgumentException e) {

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/SandboxNetworkManagerTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/SandboxNetworkManagerTest.java
@@ -1,11 +1,13 @@
 package de.tum.cit.aet.hephaestus.agent.sandbox.docker;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import de.tum.cit.aet.hephaestus.agent.sandbox.spi.SandboxInfrastructureException;
 import de.tum.cit.aet.hephaestus.testconfig.BaseUnitTest;
 import java.util.List;
 import java.util.UUID;
@@ -49,6 +51,63 @@ class SandboxNetworkManagerTest extends BaseUnitTest {
 
             assertThat(networkId).isEqualTo(NETWORK_ID);
             verify(networkOps).createNetwork("agent-net-" + JOB_ID, true);
+        }
+
+        @Test
+        @DisplayName("a network an interrupted run left under this job's name is removed, not fought over")
+        void shouldReplaceLeftoverNetworkOfTheSameJob() {
+            String networkName = "agent-net-" + JOB_ID;
+            when(networkOps.listNetworksByName(networkName))
+                    .thenReturn(List.of(new DockerOperations.NetworkInfo("stale-net", networkName)));
+            when(networkOps.createNetwork(anyString(), eq(true))).thenReturn(NETWORK_ID);
+
+            assertThat(manager.createJobNetwork(JOB_ID, false)).isEqualTo(NETWORK_ID);
+
+            verify(networkOps).disconnectFromNetwork("stale-net", "app-server-id");
+            verify(networkOps).removeNetwork("stale-net");
+            verify(networkOps).createNetwork(networkName, true);
+        }
+
+        @Test
+        @DisplayName("a leftover network that will not go is reported, not worked around")
+        void shouldFailWhenLeftoverNetworkCannotBeRemoved() {
+            String networkName = "agent-net-" + JOB_ID;
+            when(networkOps.listNetworksByName(networkName))
+                    .thenReturn(List.of(new DockerOperations.NetworkInfo("stale-net", networkName)));
+            Mockito.doThrow(new SandboxInfrastructureException("network has active endpoints"))
+                    .when(networkOps)
+                    .removeNetwork("stale-net");
+
+            assertThatThrownBy(() -> manager.createJobNetwork(JOB_ID, false))
+                    .isInstanceOf(SandboxInfrastructureException.class);
+
+            verify(networkOps, Mockito.never()).createNetwork(anyString(), Mockito.anyBoolean());
+        }
+
+        @Test
+        @DisplayName("another job's network is left alone even when the daemon returns it")
+        void shouldLeaveOtherJobsNetworksAlone() {
+            String networkName = "agent-net-" + JOB_ID;
+            when(networkOps.listNetworksByName(networkName))
+                    .thenReturn(List.of(new DockerOperations.NetworkInfo("other-net", networkName + "-suffix")));
+            when(networkOps.createNetwork(anyString(), eq(true))).thenReturn(NETWORK_ID);
+
+            assertThat(manager.createJobNetwork(JOB_ID, false)).isEqualTo(NETWORK_ID);
+
+            verify(networkOps, Mockito.never()).removeNetwork(anyString());
+        }
+
+        @Test
+        @DisplayName("a daemon that cannot list networks does not stop the create")
+        void shouldCreateWhenTheLeftoverProbeFails() {
+            String networkName = "agent-net-" + JOB_ID;
+            when(networkOps.listNetworksByName(networkName))
+                    .thenThrow(new SandboxInfrastructureException("Failed to list networks"));
+            when(networkOps.createNetwork(anyString(), eq(true))).thenReturn(NETWORK_ID);
+
+            assertThat(manager.createJobNetwork(JOB_ID, false)).isEqualTo(NETWORK_ID);
+
+            verify(networkOps).createNetwork(networkName, true);
         }
 
         @Test

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/SandboxReconcilerTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/SandboxReconcilerTest.java
@@ -110,7 +110,7 @@ class SandboxReconcilerTest extends BaseUnitTest {
             reconciler.onStartup();
 
             verify(containerManager).forceRemove("orphaned-ctr");
-            verify(networkManager).removeNetwork("net-1");
+            verify(networkManager).forceRemoveNetwork("net-1", "agent-net-" + orphanedJobId);
         }
 
         @Test
@@ -202,7 +202,7 @@ class SandboxReconcilerTest extends BaseUnitTest {
 
             reconciler.periodicReconciliation();
 
-            verify(networkManager).removeNetwork(networkId);
+            verify(networkManager).forceRemoveNetwork(networkId, "agent-net-" + orphanedJobId);
             assertThat(meterRegistry
                             .counter("sandbox.reconciler.orphaned", "resource", "network")
                             .count())
@@ -243,7 +243,7 @@ class SandboxReconcilerTest extends BaseUnitTest {
 
             reconciler.periodicReconciliation();
 
-            verify(networkManager, never()).removeNetwork(any());
+            verify(networkManager, never()).forceRemoveNetwork(any(), any());
             assertThat(meterRegistry
                             .counter("sandbox.reconciler.sweeps", "outcome", "skipped")
                             .count())
@@ -267,8 +267,7 @@ class SandboxReconcilerTest extends BaseUnitTest {
             reconciler.periodicReconciliation();
 
             verify(containerManager, never()).forceRemove(any());
-            verify(networkManager, never()).disconnectAppServer(any());
-            verify(networkManager, never()).removeNetwork(any());
+            verify(networkManager, never()).forceRemoveNetwork(any(), any());
             assertThat(meterRegistry
                             .counter("sandbox.reconciler.sweeps", "outcome", "skipped")
                             .count())
@@ -323,8 +322,7 @@ class SandboxReconcilerTest extends BaseUnitTest {
 
             reconciler.periodicReconciliation();
 
-            verify(networkManager, never()).disconnectAppServer(any());
-            verify(networkManager, never()).removeNetwork(any());
+            verify(networkManager, never()).forceRemoveNetwork(any(), any());
         }
 
         @Test
@@ -339,7 +337,7 @@ class SandboxReconcilerTest extends BaseUnitTest {
 
             reconciler.periodicReconciliation();
 
-            verify(networkManager, never()).removeNetwork(any());
+            verify(networkManager, never()).forceRemoveNetwork(any(), any());
         }
 
         @Test
@@ -356,7 +354,7 @@ class SandboxReconcilerTest extends BaseUnitTest {
 
             reconciler.periodicReconciliation();
 
-            verify(networkManager, never()).removeNetwork(any());
+            verify(networkManager, never()).forceRemoveNetwork(any(), any());
         }
 
         @Test


### PR DESCRIPTION
## What changed and why

Three reviews on staging were stuck in a retry loop that could never succeed:

```
Requeuing job 63f2e1fd-… after classified sandbox-infrastructure failure (attempt 5):
  Failed to create network: agent-net-63f2e1fd-…
Caused by: ConflictException: Status 409: network with name agent-net-63f2e1fd-… already exists
```

An application restart during a deployment kills the sandbox mid-run, and the per-job network
survives it. The network is named after the job, so every later attempt asks for a name that is
already taken and fails. `SandboxReconciler.cleanupOrphanedNetworks` cannot break the loop: it
removes a network only when its job is neither active nor in use, and a job stuck retrying is
active. Seven such networks were on the host, three of them holding a queued review hostage.

A network standing under a job's own name is that job's leftover — a job runs on one worker at a
time, fenced by the claim — so `createJobNetwork` removes it before creating its own. A network
whose name merely starts with the same string is left alone, because `listNetworksByName` matches a
prefix. Looking for the leftover fails soft: a daemon that cannot list networks is not evidence of
one, and `createNetwork` still refuses a genuine duplicate, so a transient list failure leaves a
review exactly where it was before this change. Removing a network the app server may still be
attached to is also what the reconciler does, so both callers now go through one
`forceRemoveNetwork`.

## How to test

`vp run format` and `vp run check` are clean.

`cd server && MANAGEMENT_PORT=0 SERVER_PORT=0 ./mvnw -f application/pom.xml
-Dtest='SandboxNetworkManagerTest,SandboxReconcilerTest' test --batch-mode` — 35 passing, with four
new cases on `createJobNetwork`: a leftover under this job's name is disconnected and removed before
the create; a leftover that will not go is reported rather than worked around; a network belonging to
another job is untouched even when the daemon's prefix filter returns it; and a daemon that cannot
list networks does not stop the create.

The whole sandbox package (`-Dtest='de.tum.cit.aet.hephaestus.agent.sandbox.**'`) is 418 passing.

## Release impact

`.changeset/an-interrupted-review-can-run-again.md`, `patch`. No operator action: the application
clears these networks itself from the next review of the affected job onwards, and networks left by
jobs that are no longer active were already the reconciler's.

## Notes for reviewers

The sandbox network is internal to the review runtime, so no integration adapter, wire contract,
schema, admin console or UI surface is involved, and what feedback carries is unchanged — the only
channel-visible effect is that reviews which previously produced nothing now produce feedback.
`SandboxNetworkManager` runs wherever the sandbox pool does (the `worker` role, and `server` when it
hosts its own pool); no bean is added or removed, so no runtime role gains an absence to tolerate.

The happy path now costs one extra `listNetworksByName` round trip per review, where the leftover is
absent almost every time. That is deliberate, weighed against a review that can never run.
