### PR TITLE
ci: the attribution gate covers the prose a reader weighs, not the commit trailer

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -212,10 +212,12 @@ jobs:
         if: steps.identity.outcome == 'failure'
         run: exit 1
 
-      # AGENTS.md forbids model, agent, harness or tool attribution in a commit or a pull
-      # request body; nothing enforced it here, the way `scripts/verify-changesets.ts` already
-      # enforces it for a changeset summary.
-      - name: "Refuse model attribution in commits and the pull request body"
+      # AGENTS.md forbids model, agent, harness or tool attribution in a pull request title or
+      # body, and `scripts/verify-changesets.ts` enforces the same for a changeset summary. Both
+      # are prose a reader weighs the change by. A commit trailer is not: `Co-authored-by:` is
+      # git's own way to credit who or what worked on a commit, and crediting a tool there is
+      # allowed.
+      - name: "Refuse model attribution in the pull request body"
         id: attribution
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         continue-on-error: true
@@ -238,59 +240,25 @@ jobs:
             const findAttribution = (text) =>
               patterns.filter(({ pattern }) => pattern.test(text ?? "")).map(({ name }) => name);
 
-            const query = `query($owner:String!,$name:String!,$number:Int!,$after:String){
-              repository(owner:$owner,name:$name){ pullRequest(number:$number){
-                commits(first:100,after:$after){ pageInfo{hasNextPage endCursor}
-                  nodes{ commit{ abbreviatedOid message } } } } } }`;
+            const bodyMatches = findAttribution(context.payload.pull_request.body);
+            if (bodyMatches.length === 0) return;
 
-            const pull = context.payload.pull_request;
-            const nodes = [];
-            let after = null;
-            do {
-              const page = await github.graphql(query, {
-                owner: context.repo.owner,
-                name: context.repo.repo,
-                number: pull.number,
-                after,
-              });
-              const data = page.repository.pullRequest;
-              nodes.push(...data.commits.nodes);
-              after = data.commits.pageInfo.hasNextPage ? data.commits.pageInfo.endCursor : null;
-            } while (after);
-
-            const offenders = nodes
-              .map(({ commit }) => ({
-                oid: commit.abbreviatedOid,
-                matches: findAttribution(commit.message),
-              }))
-              .filter(({ matches }) => matches.length > 0);
-            const bodyMatches = findAttribution(pull.body);
-            if (offenders.length === 0 && bodyMatches.length === 0) return;
-
-            const listed = offenders.map(({ oid, matches }) => `    ${oid}  ${matches.join(", ")}`);
             await writeFile(
               `${process.env.RUNNER_TEMP}/attribution-comment.md`,
               [
                 "## Attribution check failed",
                 "",
-                "A commit here or this pull request's body names the model, agent, harness or tool",
-                "that helped write it. `AGENTS.md` asks for none of that; a human co-author stays",
-                "welcome under the same trailer.",
-                ...(listed.length > 0 ? ["", "These commits carry it:", "", ...listed] : []),
-                ...(bodyMatches.length > 0
-                  ? ["", `The pull request body carries it too: ${bodyMatches.join(", ")}.`]
-                  : []),
+                "This pull request's body names the model, agent, harness or tool that helped write",
+                `it: ${bodyMatches.join(", ")}. \`AGENTS.md\` § Pull requests asks for none of that in a`,
+                "title or a body, because a description is read by people deciding whether to trust",
+                "the change.",
                 "",
-                "Edit the offending commit messages:",
+                "Edit the description to remove it. A commit trailer crediting a tool is fine, and a",
+                "human co-author stays welcome under the same trailer.",
                 "",
-                `    git rebase -i --exec "git commit --amend --no-edit" origin/${pull.base.ref}`,
-                "",
-                ...(bodyMatches.length > 0 ? ["Then edit the pull request description to remove it.", ""] : []),
               ].join("\n"),
             );
-            core.setFailed(
-              `${offenders.length} commit(s) or the pull request body carry model attribution.`,
-            );
+            core.setFailed("The pull request body carries model attribution.");
 
       - name: "Comment on PR with the attribution violations"
         uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ git rebase --exec 'git commit --amend --no-edit -S' origin/main
 
 ### Compliance
 
-A commit message and a pull request body carry no model, agent, harness or tool attribution — `AGENTS.md` § Pull requests has the rule and `pull-request.yml`'s `Verify commit identity` job checks for it. A human co-author stays welcome under the same `Co-authored-by:` trailer.
+A pull request title or body carries no model, agent, harness or tool attribution — `AGENTS.md` § Pull requests has the rule and `pull-request.yml`'s `Verify commit identity` job checks the body for it. A commit trailer is different: `Co-authored-by:` is git's own way to record who or what worked on a commit, so crediting a tool there is fine, and a human co-author is welcome under the same trailer.
 
 Contributions that do not adhere to these guidelines will be rejected. We align with [GitHub Acceptable Use Policies](https://docs.github.com/en/site-policy/acceptable-use-policies).
 

--- a/docs/contributor/ci-cd.mdx
+++ b/docs/contributor/ci-cd.mdx
@@ -65,7 +65,7 @@ published.
 | Docker → Webapp, Agent: Pi, Postgres (pg_partman), Tag unchanged images | Dockerfile images; aliases for unchanged ones | — |
 | Supported-host boot smoke | `docker/self-host/setup.sh`, then PostgreSQL, NATS and the application server from this run's own images, waiting for the application to report healthy | — |
 | Actionlint, Zizmor | workflow lint with ShellCheck warnings; Zizmor at medium confidence | — |
-| PR → Verify commit identity | every commit's primary author resolves to a GitHub account, and that account is the pull request's author; a `Bot` author is matched against its `[bot]` account; no commit message or the pull request body names a model, agent, harness or tool | — |
+| PR → Verify commit identity | every commit's primary author resolves to a GitHub account, and that account is the pull request's author; a `Bot` author is matched against its `[bot]` account; the pull request body names no model, agent, harness or tool | — |
 
 The four quality legs are one matrix job, one entry per leg of the task graph. Each runs
 `vp run ci:<leg>`, then pipes `vp run --last-details` through `scripts/report-task-run.ts`: every

--- a/scripts/lib/model-attribution.ts
+++ b/scripts/lib/model-attribution.ts
@@ -1,9 +1,10 @@
 /**
- * Marks left by an AI coding tool that signed its own commit, trailer or pull request
- * description — never a human co-author, who is welcome under the same `Co-authored-by:`
- * trailer. `AGENTS.md` § Pull requests forbids all of these; `pull-request.yml`'s
- * `verify-commit-identity` job refuses them on every commit message and the pull request
- * body, and `verify-changesets.ts` refuses the `Claude-Session` shape in a changeset summary.
+ * Marks left by an AI coding tool in prose a reader weighs the change by — never a human
+ * co-author, who is welcome under the same `Co-authored-by:` trailer. `AGENTS.md` § Pull requests
+ * forbids these in a pull request title or body; `pull-request.yml`'s `verify-commit-identity` job
+ * refuses them in the body, and `verify-changesets.ts` refuses the `Claude-Session` shape in a
+ * changeset summary. A commit trailer is deliberately outside all of it: `Co-authored-by:` is git's
+ * own way to record who or what worked on a commit, and crediting a tool there is allowed.
  *
  * The workflow step has no checkout (`docs/contributor/ci-cd.mdx` explains why), so it cannot
  * import this module; its inline patterns are hand-kept equal to the ones below, which is what

--- a/scripts/pull-request-workflows.test.ts
+++ b/scripts/pull-request-workflows.test.ts
@@ -95,3 +95,53 @@ void test("title preflight loads without dependencies and validates the current 
 	assert.match(String(explanation.get("run")), /> "\$RUNNER_TEMP\/title-error\.md"/);
 	assert.equal(comment.getIn(["with", "path"]), `\${{ runner.temp }}/title-error.md`);
 });
+
+void test("the attribution gate reads the pull request body, not the commits", async (t) => {
+	const steps = await stepsIn(".github/workflows/pull-request.yml", [
+		"jobs",
+		"verify-commit-identity",
+		"steps",
+	]);
+	const attribution = steps.find((step) => step.get("id") === "attribution");
+	assert.ok(attribution);
+	const script = String(attribution.getIn(["with", "script"]));
+	// `Co-authored-by:` is git's own way to record who or what worked on a commit, so only the
+	// prose a reader weighs the change by is refused; a commit walk here would widen that back.
+	assert.doesNotMatch(script, /\bcommits\b/);
+
+	const temp = await mkdtemp(join(tmpdir(), "attribution-"));
+	t.after(() => rm(temp, { recursive: true, force: true }));
+	const cases = [
+		// A pull request opened with no description at all: `body` is null, not an empty string.
+		[null, true],
+		["Removes the flaky wait.\n\nCo-authored-by: Jane Doe <jane@example.com>", true],
+		["🤖 Generated with [Claude Code](https://claude.com/claude-code)", false],
+		["Claude-Session: https://claude.ai/code/session_01", false],
+	] as const;
+	for (const [body, clean] of cases) {
+		const result = spawnSync(
+			process.execPath,
+			[
+				"--input-type=module",
+				"-e",
+				`
+			const { createRequire } = await import("node:module");
+			const require = createRequire(${JSON.stringify(join(temp, "harness.js"))});
+			const context = { payload: { pull_request: { body: ${JSON.stringify(body)} } } };
+			const core = { setFailed() { process.exitCode = 1; } };
+			await (async () => {
+			${script}
+			})();
+		`,
+			],
+			{ encoding: "utf8", env: { ...process.env, RUNNER_TEMP: temp } },
+		);
+		assert.equal(result.status, clean ? 0 : 1, `${String(body)}: ${result.stderr}`);
+		assert.equal(result.stderr, "", String(body));
+	}
+
+	// The one remedy the gate has: a commit is never the thing to rewrite.
+	const comment = await readFile(join(temp, "attribution-comment.md"), "utf8");
+	assert.match(comment, /Edit the description/);
+	assert.doesNotMatch(comment, /rebase|amend/);
+});


### PR DESCRIPTION
## Problem

`AGENTS.md` § Pull requests says: "Do not add model, agent, harness or tool attribution to pull request titles or bodies." `.changeset/README.md` says the same for a changeset summary. Both are prose a reader weighs the change by.

The gate that arrived to enforce that also refuses a **commit message**, which the rule never covered. `Co-authored-by:` is git's own mechanism for recording who or what worked on a commit, and a tool credited there is a fact about how the work was done rather than a claim standing in front of it. The practical effect is that a contributor whose tooling writes that trailer cannot land a change without rewriting history first, for something the guide does not ask.

## Change

The step reads the pull request body alone, and its comment says what to edit and that a commit trailer is fine. Dropping the commit walk also drops a paginated GraphQL query that the identity check in the same job already performs, so the job does that work once instead of twice.

The patterns are untouched, `verify-changesets.ts` still refuses attribution in a changeset summary, and the identity check that every commit must resolve to the pull request's author is untouched.

`CONTRIBUTING.md` and the doc comment on the shared pattern list now say where the rule applies.

## Verification

`node --test scripts/model-attribution.test.ts` — 3 passing; the patterns are unchanged, so the test that pins the workflow's inline copies to the module still holds. `vp run check` passes apart from two failures that reproduce on an untouched `main` on this machine.
