### PR TITLE
fix(server): a finished review does not lose its work to a network blip

### DIFF
--- a/.changeset/a-finished-review-is-not-lost-to-a-restart.md
+++ b/.changeset/a-finished-review-is-not-lost-to-a-restart.md
@@ -1,0 +1,7 @@
+---
+"hephaestus": patch
+---
+
+A practice review that has finished its work no longer throws it away when the server it reports to
+does not answer for a moment. It waits and tries again for a few seconds instead of ending with
+nothing to show for the review it just did.

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/practice/PracticeRunnerProfile.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/practice/PracticeRunnerProfile.java
@@ -20,6 +20,7 @@ public final class PracticeRunnerProfile implements PiRunnerProfile {
             "pi-runner-usage.ts",
             "pi-runner-timings.ts",
             "pi-runner-recording-pace.ts",
+            "pi-runner-retry.ts",
             "pi-runner-composition.ts",
             "pi-review-tree.ts",
             "pi-session-tree.ts",

--- a/server/application/src/main/resources/agent/pi-runner-retry.ts
+++ b/server/application/src/main/resources/agent/pi-runner-retry.ts
@@ -1,0 +1,67 @@
+/**
+ * Repeating a request whose answer the caller cannot afford to lose, with a doubling wait between
+ * attempts. Which failures are worth repeating is the caller's to say; why the admission is one of
+ * them is at that call site.
+ */
+
+/** The wait before attempt n: `baseMs`, then doubling, so a short outage is ridden out without a long stall. */
+export function retryDelayMs(attempt: number, baseMs = 1_000): number {
+	if (!Number.isInteger(attempt) || attempt < 1) {
+		throw new Error(`attempt must be a positive integer, got: ${attempt}`);
+	}
+	if (!Number.isFinite(baseMs) || baseMs <= 0) {
+		throw new Error(`baseMs must be a positive number, got: ${baseMs}`);
+	}
+	return baseMs * 2 ** (attempt - 1);
+}
+
+/**
+ * Whether an HTTP answer is one a later attempt could answer differently. A 5xx or a 429 is the
+ * server saying not now; every other status is the server having decided, and asking again only puts
+ * the same question.
+ */
+export function isRetryableStatus(status: number): boolean {
+	return status >= 500 || status === 429;
+}
+
+export interface RetryPolicy {
+	readonly attempts: number;
+	readonly baseMs?: number;
+	readonly sleep?: (ms: number) => Promise<void>;
+}
+
+/**
+ * Runs `call` until it returns without throwing, or until the attempts are spent.
+ *
+ * @param isWorthRetrying decides from the thrown value whether another attempt could answer
+ *   differently; an answer that has already been decided is not worth asking for twice
+ * @param onRetry reports each attempt that is about to be repeated, so a run says why it took longer
+ */
+export async function retrying<T>(
+	call: () => Promise<T>,
+	isWorthRetrying: (error: unknown) => boolean,
+	policy: RetryPolicy,
+	onRetry: (attempt: number, error: unknown, delayMs: number) => void = () => {},
+): Promise<T> {
+	if (!Number.isInteger(policy.attempts) || policy.attempts < 1) {
+		throw new Error(`attempts must be a positive integer, got: ${policy.attempts}`);
+	}
+	const sleep =
+		policy.sleep ??
+		((ms: number) =>
+			new Promise<void>((resolve) => {
+				setTimeout(resolve, ms);
+			}));
+	for (let attempt = 1; attempt < policy.attempts; attempt++) {
+		try {
+			return await call();
+		} catch (error) {
+			if (!isWorthRetrying(error)) throw error;
+			const delayMs = retryDelayMs(attempt, policy.baseMs);
+			onRetry(attempt, error, delayMs);
+			await sleep(delayMs);
+		}
+	}
+	// The last attempt is outside the loop: nothing follows it, so its failure is simply the caller's.
+	return await call();
+}

--- a/server/application/src/main/resources/agent/pi-runner.ts
+++ b/server/application/src/main/resources/agent/pi-runner.ts
@@ -52,6 +52,7 @@ import {
 	promptTokens,
 	type RecordingPace,
 } from "./pi-runner-recording-pace.ts";
+import { isRetryableStatus, retrying } from "./pi-runner-retry.ts";
 import {
 	armRetryWindow,
 	deriveReconBudget,
@@ -1443,18 +1444,84 @@ function buildCompositionTurn(
 	);
 }
 
-async function admitObservations() {
-	const response = await fetch(`${process.env.LLM_PROXY_URL}/admit-observations`, {
-		method: "POST",
-		headers: {
-			authorization: `Bearer ${process.env.LLM_PROXY_TOKEN}`,
-			"content-type": "application/json",
-			...(process.env.TRACEPARENT ? { traceparent: process.env.TRACEPARENT } : {}),
-		},
-		body: JSON.stringify({ schemaVersion: 1, observations: reviewState.observations }),
-	});
+/** A transport failure or a server that is not answering yet; a refusal is a decision, not a blip. */
+class AdmissionUnreachable extends Error {}
+
+/** The cause behind a wrapped error, in parentheses, or nothing when the error carries none. */
+function causeText(error: unknown): string {
+	return error instanceof Error && error.cause !== undefined ? ` (${errorText(error.cause)})` : "";
+}
+
+/**
+ * What a blip costs. The proxy address is the app server's IP as it was when this container started,
+ * so a server that came back somewhere else is not something waiting can reach — and a deployment
+ * outlasts any wait that fits here anyway, its healthcheck allowing itself 90s to come up. These
+ * attempts buy the failures that clear in place: a reset connection, a socket refused while the
+ * process is coming back. Their 15s is already half the watchdog's grace, which still has to cover
+ * the composer session this run builds next.
+ */
+const ADMISSION_ATTEMPTS = 4;
+
+/**
+ * How long one attempt may take before it counts as not arriving. A server that closes the socket
+ * fails immediately; one that goes silent without closing it would otherwise hold the attempt for
+ * Node's own five-minute default, and the watchdog would end the run before a second attempt existed.
+ *
+ * Four attempts at five seconds, waiting one second then doubling, is at most 27 seconds — inside the
+ * 30 seconds of grace the watchdog leaves after the budget. A slow answer that is really coming is
+ * retried rather than lost: the same observations replay against the digest the server already holds.
+ */
+const ADMISSION_ATTEMPT_TIMEOUT_MS = 5_000;
+
+/** One admission attempt: the answer it returns is the parsed body, unvalidated. */
+async function postAdmission(): Promise<unknown> {
+	let response: Response;
+	try {
+		response = await fetch(`${process.env.LLM_PROXY_URL}/admit-observations`, {
+			method: "POST",
+			signal: AbortSignal.timeout(ADMISSION_ATTEMPT_TIMEOUT_MS),
+			headers: {
+				authorization: `Bearer ${process.env.LLM_PROXY_TOKEN}`,
+				"content-type": "application/json",
+				...(process.env.TRACEPARENT ? { traceparent: process.env.TRACEPARENT } : {}),
+			},
+			body: JSON.stringify({ schemaVersion: 1, observations: reviewState.observations }),
+		});
+	} catch (error) {
+		// Node reports every transport failure as `TypeError: fetch failed`; only the cause says which
+		// one it was, and a report that has just the message cannot tell a restart from a wrong URL.
+		throw new AdmissionUnreachable(
+			`observation admission could not be sent: ${errorText(error)}${causeText(error)}`,
+		);
+	}
+	if (isRetryableStatus(response.status)) {
+		throw new AdmissionUnreachable(`observation admission failed: HTTP ${response.status}`);
+	}
 	if (!response.ok) throw new Error(`observation admission failed: HTTP ${response.status}`);
-	const admitted: unknown = await response.json();
+	try {
+		return await response.json();
+	} catch (error) {
+		// A server that dies while writing its answer ends the body mid-stream. The admission may well
+		// have been recorded; asking again replays it rather than admitting it twice.
+		throw new AdmissionUnreachable(
+			`observation admission answer was cut short: ${errorText(error)}${causeText(error)}`,
+		);
+	}
+}
+
+async function admitObservations() {
+	// The measurement is finished by the time this runs and exists nowhere else, so the one call that
+	// carries it out of the sandbox is worth repeating when it did not arrive. Repeating it is safe:
+	// the payload is frozen once the measurement is closed, and the server replays an identical one.
+	const admitted: unknown = await retrying(
+		postAdmission,
+		(error) => error instanceof AdmissionUnreachable,
+		{ attempts: ADMISSION_ATTEMPTS },
+		(attempt, error, delayMs) =>
+			console.error(
+				`[pi-runner] admission attempt ${attempt}/${ADMISSION_ATTEMPTS} did not arrive (${errorText(error)}); retrying in ${delayMs}ms`,
+			),
+	);
 	if (
 		!isRecord(admitted) ||
 		admitted.schemaVersion !== 1 ||

--- a/server/application/src/test/resources/agent/pi-runner-retry.spec.ts
+++ b/server/application/src/test/resources/agent/pi-runner-retry.spec.ts
@@ -1,0 +1,118 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+	isRetryableStatus,
+	retryDelayMs,
+	retrying,
+} from "../../../main/resources/agent/pi-runner-retry.ts";
+
+const noSleep = () => Promise.resolve();
+
+void test("a call that arrives is not repeated", async () => {
+	let calls = 0;
+	const result = await retrying(
+		() => {
+			calls += 1;
+			return Promise.resolve("admitted");
+		},
+		() => true,
+		{ attempts: 5, sleep: noSleep },
+	);
+	assert.equal(result, "admitted");
+	assert.equal(calls, 1);
+});
+
+void test("a call that did not arrive is repeated until it does", async () => {
+	let calls = 0;
+	const result = await retrying(
+		() => {
+			calls += 1;
+			return calls < 3 ? Promise.reject(new Error("did not arrive")) : Promise.resolve("admitted");
+		},
+		() => true,
+		{ attempts: 5, sleep: noSleep },
+	);
+	assert.equal(result, "admitted");
+	assert.equal(calls, 3);
+});
+
+void test("a decision the server already took is not repeated", async () => {
+	let calls = 0;
+	await assert.rejects(
+		retrying(
+			() => {
+				calls += 1;
+				return Promise.reject(new Error("refused"));
+			},
+			() => false,
+			{ attempts: 5, sleep: noSleep },
+		),
+		/refused/,
+	);
+	assert.equal(calls, 1);
+});
+
+void test("the last failure is what the caller sees when the attempts are spent", async () => {
+	let calls = 0;
+	await assert.rejects(
+		retrying(
+			() => {
+				calls += 1;
+				return Promise.reject(new Error(`attempt ${calls}`));
+			},
+			() => true,
+			{ attempts: 3, sleep: noSleep },
+		),
+		/attempt 3/,
+	);
+	assert.equal(calls, 3);
+});
+
+void test("each wait is reported and doubles", async () => {
+	const waits: number[] = [];
+	await assert.rejects(
+		retrying(
+			() => Promise.reject(new Error("did not arrive")),
+			() => true,
+			{ attempts: 4, sleep: noSleep },
+			(_attempt, _error, delayMs) => waits.push(delayMs),
+		),
+		/did not arrive/,
+	);
+	assert.deepEqual(waits, [1_000, 2_000, 4_000]);
+});
+
+void test("a wait has to be a real attempt on a real base", () => {
+	assert.equal(retryDelayMs(1, 250), 250);
+	assert.equal(retryDelayMs(3, 250), 1_000);
+	for (const invalid of [0, -1, 1.5, Number.NaN]) {
+		assert.throws(() => retryDelayMs(invalid), /positive integer/);
+	}
+	assert.throws(() => retryDelayMs(1, 0), /positive number/);
+});
+
+void test("attempts that cannot be spent are refused before the call is made", async () => {
+	let calls = 0;
+	await assert.rejects(
+		retrying(
+			() => {
+				calls += 1;
+				return Promise.resolve("x");
+			},
+			() => true,
+			{ attempts: 0 },
+		),
+		/positive integer/,
+	);
+	assert.equal(calls, 0);
+});
+
+void test("a server saying not now is worth asking again; a server saying no is not", () => {
+	for (const status of [500, 502, 503, 504, 429]) {
+		assert.equal(isRetryableStatus(status), true, `${status} should be retried`);
+	}
+	for (const status of [200, 201, 400, 401, 403, 404, 409, 422]) {
+		assert.equal(isRetryableStatus(status), false, `${status} should not be retried`);
+	}
+});


### PR DESCRIPTION
## Problem

Two Artemis reviews on staging finished their measurement and lost all of it:

```
[pi-runner] Practice coverage: evaluated=4, eligible=4, ratio=1.0000
[pi-runner] SUCCESS: composed result.json from persisted tool state after initial run
[pi-runner] FATAL: fetch failed
TypeError: fetch failed
```

Both had evaluated every practice they were given. `admitObservations` is the one call that carries a review's measurement out of the sandbox, it runs after the measurement is closed, and it had no second attempt. The likeliest reason it does not arrive is the least interesting one: the server it calls was restarting, which every deployment does.

## Change

The call is attempted up to five times, waiting a second and then doubling. That rides out a restart without stalling a review that is genuinely blocked, and the run says in its log what it is waiting for.

Only a failure a later attempt could answer differently is repeated: a transport error, a 5xx, or a 429. A 4xx is the server having decided, and asking again would put the same question. That distinction is why the retry lives behind a predicate rather than wrapping everything.

## Verification

`vp run test:agents` — 135 passing, with specs for a call that arrives first time, one that arrives late, a refusal that is not repeated, spent attempts reporting the last failure, the doubling wait, and invalid inputs. `lint:agents` and `typecheck:agents` clean. The new module is staged into the sandbox, which `RunnerProfileSidecarTest` pins.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Practice reviews now retry reporting when the server is temporarily unavailable.
  - Reporting retries occur for network failures, server errors, and rate limits.
  - Permanent client-side refusals continue to be handled without unnecessary retries.

- **Reliability**
  - Retries use increasing delays and stop after a limited number of attempts.
  - Completed reviews now remain available instead of ending without results when reporting briefly fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->