### PR TITLE
fix(server): the reading a review shares with every practice survives its own budget

### DIFF
--- a/.changeset/shared-review-context-reaches-every-practice.md
+++ b/.changeset/shared-review-context-reaches-every-practice.md
@@ -1,0 +1,8 @@
+---
+"hephaestus": patch
+---
+
+A practice review shares what it read about a change with every practice it then checks. The step that
+does that reading was being cut off before it could answer, so most reviews threw it away and each
+practice started from nothing: the review spent its time re-reading the same change and had less to
+say at the end of it.

--- a/server/application/src/main/resources/agent/pi-runner-timings.ts
+++ b/server/application/src/main/resources/agent/pi-runner-timings.ts
@@ -13,6 +13,24 @@ export function deriveTimeouts(agentBudgetMs: number, compositionEnabled = false
 	};
 }
 
+/**
+ * How long the shared reconnaissance may take before the groups start without it.
+ *
+ * <p>It is one model turn over the whole change, so it is bounded below by what a turn needs rather
+ * than by a share of the review: a budget that expires before the first answer buys nothing and costs
+ * every group the shared reading. The cap keeps a large review from spending its observers' time here.
+ * The reconnaissance is paid for out of the first pass, so the floor is bounded by a quarter of it:
+ * a deadline longer than the pass that funds it can never expire, and the whole review would run out
+ * of time before any group heard that it was starting alone.
+ */
+export function deriveReconBudget(initialMs: number) {
+	if (!Number.isFinite(initialMs) || initialMs <= 0) {
+		throw new Error(`initialMs must be a positive number, got: ${initialMs}`);
+	}
+	const floorMs = Math.min(120_000, Math.floor(initialMs * 0.25));
+	return Math.min(240_000, Math.max(floorMs, Math.floor(initialMs * 0.1)));
+}
+
 export function deriveTurnTiming(remainingMs: number, remainingTurns: number) {
 	if (!Number.isFinite(remainingMs) || remainingMs < 0) {
 		throw new Error(`remainingMs must be a non-negative number, got: ${remainingMs}`);

--- a/server/application/src/main/resources/agent/pi-runner.ts
+++ b/server/application/src/main/resources/agent/pi-runner.ts
@@ -47,14 +47,19 @@ import {
 	validateFeedbackEvidence,
 } from "./pi-runner-composition.ts";
 import { outputPath } from "./pi-runner-output.ts";
-import { deriveTimeouts, deriveTurnTiming, deriveWorkstreamBudget } from "./pi-runner-timings.ts";
+import {
+	deriveReconBudget,
+	deriveTimeouts,
+	deriveTurnTiming,
+	deriveWorkstreamBudget,
+} from "./pi-runner-timings.ts";
 import {
 	addAssistantUsage,
 	extractUsageFromSession,
 	newUsageLedger,
 	type UsageReport,
 } from "./pi-runner-usage.ts";
-import { forkSessions } from "./pi-session-tree.ts";
+import { forkSessions, reconnaissanceSeed } from "./pi-session-tree.ts";
 
 // ── Reading what other processes wrote ───────────────────────────────────────
 // Everything this runner is handed — the task envelope, the manifest, the practice index, the
@@ -1465,14 +1470,18 @@ let retryAborted = false;
 
 function scheduleDeadline(timeoutMs: number, onTimeout: () => void) {
 	let release = () => {};
+	// Racing `elapsed` says the wait is over, not why: the caller reads this to tell an answer from a
+	// budget that ran out.
+	const state = { expired: false };
 	const elapsed = new Promise<void>((resolve) => {
 		release = resolve;
 	});
 	const timer = setTimeout(() => {
+		state.expired = true;
 		onTimeout();
 		release();
 	}, timeoutMs);
-	return { elapsed, timer };
+	return { elapsed, timer, state };
 }
 
 function scheduleTurnTimers(
@@ -1685,10 +1694,7 @@ async function main() {
 		});
 		const unsubscribeRecon = subscribeSession(reconSession, "recon:shared");
 		activeSessions.add(reconSession);
-		const reconBudgetMs = Math.min(
-			180_000,
-			Math.max(45_000, Math.floor(INITIAL_TIMEOUT_MS * 0.05)),
-		);
+		const reconBudgetMs = deriveReconBudget(INITIAL_TIMEOUT_MS);
 		const reconDeadline = scheduleDeadline(reconBudgetMs, () => reconSession.dispose());
 		try {
 			const groupScope = tree.groups
@@ -1700,10 +1706,11 @@ async function main() {
 				),
 				reconDeadline.elapsed,
 			]);
-			const checkpointEntryId = reconSession.sessionManager.getLeafId();
-			const seedSessionFile = reconSession.sessionManager.getSessionFile();
-			if (!checkpointEntryId || !seedSessionFile)
-				throw new Error("shared reconnaissance produced no persistent checkpoint");
+			const { seedSessionFile, checkpointEntryId } = reconnaissanceSeed(
+				reconSession.sessionManager,
+				reconDeadline.state,
+				reconBudgetMs,
+			);
 			for (const fork of forkSessions({
 				seedSessionFile,
 				checkpointEntryId,

--- a/server/application/src/main/resources/agent/pi-session-tree.ts
+++ b/server/application/src/main/resources/agent/pi-session-tree.ts
@@ -12,6 +12,37 @@ export interface ForkSessionsOptions {
 	sessionDir?: string;
 }
 
+export interface ReconnaissanceSeed {
+	seedSessionFile: string;
+	checkpointEntryId: string;
+}
+
+/**
+ * What the shared reconnaissance leaves for the groups to branch from.
+ *
+ * <p>A disposed session still answers getLeafId(), and the SDK holds a session's entries back until
+ * its first assistant message, so a budget that ran out names an entry the file never received. It
+ * has to be told from an answer here, or it reads as a session-storage error against that entry
+ * further down.
+ */
+export function reconnaissanceSeed(
+	sessionManager: SessionManager,
+	deadline: { expired: boolean },
+	budgetMs: number,
+): ReconnaissanceSeed {
+	if (deadline.expired) {
+		throw new Error(
+			`Shared reconnaissance did not answer within ${Math.round(budgetMs / 1000)}s, so each group reads for itself`,
+		);
+	}
+	const checkpointEntryId = sessionManager.getLeafId();
+	const seedSessionFile = sessionManager.getSessionFile();
+	if (!checkpointEntryId || !seedSessionFile) {
+		throw new Error("Shared reconnaissance produced no persistent checkpoint");
+	}
+	return { seedSessionFile, checkpointEntryId };
+}
+
 export function forkSessions({
 	seedSessionFile,
 	checkpointEntryId,

--- a/server/application/src/test/resources/agent/pi-runner-timings.spec.ts
+++ b/server/application/src/test/resources/agent/pi-runner-timings.spec.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+	deriveReconBudget,
 	deriveTimeouts,
 	deriveTurnTiming,
 	deriveWorkstreamBudget,
@@ -13,6 +14,20 @@ void test("review budget reserves fifteen percent for a retry", () => {
 		retryMs: 135_000,
 		compositionMs: 0,
 	});
+});
+
+void test("the shared reconnaissance gets a turn's worth of time, not a share of the review", () => {
+	// One model turn over the whole change: too small a share buys nothing, and the cap keeps a large
+	// review from spending its observers' time here.
+	assert.equal(deriveReconBudget(deriveTimeouts(900_000).initialMs), 120_000);
+	assert.equal(deriveReconBudget(1_800_000), 180_000);
+	assert.equal(deriveReconBudget(9_000_000), 240_000);
+	// A pass too short to fund the floor keeps most of itself for the groups, and its deadline still
+	// expires inside the pass rather than after the review is already over.
+	assert.equal(deriveReconBudget(deriveTimeouts(120_000).initialMs), 25_500);
+	for (const invalid of [0, -1, Number.NaN]) {
+		assert.throws(() => deriveReconBudget(invalid), /positive number/);
+	}
 });
 
 void test("a small review never allocates more time than it owns", () => {

--- a/server/application/src/test/resources/agent/pi-session-tree.spec.ts
+++ b/server/application/src/test/resources/agent/pi-session-tree.spec.ts
@@ -6,7 +6,7 @@ import test from "node:test";
 
 import { SessionManager } from "@earendil-works/pi-coding-agent";
 
-import { forkSessions } from "../../../main/resources/agent/pi-session-tree.ts";
+import { forkSessions, reconnaissanceSeed } from "../../../main/resources/agent/pi-session-tree.ts";
 
 function assistantMessage(text: string) {
 	return {
@@ -80,6 +80,47 @@ void test("forks the same persisted checkpoint into independent session branches
 	} finally {
 		rmSync(root, { recursive: true, force: true });
 	}
+});
+
+void test("a reconnaissance that ran out of budget is not a seed", () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-session-tree-"));
+	try {
+		const sessionDir = join(root, "sessions");
+		const recon = SessionManager.create(root, sessionDir);
+		recon.appendMessage({
+			role: "user",
+			content: [{ type: "text", text: "Build one factual reconnaissance map" }],
+			timestamp: Date.now(),
+		});
+		// A disposed session reports this leaf either way; only the deadline knows the write behind it
+		// never landed.
+		const checkpointEntryId = recon.appendMessage(assistantMessage("Reconnaissance map"));
+		const seedSessionFile = recon.getSessionFile();
+		assert.ok(seedSessionFile);
+
+		assert.throws(
+			() => reconnaissanceSeed(recon, { expired: true }, 120_000),
+			/did not answer within 120s/,
+		);
+		assert.deepEqual(reconnaissanceSeed(recon, { expired: false }, 120_000), {
+			seedSessionFile,
+			checkpointEntryId,
+		});
+		assert.throws(
+			() =>
+				reconnaissanceSeed(SessionManager.create(root, sessionDir), { expired: false }, 120_000),
+			/no persistent checkpoint/,
+		);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+void test("a review with nothing to fork gets no forks and no seed is opened", () => {
+	assert.deepEqual(
+		forkSessions({ seedSessionFile: "unused", checkpointEntryId: "unused", keys: [] }),
+		[],
+	);
 });
 
 void test("rejects duplicate and empty keys before creating a fork", () => {


### PR DESCRIPTION
## What changed and why

A practice review opens with one reconnaissance turn over the change and forks every practice group
from that session, so each group starts with the shared reading. Eleven of fourteen staging reviews
logged this in their first three lines:

```
[pi-runner] Review tree: 15 practices, 4 evidence group(s), concurrency=4
[pi-runner] shared reconnaissance failed: Entry b5d3bd59 not found
```

The turn's budget was 5% of the first pass with a 45-second floor, which on this model and this
evidence is less than one turn takes. The deadline disposed the session before it answered, and the
runner then read the leaf from the disposed session and asked the file for it. A session's entries
are written once an exchange completes, so a session that never answered has no entry to branch
from and `createBranchedSession` throws. Confirmed against the SDK directly: after appending a user
message the session file does not exist and a reopened manager reports no leaf; both appear once an
assistant message is appended.

The cost was not cosmetic. Of the three staging reviews that delivered, the two with working
reconnaissance composed 5 and 7 pieces of feedback; the one without composed none and fell back to
the server's own rendering.

- `deriveReconBudget` gives the turn a turn's worth of time: a tenth of the first pass, floored at
  two minutes, capped at four, and never a floor larger than a quarter of a short pass, so a small
  budget is not spent here instead of on the practices.
- The deadline records that it expired, and `reconnaissanceSeed` refuses to seed the groups from a
  reconnaissance that never answered. The expiry is then reported as an expiry rather than
  surfacing further down as a session-storage error, and every group reads for itself — the
  fallback that already existed.

## How to test

`vp run test:agents` — 120 passing. The new cases cover the budget's floor, share, cap and
short-pass bound with its invalid inputs; that an expired budget is not a seed while an answered one
is; and that a review with no groups to fork returns no forks without opening a seed. Deleting the
expiry check turns "a reconnaissance that ran out of budget is not a seed" red.

`vp run check` — green.

## Release impact

`.changeset/shared-review-context-reaches-every-practice.md`, patch. No operator action: the
reconnaissance budget is derived from the review budget an operator already sets.

## Notes for reviewers

Surfaces walked: this file ships inside the agent image and executes in the sandbox the `worker`
role starts, and no bean is added or gated, so no runtime role gains an absence to tolerate.
Nothing crosses HTTP, there is no entity, changelog or ERD, and no component. All three feedback
channels — the reviewed work, the developer's practice page and conversation with Heph — improve
identically, because the change alters what a review reads, not what feedback carries.

The previous revision also branched every fork from the seed file's own leaf whenever the requested
checkpoint was missing. That is gone. Once an expired budget is reported as itself, the fallback is
reachable only through a write that never landed, and when it did fire it would have composed the
review from a silently truncated shared reading, logged nowhere but the container transcript.
Failing loudly there keeps the existing "each group reads for itself" recovery, which is honest
about what the review had.
