### PR TITLE
test(server): the constraint reader sees every changelog, and a database proves the fix

### DIFF
--- a/.changeset/issue-updates-are-reviewed-again.md
+++ b/.changeset/issue-updates-are-reviewed-again.md
@@ -2,6 +2,8 @@
 "hephaestus": patch
 ---
 
-Issue updates are reviewed again. A signal waiting for its coalescing sweep was recorded in a state the
-database refused, so the update was retried and then dropped, and no review ever ran for it. Existing
-signals are untouched and the next update on an issue is picked up normally.
+Issue updates are reviewed again, and an edited issue shows its new title, labels and description
+again. Since updates to an issue began being grouped into a single review, each update was refused as
+it was recorded, which discarded the edit along with it until a later sync read the issue afresh, and
+no practice review ran for it. Nothing already stored changes, and the next update to an issue is
+picked up normally.

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/core/signal/SignalStateConstraintIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/core/signal/SignalStateConstraintIntegrationTest.java
@@ -1,0 +1,81 @@
+package de.tum.cit.aet.hephaestus.integration.core.signal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import de.tum.cit.aet.hephaestus.testconfig.PostgreSQLTestContainer;
+import de.tum.cit.aet.hephaestus.testconfig.PostgreSQLTestContainer.TestDatabase;
+import de.tum.cit.aet.hephaestus.testconfig.SchemaRowSeeder;
+import java.util.Map;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.SingleConnectionDataSource;
+
+/**
+ * The parity test beside this one reads the changelogs; this one applies them. Every other tier builds
+ * its schema with {@code ddl-auto: create}, where {@code ck_artifact_signal_state} does not exist at
+ * all — so a state the database refuses passes all of them, which is how a deferred signal reached
+ * production: the insert was rejected, the message redelivered until the consumer dropped it as
+ * poison, and the occurrence never reviewed.
+ */
+@Tag("database")
+class SignalStateConstraintIntegrationTest {
+
+    private static final TestDatabase DATABASE =
+            PostgreSQLTestContainer.createMigratedDatabase("hephaestus_signal_state_constraint");
+
+    private final JdbcTemplate jdbcTemplate = new JdbcTemplate(
+            new SingleConnectionDataSource(DATABASE.jdbcUrl(), DATABASE.username(), DATABASE.password(), true));
+    private final SchemaRowSeeder seeder = new SchemaRowSeeder(jdbcTemplate);
+
+    @Test
+    void shouldAdmitEverySignalStateAndRejectAnUnknownOneAfterMigration() {
+        String definition = jdbcTemplate.queryForObject(
+                "SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conname = 'ck_artifact_signal_state'"
+                        + " AND conrelid = 'artifact_signal'::regclass",
+                String.class);
+        assertThat(definition)
+                .as("the changelog chain leaves ck_artifact_signal_state on artifact_signal")
+                .isNotNull();
+        for (SignalState state : SignalState.values()) {
+            assertThat(definition).as("constraint admits %s", state).contains(state.name());
+        }
+
+        // Seeding without the workspace this row points at: session_replication_role suspends foreign
+        // keys and triggers, and leaves CHECK constraints — which are what this test is about — enforced.
+        jdbcTemplate.execute("SET session_replication_role = 'replica'");
+        for (SignalState state : SignalState.values()) {
+            seeder.insert("artifact_signal", signalRow(state.name()));
+        }
+
+        assertThatThrownBy(() -> seeder.insert("artifact_signal", signalRow("NOT_A_STATE")))
+                .isInstanceOf(DataIntegrityViolationException.class)
+                .hasMessageContaining("ck_artifact_signal_state");
+
+        assertThat(jdbcTemplate.queryForObject("SELECT count(*) FROM artifact_signal", Long.class))
+                .as("one row per declared state and nothing more")
+                .isEqualTo(SignalState.values().length);
+    }
+
+    /**
+     * {@code artifact_kind} and {@code discovered_via} carry CHECKs of their own that the seeder's
+     * filler would violate. {@code signal_name} and {@code revision} carry none; they are spelled out
+     * so the row reads as one real issue update, and so the rows stay apart under
+     * {@code uq_artifact_signal} by saying so rather than by accident of the filler.
+     */
+    private static Map<String, Object> signalRow(String state) {
+        return Map.of(
+                "artifact_kind",
+                "scm.issue",
+                "discovered_via",
+                "EVENT",
+                "signal_name",
+                "scm.issue.updated",
+                "revision",
+                state,
+                "state",
+                state);
+    }
+}

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/core/signal/SignalStateConstraintParityTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/core/signal/SignalStateConstraintParityTest.java
@@ -15,8 +15,11 @@ import org.junit.jupiter.api.Test;
  * {@code artifact_signal.state} is constrained at the database by {@code ck_artifact_signal_state},
  * and a {@link SignalState} the constraint does not admit is rejected on write. The consumer retries
  * the message until it gives up and drops it, so the occurrence it carried is never reviewed and the
- * ledger keeps no record that it arrived. No other tier sees it: the suite builds its schema with
- * {@code ddl-auto: create} and applies no changelog.
+ * ledger keeps no record that it arrived. Every other tier builds its schema with
+ * {@code ddl-auto: create} and applies no changelog, so none of them sees the constraint at all;
+ * {@link SignalStateConstraintIntegrationTest} migrates a real database and asserts the same parity
+ * against what the chain actually produces, and this one answers in the unit suite rather than the
+ * database job.
  */
 @Tag("unit")
 class SignalStateConstraintParityTest {

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/testconfig/LiquibaseCheckConstraints.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/testconfig/LiquibaseCheckConstraints.java
@@ -25,10 +25,24 @@ public final class LiquibaseCheckConstraints {
 
     private static final Pattern INCLUDE = Pattern.compile("<include\\s+file=\"([^\"]+)\"");
 
-    private static final Pattern QUOTED = Pattern.compile("'([A-Z_]+)'");
+    /** Not just {@code [A-Z_]}: a constrained column may hold lower-case or dotted values. */
+    private static final Pattern QUOTED = Pattern.compile("'([^']+)'");
 
-    /** A rollback restates the definition it undoes, and an update never applies one. */
-    private static final Pattern ROLLBACK = Pattern.compile("<rollback\\b.*?</rollback>", Pattern.DOTALL);
+    /**
+     * The comma-separated literals an {@code IN} takes, and nothing after them. A CHECK may go on past
+     * the list — {@code ck_feedback_dispatch_destination} follows its {@code IN} with a conjunct that
+     * compares the same column against a literal — and a group that ran to the closing parentheses
+     * would read that literal as an admitted value.
+     */
+    private static final String VALUE_LIST = "'[^']+'(?:\\s*,\\s*'[^']+')*";
+
+    /**
+     * A rollback restates the definition it undoes, and an update never applies one. The empty form
+     * closes itself, and it has to be matched first: read only as an opening tag it would swallow every
+     * changeset between one of those and the next real {@code </rollback>}.
+     */
+    private static final Pattern ROLLBACK =
+            Pattern.compile("<rollback\\b[^>]*/>|<rollback\\b[^>]*>.*?</rollback>", Pattern.DOTALL);
 
     private LiquibaseCheckConstraints() {}
 
@@ -41,10 +55,12 @@ public final class LiquibaseCheckConstraints {
      * @return the admitted values, or an empty set when no changelog defines the constraint
      */
     public static Set<String> admittedValues(String constraintName, String columnName) throws IOException {
+        // ADD is optional: a constraint may be named inside the CREATE TABLE that introduced its column
+        // rather than added afterwards, and both spellings reach a database the same way.
         Pattern check = Pattern.compile(
-                "ADD\\s+CONSTRAINT\\s+" + Pattern.quote(constraintName) + "\\s+CHECK\\s*\\(\\s*"
+                "(?:ADD\\s+)?CONSTRAINT\\s+" + Pattern.quote(constraintName) + "\\s+CHECK\\s*\\(\\s*"
                         + Pattern.quote(columnName)
-                        + "\\s+IN\\s*\\((.*?)\\)\\s*\\)",
+                        + "\\s+IN\\s*\\(\\s*(" + VALUE_LIST + ")\\s*\\)",
                 Pattern.DOTALL | Pattern.CASE_INSENSITIVE);
         String master = Files.readString(MASTER, StandardCharsets.UTF_8);
         Matcher include = INCLUDE.matcher(master);


### PR DESCRIPTION
## Why this is a follow-up

The adversarial review of #1932 landed after that pull request had already entered the merge queue. Its migration was correct and is on `main`; every finding was in the test half, so it ships here. One finding cannot: the rollback comment inside `1788679885460_changelog.xml` overstates what a rollback can recover, and that file has now reached `main`, where a changelog is frozen.

## What the reader was missing

`LiquibaseCheckConstraints` skips rollback blocks, because a rollback restates the definition it undoes and never reaches a database on update. Three defects in how it read them:

| Input | Before | Now |
|---|---|---|
| `<rollback/>` | read as an opening tag, swallowing applied SQL up to the next `</rollback>` | recognised |
| `CONSTRAINT … CHECK` inside `CREATE TABLE` | invisible, `ADD CONSTRAINT` was required | read |
| values like `in_flight`, `openai-completions`, `scm.pull_request` | dropped, only `[A-Z_]` matched | read |

In `1785015307013_changelog.xml` the first one removed 12,220 characters of applied SQL and hid four constraints. Each failure returns an empty set, which the callers report as "has the constraint been renamed?".

## The missing half of the pair

`auth_event.event_type` is guarded by two tests: a parity test over the changelogs and a database-tier test over the migrated schema. #1932 took the parity test and not the sibling. A lint over XML cannot prove a changelog applies, and the empty-database replay does not exercise preconditions. This adds `SignalStateConstraintIntegrationTest`: one row per `SignalState` against a migrated database, plus an unknown value it must refuse.

The release note from #1932 is also rewritten in the operator's voice.

## Verification

- `./mvnw -pl application -am test -Dtest='SignalStateConstraintParityTest,AuthEventTypeConstraintParityTest'` — 2 passing, and both callers return the same sets as before the reader changed.
- `./mvnw -pl application -am test -Dsurefire.includedGroups=database -Dtest='SignalStateConstraintIntegrationTest,AuthEventTypeConstraintIntegrationTest'` — 2 passing. Removing the `<include>` for the new changelog fails it, naming `DEFERRED`.
- `vp run format:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZzUtPvAhEnBHsxqWTaRHn
