### PR TITLE
fix(server): a refused observation says why in the log

### DIFF
--- a/.changeset/a-refused-observation-says-why.md
+++ b/.changeset/a-refused-observation-says-why.md
@@ -1,0 +1,7 @@
+---
+"hephaestus": patch
+---
+
+A practice review's log now names every observation it refused to record, and why. A review that was
+refused all of them read exactly like one that found nothing, so the difference could not be seen
+from the outside.

--- a/server/application/src/main/resources/agent/pi-runner.ts
+++ b/server/application/src/main/resources/agent/pi-runner.ts
@@ -591,6 +591,37 @@ interface ReportObservationDetails {
 	remainingPractices?: string[];
 }
 
+const MAX_REFUSAL_LOG_CHARS = 500;
+
+/**
+ * Names a refused observation in the log as well as to the session.
+ *
+ * The session is told either way — that is how it corrects itself and tries again — but nothing was
+ * written for the reader, so a review whose every recording was refused read exactly like one that
+ * never recorded: the same tool lines, then an empty result.
+ *
+ * A reason can quote a model-authored field, and only the tail of a container's log is kept, so an
+ * unreasonable one is cut here rather than left to evict the transcript it is there to explain.
+ */
+function logRefusal(params: unknown, reason: string): void {
+	const slug =
+		isRecord(params) && typeof params.practiceSlug === "string" ? params.practiceSlug : "unknown";
+	const line = `[pi-runner] observation refused for ${slug}: ${reason}`;
+	console.error(
+		line.length > MAX_REFUSAL_LOG_CHARS ? `${line.slice(0, MAX_REFUSAL_LOG_CHARS)}…` : line,
+	);
+}
+
+/** Logs a refusal thrown by one step, and hands the session the same error it would have seen. */
+function refusing<T>(params: unknown, step: () => T): T {
+	try {
+		return step();
+	} catch (error) {
+		logRefusal(params, errorText(error));
+		throw error;
+	}
+}
+
 function buildReportObservationTool(allowedPracticeSlugs?: readonly string[]) {
 	const allowed = allowedPracticeSlugs ? new Set(allowedPracticeSlugs) : null;
 	const scopedObservationSchema = allowedPracticeSlugs
@@ -609,30 +640,27 @@ function buildReportObservationTool(allowedPracticeSlugs?: readonly string[]) {
 			"Persist exactly one structured observation immediately so it survives retries and timeouts. Call this as soon as one observation is ready. Do not wait to batch observations.",
 		parameters: scopedObservationSchema,
 		execute: (_toolCallId, params): Promise<AgentToolResult<ReportObservationDetails>> => {
+			// Every branch below that declines to record logs the same reason it hands to the session.
 			if (measurementClosed) {
+				const text = "Measurement is closed; this turn may only compose feedback.";
+				logRefusal(params, text);
 				return Promise.resolve({
-					content: [
-						{
-							type: "text",
-							text: "Measurement is closed; this turn may only compose feedback.",
-						},
-					],
+					content: [{ type: "text", text }],
 					details: { inserted: 0, measurementClosed: true },
 				});
 			}
-			const normalized = normalizeObservation(params);
+			const normalized = refusing(params, () => normalizeObservation(params));
 			if (allowed && !allowed.has(normalized.practiceSlug)) {
+				const text = `This observer is scoped to ${[...allowed].join(", ")}, not '${normalized.practiceSlug}'.`;
+				logRefusal(params, text);
 				return Promise.resolve({
-					content: [
-						{
-							type: "text",
-							text: `This observer is scoped to ${[...allowed].join(", ")}, not '${normalized.practiceSlug}'.`,
-						},
-					],
+					content: [{ type: "text", text }],
 					details: { inserted: 0, remainingPractices: [...allowed] },
 				});
 			}
-			const { inserted, duplicates, negatives } = appendObservations([params]);
+			const { inserted, duplicates, negatives } = refusing(params, () =>
+				appendObservations([params]),
+			);
 			const observed = new Set(reviewState.observations.map((item) => item.practiceSlug));
 			const remainingPractices = allowed
 				? [...allowed].filter((practiceSlug) => !observed.has(practiceSlug))


### PR DESCRIPTION
## Problem

Two Artemis reviews on staging did this:

```
[pi-runner] observer:code-1 tool: report_observation   (×5)
[pi-runner] observer:code-1 assistant msg: stopReason=error, toolCalls=0, types=[]   (×8)
[pi-runner] Practice coverage: evaluated=0, eligible=4, ratio=0.0000
```

Five observations were reported and none was kept. An observation the runner declines — a summary it will not take, a citation whose quote does not match the staged artifact, a practice outside the observer's scope — is handed back to the session so it can correct itself, and that is right. But nothing was written for whoever reads the transcript afterwards, so a review whose every recording was refused is indistinguishable from one that found nothing to record.

That is the difference between a model that needs a better prompt and a validation rule that is too strict, and neither can be told from the outside today.

## Change

Both places that decline a recording name the practice and the reason first. The session sees exactly what it saw before, so nothing about how a review corrects itself changes.

## Verification

`vp run test:agents`, `lint:agents`, `typecheck:agents` and `format:check`.