### PR TITLE
feat(server): a review reports the practices it reached

### DIFF
--- a/.changeset/a-review-reports-the-practices-it-reached.md
+++ b/.changeset/a-review-reports-the-practices-it-reached.md
@@ -1,0 +1,8 @@
+---
+"hephaestus": patch
+---
+
+A practice review that does not get to every practice now reports the practices it did reach, instead
+of being thrown away whole. What it could not get to is recorded as unevaluated on the developer's
+page, and a review in that state never reports that there was nothing to find, because that would be a
+claim about work it never looked at.

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/handler/DeliveryComposer.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/handler/DeliveryComposer.java
@@ -47,7 +47,8 @@ class DeliveryComposer {
         return path.startsWith(REPO_MOUNT_RELATIVE) ? path.substring(REPO_MOUNT_RELATIVE.length()) : path;
     }
 
-    private static boolean isProblem(ValidatedObservation f) {
+    /** Package-private: {@link ReviewCoverage} reads it so the two cannot disagree on what a problem is. */
+    static boolean isProblem(ValidatedObservation f) {
         return f.assessment() == Assessment.BAD;
     }
 

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/handler/IssueReviewHandler.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/handler/IssueReviewHandler.java
@@ -251,8 +251,17 @@ public class IssueReviewHandler implements JobTypeHandler {
         Map<String, String> why = practiceCatalogInjector.whyBySlug(job.getWorkspace(), ArtifactKinds.ISSUE);
         List<ComposedFeedbackUnit> units = compositionResultParser.parse(job.getOutput(), FeedbackChannel.IN_CONTEXT);
         String lead = compositionResultParser.lead(job.getOutput());
+        // Everything either surface would compose from: both render an all-clear when no problem
+        // survives the gates, so the coverage question is asked once, over the union.
+        List<PracticeDetectionResultParser.ValidatedObservation> composable = java.util.stream.Stream.concat(
+                        proposals.stream(), loudEnough.stream())
+                .toList();
+        if (ReviewCoverage.withholdsAllClear(job.getOutput(), composable)) {
+            log.info("Withholding an all-clear from a review that did not reach every practice: jobId={}", job.getId());
+            return;
+        }
         if (!proposals.isEmpty()) {
-            Set<String> included = java.util.stream.Stream.concat(proposals.stream(), loudEnough.stream())
+            Set<String> included = composable.stream()
                     .map(PracticeDetectionResultParser.ValidatedObservation::occurrenceKey)
                     .collect(java.util.stream.Collectors.toUnmodifiableSet());
             List<PracticeDetectionResultParser.ValidatedObservation> reviewPackage = observations.stream()

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/handler/PullRequestReviewHandler.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/handler/PullRequestReviewHandler.java
@@ -292,8 +292,17 @@ public class PullRequestReviewHandler implements JobTypeHandler {
         List<ComposedFeedbackUnit> units = compositionResultParser.parse(job.getOutput(), FeedbackChannel.IN_CONTEXT);
         String lead = compositionResultParser.lead(job.getOutput());
         Map<String, String> why = practiceCatalogInjector.whyBySlug(job.getWorkspace(), ArtifactKinds.PULL_REQUEST);
+        // Everything either surface would compose from: both render an all-clear when no problem
+        // survives the gates, so the coverage question is asked once, over the union.
+        List<PracticeDetectionResultParser.ValidatedObservation> composable = java.util.stream.Stream.concat(
+                        proposals.stream(), deliverable.stream())
+                .toList();
+        if (ReviewCoverage.withholdsAllClear(job.getOutput(), composable)) {
+            log.info("Withholding an all-clear from a review that did not reach every practice: jobId={}", job.getId());
+            return;
+        }
         if (!proposals.isEmpty()) {
-            Set<String> included = java.util.stream.Stream.concat(proposals.stream(), deliverable.stream())
+            Set<String> included = composable.stream()
                     .map(PracticeDetectionResultParser.ValidatedObservation::occurrenceKey)
                     .collect(java.util.stream.Collectors.toUnmodifiableSet());
             List<PracticeDetectionResultParser.ValidatedObservation> reviewPackage = scopedObservations.stream()

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/handler/ReviewCoverage.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/handler/ReviewCoverage.java
@@ -1,0 +1,41 @@
+package de.tum.cit.aet.hephaestus.agent.handler;
+
+import de.tum.cit.aet.hephaestus.agent.handler.PracticeDetectionResultParser.ValidatedObservation;
+import java.util.List;
+import org.jspecify.annotations.Nullable;
+import tools.jackson.databind.JsonNode;
+
+/**
+ * What a run's own coverage ledger permits it to say. A review may end having evaluated only some of
+ * the practices it was eligible for; the runner records which ones it reached, and this is where that
+ * record decides what the review is allowed to claim.
+ */
+final class ReviewCoverage {
+
+    private ReviewCoverage() {}
+
+    /**
+     * Whether this review must keep quiet about having found nothing. A review that reached every
+     * practice may say so; one that did not may report what it found and no more, because an all-clear
+     * covers the practices nobody evaluated as much as the ones that were — a claim about work this
+     * review never looked at. The observations are recorded either way, and a practice nobody reached
+     * reads as unevaluated on the developer's practice page.
+     */
+    static boolean withholdsAllClear(@Nullable JsonNode jobOutput, List<ValidatedObservation> composable) {
+        return !reachedEveryPractice(jobOutput) && composable.stream().noneMatch(DeliveryComposer::isProblem);
+    }
+
+    /**
+     * The ledger the runner writes and {@code PiResultParser} validates before it reaches the job
+     * output — the same record the practice trace reads to mark a practice unevaluated. A run with no
+     * ledger has not shown that it reached anything, so it does not get to claim it did: the parser
+     * drops a ledger it cannot validate, and a run that never wrote one admits no observations either.
+     */
+    private static boolean reachedEveryPractice(@Nullable JsonNode jobOutput) {
+        if (jobOutput == null) return false;
+        JsonNode coverage = jobOutput.path("practiceCoverage");
+        if (!coverage.isObject()) return false;
+        int eligible = coverage.path("eligible").asInt(-1);
+        return eligible >= 0 && coverage.path("evaluated").asInt(-1) == eligible;
+    }
+}

--- a/server/application/src/main/resources/agent/pi-runner-composition.ts
+++ b/server/application/src/main/resources/agent/pi-runner-composition.ts
@@ -31,6 +31,21 @@ export interface ComposedFeedbackEnvelope {
 	lead?: string | null;
 }
 
+/**
+ * What the composer is told about the practices the review never settled. It is not a finding and it
+ * is not a clean bill: the developer's page records them as unevaluated, and anything written about
+ * them would be a verdict the review cannot support.
+ */
+export function notReachedNote(notReached: readonly string[]): string {
+	if (notReached.length === 0) return "";
+	const subject =
+		notReached.length === 1 ? "one of its practices" : `${notReached.length} of its practices`;
+	return (
+		`\nThis review did not settle ${subject}: ${notReached.join(", ")}. ` +
+		`Say nothing about them, for or against, and do not describe this review as complete.\n\n`
+	);
+}
+
 export function validateFeedbackEvidence(
 	primaryPractice: string,
 	basedOn: readonly string[],

--- a/server/application/src/main/resources/agent/pi-runner.ts
+++ b/server/application/src/main/resources/agent/pi-runner.ts
@@ -43,6 +43,7 @@ import {
 	type ComposedFeedbackEnvelope,
 	type ComposedFeedbackUnit,
 	type PreparedFeedbackTarget,
+	notReachedNote,
 	undeliverableUnits,
 	validateFeedbackEvidence,
 } from "./pi-runner-composition.ts";
@@ -1419,6 +1420,7 @@ function normalizeQuotedText(value: string): string {
 function buildCompositionTurn(
 	request: CompositionRequest,
 	observations: readonly AdmittedObservation[],
+	notReached: readonly string[] = [],
 ): string {
 	const lanes = CHANNELS.filter((channel) => request.channels[channel].enabled)
 		.map((channel) => `${channel} (at most ${request.channels[channel].maxUnits})`)
@@ -1430,6 +1432,7 @@ function buildCompositionTurn(
 	const placementNote = request.channels.IN_CONTEXT.enabled
 		? ` IN_CONTEXT placements available here: ${request.inContextPlacementKinds.join(", ")}.`
 		: "";
+	const coverageNote = notReachedNote(notReached);
 	return (
 		`## This turn\n` +
 		`The review just finished. Its ${observations.length} measurement(s) are in ` +
@@ -1437,7 +1440,7 @@ function buildCompositionTurn(
 		`therefore carry a note on the work. Read that file first, then the history.\n\n` +
 		`Lanes open this turn: ${lanes}.${closedNote}${placementNote}` +
 		`\nA pattern claim needs at least ${request.minDistinctArtifacts} distinct pieces of work.\n\n` +
-		`Persist each unit with report_feedback as soon as it is ready, and call report_summary once for ` +
+		`${coverageNote}Persist each unit with report_feedback as soon as it is ready, and call report_summary once for ` +
 		`how the review opens. Writing nothing on a lane is a correct and common outcome; say in one line ` +
 		`why, and stop.`
 	);
@@ -1657,7 +1660,11 @@ async function main() {
 			events.push({ type: `${label}:${event.type}`, timestamp: Date.now() });
 		});
 
-	async function completeWithAdmittedComposition() {
+	/**
+	 * @param notReached the practices this review never settled, named for the composer so nothing it
+	 *   writes reads as a verdict on them
+	 */
+	async function completeWithAdmittedComposition(notReached: readonly string[]) {
 		measurementClosed = true;
 		await admitObservations();
 		const parsed = parseJson(readFileSync(RESULT_PATH, "utf8"));
@@ -1691,7 +1698,7 @@ async function main() {
 		try {
 			await Promise.race([
 				composerSession.prompt(
-					`${instructions}\n\n${buildCompositionTurn(compositionRequest, admittedObservations)}`,
+					`${instructions}\n\n${buildCompositionTurn(compositionRequest, admittedObservations, notReached)}`,
 				),
 				compositionDeadline.elapsed,
 			]);
@@ -1897,7 +1904,7 @@ async function main() {
 		console.error(
 			`[pi-runner] SUCCESS: composed result.json from persisted tool state after initial run`,
 		);
-		await completeWithAdmittedComposition();
+		await completeWithAdmittedComposition([]);
 		process.exit(0);
 	}
 
@@ -2013,24 +2020,28 @@ async function main() {
 		reviewState.observations.map((item) => item.practiceSlug),
 	);
 	logPracticeCoverage();
+	// A practice nobody reached is recorded as unevaluated and reported as such, not turned into a
+	// reason to throw away the practices that were reached. Every observation here was quoted and
+	// validated when it was recorded, and the coverage ledger already carries what is missing, so the
+	// honest outcome is a review that says what it looked at. A review that reached nothing at all has
+	// nothing to say and remains a failure.
 	if (missingAfterRetry.length > 0) {
 		console.error(
-			`[pi-runner] FAILED: ${missingAfterRetry.length} practice observer(s) still missing after retry: ${missingAfterRetry.join(", ")}`,
+			`[pi-runner] PARTIAL: ${missingAfterRetry.length} of ${allSlugs.length} practice(s) not reached: ${missingAfterRetry.join(", ")}`,
 		);
-		process.exit(1);
 	}
 
 	if (maybeWriteResultFile()) {
 		console.error(
-			`[pi-runner] SUCCESS: composed result.json from persisted tool state after retry`,
+			missingAfterRetry.length > 0
+				? `[pi-runner] SUCCESS: composed result.json from the practices this review reached`
+				: `[pi-runner] SUCCESS: composed result.json from persisted tool state after retry`,
 		);
-		await completeWithAdmittedComposition();
+		await completeWithAdmittedComposition(missingAfterRetry);
 		process.exit(0);
 	}
 
-	console.error(
-		`[pi-runner] FAILED: no complete persisted review output after initial attempt + recovery retry`,
-	);
+	console.error(`[pi-runner] FAILED: this review reached no practice at all`);
 	process.exit(1);
 }
 

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/handler/PracticeDetectionPipelineIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/handler/PracticeDetectionPipelineIntegrationTest.java
@@ -265,6 +265,14 @@ class PracticeDetectionPipelineIntegrationTest extends BaseIntegrationTest {
     }
 
     private AgentJob admitAndSetOutput(AgentJob job, String rawOutput) {
+        return admitAndSetOutput(job, rawOutput, true);
+    }
+
+    /**
+     * @param reachedEveryPractice the coverage ledger the run left behind, which decides whether this
+     *     review is allowed to say it found nothing
+     */
+    private AgentJob admitAndSetOutput(AgentJob job, String rawOutput, boolean reachedEveryPractice) {
         JsonNode observations = OBJECT_MAPPER.readTree(withEvidence(rawOutput)).path("observations");
         ((PullRequestReviewHandler) handler).admitObservations(job, observations);
         String digest = "test-admission-digest";
@@ -275,6 +283,7 @@ class PracticeDetectionPipelineIntegrationTest extends BaseIntegrationTest {
         job.setMetadata(metadata);
         ObjectNode output = OBJECT_MAPPER.createObjectNode();
         output.putObject("feedback").put("admissionDigest", digest).putArray("units");
+        output.putObject("practiceCoverage").put("eligible", 2).put("evaluated", reachedEveryPractice ? 2 : 1);
         job.setOutput(output);
         return agentJobRepository.save(job);
     }
@@ -505,6 +514,42 @@ class PracticeDetectionPipelineIntegrationTest extends BaseIntegrationTest {
             assertThat(body.getValue()).contains("What's working well here");
 
             verify(diffNotePoster).reconcileInlineNotes(eq(agentJob), eq(List.of()));
+        }
+
+        @Test
+        void allPositiveFindingsStayQuietWhenTheReviewDidNotReachEveryPractice() {
+            String output = """
+                {
+                  "observations": [
+                    {
+                      "practiceSlug": "pr-description-quality",
+                      "summary": "Good description",
+                      "presence": "PRESENT",
+                      "assessment": "GOOD",
+                      "severity": "INFO",
+                      "evidenceRationale": "The description explains the change."
+                    }
+                  ]
+                }""";
+            agentJob = admitAndSetOutput(agentJob, output, false);
+
+            handler.deliver(agentJob);
+
+            assertThat(observationRepository.findAll()).hasSize(1);
+            verify(commentPoster, never()).postFormattedBody(any(), any());
+        }
+
+        @Test
+        void aPartialReviewStillReportsTheProblemItFound() {
+            agentJob = admitAndSetOutput(agentJob, validAgentOutput(), false);
+            when(commentPoster.postFormattedBody(any(), any())).thenReturn("comment-partial");
+            when(diffNotePoster.reconcileInlineNotes(any(), any()))
+                    .thenReturn(new DiffNotePoster.DiffNoteResult(1, 0, List.of()));
+
+            handler.deliver(agentJob);
+
+            assertThat(observationRepository.findAll()).hasSize(2);
+            verify(commentPoster).postFormattedBody(eq(agentJob), any(String.class));
         }
     }
 

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/handler/PullRequestReviewHandlerTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/handler/PullRequestReviewHandlerTest.java
@@ -571,6 +571,77 @@ class PullRequestReviewHandlerTest extends BaseUnitTest {
             verify(deliveryService).deliver(eq(job), any());
         }
 
+        /** A job past admission, carrying the coverage ledger its run wrote. */
+        private AgentJob jobAwaitingDelivery(int eligible, int evaluated) {
+            ObjectNode metadata = sampleJobMetadata();
+            metadata.put(ObservationAdmissionService.DIGEST_METADATA_KEY, "digest-1");
+            AgentJob job = jobWithMetadata(metadata);
+            ObjectNode output = objectMapper.createObjectNode();
+            output.putObject("feedback").put("admissionDigest", "digest-1");
+            ObjectNode coverage = output.putObject("practiceCoverage");
+            coverage.put("eligible", eligible);
+            coverage.put("evaluated", evaluated);
+            job.setOutput(output);
+            return job;
+        }
+
+        private void observed(AgentJob job, Practice practice, Assessment assessment) {
+            when(practiceRepository.findByWorkspaceId(WORKSPACE_ID)).thenReturn(java.util.List.of(practice));
+            var observation = org.mockito.Mockito.mock(de.tum.cit.aet.hephaestus.practices.model.Observation.class);
+            lenient().when(observation.getPractice()).thenReturn(practice);
+            lenient().when(observation.getSummary()).thenReturn("What the review saw");
+            lenient()
+                    .when(observation.getPresence())
+                    .thenReturn(assessment == Assessment.BAD ? Presence.ABSENT : Presence.PRESENT);
+            lenient().when(observation.getAssessment()).thenReturn(assessment);
+            lenient()
+                    .when(observation.getSeverity())
+                    .thenReturn(assessment == Assessment.BAD ? Severity.MAJOR : Severity.INFO);
+            lenient().when(observation.getEvidenceRationale()).thenReturn("The evidence warrants it.");
+            lenient().when(observation.getOccurrenceKey()).thenReturn("occ-" + practice.getSlug());
+            lenient().when(observation.getRecurrenceKey()).thenReturn("rk-" + practice.getSlug());
+            when(observationRepository.findByAgentJobId(
+                            job.getId(), job.getWorkspace().getId()))
+                    .thenReturn(java.util.List.of(observation));
+        }
+
+        @Test
+        void shouldWithholdAnAllClearWhenTheReviewDidNotReachEveryPractice() {
+            AgentJob job = jobAwaitingDelivery(2, 1);
+            observed(
+                    job,
+                    createPractice("pr-description-quality", "PR Description Quality", "criteria"),
+                    Assessment.GOOD);
+
+            handler.deliver(job);
+
+            verify(feedbackService, never()).deliverFeedback(any(), any(), any());
+            verify(feedbackService, never()).recordProposal(any(), any(), any());
+        }
+
+        @Test
+        void shouldStillReportWhatAPartialReviewFound() {
+            AgentJob job = jobAwaitingDelivery(2, 1);
+            observed(job, createPractice("error-handling", "Error Handling", "criteria"), Assessment.BAD);
+
+            handler.deliver(job);
+
+            verify(feedbackService).deliverFeedback(eq(job), any(), any());
+        }
+
+        @Test
+        void shouldPostAnAllClearWhenTheReviewReachedEveryPractice() {
+            AgentJob job = jobAwaitingDelivery(2, 2);
+            observed(
+                    job,
+                    createPractice("pr-description-quality", "PR Description Quality", "criteria"),
+                    Assessment.GOOD);
+
+            handler.deliver(job);
+
+            verify(feedbackService).deliverFeedback(eq(job), any(), any());
+        }
+
         @Test
         void throwsWhenNoValidObservations() {
             AgentJob job = jobWithOutput("{\"observations\":[]}");

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/handler/ReviewCoverageTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/handler/ReviewCoverageTest.java
@@ -1,0 +1,65 @@
+package de.tum.cit.aet.hephaestus.agent.handler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import de.tum.cit.aet.hephaestus.practices.model.Assessment;
+import de.tum.cit.aet.hephaestus.practices.model.Presence;
+import de.tum.cit.aet.hephaestus.practices.model.Severity;
+import de.tum.cit.aet.hephaestus.testconfig.BaseUnitTest;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ObjectNode;
+
+class ReviewCoverageTest extends BaseUnitTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private PracticeDetectionResultParser.ValidatedObservation observation(Assessment assessment) {
+        return new PracticeDetectionResultParser.ValidatedObservation(
+                "ships-tests-with-the-change",
+                "A summary of what was seen",
+                Presence.PRESENT,
+                assessment,
+                assessment == Assessment.BAD ? Severity.MINOR : Severity.INFO,
+                objectMapper.createObjectNode(),
+                "The evidence warrants it.");
+    }
+
+    private JsonNode outputWithCoverage(int eligible, int evaluated) {
+        ObjectNode output = objectMapper.createObjectNode();
+        ObjectNode coverage = output.putObject("practiceCoverage");
+        coverage.put("eligible", eligible);
+        coverage.put("evaluated", evaluated);
+        return output;
+    }
+
+    @Test
+    void shouldAllowAnAllClearWhenTheRunReachedEveryPractice() {
+        assertThat(ReviewCoverage.withholdsAllClear(outputWithCoverage(4, 4), List.of(observation(Assessment.GOOD))))
+                .isFalse();
+    }
+
+    @Test
+    void shouldWithholdAnAllClearWhenAPracticeWentUnevaluated() {
+        assertThat(ReviewCoverage.withholdsAllClear(outputWithCoverage(4, 2), List.of(observation(Assessment.GOOD))))
+                .isTrue();
+    }
+
+    @Test
+    void shouldStillReportWhatAPartialReviewFound() {
+        assertThat(ReviewCoverage.withholdsAllClear(
+                        outputWithCoverage(4, 2), List.of(observation(Assessment.GOOD), observation(Assessment.BAD))))
+                .isFalse();
+    }
+
+    @Test
+    void shouldWithholdAnAllClearWhenTheRunLeftNoCoverageLedger() {
+        assertThat(ReviewCoverage.withholdsAllClear(
+                        objectMapper.createObjectNode(), List.of(observation(Assessment.GOOD))))
+                .isTrue();
+        assertThat(ReviewCoverage.withholdsAllClear(null, List.of(observation(Assessment.GOOD))))
+                .isTrue();
+    }
+}

--- a/server/application/src/test/resources/agent/pi-runner-composition.spec.ts
+++ b/server/application/src/test/resources/agent/pi-runner-composition.spec.ts
@@ -5,6 +5,7 @@ import {
 	type Channel,
 	type ComposedFeedbackEnvelope,
 	type ComposedFeedbackUnit,
+	notReachedNote,
 	undeliverableUnits,
 	validateFeedbackEvidence,
 } from "../../../main/resources/agent/pi-runner-composition.ts";
@@ -87,4 +88,18 @@ void test("one feedback intervention may synthesize related practice observation
 		validateFeedbackEvidence("review-loop", ["missing"], practices) ?? "",
 		/does not name an admitted observation/,
 	);
+});
+
+void test("a review that reached every practice says nothing about coverage", () => {
+	assert.equal(notReachedNote([]), "");
+});
+
+void test("a review names the practices it never settled and forbids a verdict on them", () => {
+	const one = notReachedNote(["ships-tests-with-the-change"]);
+	assert.match(one, /one of its practices: ships-tests-with-the-change\./);
+	assert.match(one, /Say nothing about them, for or against/);
+	assert.match(one, /do not describe this review as complete/);
+
+	const many = notReachedNote(["ships-tests-with-the-change", "describe-what-and-why"]);
+	assert.match(many, /2 of its practices: ships-tests-with-the-change, describe-what-and-why\./);
 });


### PR DESCRIPTION
## Problem

A review that could not settle every practice threw away the ones it had settled. On the ls1intum workspace that was the common case, not the edge:

| completed reviews | 28 |
|---|---|
| recorded nothing | 23 |
| practices they had evaluated first | 5 of 16, 10 of 16, 8 of 15, 10 of 20 … |

`pi-runner.ts` exited non-zero before `completeWithAdmittedComposition`, so nothing was admitted, the delivery had no admission digest to match, and the observations existed only in a container log. Every one of those observations had been quoted and validated when it was recorded.

## Change

- A review that reached at least one practice admits what it has. One that reached nothing still fails.
- The composer is told which practices went unsettled, and told to say nothing about them either way and never to describe the review as complete.
- Delivery withholds an all-clear from a review that did not reach every practice. That is the one thing a partial review must not say: it would cover the practices nobody evaluated as much as the ones that were. The observations are recorded either way, and the practice page shows the unevaluated ones as unevaluated, which the server already models.

Where that decision is read from matters. It comes from the coverage ledger the runner already writes and the result parser already validates, which is the same record the practice trace reads, rather than from a flag the run asserts about itself. A ledger that is absent or unreadable withholds the all-clear instead of licensing it, so a capture failure can never become a claim. Pull request and issue reviews compose through the same path and both carry the guard.

## Verification

The server unit tier (7182), the architecture tier (304), the affected handler suites (141) and `PracticeDetectionPipelineIntegrationTest` (8). New: `ReviewCoverageTest` for the decision itself including the no-ledger case, three delivery-level cases (withhold, still report the problem, and a control where complete coverage still posts the all-clear), and two end-to-end cases asserting on what reaches the comment poster. `vp run test:agents` (131), `lint:agents`, `typecheck:agents`, `format:check`.

## Consequences worth knowing

A run that ends this way now completes rather than failing, so a dashboard counting failed jobs will see fewer of them. The coverage ratio is where the shortfall shows.

## Noted, not fixed here

- The refusals in this path still reach the sandbox as HTTP 500 and kill the runner, which issue #1934 covers.
- A withheld all-clear leaves a log line and no ledger row. No existing suppression reason fits, and adding one reaches the wire contract and the webapp, so it is its own change.
- `PracticeTraceDeriver` still reads a ready practice with no observations as reviewed and clean when a run left no coverage ledger. Delivery now takes the opposite default; aligning the trace is a separate change, and partial runs becoming ordinary raises its stakes.
