### PR TITLE
fix(ci): the scorecard ratchet fails a push only for what that push decided

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -9,7 +9,9 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # As in `codeql.yml`: the assessment this publishes is the one the ratchet then reads, and on the
+  # default branch it is the only one that commit will ever get.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions: read-all
 

--- a/docs/contributor/ci-cd.mdx
+++ b/docs/contributor/ci-cd.mdx
@@ -142,7 +142,7 @@ changesets rather than adding one. [Release management](./release-management.mdx
 | Image vulnerability policy | image build and release | blocks fixable high or critical findings | build summary and release evidence |
 | Weekly image rescans | `rescan-main-images.yml`, `rescan-release-images.yml` | the `main` rescan upserts one tracking issue; the release rescan fails and comments on the vulnerability response issue | issues and run artifacts |
 | OpenSSF Scorecard | `main` pushes, branch-protection changes, and weekly; never on pull requests | reports | code scanning and a run artifact |
-| Scorecard ratchet | the same events, plus on demand | fails when an enforced check scores below `security/scorecard-baseline.json` | job summary and a run artifact |
+| Scorecard ratchet | the same events, plus on demand | fails when a check scores below `security/scorecard-baseline.json`; on a push, only for the checks that commit decides | job summary and a run artifact |
 | Renovate | configured schedule and vulnerability alerts | pull requests require normal review and CI | dependency dashboard |
 
 One check owns the dependency verdict: the dependency vulnerability gate in `ci-security-scan.yml`,
@@ -202,17 +202,35 @@ advanced → Disable CodeQL**, not something a workflow file can do.
 
 ### Scorecard baseline
 
-`security/scorecard-baseline.json` owns the minimum every enforced Scorecard check must hold and the
-four exclusions, each with its reason. Checks are compared one at a time, so an improvement cannot
-offset a regression, and a check the baseline does not name is not enforced. Lowering a minimum also
-edits the map in `scripts/check-scorecard.test.ts`, so the change is visible in the pull request that
-makes it.
+`security/scorecard-baseline.json` owns the minimum every enforced Scorecard check must hold, the
+four exclusions with their reasons, and what each enforced check is scored over. Checks are compared
+one at a time, so an improvement cannot offset a regression, and a check the baseline does not name
+is not enforced. Lowering a minimum also edits the map in `scripts/check-scorecard.test.ts`, so the
+change is visible in the pull request that makes it.
+
+`scoredOver` is `configuration` when [Scorecard](https://github.com/ossf/scorecard/blob/main/docs/checks.md)
+computes the score from the repository as it stands — its files, its workflows, its branch rules —
+and `history` when it computes it over a window: SAST and Code-Review over the ~30 most recent merged
+pull requests and commits, CI-Tests over the ~30 most recent commits, Signed-Releases over the 30
+most recent releases, Maintained over the previous 90 days. Every enforced check carries one and a
+one-line reason, and an enforced check without one fails the script, so a check added to the baseline
+is classified deliberately rather than by default.
+
+That classification decides who a regression is charged to. On a `push` the ratchet fails only for a
+`configuration` check, because the commit just pushed is what set the repository's configuration; a
+`history` check is written to the job summary and the run stays green, since no single commit can
+move an aggregate over the last thirty and failing `main` for one would redden every merge until the
+window rolls past. On `schedule`, `workflow_dispatch` and `branch_protection_rule` every check fails,
+because those runs ask again after the window has had time to recover and a score still below the
+baseline is a trend, not a merge. Run outside Actions, with no `GITHUB_EVENT_NAME`, the script
+enforces everything.
 
 `scripts/check-scorecard.ts` reads the posture OpenSSF publishes for this repository — the latest
-published assessment, not necessarily the current commit — and fails on a regression, a missing
-enforced check, evidence that predates the baseline or is more than eight days old, and on an API or
-parsing failure. `scorecard-ratchet.yml` runs it on `main` pushes, branch-protection changes, weekly
-and on demand, and keeps the fetched assessment as an artifact. It is a workflow of its own because
+published assessment, not necessarily the current commit — and fails on a regression it charges to
+the event, a missing enforced check, evidence that predates the baseline or is more than eight days
+old, and on an API or parsing failure. `scorecard-ratchet.yml` runs it on `main` pushes,
+branch-protection changes, weekly and on demand, and keeps the fetched assessment as an artifact.
+It is a workflow of its own because
 [OpenSSF restricts the publishing job](https://github.com/ossf/scorecard-action#workflow-restrictions)
 to allowlisted actions. Reproduce it with `node scripts/check-scorecard.ts`, or
 `node --test scripts/check-scorecard.test.ts` without network access.
@@ -344,7 +362,7 @@ why the label is the authority, and which alternatives were priced and declined,
 | `rescan-release-images.yml` | Weekly, manual | Rescans the latest published release's images and reports drift on the vulnerability response issue |
 | `ci-profile.yml` | Weekly, manual | Profiles server integration tests and Spring contexts |
 | `ci-server-clean-reference.yml` | Weekly, manual | Records cold server phases and compares generated JARs |
-| `scorecard-ratchet.yml` | Push to main, branch-protection change, weekly, manual | Fails when a Scorecard check drops below the committed baseline |
+| `scorecard-ratchet.yml` | Push to main, branch-protection change, weekly, manual | Fails when a Scorecard check drops below the committed baseline; a push fails only for the checks its own commit decides |
 | `deploy-preview.yml` | `preview` label added, or a push, reopen or ready-for-review on a labelled PR | Waits for this commit's attested CI images, deploys them, and registers the native GitHub deployment |
 | `cleanup-preview.yml` | Label removed, PR closed or drafted | Removes and verifies resources, then retains a cleanup tombstone |
 | `reconcile-previews.yml` | Nightly, manual | Re-sends teardown for any preview environment whose pull request is closed, drafted or unlabelled |
@@ -488,6 +506,12 @@ reaches no such commit builds every image itself. `detect-changes` resolves that
 - The `Quality` matrix uses `fail-fast: false`; the image matrix in `reusable-docker-build.yml` uses
   `fail-fast: true`.
 - Pull-request runs cancel superseded runs; `release.yml` never cancels.
+- A run on `main` that leaves a per-commit record — `codeql.yml`, `semgrep.yml`, `scorecard.yml`,
+  `scorecard-ratchet.yml` — is never cancelled, because it is the only run that commit will get and
+  its absence is what a later score reads as a gap. Those workflows write
+  `cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}`, and `scripts/ci-contract.test.ts`
+  holds every `main` push to it; a workflow whose newest run simply replaces the last, such as the
+  docs deploy, is named there as the exception.
 
 ## Monitoring CI
 

--- a/scripts/check-scorecard.test.ts
+++ b/scripts/check-scorecard.test.ts
@@ -19,49 +19,57 @@ const assessment = () => ({
 	),
 });
 
-/** The audit #1653 recorded, restated so that lowering a minimum is a deliberate edit here too. */
-const enforced: Record<string, number> = {
-	"Binary-Artifacts": 10,
-	"CI-Tests": 10,
-	"Code-Review": 10,
-	"Dangerous-Workflow": 10,
-	"Dependency-Update-Tool": 10,
-	License: 10,
-	Maintained: 10,
-	"Pinned-Dependencies": 10,
-	SAST: 10,
-	"Security-Policy": 10,
-	"Token-Permissions": 10,
-	Vulnerabilities: 10,
-	"Signed-Releases": 8,
-	"Branch-Protection": 4,
+/**
+ * The audit #1653 recorded, restated so that lowering a minimum is a deliberate edit here too, with
+ * the scoring each check is charged under, so that reclassifying one is a deliberate edit as well.
+ */
+const enforced: Record<string, { score: number; scoredOver: string }> = {
+	"Binary-Artifacts": { score: 10, scoredOver: "configuration" },
+	"CI-Tests": { score: 10, scoredOver: "history" },
+	"Code-Review": { score: 10, scoredOver: "history" },
+	"Dangerous-Workflow": { score: 10, scoredOver: "configuration" },
+	"Dependency-Update-Tool": { score: 10, scoredOver: "configuration" },
+	License: { score: 10, scoredOver: "configuration" },
+	Maintained: { score: 10, scoredOver: "history" },
+	"Pinned-Dependencies": { score: 10, scoredOver: "configuration" },
+	SAST: { score: 10, scoredOver: "history" },
+	"Security-Policy": { score: 10, scoredOver: "configuration" },
+	"Token-Permissions": { score: 10, scoredOver: "configuration" },
+	Vulnerabilities: { score: 10, scoredOver: "configuration" },
+	"Signed-Releases": { score: 8, scoredOver: "history" },
+	"Branch-Protection": { score: 4, scoredOver: "configuration" },
 };
 
-void test("the committed baseline enforces the recorded minimums", () => {
+const passes = { failures: [], reported: [] };
+
+void test("the committed baseline enforces the recorded minimums under the recorded scoring", () => {
 	const excluded = asRecord(baseline.excluded, "excluded");
 	assert.deepEqual(
 		Object.fromEntries(
 			asArray(baseline.checks, "checks")
 				.map((check) => asRecord(check, "check"))
 				.filter((check) => !Object.hasOwn(excluded, String(check.name)))
-				.map((check) => [check.name, check.score]),
+				.map((check) => [check.name, { score: check.score, scoredOver: check.scoredOver }]),
 		),
 		enforced,
 	);
 });
 
 void test("the committed baseline passes and improvements do not compensate for regressions", () => {
-	assert.deepEqual(checkScorecard(baseline, assessment(), now), []);
+	assert.deepEqual(checkScorecard(baseline, assessment(), now), passes);
 	const value = assessment();
 	for (const check of value.checks) {
 		if (check.name === "Branch-Protection") check.score = 10;
 		if (check.name === "Pinned-Dependencies") check.score = 9;
 	}
-	assert.deepEqual(checkScorecard(baseline, value, now), ["Pinned-Dependencies: 9 (minimum 10)"]);
+	assert.deepEqual(checkScorecard(baseline, value, now), {
+		failures: ["Pinned-Dependencies: 9 (minimum 10)"],
+		reported: [],
+	});
 });
 
 void test("each enforced check independently rejects any drop or missing evidence", () => {
-	for (const [name, minimum] of Object.entries(enforced)) {
+	for (const [name, { score: minimum }] of Object.entries(enforced)) {
 		const value = assessment();
 		assert.deepEqual(
 			checkScorecard(
@@ -69,13 +77,36 @@ void test("each enforced check independently rejects any drop or missing evidenc
 				{ ...value, checks: value.checks.filter((check) => check.name !== name) },
 				now,
 			),
-			[`${name}: missing (minimum ${minimum})`],
+			{ failures: [`${name}: missing (minimum ${minimum})`], reported: [] },
 		);
 		for (const check of value.checks) if (check.name === name) check.score = minimum - 1;
-		assert.deepEqual(checkScorecard(baseline, value, now), [
-			`${name}: ${minimum - 1} (minimum ${minimum})`,
-		]);
+		assert.deepEqual(checkScorecard(baseline, value, now), {
+			failures: [`${name}: ${minimum - 1} (minimum ${minimum})`],
+			reported: [],
+		});
 	}
+});
+
+void test("a push answers for the configuration its commit left and no other event forgives", () => {
+	const dropped = (name: keyof typeof enforced) => {
+		const value = assessment();
+		for (const check of value.checks)
+			if (check.name === name) check.score = Number(enforced[name]?.score) - 1;
+		return value;
+	};
+	assert.deepEqual(checkScorecard(baseline, dropped("SAST"), now, "push"), {
+		failures: [],
+		reported: ["SAST: 9 (minimum 10)"],
+	});
+	assert.deepEqual(checkScorecard(baseline, dropped("Branch-Protection"), now, "push"), {
+		failures: ["Branch-Protection: 3 (minimum 4)"],
+		reported: [],
+	});
+	for (const event of ["schedule", "workflow_dispatch", "branch_protection_rule", undefined])
+		assert.deepEqual(checkScorecard(baseline, dropped("SAST"), now, event), {
+			failures: ["SAST: 9 (minimum 10)"],
+			reported: [],
+		});
 });
 
 void test("only the four deliberate exclusions may drop without failure", () => {
@@ -83,20 +114,20 @@ void test("only the four deliberate exclusions may drop without failure", () => 
 	for (const check of value.checks)
 		if (["Contributors", "CII-Best-Practices", "Fuzzing", "Packaging"].includes(String(check.name)))
 			check.score = -1;
-	assert.deepEqual(checkScorecard(baseline, value, now), []);
+	assert.deepEqual(checkScorecard(baseline, value, now), passes);
 });
 
 void test("new checks do not silently become a new policy", () => {
 	const value = assessment();
 	value.checks.push({ name: "New-Check", score: 0 });
-	assert.deepEqual(checkScorecard(baseline, value, now), []);
+	assert.deepEqual(checkScorecard(baseline, value, now), passes);
 });
 
 void test("rejects stale, future, invalid and pre-baseline assessments", () => {
 	for (const date of ["2026-08-01", "2026-09-04T18:00:00Z", "2026-09-06", "not-a-date"])
 		assert.throws(() => checkScorecard(baseline, { ...assessment(), date }, now));
 	assert.throws(() => checkScorecard(baseline, assessment(), now + 8 * 86_400_000 + 1), /stale/);
-	assert.deepEqual(checkScorecard(baseline, assessment(), now + 8 * 86_400_000), []);
+	assert.deepEqual(checkScorecard(baseline, assessment(), now + 8 * 86_400_000), passes);
 });
 
 void test("rejects malformed, duplicate and wrong-repository evidence", () => {
@@ -132,11 +163,16 @@ void test("invalid policy cannot pass vacuously", () => {
 		{ excluded: { SAST: "" } },
 		{ excluded: { Typo: "reason" } },
 		{ date: "invalid" },
+		// An enforced check with no classification, or a broken one, is never charged by default.
+		{ checks: [{ name: "SAST", score: 10 }], excluded: {} },
+		{ checks: [{ name: "SAST", score: 10, scoredOver: "sometimes", reason: "why" }], excluded: {} },
+		{ checks: [{ name: "SAST", score: 10, scoredOver: "history", reason: " " }], excluded: {} },
+		{ checks: [{ name: "SAST", score: 10, reason: "why" }], excluded: {} },
 	])
 		assert.throws(() => checkScorecard({ ...baseline, ...change }, assessment(), now));
 });
 
-void test("the CLI preserves regression evidence and fails on transport and JSON errors", async (t) => {
+void test("the CLI charges a regression to its event, keeps the evidence, and fails on transport and JSON errors", async (t) => {
 	const directory = await mkdtemp(join(tmpdir(), "scorecard-cli-"));
 	t.after(() => rm(directory, { recursive: true, force: true }));
 	await mkdir(join(directory, "security"));
@@ -153,11 +189,40 @@ void test("the CLI preserves regression evidence and fails on transport and JSON
 		...current,
 		checks: current.checks.filter((check) => check.name !== "SAST"),
 	};
-	for (const [name, status, body, failure] of [
-		["passing assessment", 200, JSON.stringify(current), false],
-		["missing check", 200, JSON.stringify(regression), true],
-		["HTTP failure", 503, "service unavailable", true],
-		["invalid JSON", 200, "not JSON", true],
+	const lowered = (name: string, score: number) => ({
+		...current,
+		checks: current.checks.map((check) => (check.name === name ? { ...check, score } : check)),
+	});
+	const window = JSON.stringify(lowered("SAST", 9));
+	for (const [name, event, status, body, failure, expected] of [
+		[
+			"passing assessment",
+			"schedule",
+			200,
+			JSON.stringify(current),
+			false,
+			/All enforced checks meet/,
+		],
+		["missing check", "schedule", 200, JSON.stringify(regression), true, /SAST: missing/],
+		["a window score a push cannot have caused", "push", 200, window, false, /window of history/],
+		[
+			"the same window score once the window has had its chance",
+			"schedule",
+			200,
+			window,
+			true,
+			/SAST: 9 \(minimum 10\)/,
+		],
+		[
+			"a configuration score the push is answerable for",
+			"push",
+			200,
+			JSON.stringify(lowered("Branch-Protection", 3)),
+			true,
+			/Branch-Protection: 3 \(minimum 4\)/,
+		],
+		["HTTP failure", "schedule", 503, "service unavailable", true, undefined],
+		["invalid JSON", "schedule", 200, "not JSON", true, undefined],
 	] as const) {
 		await t.test(name, async () => {
 			await rm(summary, { force: true });
@@ -171,6 +236,7 @@ void test("the CLI preserves regression evidence and fails on transport and JSON
 					encoding: "utf8",
 					env: {
 						...process.env,
+						GITHUB_EVENT_NAME: event,
 						GITHUB_STEP_SUMMARY: summary,
 						RESPONSE_BODY: body,
 						RESPONSE_STATUS: String(status),
@@ -178,12 +244,9 @@ void test("the CLI preserves regression evidence and fails on transport and JSON
 				},
 			);
 			assert.equal(result.status, failure ? 1 : 0, result.stderr);
-			if (status === 200 && body !== "not JSON") {
+			if (expected) {
 				assert.deepEqual(JSON.parse(await readFile(evidence, "utf8")), JSON.parse(body));
-				assert.match(
-					await readFile(summary, "utf8"),
-					failure ? /SAST: missing/ : /All enforced checks meet/,
-				);
+				assert.match(await readFile(summary, "utf8"), expected);
 			} else {
 				await assert.rejects(readFile(evidence), { code: "ENOENT" });
 			}

--- a/scripts/check-scorecard.ts
+++ b/scripts/check-scorecard.ts
@@ -2,6 +2,30 @@ import { appendFile, mkdir, writeFile } from "node:fs/promises";
 
 import { asArray, asRecord, asString, readJsonFile } from "./lib/json.ts";
 
+/**
+ * What a check's score is computed from: the repository as it stands, which the pushed commit
+ * decides, or a window of recent commits, pull requests, releases or days, which it cannot.
+ */
+const SCORINGS = ["configuration", "history"] as const;
+
+type Scoring = (typeof SCORINGS)[number];
+
+export type Verdict = { failures: string[]; reported: string[] };
+
+function classifications(value: unknown): Map<string, Scoring> {
+	const result = new Map<string, Scoring>();
+	for (const item of asArray(value, "checks")) {
+		const check = asRecord(item, "check");
+		if (check.scoredOver === undefined && check.reason === undefined) continue;
+		const name = asString(check.name, "check.name");
+		const scoredOver = SCORINGS.find((scoring) => scoring === check.scoredOver);
+		if (!scoredOver || !asString(check.reason, "check.reason").trim())
+			throw new Error(`Invalid classification: ${name}`);
+		result.set(name, scoredOver);
+	}
+	return result;
+}
+
 function scores(value: unknown): Map<string, number> {
 	const result = new Map<string, number>();
 	for (const item of asArray(value, "checks")) {
@@ -22,11 +46,17 @@ function scores(value: unknown): Map<string, number> {
 	return result;
 }
 
+/**
+ * A push is answerable only for the repository the commit it carries leaves behind. Any other event
+ * asks the same question again later, by which time a score computed over a window of history has
+ * had every chance to recover, so an unset event enforces everything.
+ */
 export function checkScorecard(
 	baselineValue: unknown,
 	assessmentValue: unknown,
 	now = Date.now(),
-): string[] {
+	event?: string,
+): Verdict {
 	const baseline = asRecord(baselineValue, "baseline");
 	const assessment = asRecord(assessmentValue, "assessment");
 	const repository = asString(baseline.repository, "baseline.repository");
@@ -49,13 +79,30 @@ export function checkScorecard(
 	const enforced = [...expected].filter(([name]) => !Object.hasOwn(excluded, name));
 	if (enforced.length === 0 || enforced.some(([, minimum]) => minimum < 0))
 		throw new Error("Baseline must enforce at least one check with nonnegative minimums");
+	const scoredOver = classifications(baseline.checks);
 	const failures: string[] = [];
+	const reported: string[] = [];
 	for (const [name, minimum] of enforced) {
+		const scoring = scoredOver.get(name);
+		if (!scoring) throw new Error(`Check without a scoring classification: ${name}`);
 		const current = actual.get(name);
-		if (current === undefined || current < minimum)
-			failures.push(`${name}: ${current ?? "missing"} (minimum ${minimum})`);
+		if (current !== undefined && current >= minimum) continue;
+		const regression = `${name}: ${current ?? "missing"} (minimum ${minimum})`;
+		(event === "push" && scoring === "history" ? reported : failures).push(regression);
 	}
-	return failures;
+	return { failures, reported };
+}
+
+function summarize({ failures, reported }: Verdict): string {
+	const bullets = (entries: string[]) => entries.map((entry) => `- ${entry}`).join("\n");
+	const sections: string[] = [];
+	if (failures.length) sections.push(bullets(failures));
+	if (reported.length)
+		sections.push(
+			`Scored over a window of history, which no single push can restore; the weekly run fails on it.\n\n${bullets(reported)}`,
+		);
+	if (!sections.length) sections.push("All enforced checks meet the committed baseline.");
+	return `## Scorecard ratchet\n\n${sections.join("\n\n")}\n`;
 }
 
 async function main() {
@@ -68,11 +115,11 @@ async function main() {
 	const assessment: unknown = await response.json();
 	await mkdir("tmp", { recursive: true });
 	await writeFile("tmp/scorecard-assessment.json", `${JSON.stringify(assessment, null, 2)}\n`);
-	const failures = checkScorecard(baseline, assessment);
-	const summary = `## Scorecard ratchet\n\n${failures.length ? failures.map((failure) => `- ${failure}`).join("\n") : "All enforced checks meet the committed baseline."}\n`;
+	const verdict = checkScorecard(baseline, assessment, Date.now(), process.env.GITHUB_EVENT_NAME);
+	const summary = summarize(verdict);
 	process.stdout.write(summary);
 	if (process.env.GITHUB_STEP_SUMMARY) await appendFile(process.env.GITHUB_STEP_SUMMARY, summary);
-	if (failures.length) process.exitCode = 1;
+	if (verdict.failures.length) process.exitCode = 1;
 }
 
 if (import.meta.main) await main();

--- a/scripts/ci-contract.test.ts
+++ b/scripts/ci-contract.test.ts
@@ -1980,6 +1980,41 @@ void test("the Scorecard ratchet runs on every event that can move a score, outs
 	}
 });
 
+/**
+ * A workflow whose newest run on `main` simply replaces the one before it, so cancelling the older
+ * run loses nothing a later job reads.
+ */
+const REPLACEABLE_MAIN_RUNS: Record<string, string> = {
+	".github/workflows/cd-docs.yml": "The site the last deploy published is the site.",
+};
+
+// Every other run on `main` is the only one its commit will ever get, and something downstream reads
+// the record it leaves: a cancelled CodeQL analysis is a commit Scorecard counts as unscanned, and a
+// cancelled ratchet is a merge nobody checked. Two merges a minute apart are enough to lose one.
+void test("a workflow triggered by main does not cancel the run main is judged by", async () => {
+	const sources = await workflowSources();
+	const offenders: string[] = [];
+	for (const [file, source] of sources) {
+		const branches = parseDocument(source).getIn(["on", "push", "branches"]);
+		if (!isSeq(branches) || !branches.items.some((item) => isScalar(item) && item.value === "main"))
+			continue;
+		if (
+			parseDocument(source).getIn(["concurrency", "cancel-in-progress"]) === true &&
+			!Object.hasOwn(REPLACEABLE_MAIN_RUNS, file)
+		)
+			offenders.push(file);
+	}
+	assert.deepEqual(offenders, [], "these cancel a run on main that nothing else will repeat");
+	for (const [file, reason] of Object.entries(REPLACEABLE_MAIN_RUNS)) {
+		assert.ok(reason.trim(), `${file} must say why its run is replaceable`);
+		assert.equal(
+			parseDocument(sources.get(file) ?? "").getIn(["concurrency", "cancel-in-progress"]),
+			true,
+			`${file} no longer cancels, so it no longer needs an exception`,
+		);
+	}
+});
+
 // A toolchain claim is a job: every leg of the task graph is one matrix entry of one job, the Vite+
 // shell and the hook dispatcher run on Windows as one of them, and the documented first command of
 // a contributor runs from a clone that has nothing but the launcher.

--- a/security/scorecard-baseline.json
+++ b/security/scorecard-baseline.json
@@ -4,59 +4,87 @@
 	"checks": [
 		{
 			"name": "Binary-Artifacts",
-			"score": 10
+			"score": 10,
+			"scoredOver": "configuration",
+			"reason": "Executables committed to the tree as it stands."
 		},
 		{
 			"name": "CI-Tests",
-			"score": 10
+			"score": 10,
+			"scoredOver": "history",
+			"reason": "The share of the ~30 most recent commits a CI system reported a result on."
 		},
 		{
 			"name": "Code-Review",
-			"score": 10
+			"score": 10,
+			"scoredOver": "history",
+			"reason": "The share of the ~30 most recent commits that carry an approval."
 		},
 		{
 			"name": "Dangerous-Workflow",
-			"score": 10
+			"score": 10,
+			"scoredOver": "configuration",
+			"reason": "Dangerous patterns in the workflow files as they stand."
 		},
 		{
 			"name": "Dependency-Update-Tool",
-			"score": 10
+			"score": 10,
+			"scoredOver": "configuration",
+			"reason": "Whether an update tool is configured in the tree."
 		},
 		{
 			"name": "License",
-			"score": 10
+			"score": 10,
+			"scoredOver": "configuration",
+			"reason": "Whether a recognised license file is present."
 		},
 		{
 			"name": "Maintained",
-			"score": 10
+			"score": 10,
+			"scoredOver": "history",
+			"reason": "Commit and issue activity over the previous 90 days."
 		},
 		{
 			"name": "Pinned-Dependencies",
-			"score": 10
+			"score": 10,
+			"scoredOver": "configuration",
+			"reason": "Whether every dependency the tree declares is pinned."
 		},
 		{
 			"name": "SAST",
-			"score": 10
+			"score": 10,
+			"scoredOver": "history",
+			"reason": "The share of the ~30 most recent merged pull requests a SAST tool ran on."
 		},
 		{
 			"name": "Security-Policy",
-			"score": 10
+			"score": 10,
+			"scoredOver": "configuration",
+			"reason": "Whether the committed security policy is present and specific."
 		},
 		{
 			"name": "Token-Permissions",
-			"score": 10
+			"score": 10,
+			"scoredOver": "configuration",
+			"reason": "The permissions the workflow files grant."
 		},
 		{
 			"name": "Vulnerabilities",
-			"score": 10
+			"score": 10,
+			"scoredOver": "configuration",
+			"reason": "Advisories open against the dependencies the checkout resolves."
 		},
 		{
 			"name": "Signed-Releases",
-			"score": 8
+			"score": 8,
+			"scoredOver": "history",
+			"reason": "The share of the 30 most recent releases whose artifacts are signed."
 		},
 		{
 			"name": "Branch-Protection",
-			"score": 4
+			"score": 4,
+			"scoredOver": "configuration",
+			"reason": "The protection rules the default and release branches carry."
 		},
 		{
 			"name": "Contributors",


### PR DESCRIPTION
## What changed and why

`main` has been red on every push since 09:48 today: `Scorecard ratchet` fails with
`SAST: 9 (minimum 10)`. Nothing on `main` is broken. Scorecard scores SAST as the fraction of the
~30 most recent merged pull requests that a SAST tool ran on — ["looks for known GitHub apps such as
CodeQL … in the recent (~30) merged PRs"](https://github.com/ossf/scorecard/blob/main/docs/checks.md#sast) —
and the published detail says `28 commits out of 30 are checked with a SAST tool`. Two of those
thirty have no successful CodeQL run because `codeql.yml` cancelled a superseded analysis on `main`
until #1939 landed this morning, and a merge arriving within a minute of the last one took the
previous commit's analysis with it. Nine of the last thirty commits on `main` carry at least one
`Analyze (…) = cancelled` check run.

That is a lagging thirty-pull-request aggregate. No push can raise it, and `main` stays red until the
window rolls past the two gaps — up to twenty-eight more merges. Failing a commit for a verdict the
commit cannot change is the defect; the gap it reports is real and still worth failing on, just not
on this event.

`security/scorecard-baseline.json` now records, for every enforced check, whether Scorecard computes
its score from the repository as it stands (`configuration`) or over a window of recent commits,
pull requests, releases or days (`history`), each with a one-line reason drawn from the check
documentation. `scripts/check-scorecard.ts` reads `GITHUB_EVENT_NAME` and applies the rule:

- On `push`, fail only for a `configuration` check — the commit just pushed is what set the
  repository's configuration. A `history` regression is written to the job summary and the run stays
  green.
- On `schedule`, `workflow_dispatch` and `branch_protection_rule`, fail for every check: those runs
  ask again after the window has had time to recover, so a score still below the baseline is a trend
  rather than a merge. Run outside Actions, with no event, the script enforces everything.

An enforced check with no classification fails the script, so a check added to the baseline is
classified deliberately rather than defaulting to either side. The fetched assessment is still kept
as a run artifact and the summary is unchanged in shape.

`scorecard.yml` — the workflow that publishes the assessment the ratchet then reads — still had
`cancel-in-progress: true`, the same bug #1939 fixed in `codeql.yml`, `semgrep.yml` and
`scorecard-ratchet.yml` and missed here. It now uses
`cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}`, and `scripts/ci-contract.test.ts`
holds every workflow triggered by a push to `main` to that rule, with the docs deploy named as the
one exception whose newest run simply replaces the last.

Part of #1653.

## How to test

Against the live published assessment, which currently scores SAST at 9:

```
$ GITHUB_EVENT_NAME=push node scripts/check-scorecard.ts
## Scorecard ratchet

Scored over a window of history, which no single push can restore; the weekly run fails on it.

- SAST: 9 (minimum 10)
exit=0
```

```
$ GITHUB_EVENT_NAME=schedule node scripts/check-scorecard.ts
## Scorecard ratchet

- SAST: 9 (minimum 10)
exit=1
```

- `node --test scripts/check-scorecard.test.ts scripts/ci-contract.test.ts` — 73 pass, 0 fail. The
  new cases cover a window check below minimum on `push` (reported, exit 0) and on `schedule`
  (exit 1), a configuration check below minimum on `push` (exit 1), and a baseline whose enforced
  check carries no classification, a classification that is not one of the two, or a blank reason.
- Reverting `scorecard.yml` to `cancel-in-progress: true` fails the new contract test with
  `these cancel a run on main that nothing else will repeat` and
  `+ [ '.github/workflows/scorecard.yml' ]`.
- `pnpm exec vp run check` — green.
- `actionlint .github/workflows/scorecard.yml` — clean. `zizmor .github/workflows/scorecard.yml` —
  no findings.

## Release impact

No changeset: CI configuration and repository tooling only, with no shipped code and no operator
action.

## Notes for reviewers

The classification is a judgement about each Scorecard check, so it is worth checking against the
[check documentation](https://github.com/ossf/scorecard/blob/main/docs/checks.md): CI-Tests and
Code-Review over the ~30 most recent commits, SAST over the ~30 most recent merged pull requests,
Signed-Releases over the 30 most recent releases, Maintained over the previous 90 days; every other
enforced check reads the repository as it stands. Vulnerabilities is `configuration` because
Scorecard reads the advisories open against the dependencies the checkout resolves, which a commit
can change.

The minimums and the classification are both restated in `scripts/check-scorecard.test.ts`, so
loosening either — including reclassifying a check to escape a push — is a visible edit in two files.

This does not close the SAST gap itself. #1939 stopped new gaps appearing; the two existing ones age
out of the window as `main` merges, and the weekly run will fail until they do, which is the run that
should.
