### PR TITLE
fix(server): a review is paced by the context it has spent

### DIFF
--- a/.changeset/a-review-of-a-large-change-records-as-it-goes.md
+++ b/.changeset/a-review-of-a-large-change-records-as-it-goes.md
@@ -1,0 +1,7 @@
+---
+"hephaestus": patch
+---
+
+A practice review of a very large change no longer finishes with nothing to say. A review could spend
+everything it had reading and record none of what it had already worked out. It is now asked to write
+down what it has settled while it still has room to, and asked again as that room runs out.

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/practice/PracticeRunnerProfile.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/practice/PracticeRunnerProfile.java
@@ -19,6 +19,7 @@ public final class PracticeRunnerProfile implements PiRunnerProfile {
             "pi-runner-output.ts",
             "pi-runner-usage.ts",
             "pi-runner-timings.ts",
+            "pi-runner-recording-pace.ts",
             "pi-runner-composition.ts",
             "pi-review-tree.ts",
             "pi-session-tree.ts",

--- a/server/application/src/main/resources/agent/pi-runner-recording-pace.ts
+++ b/server/application/src/main/resources/agent/pi-runner-recording-pace.ts
@@ -1,0 +1,100 @@
+/**
+ * When a review session is asked to record what it has already settled.
+ *
+ * Context is the resource a session actually spends: every file it opens stays in the window, the
+ * window is finite, and recall degrades as it fills. So the ask is placed at shares of the session's
+ * own context rather than on a clock or a count of calls. A clock scales with the review's time
+ * budget, which is why a session on a long budget could read for a quarter of an hour before its only
+ * reminder; a count of calls says nothing about how much a call brought back, and one read of a large
+ * file can cost more of the window than twenty small ones.
+ */
+
+/** The prompt buckets pi-ai reports on an assistant message. */
+export interface PromptUsage {
+	readonly input: number;
+	readonly cacheRead: number;
+	readonly cacheWrite: number;
+}
+
+/**
+ * How much of the window the prompt the model was just sent occupies.
+ *
+ * pi-ai splits the provider's one prompt count into three disjoint buckets — it derives `input` by
+ * subtracting the cached and the newly written prefix from it — so the prompt is their sum, and a sum
+ * that leaves one out reads as a smaller prompt than was sent. Leaving out `cacheWrite` undercounts
+ * by exactly the prefix a turn added to the cache, which is largest on the turns where the window
+ * fills fastest.
+ */
+export function promptTokens(usage: PromptUsage): number {
+	return (usage.input || 0) + (usage.cacheRead || 0) + (usage.cacheWrite || 0);
+}
+
+/**
+ * The shares of the window at which a session is asked. Early enough that what it has read is still
+ * recalled well, spread so a session that only fills the window slowly is not asked repeatedly.
+ */
+export const RECORDING_CHECKPOINTS: readonly number[] = [0.4, 0.65, 0.85];
+
+export interface RecordingPace {
+	/**
+	 * Takes the tokens of the prompt the model was just sent, and answers with the share of the window
+	 * that crossing it reached, or null when no new share was reached.
+	 */
+	readonly checkpointReached: (promptSize: number) => number | null;
+}
+
+/**
+ * @param inheritsContext whether the session opens on a window it did not read: an observer forked
+ *   from the shared reconnaissance starts with that transcript, and the share it arrives holding is
+ *   not a share it spent. A session that starts empty is asked from its very first turn, because
+ *   everything in its window is something it went and read.
+ */
+export function createRecordingPace(
+	contextWindow: number,
+	inheritsContext: boolean,
+	checkpoints: readonly number[] = RECORDING_CHECKPOINTS,
+): RecordingPace {
+	if (!Number.isFinite(contextWindow) || contextWindow <= 0) {
+		throw new Error(`contextWindow must be a positive number, got: ${contextWindow}`);
+	}
+	if (checkpoints.length === 0) {
+		throw new Error("at least one checkpoint is required");
+	}
+	let previous = 0;
+	for (const checkpoint of checkpoints) {
+		if (!(checkpoint > previous) || checkpoint > 1) {
+			throw new Error(`checkpoints must ascend within (0, 1], got: ${checkpoints.join(", ")}`);
+		}
+		previous = checkpoint;
+	}
+	// How many leading shares the window is currently past. It rises as the session fills the window
+	// and falls when the window empties, so a share is answered for the occupancy it describes rather
+	// than once in the life of the session.
+	let passed = 0;
+	// The first prompt of a session that inherited its window says where the session began, not what
+	// it read.
+	let started = !inheritsContext;
+	const at = (index: number) => checkpoints[index] ?? Number.POSITIVE_INFINITY;
+	return {
+		checkpointReached(promptSize: number): number | null {
+			if (!Number.isFinite(promptSize) || promptSize <= 0) return null;
+			const share = promptSize / contextWindow;
+			// Compaction empties the window mid-review and the session reads on from a summary of what
+			// it can no longer see, which is the situation this whole pace exists for. A share the
+			// window has fallen back below is asked for again when the session fills it again.
+			while (passed > 0 && share < at(passed - 1)) passed -= 1;
+			let reached: number | null = null;
+			// A single large read can cross more than one share at once, and the session is asked once
+			// for the furthest it reached rather than once per share it stepped over.
+			while (passed < checkpoints.length && share >= at(passed)) {
+				reached = at(passed);
+				passed += 1;
+			}
+			if (!started) {
+				started = true;
+				return null;
+			}
+			return reached;
+		},
+	};
+}

--- a/server/application/src/main/resources/agent/pi-runner.ts
+++ b/server/application/src/main/resources/agent/pi-runner.ts
@@ -48,6 +48,11 @@ import {
 } from "./pi-runner-composition.ts";
 import { outputPath } from "./pi-runner-output.ts";
 import {
+	createRecordingPace,
+	promptTokens,
+	type RecordingPace,
+} from "./pi-runner-recording-pace.ts";
+import {
 	armRetryWindow,
 	deriveReconBudget,
 	deriveTimeouts,
@@ -1493,6 +1498,17 @@ function scheduleDeadline(timeoutMs: number, onTimeout: () => void) {
 	return { elapsed, timer, state };
 }
 
+/**
+ * Ends a session for good. A steer still queued when a session is disposed is not dropped: the SDK
+ * keeps it on the agent and starts a fresh run to deliver it, so a nudge that arrived just as a
+ * deadline did would spend the budget that deadline just took away. Clearing the queue first is what
+ * the SDK's own interactive mode does before it aborts.
+ */
+function stopSession(session: AgentSession) {
+	session.clearQueue();
+	session.dispose();
+}
+
 function scheduleTurnTimers(
 	session: AgentSession,
 	turnNumber: number,
@@ -1519,7 +1535,7 @@ function scheduleTurnTimers(
 		console.error(
 			`[pi-runner] turn ${turnNumber}/${turnCount} exhausted its fair share — aborting this turn`,
 		);
-		session.dispose();
+		stopSession(session);
 	});
 	return { softTimer, hardTimer: hard.timer, hardDeadline: hard.elapsed, state };
 }
@@ -1571,8 +1587,16 @@ async function main() {
 	}
 	const model = modelRuntime.getModel("hephaestus", providerConfig.modelId);
 	if (!model) throw new Error(`Hephaestus model was not registered: ${providerConfig.modelId}`);
+	// The window a session is paced against is the registered model's own, which is where the
+	// workspace's declared window and the runner's default for a model that declares none already
+	// meet. It is also the window the SDK compacts against, so pacing and compaction cannot disagree.
+	const contextWindow = model.contextWindow;
 	console.error(
-		`[pi-runner] registered hephaestus provider: apiProtocol=${providerConfig.apiProtocol} model=${providerConfig.modelId}`,
+		// The window is logged because everything downstream is measured against it: a workspace that
+		// declares it wrong says so in the first lines of every transcript, rather than only in the
+		// shape of the reviews it produces.
+		`[pi-runner] registered hephaestus provider: apiProtocol=${providerConfig.apiProtocol} ` +
+			`model=${providerConfig.modelId} contextWindow=${contextWindow}`,
 	);
 
 	const compositionRequest = loadCompositionRequest();
@@ -1586,7 +1610,11 @@ async function main() {
 		: null;
 	const events: { type: string; timestamp: number }[] = [];
 	const streamUsage = newUsageLedger();
-	const subscribeSession = (trackedSession: AgentSession, label: string) =>
+	const subscribeSession = (
+		trackedSession: AgentSession,
+		label: string,
+		pace: RecordingPace | null = null,
+	) =>
 		trackedSession.subscribe((event: AgentSessionEvent) => {
 			if (event.type === "tool_execution_start") {
 				console.error(`[pi-runner] ${label} tool: ${event.toolName}`);
@@ -1600,6 +1628,31 @@ async function main() {
 					`[pi-runner] ${label} assistant msg: stopReason=${stopReason}, toolCalls=${toolCalls}, ` +
 						`types=[${types.join(",")}]`,
 				);
+				// How much of the window this turn's prompt occupied. A turn that was aborted or that
+				// failed carries whatever counts the provider had sent before it stopped, which describes
+				// no prompt the model answered; the SDK leaves those out of its own context maths too.
+				const settled = stopReason !== "aborted" && stopReason !== "error";
+				const reached =
+					pace === null || !settled
+						? null
+						: pace.checkpointReached(promptTokens(event.message.usage));
+				if (reached !== null) {
+					console.error(
+						`[pi-runner] ${label}: ${Math.round(reached * 100)}% of its context spent — asking it to record`,
+					);
+					// Neither an order to stop reading nor a licence to keep reading, because this can
+					// arrive alongside the fair-share nudge above. The orchestrator's READ-BEFORE-NA gate
+					// makes reading the whole diff a precondition of half the answers, so a session pushed
+					// to settle a practice early settles it on evidence it cannot quote — which is the
+					// failure this whole pipeline exists to prevent.
+					trackedSession
+						.steer(
+							`You have spent ${Math.round(reached * 100)}% of your context. Record now every practice your ` +
+								`evidence already settles, one report_observation call per practice. Record nothing for a ` +
+								`practice you cannot yet quote the deciding evidence for. ${PERSIST_DISCIPLINE}`,
+						)
+						.catch((err) => console.error(`[pi-runner] steer failed: ${errorText(err)}`));
+				}
 			}
 			events.push({ type: `${label}:${event.type}`, timestamp: Date.now() });
 		});
@@ -1633,7 +1686,7 @@ async function main() {
 			console.error(
 				`[pi-runner] Composition timeout — preserving observations and composed units so far`,
 			);
-			composerSession.dispose();
+			stopSession(composerSession);
 		});
 		try {
 			await Promise.race([
@@ -1648,7 +1701,7 @@ async function main() {
 		}
 		persistComposedFeedback();
 		const combinedUsage = extractUsageFromSession(composerSession.state, streamUsage);
-		composerSession.dispose();
+		stopSession(composerSession);
 		accumulateUsage(prevUsage, combinedUsage);
 		prevUsage = combinedUsage;
 		persistUsage();
@@ -1663,7 +1716,7 @@ async function main() {
 		hardAbort.abort();
 		console.error(`[pi-runner] Hard timeout — aborting ${activeSessions.size} active session(s)`);
 		for (const activeSession of activeSessions) {
-			activeSession.dispose();
+			stopSession(activeSession);
 		}
 	}, INITIAL_TIMEOUT_MS);
 
@@ -1704,7 +1757,7 @@ async function main() {
 		const unsubscribeRecon = subscribeSession(reconSession, "recon:shared");
 		activeSessions.add(reconSession);
 		const reconBudgetMs = deriveReconBudget(INITIAL_TIMEOUT_MS);
-		const reconDeadline = scheduleDeadline(reconBudgetMs, () => reconSession.dispose());
+		const reconDeadline = scheduleDeadline(reconBudgetMs, () => stopSession(reconSession));
 		try {
 			const groupScope = tree.groups
 				.map((group) => `${group.id} [${group.practiceSlugs.join(", ")}]`)
@@ -1734,7 +1787,7 @@ async function main() {
 			clearTimeout(reconDeadline.timer);
 			activeSessions.delete(reconSession);
 			unsubscribeRecon();
-			reconSession.dispose();
+			stopSession(reconSession);
 		}
 	}
 
@@ -1760,7 +1813,11 @@ async function main() {
 					modelRuntime,
 					model,
 				});
-				const unsubscribeObserver = subscribeSession(observerSession, `observer:${group.id}`);
+				const unsubscribeObserver = subscribeSession(
+					observerSession,
+					`observer:${group.id}`,
+					createRecordingPace(contextWindow, seedFile !== undefined),
+				);
 				activeSessions.add(observerSession);
 				const remainingMs = Math.max(1, reviewDeadline - Date.now());
 				const activeSlots = Math.min(concurrency, remainingGroups);
@@ -1797,7 +1854,7 @@ async function main() {
 					clearTimeout(timers.hardTimer);
 					activeSessions.delete(observerSession);
 					unsubscribeObserver();
-					observerSession.dispose();
+					stopSession(observerSession);
 					remainingGroups--;
 				}
 			},
@@ -1858,7 +1915,7 @@ async function main() {
 			retryAbort.abort();
 			console.error(`[pi-runner] Retry hard timeout — aborting`);
 			for (const activeSession of activeSessions) {
-				activeSession.dispose();
+				stopSession(activeSession);
 			}
 		},
 	);
@@ -1894,12 +1951,16 @@ async function main() {
 					modelRuntime,
 					model,
 				});
-				const unsubscribeRetry = subscribeSession(retrySession, `retry:${group.id}`);
+				const unsubscribeRetry = subscribeSession(
+					retrySession,
+					`retry:${group.id}`,
+					createRecordingPace(contextWindow, priorSessionFile !== undefined),
+				);
 				activeSessions.add(retrySession);
 				const activeSlots = Math.min(concurrency, retriesRemaining);
 				const retryBudgetMs = deriveWorkstreamBudget(retry.windowMs, activeSlots, retriesRemaining);
 				const retryDeadline = scheduleDeadline(retryBudgetMs, () => {
-					retrySession.dispose();
+					stopSession(retrySession);
 				});
 				try {
 					await Promise.race([
@@ -1917,7 +1978,7 @@ async function main() {
 					clearTimeout(retryDeadline.timer);
 					activeSessions.delete(retrySession);
 					unsubscribeRetry();
-					retrySession.dispose();
+					stopSession(retrySession);
 					retriesRemaining--;
 				}
 			},

--- a/server/application/src/test/resources/agent/pi-runner-recording-pace.spec.ts
+++ b/server/application/src/test/resources/agent/pi-runner-recording-pace.spec.ts
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+	createRecordingPace,
+	promptTokens,
+	RECORDING_CHECKPOINTS,
+} from "../../../main/resources/agent/pi-runner-recording-pace.ts";
+
+void test("the prompt is every bucket the provider split it into", () => {
+	assert.equal(promptTokens({ input: 300, cacheRead: 20_000, cacheWrite: 5_000 }), 25_300);
+});
+
+void test("a session is asked once at each share of its context", () => {
+	const pace = createRecordingPace(1000, true, [0.4, 0.8]);
+	assert.equal(pace.checkpointReached(200), null);
+	assert.equal(pace.checkpointReached(400), 0.4);
+	assert.equal(pace.checkpointReached(500), null, "the same share is not asked for twice");
+	assert.equal(pace.checkpointReached(810), 0.8);
+	assert.equal(pace.checkpointReached(999), null, "there is nothing left to ask for");
+});
+
+void test("one turn that crosses several shares is asked once, for the furthest", () => {
+	const pace = createRecordingPace(1000, true, [0.4, 0.65, 0.85]);
+	assert.equal(pace.checkpointReached(100), null);
+	assert.equal(pace.checkpointReached(900), 0.85);
+	assert.equal(pace.checkpointReached(950), null);
+});
+
+void test("the window a session starts with is not a share it spent", () => {
+	const pace = createRecordingPace(1000, true, [0.4, 0.65, 0.85]);
+	assert.equal(pace.checkpointReached(700), null, "a forked session inherits a full window");
+	assert.equal(pace.checkpointReached(720), null, "the shares it began past stay answered");
+	assert.equal(pace.checkpointReached(860), 0.85);
+});
+
+void test("a window that empties is asked for again as it refills", () => {
+	const pace = createRecordingPace(1000, true, [0.4, 0.8]);
+	assert.equal(pace.checkpointReached(100), null);
+	assert.equal(pace.checkpointReached(850), 0.8);
+	assert.equal(pace.checkpointReached(150), null, "compaction is not itself an ask");
+	assert.equal(pace.checkpointReached(450), 0.4, "what it fills again it is asked for again");
+	assert.equal(pace.checkpointReached(900), 0.8);
+});
+
+void test("a turn that reports no usage is not a share of anything", () => {
+	const pace = createRecordingPace(1000, true, [0.4]);
+	assert.equal(pace.checkpointReached(0), null);
+	assert.equal(pace.checkpointReached(Number.NaN), null);
+	assert.equal(pace.checkpointReached(100), null);
+	assert.equal(pace.checkpointReached(400), 0.4);
+});
+
+void test("the shipped checkpoints ask early and stay inside the window", () => {
+	assert.ok(RECORDING_CHECKPOINTS.length > 0);
+	assert.ok(
+		(RECORDING_CHECKPOINTS[0] ?? 1) <= 0.5,
+		"the first ask comes before the window is half spent",
+	);
+	assert.ok((RECORDING_CHECKPOINTS.at(-1) ?? 0) < 1, "the last ask leaves room to answer it");
+});
+
+void test("a session that starts empty is asked from its first turn", () => {
+	// Nothing in its window arrived with it, so the first prompt is already something it went and read.
+	const fresh = createRecordingPace(1000, false, [0.4, 0.85]);
+	assert.equal(fresh.checkpointReached(900), 0.85);
+
+	// A session forked from the shared reconnaissance opens on a window it did not read.
+	const forked = createRecordingPace(1000, true, [0.4, 0.85]);
+	assert.equal(forked.checkpointReached(900), null);
+	assert.equal(
+		forked.checkpointReached(950),
+		null,
+		"the shares it arrived holding are not asked for",
+	);
+});
+
+void test("a window and its checkpoints have to make sense", () => {
+	for (const invalid of [0, -1, Number.NaN]) {
+		assert.throws(() => createRecordingPace(invalid, true), /positive number/);
+	}
+	assert.throws(() => createRecordingPace(1000, true, []), /at least one checkpoint/);
+	assert.throws(() => createRecordingPace(1000, true, [0.8, 0.4]), /ascend/);
+	assert.throws(() => createRecordingPace(1000, true, [0, 0.4]), /ascend/);
+	assert.throws(() => createRecordingPace(1000, true, [0.4, 0.4]), /ascend/);
+	assert.throws(() => createRecordingPace(1000, true, [0.4, 1.2]), /ascend/);
+	assert.throws(() => createRecordingPace(1000, true, [Number.NaN]), /ascend/);
+});


### PR DESCRIPTION
## Problem

The first review to run under the narrowed ls1intum configuration, on an Artemis pull request adding 6,770 lines across 23 files:

| what the transcript shows | |
|---|---|
| practices in the review | 4, in one group |
| assistant turns | 20 |
| evidence calls | 32 reads, 11 searches |
| observations recorded | 0 |
| reminders to record | 1, twelve minutes in |
| result | `FAILED: 4 practice observer(s) still missing`, nothing delivered |

The only thing pacing an observer is `scheduleTurnTimers`, whose soft nudge fires at 60% of the turn's fair share. A fair share is a slice of the review's time budget, so the larger the budget the later the only reminder lands. On a single-group review it arrived after twelve minutes of reading, and the session ignored it and kept reading until the pass ended.

Recording nothing is the worst outcome available: there is no partial result to deliver and no record on anyone's practice page that the change was looked at.

Its twenty turns averaged 37,600 tokens of prompt against the model's 65,536-token window, so it was spending more than half its context per turn well before the end. Under this change it would have been asked to record at least twice.

## Pacing by context, not by the clock

Context is what a review session actually spends. Every file it opens stays in the window, the window is finite, and recall degrades as it fills, which is the constraint the current guidance on agent design puts first. So the ask is placed at shares of the session's own context: two fifths, two thirds, and most of the way.

- A **clock** scales with the time budget rather than with the work. That is precisely how a session came to read for a quarter of an hour before being reminded once.
- A **count of calls** says nothing about what a call brought back. One read of a large file can cost more of the window than twenty small ones.
- A **share of the window** is the same pacing on any budget, any model and any size of change, and it is the signal the model's own budget awareness uses.

The window is the one the model registered, so this and the SDK's own compaction measure against the same number. A turn that crosses several shares at once is asked once, for the furthest it reached.

Three edges decide whether that works in practice, and the review found all three:

- **What occupies the window is the whole prompt.** The three token buckets are disjoint, so the cached prefix a turn writes counts as much as the part sent fresh, and it is largest on exactly the turns that fill the window fastest.
- **An observer inherits a window.** It forks from the shared reconnaissance, so its first prompt already carries that transcript and the orchestrator. Shares that arrive with it are marked passed rather than asked for, so nothing is asked before the session has read anything.
- **Compaction empties the window again**, at roughly 75% of it on this model. A share the session falls back below is asked for once more, because a session that has just lost the detail it was reading from is the one that most needs its answers written down.

A turn that ended in an error or an abort reports counts for a prompt no model answered, and is not paced on.

The ask names the share spent, asks only for the practices the session can already quote the deciding evidence for, and neither orders it to stop reading nor licenses more. The orchestrator's read-before-inapplicable gate makes reading the whole diff a precondition of half the answers, so a session pushed to settle early settles on evidence it cannot quote. The reconnaissance and composer sessions record no observations and are left alone.

## A second fault this made likely

A queued steer outlives the abort that ends a turn. The SDK's dispose leaves the queue standing, and the next post-run check drains it by starting a fresh model run, spending budget the deadline just took away. One nudge per turn made that unlikely; asking repeatedly makes it ordinary. Every teardown now clears the queue before disposing.

## Verification

`vp run test:agents` — 137 passing, with a spec covering one ask per share, a turn that crosses several at once, a turn that reports no usage, the shipped checkpoints, and invalid windows and checkpoints. `lint:agents` and `typecheck:agents` clean.

## Sources for the approach

- [Effective context engineering for AI agents](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents)
- [Effective harnesses for long-running agents](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents)
- [Managing context on the Claude Developer Platform](https://anthropic.com/news/context-management)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Review sessions now prompt for recording findings as the context window fills, helping preserve observations during very large reviews.
  * Recording prompts can reappear after context compaction as the review continues.

* **Bug Fixes**
  * Very large reviews no longer finish without recorded output when findings could still be captured.
  * Queued instructions at session deadlines are no longer carried into a fresh run unexpectedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->