### PR TITLE
fix(db): the database admits the state a signal waits in to be coalesced

### DIFF
--- a/.changeset/issue-updates-are-reviewed-again.md
+++ b/.changeset/issue-updates-are-reviewed-again.md
@@ -1,0 +1,7 @@
+---
+"hephaestus": patch
+---
+
+Issue updates are reviewed again. A signal waiting for its coalescing sweep was recorded in a state the
+database refused, so the update was retried and then dropped, and no review ever ran for it. Existing
+signals are untouched and the next update on an issue is picked up normally.

--- a/server/application/src/main/resources/db/changelog/1788679885460_changelog.xml
+++ b/server/application/src/main/resources/db/changelog/1788679885460_changelog.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+    <changeSet author="hephaestus" id="1788679885460-1">
+        <preConditions onFail="MARK_RAN" onFailMessage="signal states already admit DEFERRED">
+            <sqlCheck expectedResult="0">
+                SELECT count(*) FROM pg_constraint
+                WHERE conname = 'ck_artifact_signal_state'
+                  AND conrelid = 'artifact_signal'::regclass
+                  AND pg_get_constraintdef(oid) LIKE '%DEFERRED%'
+            </sqlCheck>
+        </preConditions>
+        <comment>
+            Admit the state a signal waits in for a coalescing sweep. The state existed in the
+            application before it existed here, so every deferred signal was refused by the database
+            and its message was retried until the consumer dropped it as poison, losing the occasion.
+        </comment>
+        <sql splitStatements="true" endDelimiter=";"><![CDATA[
+            ALTER TABLE artifact_signal DROP CONSTRAINT IF EXISTS ck_artifact_signal_state;
+            ALTER TABLE artifact_signal ADD CONSTRAINT ck_artifact_signal_state
+                CHECK (state IN ('RECORDED','DEFERRED','TRIGGERED','SUPPRESSED','PENDING','LAPSED'));
+        ]]></sql>
+        <rollback><![CDATA[
+            -- Narrowing the vocabulary makes these rows unrepresentable, and a deferred signal is one
+            -- still waiting to be decided: returning it to RECORDED is what it was before the sweep
+            -- claimed it, so the reaper offers it again rather than losing the occurrence.
+            UPDATE artifact_signal SET state = 'RECORDED' WHERE state = 'DEFERRED';
+            ALTER TABLE artifact_signal DROP CONSTRAINT IF EXISTS ck_artifact_signal_state;
+            ALTER TABLE artifact_signal ADD CONSTRAINT ck_artifact_signal_state
+                CHECK (state IN ('RECORDED','TRIGGERED','SUPPRESSED','PENDING','LAPSED'));
+        ]]></rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/server/application/src/main/resources/db/master.xml
+++ b/server/application/src/main/resources/db/master.xml
@@ -109,4 +109,5 @@
     <include file="./changelog/1788521746862_changelog.xml" relativeToChangelogFile="true"/>
     <include file="./changelog/1788595793303_changelog.xml" relativeToChangelogFile="true"/>
     <include file="./changelog/1788616652575_changelog.xml" relativeToChangelogFile="true"/>
+    <include file="./changelog/1788679885460_changelog.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/auth/audit/AuthEventTypeConstraintParityTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/auth/audit/AuthEventTypeConstraintParityTest.java
@@ -2,17 +2,12 @@ package de.tum.cit.aet.hephaestus.core.auth.audit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import de.tum.cit.aet.hephaestus.testconfig.LiquibaseCheckConstraints;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -29,23 +24,12 @@ import org.junit.jupiter.api.Test;
 @Tag("unit")
 class AuthEventTypeConstraintParityTest {
 
-    private static final Path MASTER = Path.of("src/main/resources/db/master.xml");
-
-    private static final Pattern INCLUDE = Pattern.compile("<include\\s+file=\"([^\"]+)\"");
-
-    /** The `event_type IN ( … )` list of the most recently defined CHECK wins, as replays apply in order. */
-    private static final Pattern CHECK_CONSTRAINT = Pattern.compile(
-            "ADD\\s+CONSTRAINT\\s+ck_auth_event_event_type\\s+CHECK\\s*\\(\\s*event_type\\s+IN\\s*\\((.*?)\\)\\s*\\)",
-            Pattern.DOTALL | Pattern.CASE_INSENSITIVE);
-
-    private static final Pattern QUOTED = Pattern.compile("'([A-Z_]+)'");
-
     @Test
     void everyEventTypeConstantIsAdmittedByTheDatabaseConstraint() throws IOException {
-        Set<String> admitted = admittedByLatestConstraint();
+        Set<String> admitted = LiquibaseCheckConstraints.admittedValues("ck_auth_event_event_type", "event_type");
         Set<String> declared = Arrays.stream(AuthEvent.EventType.values())
                 .map(Enum::name)
-                .collect(java.util.stream.Collectors.toCollection(LinkedHashSet::new));
+                .collect(Collectors.toCollection(LinkedHashSet::new));
 
         assertThat(admitted)
                 .as("no changelog defines ck_auth_event_event_type — has the constraint been renamed?")
@@ -55,41 +39,5 @@ class AuthEventTypeConstraintParityTest {
                         + "one would be rejected by Postgres and the audited action would commit unaudited — widen the "
                         + "CHECK in a new changelog")
                 .isSubsetOf(admitted);
-    }
-
-    /**
-     * Walks {@code master.xml}'s include list in reverse — the order Liquibase actually applies, which
-     * the filename order is only conventionally aligned with. A changelog on disk but absent from
-     * {@code master.xml} therefore cannot satisfy this test, because it never reaches a database either.
-     */
-    private static Set<String> admittedByLatestConstraint() throws IOException {
-        String master = Files.readString(MASTER, StandardCharsets.UTF_8);
-        Matcher include = INCLUDE.matcher(master);
-        List<String> included = new ArrayList<>();
-        while (include.find()) {
-            included.add(include.group(1));
-        }
-        Path changelogDirectory = MASTER.getParent();
-        org.junit.jupiter.api.Assertions.assertNotNull(changelogDirectory);
-        for (String changelog : included.reversed()) {
-            Path path = changelogDirectory.resolve(changelog).normalize();
-            if (!Files.exists(path)) {
-                continue;
-            }
-            Matcher constraint = CHECK_CONSTRAINT.matcher(Files.readString(path, StandardCharsets.UTF_8));
-            String lastInFile = null;
-            while (constraint.find()) {
-                lastInFile = constraint.group(1);
-            }
-            if (lastInFile != null) {
-                Set<String> values = new LinkedHashSet<>();
-                Matcher value = QUOTED.matcher(lastInFile);
-                while (value.find()) {
-                    values.add(value.group(1));
-                }
-                return values;
-            }
-        }
-        return Set.of();
     }
 }

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/core/signal/SignalStateConstraintParityTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/core/signal/SignalStateConstraintParityTest.java
@@ -1,0 +1,39 @@
+package de.tum.cit.aet.hephaestus.integration.core.signal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import de.tum.cit.aet.hephaestus.testconfig.LiquibaseCheckConstraints;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@code artifact_signal.state} is constrained at the database by {@code ck_artifact_signal_state},
+ * and a {@link SignalState} the constraint does not admit is rejected on write. The consumer retries
+ * the message until it gives up and drops it, so the occurrence it carried is never reviewed and the
+ * ledger keeps no record that it arrived. No other tier sees it: the suite builds its schema with
+ * {@code ddl-auto: create} and applies no changelog.
+ */
+@Tag("unit")
+class SignalStateConstraintParityTest {
+
+    @Test
+    void everySignalStateIsAdmittedByTheDatabaseConstraint() throws IOException {
+        Set<String> admitted = LiquibaseCheckConstraints.admittedValues("ck_artifact_signal_state", "state");
+        Set<String> declared = Arrays.stream(SignalState.values())
+                .map(Enum::name)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+
+        assertThat(admitted)
+                .as("no changelog defines ck_artifact_signal_state — has the constraint been renamed?")
+                .isNotEmpty();
+        assertThat(declared)
+                .as("these SignalState constants are not admitted by ck_artifact_signal_state, so a signal in one "
+                        + "would be refused by Postgres and its occurrence lost — widen the CHECK in a new changelog")
+                .isSubsetOf(admitted);
+    }
+}

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/testconfig/LiquibaseCheckConstraints.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/testconfig/LiquibaseCheckConstraints.java
@@ -1,0 +1,82 @@
+package de.tum.cit.aet.hephaestus.testconfig;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * The values a Liquibase {@code CHECK ... IN (…)} constraint admits, read from the changelogs.
+ *
+ * <p>The suite builds its schema with {@code ddl-auto: create} and applies no changelog, so a Java
+ * enum that has outgrown the constraint pinning its column is invisible to every other tier: the test
+ * passes and the production insert is rejected. A parity test per constrained column is what closes
+ * that, and this is the reading half they share.
+ */
+public final class LiquibaseCheckConstraints {
+
+    private static final Path MASTER = Path.of("src/main/resources/db/master.xml");
+
+    private static final Pattern INCLUDE = Pattern.compile("<include\\s+file=\"([^\"]+)\"");
+
+    private static final Pattern QUOTED = Pattern.compile("'([A-Z_]+)'");
+
+    /** A rollback restates the definition it undoes, and an update never applies one. */
+    private static final Pattern ROLLBACK = Pattern.compile("<rollback\\b.*?</rollback>", Pattern.DOTALL);
+
+    private LiquibaseCheckConstraints() {}
+
+    /**
+     * Walks {@code master.xml}'s include list in reverse — the order Liquibase actually applies, which
+     * the filename order is only conventionally aligned with — and returns the values the last
+     * definition of {@code constraintName} admits. A changelog on disk but absent from
+     * {@code master.xml} therefore cannot satisfy a caller, because it never reaches a database either.
+     *
+     * @return the admitted values, or an empty set when no changelog defines the constraint
+     */
+    public static Set<String> admittedValues(String constraintName, String columnName) throws IOException {
+        Pattern check = Pattern.compile(
+                "ADD\\s+CONSTRAINT\\s+" + Pattern.quote(constraintName) + "\\s+CHECK\\s*\\(\\s*"
+                        + Pattern.quote(columnName)
+                        + "\\s+IN\\s*\\((.*?)\\)\\s*\\)",
+                Pattern.DOTALL | Pattern.CASE_INSENSITIVE);
+        String master = Files.readString(MASTER, StandardCharsets.UTF_8);
+        Matcher include = INCLUDE.matcher(master);
+        List<String> included = new ArrayList<>();
+        while (include.find()) {
+            included.add(include.group(1));
+        }
+        Path changelogDirectory = MASTER.getParent();
+        if (changelogDirectory == null) {
+            return Set.of();
+        }
+        for (String changelog : included.reversed()) {
+            Path path = changelogDirectory.resolve(changelog).normalize();
+            if (!Files.exists(path)) {
+                continue;
+            }
+            String applied = ROLLBACK.matcher(Files.readString(path, StandardCharsets.UTF_8))
+                    .replaceAll("");
+            Matcher constraint = check.matcher(applied);
+            String lastInFile = null;
+            while (constraint.find()) {
+                lastInFile = constraint.group(1);
+            }
+            if (lastInFile != null) {
+                Set<String> values = new LinkedHashSet<>();
+                Matcher value = QUOTED.matcher(lastInFile);
+                while (value.find()) {
+                    values.add(value.group(1));
+                }
+                return values;
+            }
+        }
+        return Set.of();
+    }
+}


### PR DESCRIPTION
## Problem

The ls1intum workspace logs this every few minutes, for every issue update:

```
ERROR: new row for relation "artifact_signal" violates check constraint "ck_artifact_signal_state"
  Detail: Failing row contains (…, 7, scm.issue, 3245448381, scm.issue.updated, …, EVENT, DEFERRED, …)
Handler failed for subject=github.ls1intum.edutelligence.issues
Poison message detected, ACKing to break redelivery loop: deliveredCount=10, reason=redelivery limit exceeded
```

Coalescing issue updates introduced `SignalState.DEFERRED`, the state a signal waits in for its sweep. `ck_artifact_signal_state` still admits only the five states that predate it, so `LedgerSignalRecorder.defer` is rejected by Postgres, the consumer redelivers ten times and then drops the message, and the occurrence is never reviewed and leaves no record that it arrived.

## Fix

A new changelog recreates the constraint with the state the enum holds, following the shape the constraint's own earlier widening used, including the guarded precondition. Its rollback returns any deferred signal to `RECORDED`, which is what it was before a sweep claimed it, so the reaper offers the occurrence again instead of losing it.

## Why no test caught it, and what does now

The suite builds its schema with `ddl-auto: create` and applies no changelog, so this constraint is absent from every test database, including `DeferredSignalIntegrationTest`, which passes while production rejects the write.

The same class of defect was found once before on `auth_event.event_type` and answered with a parity test that reads the changelogs. This moves that test's reading half into one place, adds the matching parity test for `artifact_signal.state`, and teaches both to ignore rollback SQL, which restates the definition it undoes and never reaches a database on update. Without that last part the reader picks up the narrower list a rollback restores.

## Verification

`./mvnw -pl application -am test -Dtest='SignalStateConstraintParityTest,AuthEventTypeConstraintParityTest'` — 2 passing. The new test fails against the constraint as it stands on main, naming `DEFERRED` as the value Postgres would refuse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZzUtPvAhEnBHsxqWTaRHn
