### PR TITLE
fix(server): a review whose server moved on runs again

### DIFF
--- a/.changeset/a-review-outlives-a-server-restart.md
+++ b/.changeset/a-review-outlives-a-server-restart.md
@@ -1,0 +1,8 @@
+---
+"hephaestus": patch
+---
+
+A practice review whose work finished while the server was being restarted now runs again instead of
+ending with nothing. The sandbox can only reach the server at the address it had when the review
+started, so a server that comes back elsewhere is out of reach for the rest of that run; the review
+is queued for another attempt, and what the first attempt reported about itself stays on record.

--- a/.changeset/a-review-outlives-a-server-restart.md
+++ b/.changeset/a-review-outlives-a-server-restart.md
@@ -4,5 +4,6 @@
 
 A practice review whose work finished while the server was being restarted now runs again instead of
 ending with nothing. The sandbox can only reach the server at the address it had when the review
-started, so a server that comes back elsewhere is out of reach for the rest of that run; the review
-is queued for another attempt, and what the first attempt reported about itself stays on record.
+started, so a server that comes back elsewhere is unreachable for the rest of that run. The review is
+queued for another attempt unless its observations did reach the server, in which case they are
+already on record, and what the first attempt reported about itself stays on record either way.

--- a/docs/contributor/agent/workspace-abi.mdx
+++ b/docs/contributor/agent/workspace-abi.mdx
@@ -139,7 +139,9 @@ for the rest of that run, whatever the runner's own retries do. The server answe
 the work for another attempt with a rotated token and the usual backoff, keeping the finished
 attempt's transcript on the row; past the retry cap it terminalizes like any other non-zero exit. A
 job whose observations did reach the server — the admission committed and only its answer was lost —
-is never repeated: a second payload against a digest the job already carries is refused.
+is never repeated: a second payload against a digest the job already carries is refused. That decision
+is taken under the row lock the admission itself takes, and governs every requeue, including the one a
+classified infrastructure failure asks for.
 
 ## Versioning policy
 

--- a/docs/contributor/agent/workspace-abi.mdx
+++ b/docs/contributor/agent/workspace-abi.mdx
@@ -128,9 +128,18 @@ worker filesystem.
 | 2    | Fatal runner error — an unhandled rejection or uncaught exception. Debug and usage files are persisted first |
 | 3    | Watchdog hard-kill (budget + grace exceeded); writes `out/watchdog-killed.json` first |
 | 42   | Envelope mismatch (unsupported `schemaVersion` or unknown `kind`) — image/server drift |
+| 75   | The review finished, but the call admitting its observations never reached the server |
 
-`137` is a container SIGKILL from the runtime, not a runner code. The server treats `0` as success and
-`42` as drift; every other non-zero code is a generic failure.
+`137` is a container SIGKILL from the runtime, not a runner code. The server treats `0` as success,
+`42` as drift and `75` as an attempt to repeat; every other non-zero code is a generic failure.
+
+A sandbox reaches the server at the address the app server held when the container started, so a
+server that came back somewhere else — a deploy, a restart that moved the container — is unreachable
+for the rest of that run, whatever the runner's own retries do. The server answers `75` by queueing
+the work for another attempt with a rotated token and the usual backoff, keeping the finished
+attempt's transcript on the row; past the retry cap it terminalizes like any other non-zero exit. A
+job whose observations did reach the server — the admission committed and only its answer was lost —
+is never repeated: a second payload against a digest the job already carries is refused.
 
 ## Versioning policy
 

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobExecutor.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobExecutor.java
@@ -7,6 +7,7 @@ import de.tum.cit.aet.hephaestus.agent.config.WorkspaceAgentBinding;
 import de.tum.cit.aet.hephaestus.agent.config.WorkspaceAgentBindingRepository;
 import de.tum.cit.aet.hephaestus.agent.context.InsufficientEvidenceException;
 import de.tum.cit.aet.hephaestus.agent.handler.JobTypeHandlerRegistry;
+import de.tum.cit.aet.hephaestus.agent.handler.ObservationAdmissionService;
 import de.tum.cit.aet.hephaestus.agent.handler.spi.JobTypeHandler;
 import de.tum.cit.aet.hephaestus.agent.handler.spi.PreparedJobInputs;
 import de.tum.cit.aet.hephaestus.agent.metrics.AgentMetrics;
@@ -618,6 +619,22 @@ public class AgentJobExecutor {
             SandboxResult result = sandboxManager.execute(sandboxSpec);
             AgentResult agentResult = practiceAgent.parseResult(result);
 
+            // The review itself succeeded and only the call carrying it home did not arrive, so there is
+            // nothing to deliver and nothing to learn from ending it here: the sandbox holds an address
+            // the server has since moved away from, which no further attempt inside that container can
+            // reach. Another attempt runs the same review against a server it can reach. Past the retry
+            // cap this falls through and terminalizes exactly as it did before.
+            if (result.exitCode() == SandboxLayout.EXIT_SERVER_UNREACHABLE
+                    && !observationsAlreadyAdmitted(jobId)
+                    && requeueForAnotherAttempt(jobId, job, "server-unreachable", true, result.logs())) {
+                metricOutcome = "REQUEUED";
+                log.warn(
+                        "Requeuing job {}: the review finished but could not reach this server to admit its observations (attempt {})",
+                        jobId,
+                        job.getRetryCount() + 1);
+                return;
+            }
+
             JobTypeHandler handler = handlerRegistry.getHandler(job.getJobType());
             AgentJobStatus terminalStatus = completeJob(jobId, agentResult, result, handler, job);
             metricOutcome = terminalStatus != null ? terminalStatus.name() : "unknown";
@@ -904,20 +921,7 @@ public class AgentJobExecutor {
 
         if (workerId != null && isRetryableInfraFailure(e)) {
             int currentRetryCount = job.getRetryCount();
-            Integer updated = transactionTemplate.execute(status -> {
-                // BEFORE requeuing: the requeue zeroes the accumulators, so a later read bills zero.
-                AgentJobLlmUsage retryCounts = sandboxExecutionStarted
-                        ? jobRepository.findLlmUsageById(jobId).orElse(null)
-                        : null;
-                int rows = requeueOrphanWithRotation(jobId, workerId, currentRetryCount);
-                if (rows > 0 && sandboxExecutionStarted) {
-                    billTerminatedJob(
-                            job, "infra-failure retry (attempt " + (currentRetryCount + 1) + ")", retryCounts);
-                }
-                return rows;
-            });
-            if (updated != null && updated > 0) {
-                infraRetryRequeued.increment();
+            if (requeueForAnotherAttempt(jobId, job, "infra-failure", sandboxExecutionStarted, null)) {
                 log.warn(
                         "Requeuing job {} after classified sandbox-infrastructure failure (attempt {}): {}",
                         jobId,
@@ -945,6 +949,63 @@ public class AgentJobExecutor {
      */
     static boolean isRetryableInfraFailure(Exception e) {
         return e instanceof SandboxInfrastructureException || e instanceof IOException;
+    }
+
+    /**
+     * Whether this job's observations reached the server after all — the admission committed and only
+     * its answer was lost. Repeating the review would submit a different payload against the digest the
+     * job already carries, which the admission refuses, so an attempt that got this far is finished
+     * even though its runner could not tell.
+     */
+    private boolean observationsAlreadyAdmitted(UUID jobId) {
+        return jobRepository
+                .findById(jobId)
+                .map(AgentJob::getMetadata)
+                .map(metadata -> !metadata.path(ObservationAdmissionService.DIGEST_METADATA_KEY)
+                        .asString()
+                        .isBlank())
+                .orElse(false);
+    }
+
+    /**
+     * Hands the job back to the queue for another attempt, billing what this attempt already spent.
+     * The usage read happens inside the same transaction and before the requeue, which zeroes the
+     * accumulators — a later read would bill zero.
+     *
+     * @param transcript this attempt's container log, kept on the row so the next reader can still see
+     *     why the attempt was given up on; the following attempt's terminal write replaces it
+     * @param bill whether provider work happened at all — nothing accrues before the sandbox starts
+     * @return whether the job is queued again; false means the retry cap is spent or the fence is
+     *     lost, and the caller owns the terminal outcome
+     */
+    private boolean requeueForAnotherAttempt(
+            UUID jobId, AgentJob job, String reason, boolean bill, @Nullable String transcript) {
+        if (workerId == null) {
+            return false;
+        }
+        int currentRetryCount = job.getRetryCount();
+        Integer updated = transactionTemplate.execute(status -> {
+            AgentJobLlmUsage retryCounts =
+                    bill ? jobRepository.findLlmUsageById(jobId).orElse(null) : null;
+            int rows = requeueOrphanWithRotation(jobId, workerId, currentRetryCount);
+            if (rows == 0) {
+                // The fence is lost: this row belongs to another attempt now, and nothing this one has
+                // to say about itself may be written over it.
+                return 0;
+            }
+            if (bill) {
+                billTerminatedJob(job, reason + " retry (attempt " + (currentRetryCount + 1) + ")", retryCounts);
+            }
+            if (transcript != null) {
+                jobRepository.findById(jobId).ifPresent(requeued -> requeued.setContainerLogs(transcript));
+            }
+            return rows;
+        });
+        if (updated == null || updated == 0) {
+            return false;
+        }
+        infraRetryRequeued.increment();
+        return true;
     }
 
     /**

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobExecutor.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobExecutor.java
@@ -625,7 +625,6 @@ public class AgentJobExecutor {
             // reach. Another attempt runs the same review against a server it can reach. Past the retry
             // cap this falls through and terminalizes exactly as it did before.
             if (result.exitCode() == SandboxLayout.EXIT_SERVER_UNREACHABLE
-                    && !observationsAlreadyAdmitted(jobId)
                     && requeueForAnotherAttempt(jobId, job, "server-unreachable", true, result.logs())) {
                 metricOutcome = "REQUEUED";
                 log.warn(
@@ -957,14 +956,12 @@ public class AgentJobExecutor {
      * job already carries, which the admission refuses, so an attempt that got this far is finished
      * even though its runner could not tell.
      */
-    private boolean observationsAlreadyAdmitted(UUID jobId) {
-        return jobRepository
-                .findById(jobId)
-                .map(AgentJob::getMetadata)
-                .map(metadata -> !metadata.path(ObservationAdmissionService.DIGEST_METADATA_KEY)
-                        .asString()
-                        .isBlank())
-                .orElse(false);
+    private static boolean observationsAdmitted(AgentJob job) {
+        JsonNode metadata = job.getMetadata();
+        return metadata != null
+                && !metadata.path(ObservationAdmissionService.DIGEST_METADATA_KEY)
+                        .asString("")
+                        .isBlank();
     }
 
     /**
@@ -985,6 +982,17 @@ public class AgentJobExecutor {
         }
         int currentRetryCount = job.getRetryCount();
         Integer updated = transactionTemplate.execute(status -> {
+            // Under the same row lock the admission takes, so the two decisions serialize: a review
+            // whose observations reached the server is finished, whatever its sandbox went on to do.
+            // Running it again would submit a different payload against the digest the job already
+            // carries, which the admission refuses — a second attempt could only lose what the first
+            // recorded.
+            AgentJob locked =
+                    jobRepository.findByIdWithWorkspaceForUpdate(jobId).orElse(null);
+            if (locked != null && observationsAdmitted(locked)) {
+                log.info("Not requeuing job {}: its observations already reached this server", jobId);
+                return 0;
+            }
             AgentJobLlmUsage retryCounts =
                     bill ? jobRepository.findLlmUsageById(jobId).orElse(null) : null;
             int rows = requeueOrphanWithRotation(jobId, workerId, currentRetryCount);

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/runtime/SandboxLayout.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/runtime/SandboxLayout.java
@@ -141,6 +141,15 @@ public final class SandboxLayout {
     /** Exit code emitted by the Pi runner on envelope/image drift (unsupported {@code schemaVersion} or {@code kind}). */
     public static final int EXIT_ENVELOPE_MISMATCH = 42;
 
+    /**
+     * Exit code emitted by the Pi runner when the review finished but the call admitting it never
+     * reached this server — the sandbox holds the app server's address as it was when the container
+     * started, so a server that came back somewhere else is unreachable for the rest of the run. The
+     * work is requeued rather than ended, since the same review against a reachable server is the
+     * outcome that was wanted.
+     */
+    public static final int EXIT_SERVER_UNREACHABLE = 75;
+
     /** OCI label declaring the agent image runtime contract. */
     public static final String RUNTIME_CONTRACT_LABEL = "hephaestus.agent.runtime-contract";
 

--- a/server/application/src/main/resources/agent/pi-runner.ts
+++ b/server/application/src/main/resources/agent/pi-runner.ts
@@ -736,6 +736,12 @@ const PERSIST_DISCIPLINE =
 	`Use tools only from this point onward. Do not write planning prose or plain-text commentary.`;
 
 const ENVELOPE_MISMATCH_EXIT = 42;
+/**
+ * The review is finished and only the call carrying it home did not arrive. The server keeps the
+ * work queued for another attempt when it sees this, so the measurement is repeated against a
+ * server the next sandbox can reach rather than recorded as a review that produced nothing.
+ */
+const SERVER_UNREACHABLE_EXIT = 75;
 const SUPPORTED_SCHEMA_VERSION = 1;
 const SUPPORTED_KIND = "practice_review";
 const TASK_PATH = `${CWD}/task.json`;
@@ -2158,5 +2164,8 @@ main().catch((err: unknown) => {
 	console.error(`[pi-runner] FATAL: ${errorText(err)}\n${err instanceof Error ? err.stack : ""}`);
 	persistRunnerDebug();
 	persistUsage();
-	process.exit(2);
+	// A server this container never reached is not a defect in the review, and the attempts above have
+	// already ridden out the failures that clear in place. Saying so distinctly is what lets the server
+	// try the same work again instead of ending it.
+	process.exit(err instanceof AdmissionUnreachable ? SERVER_UNREACHABLE_EXIT : 2);
 });

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobExecutorTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobExecutorTest.java
@@ -1190,6 +1190,7 @@ class AgentJobExecutorTest extends BaseUnitTest {
             AgentJob admittedJob = freshJob();
             admittedJob.setMetadata(
                     objectMapper.createObjectNode().put(ObservationAdmissionService.DIGEST_METADATA_KEY, "abc123"));
+            when(jobRepository.findByIdWithWorkspaceForUpdate(jobId)).thenReturn(Optional.of(admittedJob));
             when(jobRepository.findById(any(UUID.class))).thenReturn(Optional.of(admittedJob));
             when(jobRepository.saveAndFlush(any())).thenAnswer(inv -> inv.getArgument(0));
             when(jobRepository.transitionStatusOwnedBy(any(), any(), any(), any(), any(), any()))
@@ -1264,6 +1265,63 @@ class AgentJobExecutorTest extends BaseUnitTest {
                             eq("Container exited with code " + SandboxLayout.EXIT_SERVER_UNREACHABLE),
                             eq(Set.of(AgentJobStatus.RUNNING)),
                             eq("unreachable-worker"));
+        }
+
+        @Test
+        @DisplayName("an infra failure after the observations were admitted fails terminally instead of repeating")
+        void infraFailureDoesNotRepeatAnAdmittedReview() {
+            executor = new AgentJobExecutor(
+                    AGENT_PROPS,
+                    jobRepository,
+                    bindingRepository,
+                    handlerRegistry,
+                    practiceAgent,
+                    workerJwtIssuer,
+                    sandboxManager,
+                    sandboxExecutor,
+                    transactionTemplate,
+                    objectMapper,
+                    meterRegistry,
+                    new PracticeReviewRefusalMetrics(meterRegistry),
+                    new AgentJobTelemetry(meterRegistry),
+                    usageRecorder,
+                    llmBudgetService,
+                    NO_LIVE_ADMISSION,
+                    Optional.empty(),
+                    Optional.of(workerProps("infra-retry-worker")));
+            when(jobRepository.findByIdQueuedForUpdateSkipLocked(eq(jobId), any()))
+                    .thenReturn(Optional.of(job));
+            when(bindingRepository.findByWorkspaceIdAndPurpose(99L, AgentPurpose.PRACTICE_REVIEW))
+                    .thenReturn(Optional.of(binding));
+            when(jobRepository.countByWorkspaceIdAndPurposeAndStatusIn(
+                            eq(99L), eq(AgentPurpose.PRACTICE_REVIEW), any()))
+                    .thenReturn(0L);
+            when(jobRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+            AgentJob admittedJob = freshJob();
+            admittedJob.setMetadata(
+                    objectMapper.createObjectNode().put(ObservationAdmissionService.DIGEST_METADATA_KEY, "abc123"));
+            when(jobRepository.findByIdWithWorkspaceForUpdate(jobId)).thenReturn(Optional.of(admittedJob));
+            when(jobRepository.transitionStatusOwnedBy(any(), any(), any(), any(), any(), any()))
+                    .thenReturn(1);
+
+            setupFullExecutionWithException(
+                    new de.tum.cit.aet.hephaestus.agent.sandbox.spi.SandboxInfrastructureException(
+                            "output collection failed"));
+
+            executor.processJob(jobId);
+
+            // The observations are on record; a second attempt would submit a different payload against
+            // the digest this job already carries, and the admission refuses that.
+            verify(jobRepository, never()).requeueOrphan(any(), any(), anyInt(), any(), any(), any());
+            verify(jobRepository)
+                    .transitionStatusOwnedBy(
+                            eq(jobId),
+                            eq(AgentJobStatus.FAILED),
+                            any(),
+                            any(),
+                            eq(Set.of(AgentJobStatus.RUNNING)),
+                            eq("infra-retry-worker"));
         }
 
         @Test

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobExecutorTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobExecutorTest.java
@@ -25,6 +25,7 @@ import de.tum.cit.aet.hephaestus.agent.config.WorkspaceAgentBinding;
 import de.tum.cit.aet.hephaestus.agent.config.WorkspaceAgentBindingRepository;
 import de.tum.cit.aet.hephaestus.agent.context.InsufficientEvidenceException;
 import de.tum.cit.aet.hephaestus.agent.handler.JobTypeHandlerRegistry;
+import de.tum.cit.aet.hephaestus.agent.handler.ObservationAdmissionService;
 import de.tum.cit.aet.hephaestus.agent.handler.spi.JobTypeHandler;
 import de.tum.cit.aet.hephaestus.agent.handler.spi.PreparedJobInputs;
 import de.tum.cit.aet.hephaestus.agent.practice.PracticeAgentRequest;
@@ -1084,6 +1085,185 @@ class AgentJobExecutorTest extends BaseUnitTest {
             verify(jobRepository, never()).transitionStatus(any(), eq(AgentJobStatus.FAILED), any(), any(), any());
             verify(jobRepository, never())
                     .transitionStatusOwnedBy(any(), eq(AgentJobStatus.FAILED), any(), any(), any(), any());
+        }
+
+        @Test
+        @DisplayName("a review the runner could not admit (exit 75) is requeued, keeping its transcript on the row")
+        void unreachableServerIsRequeuedWithItsTranscript() {
+            executor = new AgentJobExecutor(
+                    AGENT_PROPS,
+                    jobRepository,
+                    bindingRepository,
+                    handlerRegistry,
+                    practiceAgent,
+                    workerJwtIssuer,
+                    sandboxManager,
+                    sandboxExecutor,
+                    transactionTemplate,
+                    objectMapper,
+                    meterRegistry,
+                    new PracticeReviewRefusalMetrics(meterRegistry),
+                    new AgentJobTelemetry(meterRegistry),
+                    usageRecorder,
+                    llmBudgetService,
+                    NO_LIVE_ADMISSION,
+                    Optional.empty(),
+                    Optional.of(workerProps("unreachable-worker")));
+            when(jobRepository.findByIdQueuedForUpdateSkipLocked(eq(jobId), any()))
+                    .thenReturn(Optional.of(job));
+            when(bindingRepository.findByWorkspaceIdAndPurpose(99L, AgentPurpose.PRACTICE_REVIEW))
+                    .thenReturn(Optional.of(binding));
+            when(jobRepository.countByWorkspaceIdAndPurposeAndStatusIn(
+                            eq(99L), eq(AgentPurpose.PRACTICE_REVIEW), any()))
+                    .thenReturn(0L);
+            when(jobRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+            when(jobRepository.requeueOrphan(
+                            eq(jobId), eq("unreachable-worker"), eq(AGENT_PROPS.maxRetries()), any(), any(), any()))
+                    .thenReturn(1);
+
+            String transcript = "[pi-runner] FATAL: observation admission could not be sent: fetch failed";
+            JobTypeHandler handler = setupFullExecution(new SandboxResult(
+                    SandboxLayout.EXIT_SERVER_UNREACHABLE, Map.of(), transcript, false, Duration.ofMinutes(9)));
+            AgentJob runningJob = freshJob();
+            when(jobRepository.findById(any(UUID.class))).thenReturn(Optional.of(runningJob));
+
+            executor.processJob(jobId);
+
+            var newToken = ArgumentCaptor.forClass(String.class);
+            verify(jobRepository)
+                    .requeueOrphan(
+                            eq(jobId),
+                            eq("unreachable-worker"),
+                            eq(AGENT_PROPS.maxRetries()),
+                            any(),
+                            newToken.capture(),
+                            any());
+            assertThat(newToken.getValue()).isNotEqualTo("test-token").isNotBlank();
+            // The attempt is given up on, not erased: what it said about itself is why an operator can
+            // tell an unreachable server from a review that had nothing to say.
+            assertThat(runningJob.getContainerLogs()).isEqualTo(transcript);
+            // Nothing was admitted, so there is nothing to deliver and no terminal state to record.
+            verify(handler, never()).deliver(any());
+            verify(jobRepository, never()).transitionStatus(any(), any(), any(), any(), any());
+            verify(jobRepository, never()).transitionStatusOwnedBy(any(), any(), any(), any(), any(), any());
+        }
+
+        @Test
+        @DisplayName("a review whose observations did reach the server is NOT run again (exit 75, digest on the row)")
+        void unreachableServerDoesNotRepeatAnAdmittedReview() {
+            executor = new AgentJobExecutor(
+                    AGENT_PROPS,
+                    jobRepository,
+                    bindingRepository,
+                    handlerRegistry,
+                    practiceAgent,
+                    workerJwtIssuer,
+                    sandboxManager,
+                    sandboxExecutor,
+                    transactionTemplate,
+                    objectMapper,
+                    meterRegistry,
+                    new PracticeReviewRefusalMetrics(meterRegistry),
+                    new AgentJobTelemetry(meterRegistry),
+                    usageRecorder,
+                    llmBudgetService,
+                    NO_LIVE_ADMISSION,
+                    Optional.empty(),
+                    Optional.of(workerProps("unreachable-worker")));
+            when(jobRepository.findByIdQueuedForUpdateSkipLocked(eq(jobId), any()))
+                    .thenReturn(Optional.of(job));
+            when(bindingRepository.findByWorkspaceIdAndPurpose(99L, AgentPurpose.PRACTICE_REVIEW))
+                    .thenReturn(Optional.of(binding));
+            when(jobRepository.countByWorkspaceIdAndPurposeAndStatusIn(
+                            eq(99L), eq(AgentPurpose.PRACTICE_REVIEW), any()))
+                    .thenReturn(0L);
+            when(jobRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+            setupFullExecution(new SandboxResult(
+                    SandboxLayout.EXIT_SERVER_UNREACHABLE,
+                    Map.of(),
+                    "the answer never came back",
+                    false,
+                    Duration.ofMinutes(9)));
+            // The admission committed and only its answer was lost, so the observations are on record
+            // and the same review would now be refused as a different payload.
+            AgentJob admittedJob = freshJob();
+            admittedJob.setMetadata(
+                    objectMapper.createObjectNode().put(ObservationAdmissionService.DIGEST_METADATA_KEY, "abc123"));
+            when(jobRepository.findById(any(UUID.class))).thenReturn(Optional.of(admittedJob));
+            when(jobRepository.saveAndFlush(any())).thenAnswer(inv -> inv.getArgument(0));
+            when(jobRepository.transitionStatusOwnedBy(any(), any(), any(), any(), any(), any()))
+                    .thenReturn(1);
+
+            executor.processJob(jobId);
+
+            verify(jobRepository, never()).requeueOrphan(any(), any(), anyInt(), any(), any(), any());
+            verify(jobRepository)
+                    .transitionStatusOwnedBy(
+                            eq(jobId),
+                            any(),
+                            any(),
+                            any(),
+                            eq(Set.of(AgentJobStatus.RUNNING)),
+                            eq("unreachable-worker"));
+        }
+
+        @Test
+        @DisplayName("an unadmitted review terminalizes as before once the retry cap is spent (exit 75, CAS loses)")
+        void unreachableServerFallsThroughWhenRequeueLoses() {
+            executor = new AgentJobExecutor(
+                    AGENT_PROPS,
+                    jobRepository,
+                    bindingRepository,
+                    handlerRegistry,
+                    practiceAgent,
+                    workerJwtIssuer,
+                    sandboxManager,
+                    sandboxExecutor,
+                    transactionTemplate,
+                    objectMapper,
+                    meterRegistry,
+                    new PracticeReviewRefusalMetrics(meterRegistry),
+                    new AgentJobTelemetry(meterRegistry),
+                    usageRecorder,
+                    llmBudgetService,
+                    NO_LIVE_ADMISSION,
+                    Optional.empty(),
+                    Optional.of(workerProps("unreachable-worker")));
+            when(jobRepository.findByIdQueuedForUpdateSkipLocked(eq(jobId), any()))
+                    .thenReturn(Optional.of(job));
+            when(bindingRepository.findByWorkspaceIdAndPurpose(99L, AgentPurpose.PRACTICE_REVIEW))
+                    .thenReturn(Optional.of(binding));
+            when(jobRepository.countByWorkspaceIdAndPurposeAndStatusIn(
+                            eq(99L), eq(AgentPurpose.PRACTICE_REVIEW), any()))
+                    .thenReturn(0L);
+            when(jobRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+            when(jobRepository.requeueOrphan(any(), any(), anyInt(), any(), any(), any()))
+                    .thenReturn(0);
+
+            setupFullExecution(new SandboxResult(
+                    SandboxLayout.EXIT_SERVER_UNREACHABLE,
+                    Map.of(),
+                    "admission never arrived",
+                    false,
+                    Duration.ofMinutes(9)));
+            when(jobRepository.findById(any(UUID.class))).thenReturn(Optional.of(freshJob()));
+            when(jobRepository.saveAndFlush(any())).thenAnswer(inv -> inv.getArgument(0));
+            when(jobRepository.transitionStatusOwnedBy(any(), any(), any(), any(), any(), any()))
+                    .thenReturn(1);
+
+            executor.processJob(jobId);
+
+            // Past the cap the exit is treated as any other non-zero one: whatever the attempt produced
+            // decides the terminal state, and the code it exited with is on the row.
+            verify(jobRepository)
+                    .transitionStatusOwnedBy(
+                            eq(jobId),
+                            eq(AgentJobStatus.FAILED),
+                            any(),
+                            eq("Container exited with code " + SandboxLayout.EXIT_SERVER_UNREACHABLE),
+                            eq(Set.of(AgentJobStatus.RUNNING)),
+                            eq("unreachable-worker"));
         }
 
         @Test

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/runtime/SandboxLayoutSyncTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/runtime/SandboxLayoutSyncTest.java
@@ -42,6 +42,10 @@ class SandboxLayoutSyncTest extends BaseUnitTest {
                 .contains("ENVELOPE_MISMATCH_EXIT = " + SandboxLayout.EXIT_ENVELOPE_MISMATCH);
 
         assertThat(body)
+                .as("runner pins SERVER_UNREACHABLE_EXIT to SandboxLayout.EXIT_SERVER_UNREACHABLE")
+                .contains("SERVER_UNREACHABLE_EXIT = " + SandboxLayout.EXIT_SERVER_UNREACHABLE);
+
+        assertThat(body)
                 .as("runner writes its output under SandboxLayout.OUTPUT_PATH")
                 .contains(SandboxLayout.OUTPUT_PATH.substring(SandboxLayout.WORKSPACE_ROOT.length()));
 


### PR DESCRIPTION
## Problem

A practice review that finished its work while the app server was being replaced had nowhere to send
it. The sandbox reaches the server at the address it held when the container started, so a server
that comes back somewhere else is unreachable for the rest of that run, whatever the runner's own
retries do. On staging this cost a full Artemis review: `admission attempt 1..4 did not arrive
(connect ECONNREFUSED 172.31.0.2:8081)`, then `FATAL`, and the job was recorded as completed with a
failed delivery. Everything the review found was lost.

## Solution

The runner exits `75` when the admission never arrived, distinct from a fatal runner error. The
server answers `75` by queueing the work for another attempt with a rotated token and the usual
backoff, and keeps the finished attempt's transcript on the row so an operator can still see why the
attempt was given up on. Past the retry cap the exit terminalizes like any other non-zero one.

A job whose observations did reach the server — the admission committed and only its answer was lost
— is never repeated: a second payload against the digest the job already carries would be refused, so
repeating it could only waste a review. That guard also closes the same latent hole on the
pre-existing infra-failure requeue path, which now shares one requeue routine with this one.

## Verification

`AgentJobExecutorTest` and `SandboxLayoutSyncTest` (70 tests) cover the new paths: the requeue with
rotation and transcript, the fall-through when the retry cap is spent, and the job that is not
repeated because its observations already landed. `vp run format` and `vp run check:affected` are
clean apart from two contract tests that fail identically on `main` in this local environment
(`ci-contract` fork buildpack build, `check-runner-contract` failed-run report).
