### PR TITLE
ci: refuse model attribution in commits and pull request bodies

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -212,6 +212,104 @@ jobs:
         if: steps.identity.outcome == 'failure'
         run: exit 1
 
+      # AGENTS.md forbids model, agent, harness or tool attribution in a commit or a pull
+      # request body; nothing enforced it here, the way `scripts/verify-changesets.ts` already
+      # enforces it for a changeset summary.
+      - name: "Refuse model attribution in commits and the pull request body"
+        id: attribution
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        continue-on-error: true
+        with:
+          script: |
+            const { writeFile } = require("node:fs/promises");
+
+            // Kept equal to `scripts/lib/model-attribution.ts` by
+            // `scripts/model-attribution.test.ts`; this job has no checkout to import it from.
+            const patterns = [
+              {
+                name: "a Co-Authored-By trailer naming a model or tool",
+                pattern:
+                  /^co-authored-by:.*(?:claude|codex|copilot|gpt|openai|anthropic|gemini|cursor|noreply@anthropic\.com)/im,
+              },
+              { name: "a Claude-Session trailer", pattern: /^claude-session:/im },
+              { name: 'a "Generated with" marker', pattern: /generated with/i },
+              { name: "a claude.ai/code or session link", pattern: /claude\.ai\/(?:code|session)/i },
+            ];
+            const findAttribution = (text) =>
+              patterns.filter(({ pattern }) => pattern.test(text ?? "")).map(({ name }) => name);
+
+            const query = `query($owner:String!,$name:String!,$number:Int!,$after:String){
+              repository(owner:$owner,name:$name){ pullRequest(number:$number){
+                commits(first:100,after:$after){ pageInfo{hasNextPage endCursor}
+                  nodes{ commit{ abbreviatedOid message } } } } } }`;
+
+            const pull = context.payload.pull_request;
+            const nodes = [];
+            let after = null;
+            do {
+              const page = await github.graphql(query, {
+                owner: context.repo.owner,
+                name: context.repo.repo,
+                number: pull.number,
+                after,
+              });
+              const data = page.repository.pullRequest;
+              nodes.push(...data.commits.nodes);
+              after = data.commits.pageInfo.hasNextPage ? data.commits.pageInfo.endCursor : null;
+            } while (after);
+
+            const offenders = nodes
+              .map(({ commit }) => ({
+                oid: commit.abbreviatedOid,
+                matches: findAttribution(commit.message),
+              }))
+              .filter(({ matches }) => matches.length > 0);
+            const bodyMatches = findAttribution(pull.body);
+            if (offenders.length === 0 && bodyMatches.length === 0) return;
+
+            const listed = offenders.map(({ oid, matches }) => `    ${oid}  ${matches.join(", ")}`);
+            await writeFile(
+              `${process.env.RUNNER_TEMP}/attribution-comment.md`,
+              [
+                "## Attribution check failed",
+                "",
+                "A commit here or this pull request's body names the model, agent, harness or tool",
+                "that helped write it. `AGENTS.md` asks for none of that; a human co-author stays",
+                "welcome under the same trailer.",
+                ...(listed.length > 0 ? ["", "These commits carry it:", "", ...listed] : []),
+                ...(bodyMatches.length > 0
+                  ? ["", `The pull request body carries it too: ${bodyMatches.join(", ")}.`]
+                  : []),
+                "",
+                "Edit the offending commit messages:",
+                "",
+                `    git rebase -i --exec "git commit --amend --no-edit" origin/${pull.base.ref}`,
+                "",
+                ...(bodyMatches.length > 0 ? ["Then edit the pull request description to remove it.", ""] : []),
+              ].join("\n"),
+            );
+            core.setFailed(
+              `${offenders.length} commit(s) or the pull request body carry model attribution.`,
+            );
+
+      - name: "Comment on PR with the attribution violations"
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
+        if: steps.attribution.outcome == 'failure'
+        with:
+          header: pr-attribution-error
+          path: ${{ runner.temp }}/attribution-comment.md
+
+      - name: "Remove attribution error comment on success"
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
+        if: steps.attribution.outcome == 'success'
+        with:
+          header: pr-attribution-error
+          delete: true
+
+      - name: "Fail workflow if the attribution check failed"
+        if: steps.attribution.outcome == 'failure'
+        run: exit 1
+
   assign-author:
     name: "Assign author"
     timeout-minutes: 5

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,8 @@ git rebase --exec 'git commit --amend --no-edit -S' origin/main
 
 ### Compliance
 
+A commit message and a pull request body carry no model, agent, harness or tool attribution — `AGENTS.md` § Pull requests has the rule and `pull-request.yml`'s `Verify commit identity` job checks for it. A human co-author stays welcome under the same `Co-authored-by:` trailer.
+
 Contributions that do not adhere to these guidelines will be rejected. We align with [GitHub Acceptable Use Policies](https://docs.github.com/en/site-policy/acceptable-use-policies).
 
 ## Issues

--- a/docs/contributor/ci-cd.mdx
+++ b/docs/contributor/ci-cd.mdx
@@ -65,7 +65,7 @@ published.
 | Docker → Webapp, Agent: Pi, Postgres (pg_partman), Tag unchanged images | Dockerfile images; aliases for unchanged ones | — |
 | Supported-host boot smoke | `docker/self-host/setup.sh`, then PostgreSQL, NATS and the application server from this run's own images, waiting for the application to report healthy | — |
 | Actionlint, Zizmor | workflow lint with ShellCheck warnings; Zizmor at medium confidence | — |
-| PR → Verify commit identity | every commit's primary author resolves to a GitHub account, and that account is the pull request's author; a `Bot` author is matched against its `[bot]` account | — |
+| PR → Verify commit identity | every commit's primary author resolves to a GitHub account, and that account is the pull request's author; a `Bot` author is matched against its `[bot]` account; no commit message or the pull request body names a model, agent, harness or tool | — |
 
 The four quality legs are one matrix job, one entry per leg of the task graph. Each runs
 `vp run ci:<leg>`, then pipes `vp run --last-details` through `scripts/report-task-run.ts`: every

--- a/scripts/lib/model-attribution.ts
+++ b/scripts/lib/model-attribution.ts
@@ -1,0 +1,48 @@
+/**
+ * Marks left by an AI coding tool that signed its own commit, trailer or pull request
+ * description — never a human co-author, who is welcome under the same `Co-authored-by:`
+ * trailer. `AGENTS.md` § Pull requests forbids all of these; `pull-request.yml`'s
+ * `verify-commit-identity` job refuses them on every commit message and the pull request
+ * body, and `verify-changesets.ts` refuses the `Claude-Session` shape in a changeset summary.
+ *
+ * The workflow step has no checkout (`docs/contributor/ci-cd.mdx` explains why), so it cannot
+ * import this module; its inline patterns are hand-kept equal to the ones below, which is what
+ * `scripts/model-attribution.test.ts` exists to pin down.
+ */
+
+const TOOL_NAMES = [
+	"claude",
+	"codex",
+	"copilot",
+	"gpt",
+	"openai",
+	"anthropic",
+	"gemini",
+	"cursor",
+	"noreply@anthropic\\.com",
+] as const;
+
+export type AttributionPattern = {
+	readonly name: string;
+	readonly pattern: RegExp;
+};
+
+/** `Co-authored-by:` naming a model or tool; a human co-author never matches this. */
+export const COAUTHOR_PATTERN = new RegExp(
+	String.raw`^co-authored-by:.*(?:${TOOL_NAMES.join("|")})`,
+	"im",
+);
+
+/** The trailer Claude Code writes to record its own session; `verify-changesets.ts` reuses it. */
+export const CLAUDE_SESSION_PATTERN = /^claude-session:/im;
+
+export const MODEL_ATTRIBUTION_PATTERNS: readonly AttributionPattern[] = [
+	{ name: "a Co-Authored-By trailer naming a model or tool", pattern: COAUTHOR_PATTERN },
+	{ name: "a Claude-Session trailer", pattern: CLAUDE_SESSION_PATTERN },
+	{ name: 'a "Generated with" marker', pattern: /generated with/i },
+	{ name: "a claude.ai/code or session link", pattern: /claude\.ai\/(?:code|session)/i },
+];
+
+/** The names of every pattern in `text`, or an empty array when none match. */
+export const findModelAttribution = (text: string): readonly string[] =>
+	MODEL_ATTRIBUTION_PATTERNS.filter(({ pattern }) => pattern.test(text)).map(({ name }) => name);

--- a/scripts/model-attribution.test.ts
+++ b/scripts/model-attribution.test.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { findModelAttribution, MODEL_ATTRIBUTION_PATTERNS } from "./lib/model-attribution.ts";
+
+void test("catches every attribution pattern", () => {
+	assert.deepEqual(
+		findModelAttribution("Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>"),
+		["a Co-Authored-By trailer naming a model or tool"],
+	);
+	assert.deepEqual(findModelAttribution("Co-authored-by: gpt-5 <bot@example.com>"), [
+		"a Co-Authored-By trailer naming a model or tool",
+	]);
+	assert.deepEqual(
+		findModelAttribution("Claude-Session: https://claude.ai/code/session_01GZzUtPvAhEnBHsxqWTaRHn"),
+		["a Claude-Session trailer", "a claude.ai/code or session link"],
+	);
+	assert.deepEqual(
+		findModelAttribution("🤖 Generated with [Claude Code](https://claude.com/claude-code)"),
+		['a "Generated with" marker'],
+	);
+	assert.deepEqual(
+		findModelAttribution("See https://claude.ai/code/session_abc for the transcript."),
+		["a claude.ai/code or session link"],
+	);
+});
+
+void test("leaves a human Co-authored-by trailer alone", () => {
+	assert.deepEqual(findModelAttribution("Co-authored-by: Jane Doe <jane@example.com>"), []);
+	assert.deepEqual(
+		findModelAttribution("Fixes the flaky test.\n\nCo-authored-by: Jane Doe <jane@example.com>"),
+		[],
+	);
+});
+
+void test("every pattern has a name unique enough to report on its own", () => {
+	const names = MODEL_ATTRIBUTION_PATTERNS.map(({ name }) => name);
+	assert.equal(new Set(names).size, names.length);
+});

--- a/scripts/verify-changesets.ts
+++ b/scripts/verify-changesets.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { basename } from "node:path";
 
 import { asArray, asRecord, asString, readJsonFile } from "./lib/json.ts";
+import { CLAUDE_SESSION_PATTERN } from "./lib/model-attribution.ts";
 
 const changesetEntries = (status: unknown): Map<string, Record<string, unknown>> => {
 	const entries = asArray(
@@ -61,7 +62,10 @@ export const verifyChangesets = (
 					: `${file}: a release changeset needs a user- or operator-facing summary`,
 			);
 		}
-		if (/^(?:Co-authored-by|Claude-Session):/im.test(summary)) {
+		// A changeset summary is a release note: it carries no trailer at all, not even a human
+		// co-author's, so `Co-authored-by:` is refused outright rather than only the model-named
+		// shape `scripts/lib/model-attribution.ts` matches.
+		if (/^co-authored-by:/im.test(summary) || CLAUDE_SESSION_PATTERN.test(summary)) {
 			throw new Error(
 				`${file}: release notes must not contain Co-authored-by or Claude-Session metadata`,
 			);


### PR DESCRIPTION
## Problem

`AGENTS.md` forbids model, agent, harness or tool attribution in a commit or a pull request body, and `.changeset/README.md` already refuses `Co-authored-by`/`Claude-Session` in a changeset summary, but nothing checked a commit message or a pull request body. Two pull requests landed with a `Co-Authored-By` trailer naming a model, a `Claude-Session` trailer, and a "Generated with" marker plus a session link in the body.

## Fix

The `verify-commit-identity` job in `pull-request.yml` gains a second check, in the same shape as the existing identity check: it scans every commit's message and the pull request body for a `Co-Authored-By` trailer naming a model or tool (`claude`, `codex`, `copilot`, `gpt`, `openai`, `anthropic`, `gemini`, `cursor`, `noreply@anthropic.com`), a `Claude-Session` trailer, a "Generated with" marker, or a `claude.ai/code`/session link, and leaves a sticky comment naming the offenders with the rebase that clears them. A human co-author stays welcome under the same trailer.

The pattern list lives in one home, `scripts/lib/model-attribution.ts`; the workflow step has no checkout (kept that way — see its `pull_request_target` annotation) so it cannot import the module and instead keeps an equal inline copy, which `scripts/model-attribution.test.ts` pins down pattern by pattern plus a human `Co-authored-by` negative case. `scripts/verify-changesets.ts` reuses the shared `Claude-Session` pattern instead of keeping its own copy.

`CONTRIBUTING.md` § Compliance states the rule once, pointing at `AGENTS.md`, and the `ci-cd.mdx` quality-gates table row for `Verify commit identity` names the new check.

## Verification

- `pnpm exec vp run check` — exit 0 (41 tasks)
- `node --test scripts/model-attribution.test.ts scripts/verify-changesets.test.ts scripts/ci-contract.test.ts` — 62 pass, 0 fail
- `actionlint 1.7.7` on `.github/workflows/pull-request.yml` — exit 0
- `zizmor 1.29.0 --min-confidence medium` on the same file — "No findings to report", the `pull_request_target` annotation intact
- `vp run docs:lint` — exit 0

## Release impact

No changeset. Repository tooling and a workflow, no shipped code.

Part of #1608