### PR TITLE
fix(server): a review's whole transcript is kept

### DIFF
--- a/.changeset/a-reviews-whole-transcript-is-kept.md
+++ b/.changeset/a-reviews-whole-transcript-is-kept.md
@@ -1,0 +1,11 @@
+---
+"hephaestus": patch
+---
+
+A practice review's transcript is now kept whole, so what a review actually did can be read back. Only
+its ending was stored, and that ending was itself collected from the last few hundred lines the run
+printed, so what the review was asked, what it read and what it was refused had been thrown away before
+anyone could look. A run large enough to threaten the server now keeps its beginning and its ending with
+a line between them naming exactly how much is missing, and collection that gives up early says so
+rather than stopping quietly. Transcripts take correspondingly more room until retention clears them, on
+the schedule it always did.

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobExecutor.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobExecutor.java
@@ -109,7 +109,6 @@ public class AgentJobExecutor {
     private static final String MDC_JOB_ID = StructuredLogKeys.JOB_ID;
     private static final String MDC_JOB_TYPE = "agent.jobType";
     private static final int MAX_ERROR_MESSAGE_LENGTH = 4000;
-    private static final int MAX_CONTAINER_LOGS_CHARS = 65536; // 64KB
     // How long a claim-blocked job waits before the poll loop re-evaluates the cap.
     private static final Duration BUDGET_HOLD_INTERVAL = Duration.ofHours(1);
     // Measured from submission, not from when the hold started: what goes stale is the work the job
@@ -1255,12 +1254,12 @@ public class AgentJobExecutor {
 
             freshJob.setOutput(objectMapper.valueToTree(agentResult.output()));
             freshJob.setExitCode(sandboxResult.exitCode());
+            // The whole transcript, not its ending. It is the only account of what a review did — which
+            // practices it settled, what it was refused and why, where its time went — and a review that
+            // is not doing what it should is diagnosed from the part that a tail drops. Collection has
+            // already bounded it, and the retention sweep clears it on its own schedule.
             if (sandboxResult.logs() != null && !sandboxResult.logs().isBlank()) {
-                String logs = sandboxResult.logs();
-                freshJob.setContainerLogs(
-                        logs.length() > MAX_CONTAINER_LOGS_CHARS
-                                ? logs.substring(logs.length() - MAX_CONTAINER_LOGS_CHARS)
-                                : logs);
+                freshJob.setContainerLogs(sandboxResult.logs());
             }
             if (terminalStatus == AgentJobStatus.COMPLETED) {
                 freshJob.setDeliveryStatus(DeliveryStatus.PENDING);

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/BoundedTranscript.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/BoundedTranscript.java
@@ -1,0 +1,82 @@
+package de.tum.cit.aet.hephaestus.agent.sandbox.docker;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.Objects;
+
+/**
+ * A container's output, collected whole unless it is enormous, and never silently cut.
+ *
+ * <p>A review's transcript is the only account of what it did: which practices it observed, what it was
+ * refused and why, where its time went. Keeping a prefix loses the ending, where a run says how it
+ * failed; keeping a suffix loses the beginning, where it says what it was asked and what it read. So
+ * everything is kept until a run is large enough to threaten the collecting process, and past that
+ * point both ends are kept with a line between them saying exactly how much is missing — a reader is
+ * never left to wonder whether they are looking at the whole thing.
+ */
+final class BoundedTranscript {
+
+    private final int headLimit;
+    private final int tailLimit;
+    private final StringBuilder head = new StringBuilder();
+    private final Deque<String> tail = new ArrayDeque<>();
+    private int tailChars;
+    private long dropped;
+
+    BoundedTranscript(int headLimit, int tailLimit) {
+        if (headLimit <= 0 || tailLimit <= 0) {
+            throw new IllegalArgumentException("head and tail limits must be positive");
+        }
+        this.headLimit = headLimit;
+        this.tailLimit = tailLimit;
+    }
+
+    /** Frames arrive on a Docker callback thread while the caller waits on completion. */
+    synchronized void append(String chunk) {
+        if (chunk.isEmpty()) {
+            return;
+        }
+        String rest = chunk;
+        if (head.length() < headLimit) {
+            int room = Math.min(headLimit - head.length(), rest.length());
+            head.append(rest, 0, room);
+            rest = rest.substring(room);
+            if (rest.isEmpty()) {
+                return;
+            }
+        }
+        tail.addLast(rest);
+        tailChars += rest.length();
+        // Whole chunks leave the front, and the one whose departure would take the tail under its limit
+        // stays: trimming costs the chunks it drops rather than a copy of everything it keeps, and no
+        // chunk is ever split. The deque therefore never empties, so the chunk that arrived last — the
+        // ending — is never the one evicted.
+        while (tailChars - Objects.requireNonNull(tail.peekFirst()).length() >= tailLimit) {
+            String evicted = tail.removeFirst();
+            tailChars -= evicted.length();
+            dropped += evicted.length();
+        }
+    }
+
+    /** How many characters were dropped from the middle; zero means this transcript is complete. */
+    synchronized long dropped() {
+        return dropped;
+    }
+
+    @Override
+    public synchronized String toString() {
+        StringBuilder out = new StringBuilder(head.length() + tailChars + 128);
+        out.append(head);
+        if (dropped > 0) {
+            out.append("\n[hephaestus] ")
+                    .append(dropped)
+                    .append(" characters of this transcript were dropped here: the run produced more output than ")
+                    .append(headLimit + tailLimit)
+                    .append(" characters. What follows is its ending.\n");
+        }
+        for (String chunk : tail) {
+            out.append(chunk);
+        }
+        return out.toString();
+    }
+}

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/DockerClientOperations.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/DockerClientOperations.java
@@ -42,11 +42,13 @@ public class DockerClientOperations
     static final Duration IMAGE_PULL_TIMEOUT = Duration.ofMinutes(5);
 
     /**
-     * Maximum log output to collect from a container (prevents OOM from runaway output). This is
-     * the <em>collection</em> limit; see {@link DockerSandboxAdapter#MAX_LOG_EVENT_BYTES} for the
-     * downstream <em>emission</em> limit (32 KB) applied when logging captured output.
+     * How much of a container's output is held in memory before its middle is dropped, split evenly
+     * between the beginning and the ending. A review's transcript is the only account of what it did,
+     * so the whole of it is kept unless a run is large enough to threaten the collecting process; see
+     * {@link DockerSandboxAdapter#MAX_LOG_EVENT_CHARS} for the separate limit on what is echoed to the
+     * application's own log.
      */
-    static final int MAX_LOG_BYTES = 1024 * 1024; // 1 MB
+    static final int MAX_LOG_CHARS = 8 * 1024 * 1024; // 8 MB
 
     private final DockerClient dockerClient;
 
@@ -291,21 +293,22 @@ public class DockerClientOperations
 
     @Override
     public String getLogs(String containerId, int tailLines) {
-        // Best-effort log collection: timeout and errors return partial/empty data.
+        // Best-effort log collection: an error returns nothing, and a timeout says so in the transcript.
         try {
-            // StringBuffer is thread-safe: onNext is called from a Docker callback thread
-            StringBuffer logs = new StringBuffer();
+            // Synchronised inside: onNext is called from a Docker callback thread.
+            BoundedTranscript logs = new BoundedTranscript(MAX_LOG_CHARS / 2, MAX_LOG_CHARS / 2);
             var callback = new ResultCallback.Adapter<Frame>() {
                 @Override
                 public void onNext(Frame frame) {
-                    if (frame != null && frame.getPayload() != null && logs.length() < MAX_LOG_BYTES) {
+                    if (frame != null && frame.getPayload() != null) {
                         logs.append(new String(frame.getPayload(), StandardCharsets.UTF_8));
                     }
                 }
             };
 
+            boolean complete;
             try {
-                dockerClient
+                complete = dockerClient
                         .logContainerCmd(containerId)
                         .withStdOut(true)
                         .withStdErr(true)
@@ -315,6 +318,12 @@ public class DockerClientOperations
                         .awaitCompletion(LOG_COLLECTION_TIMEOUT_SECONDS, TimeUnit.SECONDS);
             } finally {
                 callback.close();
+            }
+            if (!complete) {
+                // Say so in the transcript itself: a reader who cannot tell a short run from an
+                // abandoned collection cannot trust either.
+                logs.append("\n[hephaestus] Log collection stopped after " + LOG_COLLECTION_TIMEOUT_SECONDS
+                        + " seconds; this transcript ends early.\n");
             }
 
             return logs.toString();

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/DockerSandboxAdapter.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/DockerSandboxAdapter.java
@@ -38,7 +38,16 @@ public class DockerSandboxAdapter implements SandboxManager {
     private static final Logger log = LoggerFactory.getLogger(DockerSandboxAdapter.class);
     private static final String CONTAINER_USER = "1000:1000";
     private static final String CONTAINER_HOSTNAME = "agent";
-    private static final int LOG_TAIL_LINES = 500;
+    /**
+     * Docker's tail is applied by the daemon, before anything here sees a line, so the persisted
+     * transcript asks for every line: a tail would drop the beginning — what the run was asked and what
+     * it read — and leave nothing downstream able to put it back.
+     */
+    private static final int WHOLE_TRANSCRIPT = 0;
+
+    /** The error-path echo is cut to {@link #MAX_LOG_EVENT_CHARS} before it is logged, so it reads a tail. */
+    private static final int ERROR_ECHO_TAIL_LINES = 500;
+
     private static final String PROXY_URL_PLACEHOLDER = "{appServerIp}";
 
     private static final String MDC_JOB_ID = "sandbox.jobId";
@@ -46,7 +55,7 @@ public class DockerSandboxAdapter implements SandboxManager {
 
     /**
      * Limits each diagnostic event so a large container log cannot overflow the aggregator. This is the
-     * <em>emission</em> limit; {@link DockerClientOperations#MAX_LOG_BYTES} is the upstream
+     * <em>emission</em> limit; {@link DockerClientOperations#MAX_LOG_CHARS} is the upstream
      * <em>collection</em> limit.
      */
     private static final int MAX_LOG_EVENT_CHARS = 32 * 1024;
@@ -233,7 +242,7 @@ public class DockerSandboxAdapter implements SandboxManager {
                 outputFiles = Map.of();
             }
 
-            String logs = containerManager.getLogs(containerId, LOG_TAIL_LINES);
+            String logs = containerManager.getLogs(containerId, WHOLE_TRANSCRIPT);
 
             if (waitOutcome.timedOut()) {
                 executionsTimedOut.increment();
@@ -378,7 +387,7 @@ public class DockerSandboxAdapter implements SandboxManager {
             return;
         }
         try {
-            String logs = containerManager.getLogs(containerId, LOG_TAIL_LINES);
+            String logs = containerManager.getLogs(containerId, ERROR_ECHO_TAIL_LINES);
             if (logs != null && !logs.isEmpty()) {
                 String truncated = logs.length() > MAX_LOG_EVENT_CHARS
                         ? logs.substring(0, MAX_LOG_EVENT_CHARS) + "\n... [truncated, "

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/sandbox/spi/SandboxResult.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/sandbox/spi/SandboxResult.java
@@ -8,7 +8,8 @@ import java.util.Map;
  *
  * @param exitCode container exit code (0 = success, 137 = OOM-killed, etc.)
  * @param outputFiles files collected from the container's output path (relative path → content)
- * @param logs last N lines of container stdout/stderr (captured before removal)
+ * @param logs container stdout and stderr, captured before removal; whole unless the run outgrew what
+ *     the collector holds, in which case it names how much of its middle is missing
  * @param timedOut whether the container was killed due to exceeding {@link
  *     ResourceLimits#maxRuntime()}
  * @param duration wall-clock execution time (container start to exit)

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobExecutorTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobExecutorTest.java
@@ -816,6 +816,33 @@ class AgentJobExecutorTest extends BaseUnitTest {
         }
 
         @Test
+        @DisplayName("a transcript far larger than the old 64 KB cut reaches the row whole")
+        void shouldStoreTheWholeTranscriptWhenItIsLargerThanTheOldCut() {
+            when(jobRepository.findByIdQueuedForUpdateSkipLocked(eq(jobId), any()))
+                    .thenReturn(Optional.of(job));
+            when(bindingRepository.findByWorkspaceIdAndPurpose(99L, AgentPurpose.PRACTICE_REVIEW))
+                    .thenReturn(Optional.of(binding));
+            when(jobRepository.countByWorkspaceIdAndPurposeAndStatusIn(
+                            eq(99L), eq(AgentPurpose.PRACTICE_REVIEW), any()))
+                    .thenReturn(0L);
+            when(jobRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+            String transcript =
+                    "BEGINNING: what this review was asked\n" + "x".repeat(200_000) + "\nENDING: how it went";
+            setupFullExecution(new SandboxResult(0, Map.of(), transcript, false, Duration.ofMinutes(2)));
+
+            AgentJob freshJob = freshJob();
+            when(jobRepository.findById(any(UUID.class))).thenReturn(Optional.of(freshJob));
+            when(jobRepository.saveAndFlush(any())).thenAnswer(inv -> inv.getArgument(0));
+            when(jobRepository.transitionStatus(any(), eq(AgentJobStatus.COMPLETED), any(), any(), any()))
+                    .thenReturn(1);
+
+            executor.processJob(jobId);
+
+            assertThat(freshJob.getContainerLogs()).isEqualTo(transcript);
+        }
+
+        @Test
         void shouldMarkFailedWithAnErrorMessageNamingTheExitCode() {
             when(jobRepository.findByIdQueuedForUpdateSkipLocked(eq(jobId), any()))
                     .thenReturn(Optional.of(job));

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/BoundedTranscriptTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/BoundedTranscriptTest.java
@@ -1,0 +1,87 @@
+package de.tum.cit.aet.hephaestus.agent.sandbox.docker;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import de.tum.cit.aet.hephaestus.testconfig.BaseUnitTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class BoundedTranscriptTest extends BaseUnitTest {
+
+    @Test
+    @DisplayName("a transcript that fits in the head is kept exactly as it arrived")
+    void shouldKeepEveryCharacterWhenTheHeadHoldsItAll() {
+        var transcript = new BoundedTranscript(64, 64);
+        transcript.append("first\n");
+        transcript.append("second\n");
+        transcript.append("third\n");
+
+        assertThat(transcript.toString()).isEqualTo("first\nsecond\nthird\n");
+        assertThat(transcript.dropped()).isZero();
+    }
+
+    @Test
+    @DisplayName("a transcript that spills into the tail without overflowing is still byte-identical")
+    void shouldKeepEveryCharacterWhenTheTailHoldsTheOverflow() {
+        var transcript = new BoundedTranscript(8, 32);
+        String written = "0123456789abcdefghij";
+        for (int i = 0; i < written.length(); i++) {
+            transcript.append(String.valueOf(written.charAt(i)));
+        }
+
+        assertThat(transcript.toString()).isEqualTo(written);
+        assertThat(transcript.dropped()).isZero();
+    }
+
+    @Test
+    @DisplayName("a transcript too large to hold keeps both ends and says what is missing")
+    void shouldKeepBothEndsAndNameTheGapWhenTheRunOutgrowsTheLimits() {
+        var transcript = new BoundedTranscript(10, 10);
+        transcript.append("HEAD012345");
+        for (int i = 0; i < 20; i++) {
+            transcript.append("middle----");
+        }
+        transcript.append("THE ENDING");
+
+        String out = transcript.toString();
+        assertThat(out).startsWith("HEAD012345");
+        assertThat(out).endsWith("THE ENDING");
+        assertThat(out).contains("200 characters of this transcript were dropped here");
+        assertThat(transcript.dropped()).isEqualTo(200);
+    }
+
+    @Test
+    @DisplayName("the ending survives even behind a chunk larger than the whole tail")
+    void shouldKeepTheEndingWhenOneChunkExceedsTheTailLimit() {
+        var transcript = new BoundedTranscript(4, 4);
+        transcript.append("head");
+        transcript.append("a".repeat(100));
+        transcript.append("FATAL: the reason the run ended");
+
+        assertThat(transcript.toString()).endsWith("FATAL: the reason the run ended");
+        assertThat(transcript.dropped()).isEqualTo(100);
+    }
+
+    @Test
+    @DisplayName("appending after a large drop still lands at the end, and the gap keeps counting")
+    void shouldGoOnRecordingWhenAppendFollowsALargeDrop() {
+        var transcript = new BoundedTranscript(4, 4);
+        transcript.append("head");
+        for (int i = 0; i < 50; i++) {
+            transcript.append("dropped---");
+        }
+        transcript.append("");
+        transcript.append("last");
+
+        assertThat(transcript.toString()).startsWith("head").endsWith("last");
+        assertThat(transcript.dropped()).isEqualTo(500);
+    }
+
+    @Test
+    @DisplayName("limits that could hold nothing are refused")
+    void shouldRefuseLimitsThatCannotHoldAnything() {
+        assertThatThrownBy(() -> new BoundedTranscript(0, 10)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new BoundedTranscript(10, 0)).isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/DockerSandboxAdapterTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/DockerSandboxAdapterTest.java
@@ -154,7 +154,9 @@ class DockerSandboxAdapterTest extends BaseUnitTest {
             verify(containerManager).startContainer(CONTAINER_ID);
             verify(containerManager).waitForCompletion(eq(CONTAINER_ID), any());
             verify(workspaceManager).collectOutput(CONTAINER_ID, "/workspace/out");
-            verify(containerManager).getLogs(CONTAINER_ID, 500);
+            // 0 is every line: a Docker tail is applied by the daemon, so a persisted transcript that
+            // asked for one would arrive already missing its beginning.
+            verify(containerManager).getLogs(CONTAINER_ID, 0);
 
             verify(containerManager).forceRemove(CONTAINER_ID);
             verify(networkManager).disconnectAppServer(NETWORK_ID);
@@ -545,7 +547,8 @@ class DockerSandboxAdapterTest extends BaseUnitTest {
                     .isInstanceOf(SandboxException.class)
                     .hasMessageContaining("Docker daemon lost");
 
-            // 500 mirrors DockerSandboxAdapter.LOG_TAIL_LINES; a truncated tail is no diagnostics at all.
+            // 500 mirrors DockerSandboxAdapter.ERROR_ECHO_TAIL_LINES: this echo only reaches the log, cut
+            // to 32 KB, so it reads a tail rather than the whole stream.
             InOrder inOrder = inOrder(containerManager);
             inOrder.verify(containerManager).getLogs(CONTAINER_ID, 500);
             inOrder.verify(containerManager).forceRemove(CONTAINER_ID);


### PR DESCRIPTION
## Problem

A review's transcript is the only account of what it did, and it was cut twice on the way to storage, at opposite ends.

| Stage | Limit | What it kept | What it lost |
|---|---|---|---|
| Collection, `DockerClientOperations.getLogs` | 1 MB | the beginning | the ending, where a run says how it failed |
| Persistence, `AgentJobExecutor` | 64 KB | the ending | the beginning, where it says what it was asked and what it read |

A run between those two sizes lost its middle to one cut and its start to the other, and nothing in the stored text said so. Diagnosing a review that is not doing what it should means reading which practices it settled, what it was refused and why, and where its time went — and a 64 KB tail routinely does not reach any of that.

## Change

- Collection keeps everything until a run is large enough to threaten the collecting process. Past that point it keeps the beginning and the ending, with a line between them naming exactly how many characters are missing, so a reader is never left guessing whether they have the whole thing. The ending is never what gets dropped.
- Persistence keeps what collection gave it.

The retention sweep is untouched: a transcript is still cleared fourteen days after the review finishes by default, so this changes what can be read while a review still matters, not how long anything is held.

## Verification

`BoundedTranscriptTest` — a transcript that fits is kept byte for byte, one too large keeps both ends and names the gap, the ending always survives, and limits that cannot hold anything are refused. `AgentJobExecutorTest`, `DockerClientOperationsTest` and `DockerSandboxAdapterTest` — 187 passing.