### PR TITLE
fix(server): a failed model turn says why in the transcript

### DIFF
--- a/.changeset/a-failed-model-turn-says-why.md
+++ b/.changeset/a-failed-model-turn-says-why.md
@@ -1,0 +1,7 @@
+---
+"hephaestus": patch
+---
+
+A review transcript now says why a model turn failed instead of only that it stopped, and reports the
+provider retries the run rode out. A review that gave up because its provider kept refusing can be
+told apart from one that simply had nothing to say.

--- a/server/application/src/main/resources/agent/pi-runner.ts
+++ b/server/application/src/main/resources/agent/pi-runner.ts
@@ -1717,14 +1717,36 @@ async function main() {
 			if (event.type === "tool_execution_start") {
 				console.error(`[pi-runner] ${label} tool: ${event.toolName}`);
 			}
+			// The SDK rides out a retryable provider failure on its own. A run that took longer, or that
+			// gave up after several of these, says so here rather than looking like an idle session.
+			if (event.type === "auto_retry_start") {
+				console.error(
+					`[pi-runner] ${label} provider call failed, retrying in ${event.delayMs}ms ` +
+						`(attempt ${event.attempt}/${event.maxAttempts}): ${event.errorMessage}`,
+				);
+			}
+			if (event.type === "auto_retry_end" && !event.success) {
+				const finalError = event.finalError ?? "no error given";
+				console.error(
+					`[pi-runner] ${label} provider call failed for good after ${event.attempt} retries: ${finalError}`,
+				);
+			}
 			if (event.type === "message_end" && event.message.role === "assistant") {
 				addAssistantUsage(streamUsage, event.message);
 				const stopReason = event.message.stopReason;
 				const types = listOrEmpty(event.message.content).map((c) => c.type);
 				const toolCalls = types.filter((t) => t === "toolCall").length;
+				// A turn that ended in an error or ran out of room said why, and without it the
+				// transcript shows a session that simply stopped answering — the one thing a reader
+				// cannot diagnose afterwards.
+				const rawStopReason = event.message.rawStopReason;
+				const failure =
+					stopReason === "error" || stopReason === "length"
+						? `, error=${event.message.errorMessage ?? "none given"}${rawStopReason ? `, rawStopReason=${rawStopReason}` : ""}`
+						: "";
 				console.error(
 					`[pi-runner] ${label} assistant msg: stopReason=${stopReason}, toolCalls=${toolCalls}, ` +
-						`types=[${types.join(",")}]`,
+						`types=[${types.join(",")}]${failure}`,
 				);
 				// How much of the window this turn's prompt occupied. A turn that was aborted or that
 				// failed carries whatever counts the provider had sent before it stopped, which describes


### PR DESCRIPTION
## Problem

Two of the last Artemis reviews on staging died with nothing but this in the transcript, repeated
four times per lane:

```
[pi-runner] observer:code-1 assistant msg: stopReason=error, toolCalls=0, types=[]
```

The job's debug file counted eight errored turns across the run and named none of them. A review that
lost a practice lane to its provider is indistinguishable from one that stopped on its own, so there
is no way to tell an overloaded provider from a prompt the model refused. The SDK carries the error
text on the message and retries retryable failures on its own budget; the transcript reported
neither.

## Solution

A failed or truncated turn now logs the provider's error text and the raw stop reason, and each
provider retry logs its attempt, delay and cause. Successful turns log exactly as before.

## Verification

`vp run typecheck:agents` and `vp run gate:agents-lint` are clean. The fields used are the SDK's own
typed `errorMessage`, `rawStopReason` and auto-retry events.
