### PR TITLE
ci: the analysis of the default branch is not cancelled by the next merge

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,7 +15,11 @@ permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # A superseded analysis of a branch is wasted work, but on the default branch it is the only
+  # analysis that commit will ever get: cancelling it leaves the tip unanalysed, the SAST score drops
+  # and the scorecard ratchet fails on a main nobody broke. Two merges landing within a minute of each
+  # other is enough to trigger it.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   analyze:

--- a/.github/workflows/scorecard-ratchet.yml
+++ b/.github/workflows/scorecard-ratchet.yml
@@ -14,7 +14,9 @@ permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # The verdict on the tip of the default branch is the one that has to exist: cancelling it leaves
+  # a merge unratcheted, which is the state this job is here to notice.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   ratchet:

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -10,7 +10,9 @@ permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # As in `codeql.yml`: a superseded scan of a branch is wasted work, and a superseded scan of the
+  # default branch is the only scan that commit will ever get.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   scan:


### PR DESCRIPTION
## Problem

The Scorecard ratchet failed on `main`:

```
## Scorecard ratchet

- SAST: 9 (minimum 10)
```

Nothing about the merged change lowered it. Pull requests 1935 and 1936 merged about an hour apart, and the CodeQL run for the earlier one was still going when the later push arrived. `codeql.yml` sets `cancel-in-progress: true` on a group keyed by `github.ref`, so the push cancelled it:

```
Analyze (java-kotlin)  ##[error]The operation was canceled.
```

The tip of `main` was therefore never analysed, the published scorecard saw SAST drop a point, and the ratchet failed on a `main` nobody had broken.

## Change

On a branch, a superseded run is wasted work and cancelling it is right. On the default branch it is the only run that commit will ever get. `codeql.yml`, `semgrep.yml` and `scorecard-ratchet.yml` now cancel in progress everywhere except `main`, which is the shape `cicd.yml` already uses for the same reason.

## Verification

`node --test scripts/ci-contract.test.ts` — 54 passing, 1 failure that reproduces on an untouched `main` on this machine (a fork's buildpack build; the step uses a bash 4 builtin and macOS ships bash 3.2). `vp run format:check` clean.
