### PR TITLE
docs(ci): the merge queue builds two groups, and why

### DIFF
--- a/docs/contributor/ci-cd.mdx
+++ b/docs/contributor/ci-cd.mdx
@@ -94,9 +94,11 @@ A required context may be filtered because a ruleset accepts a skipped check as 
 still reports `skipped`, not `success`. A workflow that never triggers reports nothing at all, and a
 required context left pending blocks the queue for good — `merge_group` supports no `paths:` filter
 in any case, so the filtering lives in each job's `if`. The queue builds up to
-`max_entries_to_build: 3` groups speculatively, a repository-ruleset field rather than a file here,
+`max_entries_to_build: 2` groups speculatively, a repository-ruleset field rather than a file here,
 and each group costs a whole `CI/CD` run, so a job added to `cicd.yml` is paid for once per group in
-flight.
+flight. Two rather than three because the plan allows 20 concurrent jobs across every run in the
+repository: a third group starved pull-request runs and its own siblings for the sake of a merge
+pace the queue rarely reaches.
 
 A failed merge group drops its pull requests from the queue without failing any check on them, so
 CI updates a comment on the pull request named by the merge group's head ref with the run link. It


### PR DESCRIPTION
## What changed and why

`docs/contributor/ci-cd.mdx` said the merge queue builds up to three groups. The ruleset now builds two: the plan allows 20 concurrent jobs across every run in the repository, and a third speculative group of ~40 jobs starved pull-request runs and its own siblings for a merge pace the queue rarely reached (#1908). The value is a ruleset field, so this paragraph is its one written home; it now states the number and the reason.

Fixes #1908 — the other two bullets landed in #1914.

## How to test

- `vp run docs:lint`
- The ruleset: `gh api repos/hephaestus-build/Hephaestus/rulesets/1290597 --jq '.rules[]|select(.type=="merge_queue").parameters.max_entries_to_build'` → `2`.

## Release impact

None; contributor documentation. No changeset.