### PR TITLE
fix(scripts): a host following commits rebuilds its database image when main does

### DIFF
--- a/.changeset/database-stays-up-across-staging-applies.md
+++ b/.changeset/database-stays-up-across-staging-applies.md
@@ -5,6 +5,8 @@
 A host that follows the default branch no longer restarts its database on every apply. The
 PostgreSQL image is rebuilt for every commit, so each apply used to bring the database container
 back up under a new image, dropping every connection for minutes, failing the practice reviews in
-flight and answering 503 meanwhile. The host now keeps the PostgreSQL image it runs until a commit
-changes what that image is built from; a release still applies exactly the images it was signed
-with.
+flight and answering 503 meanwhile. The host now carries the PostgreSQL image it runs across
+applies. It takes the commit's image when that commit changes what the image is built from, and
+otherwise on the first apply of a new day, so the security updates the rebuild carries still reach
+the host within a day. Promote with **refresh-database-image** to take a commit's image at once. A
+release still applies exactly the images it was signed with.

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -31,6 +31,10 @@ on:
         description: Hold the environment where it is and ignore this release
         type: boolean
         default: false
+      refresh-database-image:
+        description: Recreate the database on the commit's PostgreSQL image instead of the carried one
+        type: boolean
+        default: false
 permissions: {}
 
 concurrency:
@@ -115,6 +119,7 @@ jobs:
           COMMIT: ${{ inputs.commit }}
           ALLOW_ROLLBACK: ${{ inputs.allow-rollback || false }}
           FREEZE: ${{ inputs.freeze || false }}
+          REFRESH_DATABASE_IMAGE: ${{ inputs.refresh-database-image || false }}
           HOSTNAME: ${{ vars.APP_HOSTNAME }}
         run: node scripts/resolve-promotion.ts
 

--- a/docs/admin/pull-based-deployment.mdx
+++ b/docs/admin/pull-based-deployment.mdx
@@ -33,9 +33,10 @@ do not order manual transitions between releases and commits; choose those targe
 | `freeze` | holds the environment where it is, for an incident |
 
 Staging can follow successful builds of `main` instead of releases. Its channel names a full
-`commit` SHA instead of `release`, plus an `images` map of digest-pinned references. The promotion
-workflow verifies first-party image provenance against that source commit before signing the channel.
-Upstream image pins come from that commit's inventory.
+`commit` SHA instead of `release`, plus an `images` map of digest-pinned references and a
+`refreshDatabaseImage` flag (see [What restarts the database](#what-restarts-the-database)). The
+promotion workflow verifies first-party image provenance against that source commit before signing
+the channel. Upstream image pins come from that commit's inventory.
 
 Automatic promotions check the latest channel while holding the promotion lock. A frozen channel,
 an already-promoted commit, or an older completed build leaves the channel unchanged, including
@@ -157,6 +158,7 @@ ingress, omit `proxy` and use `core app`.
 | Hold an environment | Promote with **freeze** |
 | Resume a held environment | Manually promote the desired release or commit with **freeze** cleared |
 | Reapply Compose configuration | Promote the release or commit the host already runs |
+| Move a following host onto the commit's database image | Promote the commit with **refresh-database-image** |
 | Prevent new reconciliation runs | `sudo systemctl disable --now hephaestus-reconcile.timer` |
 | See what a host runs | `cat /var/lib/hephaestus/applied.json` |
 
@@ -173,12 +175,25 @@ The reconciler refuses a release checkout with modified tracked files.
 
 An apply recreates a container whose image or Compose definition changed, and recreating PostgreSQL
 drops every connection to it for as long as the application services take to stop and come back.
-Every commit of the default branch rebuilds the PostgreSQL image, so on a host following commits the
-reconciler keeps the PostgreSQL image it already runs and applies the rest of the channel; the
-database restarts only when the commit changes what that image is built from (`docker/postgres/`),
-when the `postgres` service in `docker/compose.app.yaml` changes, or when the host has no record of
-the image it runs. A release is applied exactly as its signed lock names it, so a release that
-rebuilt the image restarts the database.
+Every commit of the default branch rebuilds the PostgreSQL image — the rebuild is what carries
+Debian's security updates into it — so a host following commits is offered a new digest on every
+apply. Taking each one would restart the database several times a day, so the reconciler keeps the
+image it already runs and applies the rest of the channel.
+
+On such a host the database restarts when:
+
+- the commit changes what the image is built from — `docker/postgres/`, or the workflows that build
+  it;
+- the first commit of a later day is applied, so the security updates in that day's rebuild land
+  within a day of the push that built them;
+- the `postgres` service in `docker/compose.app.yaml` changes;
+- the host has no usable record of the image it runs — no applied commit, no lock for it, or a
+  checkout that cannot resolve the two commits;
+- you promote with **refresh-database-image**, which takes that commit's image once. The next
+  automatic promotion goes back to carrying it.
+
+A release is applied exactly as its signed lock names it, so a release that rebuilt the image
+restarts the database.
 
 ## Watching it
 

--- a/docs/decisions/0042-hosts-pull-their-own-releases.md
+++ b/docs/decisions/0042-hosts-pull-their-own-releases.md
@@ -104,14 +104,13 @@ it. Rootless Podman with Quadlet would close the remaining gap and is not attemp
 
 An operator must disable the timer before hand-patching a host, or the next tick reverts the fix.
 
-A host following commits does not move its database image on every apply. Every commit rebuilds the
-PostgreSQL image, so the channel pins a new digest for it each time and applying that would recreate
-the container and drop every connection to it; the host keeps the digest it last applied while
-`docker/postgres` is unchanged between the applied commit and the one being applied. That digest was
-named and signed by the channel that first applied it, so nothing runs that a channel signature never
-covered — but for that one image the `deploy-state` history records what a host was offered rather
-than what it runs, and the host's own lock under `release-locks/` is what says which. Releases are
-unaffected: a release is applied exactly as its signed lock names it.
+A host following commits carries its database image forward rather than applying the new digest
+every channel names for it, because recreating that container drops every connection to it. The
+digest it keeps was named and signed by the channel that first applied it, so nothing runs that a
+channel signature never covered — but for that one image the `deploy-state` history records what a
+host was offered rather than what it runs, and the host's own lock under `release-locks/` is what
+says which. Releases are unaffected: a release is applied exactly as its signed lock names it.
+`docs/admin/pull-based-deployment.mdx` § What restarts the database has the rule the host applies.
 
 Preview environments are unaffected. They are ephemeral, per-pull-request, and managed by Coolify on
 the staging host; the reconciler owns only the Compose projects it is configured for, so the two

--- a/scripts/reconcile-deployment.test.ts
+++ b/scripts/reconcile-deployment.test.ts
@@ -1,12 +1,15 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
 import { mkdir, mkdtemp, readFile, readlink, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "node:test";
 
+import { parseDocument } from "yaml";
+
 import { environmentForGitFixture, GIT_REPOSITORY_VARIABLES } from "./lib/git-environment.ts";
-import { parseJson } from "./lib/json.ts";
+import { at, parseJson } from "./lib/json.ts";
 import {
 	adoptTooling,
 	appliedCommit,
@@ -212,6 +215,7 @@ await test("a channel may follow the default branch by naming a commit and what 
 		images,
 		allowRollback: false,
 		freeze: false,
+		refreshDatabaseImage: false,
 	});
 });
 
@@ -277,12 +281,10 @@ await test("an environment following the branch reports the commit it runs", () 
 	assert.ok(rendered.endsWith("\n"));
 });
 
-await test("a host following commits moves its database only when the image's inputs did", () => {
-	// Every commit of the default branch rebuilds the PostgreSQL image, so two consecutive channels
-	// name two digests for it; Compose recreates a container whose image changed, and the database
-	// coming back means every connection pool and review in flight is lost.
-	const running = `ghcr.io/o/postgres@sha256:${"a".repeat(64)}`;
-	const rebuilt = `ghcr.io/o/postgres@sha256:${"b".repeat(64)}`;
+const running = `ghcr.io/o/postgres@sha256:${"a".repeat(64)}`;
+const rebuilt = `ghcr.io/o/postgres@sha256:${"b".repeat(64)}`;
+
+await test("a host following commits keeps the database pin it applied until the image is rebuilt", () => {
 	const channel = { ...images, HEPHAESTUS_IMAGE_POSTGRES: rebuilt };
 	const appliedLock = commitLockEnvironment("d".repeat(40), {
 		...images,
@@ -294,8 +296,6 @@ await test("a host following commits moves its database only when the image's in
 	// with the same pin — and the same Compose configuration — as before.
 	assert.deepEqual(unlockedImages([running], commitLockEnvironment(commit, kept)), []);
 
-	// A change under the image's inputs is applied, and so is the channel's pin on a host that has
-	// no record of what it ran, or one whose record is not a digest.
 	assert.deepEqual(carryPostgresImage(channel, appliedLock, true), channel);
 	assert.deepEqual(carryPostgresImage(channel, undefined, false), channel);
 	assert.deepEqual(
@@ -315,56 +315,85 @@ await test("a host following commits moves its database only when the image's in
 		),
 		{ ...images, HEPHAESTUS_IMAGE_POSTGRES: `ghcr.io/elsewhere/postgres@sha256:${"b".repeat(64)}` },
 	);
+	// A lock a host wrote with CRLF line endings still names the pin it wrote.
+	assert.deepEqual(carryPostgresImage(channel, `HEPHAESTUS_IMAGE_POSTGRES=${running}\r\n`, false), {
+		...images,
+		HEPHAESTUS_IMAGE_POSTGRES: running,
+	});
 });
 
-await test("the database image is kept while git says its tree stands still", async () => {
+await test("the `postgres` service takes the carried pin and nothing else the commit decides", () => {
+	// Carrying one lock value only leaves the container alone if that value is the whole of what the
+	// commit puts into the service; a label or an environment entry rendered from the lock would
+	// recreate it anyway.
+	const stack: unknown = parseDocument(readFileSync("docker/compose.app.yaml", "utf8")).toJS();
+	const service = at(stack, ["services", "postgres"], "docker/compose.app.yaml");
+	// `$$` is Compose's escape for a literal `$`, so only a single one interpolates.
+	const interpolated = new Set(
+		[...JSON.stringify(service).matchAll(/(?<!\$)\$\{(\w+)/g)].map(([, name]) => name),
+	);
+	assert.deepEqual([...interpolated], ["HEPHAESTUS_IMAGE_POSTGRES"]);
+});
+
+await test("the database image is kept while git says nothing rebuilt it that day", async () => {
 	const directory = await mkdtemp(join(tmpdir(), "reconcile-images-"));
 	try {
 		const checkout = join(directory, "checkout");
 		await mkdir(join(checkout, "docker", "postgres"), { recursive: true });
-		const git = (...args: string[]): string =>
+		await mkdir(join(checkout, ".github", "workflows"), { recursive: true });
+		const git = (date: string, ...args: string[]): string =>
 			execFileSync("git", args, {
 				cwd: checkout,
 				encoding: "utf8",
-				env: environmentForGitFixture(),
+				env: environmentForGitFixture({ GIT_AUTHOR_DATE: date, GIT_COMMITTER_DATE: date }),
 			}).trim();
-		git("init", "--quiet", "--initial-branch=main");
-		git("config", "user.email", "host@example.invalid");
-		git("config", "user.name", "host");
-		const commitAll = (message: string): string => {
-			git("add", "--all");
-			git("commit", "--quiet", "-m", message);
-			return git("rev-parse", "HEAD");
+		const day = "2026-09-03T12:00:00+0000";
+		git(day, "init", "--quiet", "--initial-branch=main");
+		git(day, "config", "user.email", "host@example.invalid");
+		git(day, "config", "user.name", "host");
+		const commitAll = (message: string, date = day): string => {
+			git(date, "add", "--all");
+			git(date, "commit", "--quiet", "-m", message);
+			return git(date, "rev-parse", "HEAD");
 		};
 		const dockerfile = join(checkout, "docker", "postgres", "Dockerfile");
+		const buildWorkflow = join(checkout, ".github", "workflows", "reusable-docker-build.yml");
 		await writeFile(dockerfile, "FROM postgres:18\n");
+		await writeFile(buildWorkflow, "on: workflow_call\n");
 		await writeFile(join(checkout, "compose.yaml"), "services: {}\n");
 		const first = commitAll("first");
 		await writeFile(join(checkout, "compose.yaml"), "services: {app: {}}\n");
 		const unrelated = commitAll("a commit that leaves the image alone");
+		await writeFile(join(checkout, "compose.yaml"), "services: {app: {ports: []}}\n");
+		const nextDay = commitAll("the first commit of the next day", "2026-09-04T09:00:00+0000");
 		await writeFile(dockerfile, "FROM postgres:19\n");
 		const rebuild = commitAll("a commit that rebuilds the image");
+		await writeFile(buildWorkflow, "on: workflow_call\n# and a build argument\n");
+		const rebuiltByWorkflow = commitAll("a commit that changes how the image is built");
 
-		const running = `ghcr.io/o/postgres@sha256:${"a".repeat(64)}`;
-		const channel = {
-			...images,
-			HEPHAESTUS_IMAGE_POSTGRES: `ghcr.io/o/postgres@sha256:${"b".repeat(64)}`,
-		};
+		const channel = { ...images, HEPHAESTUS_IMAGE_POSTGRES: rebuilt };
+		const carried = { ...images, HEPHAESTUS_IMAGE_POSTGRES: running };
 		const lockDirectory = join(directory, "release-locks");
 		await mkdir(lockDirectory);
-		await writeFile(
-			join(lockDirectory, `${first}.env`),
-			commitLockEnvironment(first, { ...images, HEPHAESTUS_IMAGE_POSTGRES: running }),
-		);
+		await writeFile(join(lockDirectory, `${first}.env`), commitLockEnvironment(first, carried));
 		const ran = { release: first, channelCommit: "e".repeat(40), appliedAt: applied.appliedAt };
 
-		assert.deepEqual(await commitImages(checkout, lockDirectory, ran, unrelated, channel), {
-			...images,
-			HEPHAESTUS_IMAGE_POSTGRES: running,
-		});
-		// The image's tree moved, so the channel's pin is applied — and so it is when the host cannot
-		// order the two commits at all, or has never applied anything.
+		assert.deepEqual(await commitImages(checkout, lockDirectory, ran, unrelated, channel), carried);
+		// CI rebuilds the image for either tree, so a host that watched only one would run neither
+		// rebuild; the day after, it takes the rebuild every push earns whatever the diff says.
 		assert.deepEqual(await commitImages(checkout, lockDirectory, ran, rebuild, channel), channel);
+		assert.deepEqual(
+			await commitImages(checkout, lockDirectory, ran, rebuiltByWorkflow, channel),
+			channel,
+		);
+		assert.deepEqual(await commitImages(checkout, lockDirectory, ran, nextDay, channel), channel);
+		// The operator asked for the channel's pin, so the day and the diff decide nothing.
+		assert.deepEqual(
+			await commitImages(checkout, lockDirectory, ran, unrelated, channel, true),
+			channel,
+		);
+		// The channel's pin is applied when the host cannot order the two commits at all, or has
+		// never applied anything.
 		assert.deepEqual(
 			await commitImages(checkout, lockDirectory, ran, "f".repeat(40), channel),
 			channel,

--- a/scripts/reconcile-deployment.ts
+++ b/scripts/reconcile-deployment.ts
@@ -50,6 +50,8 @@ export interface Channel {
 	images?: Readonly<Record<string, string>>;
 	allowRollback?: boolean;
 	freeze?: boolean;
+	/** Take this channel's PostgreSQL pin now instead of the one the host carries. */
+	refreshDatabaseImage?: boolean;
 }
 
 export interface AppliedState {
@@ -99,6 +101,10 @@ export function parseChannel(value: unknown): Channel {
 	const record = asRecord(value, "channel");
 	const allowRollback = optionalBoolean(record.allowRollback, "channel.allowRollback");
 	const freeze = optionalBoolean(record.freeze, "channel.freeze");
+	const refreshDatabaseImage = optionalBoolean(
+		record.refreshDatabaseImage,
+		"channel.refreshDatabaseImage",
+	);
 
 	if (record.commit !== undefined) {
 		if (record.release !== undefined)
@@ -106,7 +112,13 @@ export function parseChannel(value: unknown): Channel {
 		const commit = asString(record.commit, "channel.commit");
 		if (!isCommit(commit))
 			throw new Error(`channel.commit must be a full 40-character commit, not ${commit}`);
-		return { release: commit, images: parseImages(record.images), allowRollback, freeze };
+		return {
+			release: commit,
+			images: parseImages(record.images),
+			allowRollback,
+			freeze,
+			refreshDatabaseImage,
+		};
 	}
 
 	const release = asString(record.release, "channel.release");
@@ -118,8 +130,15 @@ export function parseChannel(value: unknown): Channel {
 /** The channel file the promotion signs, in the shape `parseChannel` reads back. */
 export function serializeChannel(channel: Channel): string {
 	const { release, images, allowRollback = false, freeze = false } = channel;
+	// Only a commit channel carries an image pin, so only it can be asked to stop carrying one.
 	const record = images
-		? { commit: release, images, allowRollback, freeze }
+		? {
+				commit: release,
+				images,
+				allowRollback,
+				freeze,
+				refreshDatabaseImage: channel.refreshDatabaseImage ?? false,
+			}
 		: { release, allowRollback, freeze };
 	return `${JSON.stringify(record, null, "\t")}\n`;
 }
@@ -265,7 +284,7 @@ function lockValues(lockEnv: string, key: string): string[] {
 	return lockEnv
 		.split("\n")
 		.filter((line) => line.startsWith(`${key}=`))
-		.map((line) => line.slice(key.length + 1));
+		.map((line) => line.slice(key.length + 1).trim());
 }
 
 export function lockedReleaseCommit(lockEnv: string): string {
@@ -277,27 +296,32 @@ export function lockedReleaseCommit(lockEnv: string): string {
 
 const POSTGRES_IMAGE = "HEPHAESTUS_IMAGE_POSTGRES";
 
-/** The PostgreSQL image's build context and Dockerfile; CI's `postgres-image` filter is that tree. */
-export const POSTGRES_IMAGE_INPUTS = "docker/postgres";
+/**
+ * The paths whose change makes CI rebuild the PostgreSQL image, as `cicd.yml` names them; one test
+ * holds the two lists together. CI rebuilds on more than these — see `commitImages`.
+ */
+export const POSTGRES_IMAGE_INPUTS = [
+	"docker/postgres/**",
+	".github/workflows/ci-docker-build.yml",
+	".github/workflows/reusable-docker-build.yml",
+] as const;
 
 /**
  * The images a commit channel runs on this host: the channel's, except that PostgreSQL stays at the
- * pin the host last applied while the image's own inputs are unchanged.
+ * pin the host last applied unless `rebuilt` says to take the channel's.
  *
- * Every push to the default branch rebuilds the PostgreSQL image — `docker/postgres/Dockerfile` says
- * why — so a commit channel names a new digest for it on every commit. Compose recreates a container
- * whose image changed, and a recreated database drops every connection pool and kills the reviews in
- * flight. A host following commits therefore moves PostgreSQL only when what it is built from moved.
- * A release is applied as signed: its lock is the artifact its evidence describes, and a rebuilt
- * image is part of it.
+ * A commit channel names a new PostgreSQL digest on every commit — `docker/postgres/Dockerfile` says
+ * why the image is rebuilt that often — and Compose recreates a container whose image changed, which
+ * drops every connection pool and kills the practice reviews in flight. A release is applied as
+ * signed: its lock is the artifact its evidence describes, so this never touches one.
  */
 export function carryPostgresImage(
 	images: Readonly<Record<string, string>>,
 	appliedLockEnv: string | undefined,
-	inputsChanged: boolean,
+	rebuilt: boolean,
 ): Readonly<Record<string, string>> {
 	const pinned = images[POSTGRES_IMAGE];
-	if (inputsChanged || appliedLockEnv === undefined || pinned === undefined) return images;
+	if (rebuilt || appliedLockEnv === undefined || pinned === undefined) return images;
 	const [kept, ...rest] = lockValues(appliedLockEnv, POSTGRES_IMAGE);
 	if (kept === undefined || rest.length > 0 || !IMAGE_DIGEST.test(kept)) return images;
 	// The digest is kept, never the repository it sits in: a channel naming the image somewhere else
@@ -561,6 +585,7 @@ async function main(): Promise<void> {
 			applied,
 			releaseCommit,
 			channel.images,
+			channel.refreshDatabaseImage,
 		);
 		await writeFile(lockFile, commitLockEnvironment(decision.release, images), { mode: 0o600 });
 	} else {
@@ -665,10 +690,44 @@ async function main(): Promise<void> {
 	await followTooling(config, releaseTree);
 }
 
+const DAY_SECONDS = 24 * 60 * 60;
+
+/**
+ * Whether the two commits carry committer dates in the same UTC day. Bucketing the commits rather
+ * than reading a clock keeps the answer the same on every tick and on every host, so a run that is
+ * retried does not decide differently from the one before it. A commit the checkout does not have
+ * answers no, which is the direction that applies the channel.
+ */
+async function sameDay(checkout: string, previous: string, target: string): Promise<boolean> {
+	let stamps: number[];
+	try {
+		stamps = (
+			await output("git", ["show", "--no-patch", "--format=%ct", previous, target], {
+				cwd: checkout,
+			})
+		)
+			.trim()
+			.split("\n")
+			.map(Number);
+	} catch {
+		return false;
+	}
+	const [before, after] = stamps;
+	if (stamps.length !== 2 || before === undefined || after === undefined) return false;
+	if (!Number.isSafeInteger(before) || !Number.isSafeInteger(after)) return false;
+	return Math.floor(before / DAY_SECONDS) === Math.floor(after / DAY_SECONDS);
+}
+
 /**
  * `carryPostgresImage` with what this host knows: the lock it wrote for the applied release, which
- * is its own record of the pins it verified and ran, and git's word on whether the PostgreSQL
- * image's inputs changed between the applied commit and the one being applied.
+ * is its own record of the pins it verified and ran, and git's word on the two commits.
+ *
+ * CI rebuilds the PostgreSQL image whenever `POSTGRES_IMAGE_INPUTS` changed, and on top of that
+ * unconditionally for every push to the default branch. The host takes the first rebuild the commit
+ * it is applying earned, and the unconditional one once a day rather than on every apply — so the
+ * `apt-get upgrade` the image exists to run reaches a following host within a day of the push that
+ * built it, instead of the host freezing on one digest between changes to the image's own tree.
+ * `refresh` is the operator asking for the channel's pin before either of those says so.
  */
 export async function commitImages(
 	checkout: string,
@@ -676,8 +735,9 @@ export async function commitImages(
 	applied: AppliedState | undefined,
 	releaseCommit: string,
 	images: Readonly<Record<string, string>>,
+	refresh = false,
 ): Promise<Readonly<Record<string, string>>> {
-	if (applied === undefined) return images;
+	if (applied === undefined || refresh) return images;
 	const previous = appliedCommit(applied);
 	if (previous === undefined) return images;
 	let appliedLockEnv: string | undefined;
@@ -686,15 +746,16 @@ export async function commitImages(
 	} catch (error) {
 		if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) throw error;
 	}
-	// `--quiet` exits 0 only when nothing under the path differs. A commit the checkout does not have
+	// `--quiet` exits 0 only when nothing under the paths differs. A commit the checkout does not have
 	// fails it too, and that reads as changed: when the host cannot tell, it runs what the channel
 	// names rather than keep an image on a guess.
 	const unchanged = await succeeds(
 		"git",
-		["diff", "--quiet", previous, releaseCommit, "--", POSTGRES_IMAGE_INPUTS],
+		["diff", "--quiet", previous, releaseCommit, "--", ...POSTGRES_IMAGE_INPUTS],
 		{ cwd: checkout },
 	);
-	return carryPostgresImage(images, appliedLockEnv, !unchanged);
+	const rebuilt = !unchanged || !(await sameDay(checkout, previous, releaseCommit));
+	return carryPostgresImage(images, appliedLockEnv, rebuilt);
 }
 
 /**

--- a/scripts/release-deployment-policy.test.ts
+++ b/scripts/release-deployment-policy.test.ts
@@ -4,6 +4,7 @@ import { test } from "node:test";
 
 import { parseDocument } from "yaml";
 
+import { asArray, asRecord, asString, asStringArray, at } from "./lib/json.ts";
 import { releaseSignerIdentity, releaseSignerRepository } from "./lib/release-signer.ts";
 import { SMOKE_HOSTNAME } from "./prepare-host-smoke-env.ts";
 import { parseStacks, POSTGRES_IMAGE_INPUTS } from "./reconcile-deployment.ts";
@@ -154,14 +155,58 @@ await test("every promotion decision is taken by the script that owns it", () =>
 	assert.match(reconciler, /^if \(import\.meta\.main\) \{/m);
 });
 
-await test("the reconciler and CI agree on what the PostgreSQL image is built from", () => {
-	// A host keeps its database image while this tree is unchanged, so the tree it watches has to be
-	// the one CI treats as the image's own inputs; widening the filter without widening the constant
-	// would leave a rebuilt image unapplied.
-	const cicd = readFileSync(".github/workflows/cicd.yml", "utf8");
-	const filter = /^ +postgres-image:\n((?: +- .*\n)+)/m.exec(cicd)?.[1];
-	assert.ok(filter, "detect-changes must declare the postgres-image filter");
-	assert.equal(filter.trim(), `- '${POSTGRES_IMAGE_INPUTS}/**'`);
+function referenced(expression: string, pattern: RegExp): string[] {
+	return [...expression.matchAll(pattern)].flatMap(([, name]) =>
+		name === undefined ? [] : [name],
+	);
+}
+
+/**
+ * What makes `cicd.yml` rebuild the published PostgreSQL image, split into the path globs the change
+ * filters behind it name and the outputs that decide a rebuild without reading a diff at all.
+ */
+function postgresRebuildTriggers(): { paths: string[]; unconditional: string[] } {
+	const workflow: unknown = parseDocument(
+		readFileSync(".github/workflows/cicd.yml", "utf8"),
+	).toJS();
+	const detect = asRecord(at(workflow, ["jobs", "detect-changes"], "cicd.yml"), "detect-changes");
+	const outputs = asRecord(detect.outputs, "detect-changes.outputs");
+	const step = asArray(detect.steps, "detect-changes.steps")
+		.map((value, index) => asRecord(value, `detect-changes.steps[${index}]`))
+		.find((candidate) => candidate.id === "filter");
+	if (step === undefined) throw new Error("detect-changes declares no `filter` step");
+	// dorny/paths-filter takes its filters as YAML inside a string, so they parse in a second pass.
+	const filters = asRecord(
+		parseDocument(
+			asString(asRecord(step.with, "the filter step").filters, "the filter step's filters"),
+		).toJS(),
+		"the change filters",
+	);
+	const condition = asString(
+		at(workflow, ["jobs", "Docker", "with", "postgres_image_changed"], "cicd.yml"),
+		"Docker's postgres_image_changed input",
+	);
+
+	const paths = new Set<string>();
+	const unconditional = new Set<string>();
+	for (const name of referenced(condition, /needs\.detect-changes\.outputs\.([\w-]+)/g)) {
+		const expression = asString(outputs[name], `detect-changes.outputs.${name}`);
+		const behind = referenced(expression, /steps\.filter\.outputs\.([\w-]+)/g);
+		if (behind.length === 0) unconditional.add(name);
+		for (const filter of behind)
+			for (const glob of asStringArray(filters[filter], `the ${filter} filter`)) paths.add(glob);
+	}
+	return { paths: [...paths], unconditional: [...unconditional].toSorted() };
+}
+
+await test("a host following commits watches every path CI rebuilds the database image for", () => {
+	const { paths, unconditional } = postgresRebuildTriggers();
+	// A path CI rebuilds for that the host does not diff is a rebuilt image the host never applies.
+	assert.deepEqual([...paths].toSorted(), [...POSTGRES_IMAGE_INPUTS].toSorted());
+	// What is left decides a rebuild without reading the diff, so the host cannot answer it from the
+	// two commits; it takes those rebuilds on a day's cadence instead. A new entry here is a decision
+	// about `commitImages`, not a list to extend.
+	assert.deepEqual(unconditional, ["all-images"]);
 });
 
 await test("derives the canonical signer identity and refuses missing CI identity", () => {

--- a/scripts/resolve-promotion.test.ts
+++ b/scripts/resolve-promotion.test.ts
@@ -5,7 +5,7 @@ import { resolvePromotion, type PromotionSources } from "./resolve-promotion.ts"
 
 const commit = "a".repeat(40);
 const images = { HEPHAESTUS_IMAGE_WEBAPP: `ghcr.io/o/webapp@sha256:${"1".repeat(64)}` };
-const request = { allowRollback: false, freeze: false };
+const request = { allowRollback: false, freeze: false, refreshDatabaseImage: false };
 const never = (what: string) => (): Promise<never> =>
 	Promise.reject(new Error(`${what} must not be consulted`));
 const sources: PromotionSources = {
@@ -51,7 +51,16 @@ await test("a commit of the default branch is promoted with the digests its buil
 					images: (at) => Promise.resolve(at === commit ? images : {}),
 				},
 			),
-			{ channel: { release: commit, images, allowRollback: true, freeze: false }, version: commit },
+			{
+				channel: {
+					release: commit,
+					images,
+					allowRollback: true,
+					freeze: false,
+					refreshDatabaseImage: false,
+				},
+				version: commit,
+			},
 		);
 		assert.deepEqual(compared, [`${commit}...main`]);
 	}
@@ -86,4 +95,35 @@ await test("a promotion names exactly one target, and a commit is named whole", 
 			resolvePromotion({ ...request, commit: short }, sources),
 			/full commit SHA/,
 		);
+});
+
+await test("only a commit channel can be asked to take the database image it names", async () => {
+	assert.deepEqual(
+		await resolvePromotion(
+			{ ...request, commit, refreshDatabaseImage: true },
+			{
+				...sources,
+				compare: () => Promise.resolve("identical"),
+				images: () => Promise.resolve(images),
+			},
+		),
+		{
+			channel: {
+				release: commit,
+				images,
+				allowRollback: false,
+				freeze: false,
+				refreshDatabaseImage: true,
+			},
+			version: commit,
+		},
+	);
+	// A release runs the images its evidence describes, so it carries nothing to refresh.
+	await assert.rejects(
+		resolvePromotion(
+			{ ...request, release: "v1.2.3", refreshDatabaseImage: true },
+			{ ...sources, isDraft: () => Promise.resolve(false) },
+		),
+		/applies to a commit, not to a release/,
+	);
 });

--- a/scripts/resolve-promotion.ts
+++ b/scripts/resolve-promotion.ts
@@ -17,6 +17,7 @@ export interface PromotionRequest {
 	commit?: string;
 	allowRollback: boolean;
 	freeze: boolean;
+	refreshDatabaseImage: boolean;
 }
 
 export interface PromotionSources {
@@ -37,7 +38,7 @@ export async function resolvePromotion(
 	request: PromotionRequest,
 	sources: PromotionSources,
 ): Promise<Promotion> {
-	const { release, commit, allowRollback, freeze } = request;
+	const { release, commit, allowRollback, freeze, refreshDatabaseImage } = request;
 	if (commit !== undefined) {
 		if (release !== undefined) throw new Error("Name a release or a commit, not both");
 		if (!isCommit(commit)) throw new Error(`Follow a full commit SHA, not '${commit}'`);
@@ -46,9 +47,15 @@ export async function resolvePromotion(
 		if (status !== "identical" && status !== "ahead")
 			throw new Error(`${commit} is not on the default branch`);
 		const images = await sources.images(commit);
-		return { channel: { release: commit, images, allowRollback, freeze }, version: commit };
+		return {
+			channel: { release: commit, images, allowRollback, freeze, refreshDatabaseImage },
+			version: commit,
+		};
 	}
 	if (release === undefined) throw new Error("Name a release or a commit");
+	// A release runs the images its evidence describes, so there is no carried pin to refresh.
+	if (refreshDatabaseImage)
+		throw new Error("refresh-database-image applies to a commit, not to a release");
 	if (!RELEASE_TAG.test(release))
 		throw new Error(`Promote an immutable vX.Y.Z release, not '${release}'`);
 	// The host binds the tag's source tree to the signed release lock before applying it.
@@ -72,6 +79,7 @@ if (import.meta.main) {
 			commit: optional("COMMIT"),
 			allowRollback: process.env.ALLOW_ROLLBACK === "true",
 			freeze: process.env.FREEZE === "true",
+			refreshDatabaseImage: process.env.REFRESH_DATABASE_IMAGE === "true",
 		},
 		{
 			compare: (base, head) => compareStatus(repository, base, head),


### PR DESCRIPTION
## What changed and why

A host that follows the default branch carried its PostgreSQL pin for as long as `docker/postgres/**`
was unchanged between the applied commit and the one being applied. That is not what makes CI publish
a new PostgreSQL image. `cicd.yml` passes `postgres_image_changed` to the `Docker` workflow as
`postgres-image || docker-config || all-images`, and `all-images` is true for every push to `main`,
so the image is rebuilt and republished on every commit whatever the diff says.

Two consequences, both real on `main` today:

- A commit-following host froze on one digest indefinitely. `docker/postgres/Dockerfile` runs
  `apt-get upgrade` for a stated reason — closing the window between a Debian security publication
  and the next upstream rebuild — and that upgrade stopped reaching staging until someone changed
  the image's own tree.
- A rebuild triggered by `docker-config` (`ci-docker-build.yml`, `reusable-docker-build.yml`) was
  published, pinned by the channel, and then discarded by the host, with nothing to say so.

The carry now uses the rule CI uses.

- `POSTGRES_IMAGE_INPUTS` is the set of path globs behind CI's own `postgres_image_changed`, and the
  policy test derives that set from `cicd.yml` — the `Docker` job's input, the `detect-changes`
  outputs it names, and the `dorny/paths-filter` globs behind those — instead of pinning a filter's
  literal text. Renaming or reordering a glob does not fail it; a path CI rebuilds for that the host
  does not diff does. On `main` before this change it fails, which was the point.
- The one term CI decides without reading a diff — every push rebuilds — cannot be answered from two
  commits, so the host takes it on a day's cadence rather than on every apply: the first commit it
  applies from a later UTC day moves the image. The rebuild's security updates land within a day of
  the push that built them, and the database is recreated at most once a day instead of several
  times.
- Reverse state: promoting with **refresh-database-image** writes the flag into the signed channel
  and the host takes that commit's image at once. It is one-shot; the next automatic promotion goes
  back to carrying.

Also here: `lockValues` trims like the adjacent `unlockedImages`, so a `\r`-terminated lock no longer
falls back silently; the "every push rebuilds because the Dockerfile bakes the source commit into a
layer" rationale keeps its one home in `docker/postgres/Dockerfile`, with the reconciler, ADR 0042
and the admin page pointing at it.

Part of #1882.

## How to test

- `node --test scripts/reconcile-deployment.test.ts scripts/release-deployment-policy.test.ts scripts/resolve-promotion.test.ts`
- `vp run check` — full local quality gate, green.
- `actionlint .github/workflows/promote.yml` — clean. Zizmor was not available locally; the new
  `${{ }}` is an `env:` entry beside the existing `FREEZE`, not a `run:` interpolation.

Reverting any one of the three fix hunks — the widened input set, the day bound, or the operator
escape — fails `the database image is kept while git says nothing rebuilt it that day`. Reverting the
input set alone also fails the policy test.

## Release impact

`.changeset/database-stays-up-across-staging-applies.md`, still pending from the change this
corrects, is updated rather than duplicated: the release note now states the real rule and the
escape. No operator action is required — a host picks the new behaviour up with the tooling of the
release it applies.

## Notes for reviewers

**On #1882's first *Done when*.** It asks for a `scripts/` test that renders the app stack for two
locks and asserts the `postgres` service's rendered configuration is identical. Two locks differing
only in application digests render that service identically on `main` whatever this PR does — the
service interpolates exactly one value — so the literal test would be tautological, and
`test:tooling` also runs on the Windows quality leg, which should not need a container runtime.
The two tests here prove the same thing without one: `the postgres service takes the carried pin and
nothing else the commit decides` parses `docker/compose.app.yaml` and asserts the service's whole
interpolated set is `{HEPHAESTUS_IMAGE_POSTGRES}` — a label or environment entry rendered from the
lock would fail it — and the `commitImages` test asserts two consecutive commits get the same value
for it. Real Compose rendering stays in `ci-compose-validate.yml`. Hence `Part of #1882`, not
`Fixes`.

**Why not fix `SOURCE_COMMIT` instead.** Making the published digest stable across commits would
remove the divergence at its source, but the promotion path verifies each image's provenance with
`gh attestation verify --source-digest <commit>`, so an image whose attestation names an earlier
commit cannot be promoted. That is why CI aliases unchanged images only for previews.

**Surfaces walked.** Integrations, runtime roles, wire contract, schema, channels, both admin
consoles and UI states: not applicable — host tooling, no adapter, no bean, nothing over HTTP, no
entity, no component. Reverse states: the **refresh-database-image** escape. Docs by audience:
`docs/admin/` in operator voice, ADR 0042 for the decision. Release note: the pending changeset.
