### PR TITLE
fix(server): a review that read the change and found nothing is not a stale diff

### DIFF
--- a/.changeset/a-review-that-finds-nothing-still-counts.md
+++ b/.changeset/a-review-that-finds-nothing-still-counts.md
@@ -1,0 +1,8 @@
+---
+"hephaestus": patch
+---
+
+A review that reads a change and finds none of its practices in it is no longer thrown away. That
+outcome was treated as a sign that the review had been handed an empty change, so the whole review was
+refused and the developer's practice page kept no record of it. A review is only refused now when it
+never quoted the change at all.

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/handler/PullRequestReviewHandler.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/handler/PullRequestReviewHandler.java
@@ -356,21 +356,26 @@ public class PullRequestReviewHandler implements JobTypeHandler {
                         ? scanForSecrets(unifiedDiff)
                         : List.of();
 
-        // A run that decided nothing at all over a non-empty diff is the stale-diff signature. Both
-        // valence-free presences count here: an empty diff yields NOT_APPLICABLE, a truncated one yields
-        // INCONCLUSIVE, and the harness fault is identical either way.
+        // What is left to catch is a review that answered without reading the change. The file count
+        // above and the patch staged for the run are the same bytes — the evidence snapshot is built
+        // from the very map that becomes the sandbox's input files — so an empty patch cannot coexist
+        // with a non-empty file count, and a stale one is stale on both sides and invisible from here.
+        // A diff citation is the one thing that cannot be produced without the patch: the runner
+        // re-reads every citation out of the artifact it names (citationMatchesArtifact in
+        // pi-observation-normalize.ts) and rejects the observation when the quote is not there.
+        // Both valence-free presences count as deciding nothing — NOT_APPLICABLE and INCONCLUSIVE
+        // differ in what the run could tell, not in whether it settled anything.
         boolean nothingDecided =
                 parsed.validObservations().stream().noneMatch(f -> f.presence().carriesValence());
-        if (nothingDecided && secretObservations.isEmpty()) {
-            boolean hasDiffContent = !diffFiles.isEmpty();
-            if (hasDiffContent) {
-                throw new JobDeliveryException(
-                        "No observation decided anything (all NOT_APPLICABLE/INCONCLUSIVE) but the diff contains "
-                                + diffFiles.size()
-                                + " files — likely a stale/empty diff was provided to the agent. "
-                                + "Refusing to deliver. jobId="
-                                + job.getId());
-            }
+        if (nothingDecided
+                && secretObservations.isEmpty()
+                && !diffFiles.isEmpty()
+                && !readTheDiff(parsed.validObservations())) {
+            throw new JobDeliveryException("No observation decided anything or quoted the diff, and the diff contains "
+                    + diffFiles.size()
+                    + " files — the review answered without reading the change. "
+                    + "Refusing to deliver. jobId="
+                    + job.getId());
         }
 
         var scopedObservations = new ArrayList<>(filterByDiffScope(parsed.validObservations(), diffFiles));
@@ -584,6 +589,40 @@ public class PullRequestReviewHandler implements JobTypeHandler {
         }
         return paths;
     }
+
+    /**
+     * Whether any observation cites the pull request's own diff. The runner admits a citation only after
+     * finding its quote at the coordinates it names inside the staged artifact, so this is a report about
+     * bytes that were read rather than a claim the model makes about itself.
+     */
+    static boolean readTheDiff(List<PracticeDetectionResultParser.ValidatedObservation> observations) {
+        for (var observation : observations) {
+            JsonNode evidence = observation.evidence();
+            if (evidence == null) {
+                continue;
+            }
+            for (JsonNode citation : evidence.path("citations")) {
+                if (DIFF_SOURCE_KIND.equals(citation.path("sourceKind").asString())) {
+                    return true;
+                }
+            }
+            // A practice whose subject lives in the metadata rather than the code answers without a
+            // diff citation, and its warrant is where it names the diff among the sources it walked.
+            // The model writes that list, so it is weaker than a quote — which is why it only widens a
+            // refusal, and never stands in for the evidence an observation itself owes.
+            for (String warrant : List.of("search", "inapplicability", "undecidability")) {
+                for (JsonNode consulted : evidence.path(warrant).path("consulted")) {
+                    if (DIFF_SOURCE_KIND.equals(consulted.asString())) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    /** The staged artifact a review reads the change from. */
+    private static final String DIFF_SOURCE_KIND = "scm.pull-request.diff";
 
     static List<PracticeDetectionResultParser.ValidatedObservation> filterByDiffScope(
             List<PracticeDetectionResultParser.ValidatedObservation> observations, Set<String> diffFiles) {

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/handler/PullRequestReviewHandlerStaticMethodsTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/handler/PullRequestReviewHandlerStaticMethodsTest.java
@@ -19,6 +19,91 @@ class PullRequestReviewHandlerStaticMethodsTest extends BaseUnitTest {
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Nested
+    class ReadTheDiff {
+
+        private PracticeDetectionResultParser.ValidatedObservation observation(String sourceKind) {
+            ObjectNode evidence = objectMapper.createObjectNode();
+            ArrayNode citations = objectMapper.createArrayNode();
+            ObjectNode citation = objectMapper.createObjectNode();
+            citation.put("sourceKind", sourceKind);
+            citation.put("path", "src/Main.java");
+            citation.put("startLine", 1);
+            citations.add(citation);
+            evidence.set("citations", citations);
+            return new PracticeDetectionResultParser.ValidatedObservation(
+                    "ships-tests-with-the-change",
+                    "Nothing to say here",
+                    Presence.NOT_APPLICABLE,
+                    null,
+                    Severity.INFO,
+                    evidence,
+                    "The practice has no subject in this change.");
+        }
+
+        @Test
+        void aDiffCitationCountsAsHavingReadTheChange() {
+            assertThat(PullRequestReviewHandler.readTheDiff(List.of(observation("scm.pull-request.diff"))))
+                    .isTrue();
+        }
+
+        @Test
+        void citingOnlyOtherSourcesDoesNot() {
+            assertThat(PullRequestReviewHandler.readTheDiff(
+                            List.of(observation("scm.pull-request.core"), observation("scm.linked-work-items"))))
+                    .isFalse();
+        }
+
+        @Test
+        void namingTheDiffAmongTheSourcesItWalkedAlsoCounts() {
+            ObjectNode evidence = objectMapper.createObjectNode();
+            ArrayNode citations = objectMapper.createArrayNode();
+            ObjectNode citation = objectMapper.createObjectNode();
+            citation.put("sourceKind", "scm.pull-request.core");
+            citation.put("path", "metadata.json");
+            citation.put("startLine", 1);
+            citations.add(citation);
+            evidence.set("citations", citations);
+            ObjectNode inapplicability = objectMapper.createObjectNode();
+            ArrayNode consulted = objectMapper.createArrayNode();
+            consulted.add("scm.pull-request.core");
+            consulted.add("scm.pull-request.diff");
+            inapplicability.set("consulted", consulted);
+            evidence.set("inapplicability", inapplicability);
+            var observation = new PracticeDetectionResultParser.ValidatedObservation(
+                    "describe-what-and-why",
+                    "The change explains itself",
+                    Presence.NOT_APPLICABLE,
+                    null,
+                    Severity.INFO,
+                    evidence,
+                    "The practice has no subject in this change.");
+
+            assertThat(PullRequestReviewHandler.readTheDiff(List.of(observation)))
+                    .isTrue();
+        }
+
+        @Test
+        void noObservationAtAllDoesNot() {
+            assertThat(PullRequestReviewHandler.readTheDiff(List.of())).isFalse();
+        }
+
+        @Test
+        void anObservationCarryingNoEvidenceDoesNot() {
+            var withoutEvidence = new PracticeDetectionResultParser.ValidatedObservation(
+                    "ships-tests-with-the-change",
+                    "Nothing to say here",
+                    Presence.NOT_APPLICABLE,
+                    null,
+                    Severity.INFO,
+                    null,
+                    "The practice has no subject in this change.");
+
+            assertThat(PullRequestReviewHandler.readTheDiff(List.of(withoutEvidence)))
+                    .isFalse();
+        }
+    }
+
+    @Nested
     class FilterByDiffScope {
 
         private PracticeDetectionResultParser.ValidatedObservation makeObservation(

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/handler/PullRequestReviewHandlerTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/handler/PullRequestReviewHandlerTest.java
@@ -640,8 +640,46 @@ class PullRequestReviewHandlerTest extends BaseUnitTest {
 
             assertThatThrownBy(() -> admit(job, rawOutput))
                     .isInstanceOf(JobDeliveryException.class)
-                    .hasMessageContaining("stale/empty diff");
+                    .hasMessageContaining("answered without reading the change");
             verifyNoInteractions(deliveryService);
+        }
+
+        @Test
+        void admitsWhenNothingDecidedButAnObservationQuotesTheDiff() {
+            String rawOutput = """
+                {
+                  "observations": [{
+                    "practiceSlug": "pr-description-quality",
+                    "summary": "Not applicable here",
+                    "presence": "NOT_APPLICABLE",
+                    "evidenceRationale": "The practice has no subject in this change.",
+                    "evidence": {
+                      "citations": [{
+                        "sourceKind": "scm.pull-request.diff",
+                        "artifactPath": "inputs/context/diff.patch",
+                        "path": "Sources/Auth.swift",
+                        "side": "NEW",
+                        "startLine": 1,
+                        "endLine": 1,
+                        "quote": "+changed"
+                      }],
+                      "inapplicability": { "reason": "No relevant subject exists." }
+                    }
+                  }]
+                }
+                """;
+            AgentJob job = jobWithMetadata(sampleJobMetadata());
+            ObjectNode output = objectMapper.createObjectNode();
+            output.put("rawOutput", rawOutput);
+            job.setOutput(output);
+            stubDiff(
+                    "diff --git a/Sources/Auth.swift b/Sources/Auth.swift\n+++ b/Sources/Auth.swift\n@@ -1 +1 @@\n+changed\n");
+            when(deliveryService.deliver(eq(job), any()))
+                    .thenAnswer(inv -> new DeliveryResult(1, 0, false, inv.getArgument(1)));
+
+            admit(job, rawOutput);
+
+            verify(deliveryService).deliver(eq(job), any());
         }
 
         @Test


### PR DESCRIPTION
## Problem

An Artemis review finished with complete coverage and then died:

```
[pi-runner] Practice coverage: evaluated=3, eligible=3, ratio=1.0000
[pi-runner] SUCCESS: composed result.json from persisted tool state after initial run
[pi-runner] FATAL: observation admission failed: HTTP 500
```

The 500 is `PullRequestReviewHandler.processObservations` refusing the review: every observation came back NOT_APPLICABLE or INCONCLUSIVE while the diff had four files, which the guard reads as a stale or empty patch reaching the agent.

That inference held when a review carried fifteen to twenty-three practices. It stops holding as soon as a workspace narrows its set: with six practices, a change that touches no security, error-handling or testing concern decides nothing, honestly. The refusal then discards the entire review, including the inapplicable records the developer's practice page is supposed to show. It has fired four times, and the ls1intum workspace has just been narrowed to six practices, so it would fire far more often.

## Fix

What the guard is for is a review that answered without reading, so that is what it tests now.

- A review that quoted `scm.pull-request.diff` read the change.
- A review whose practices live in the metadata rather than the code answers without quoting the diff, and names it among the sources it walked instead. The model writes that list, so it only ever widens a refusal and never stands in for the evidence an observation owes. Two of the six practices ls1intum now runs are of this kind, so without it the guard would keep firing on honest reviews there.
- A review that did neither, over a diff that carries files, is still refused.

An empty or truncated patch cannot defeat this: every diff citation is re-read against the staged bytes and rejected if it does not match, so a review handed an empty patch has no valid observations at all and is stopped a step earlier.

## Verification

`PullRequestReviewHandlerStaticMethodsTest` and `PullRequestReviewHandlerTest` — 38 passing. New cases: a diff citation counts, a walked-sources warrant counts, citations from other sources do not, an observation with no evidence does not, and the review that used to be refused is now admitted. That last one fails without the change.

## Noted, not fixed here

The refusal reaches the sandbox as HTTP 500 and kills the run with exit 2. A deliberate refusal should be a clean response that the runner records and reports, which is a separate change to the admission controller and the runner.
