### PR TITLE
fix(server): a provider blip does not end a practice lane

### DIFF
--- a/.changeset/a-provider-blip-does-not-end-a-lane.md
+++ b/.changeset/a-provider-blip-does-not-end-a-lane.md
@@ -1,0 +1,7 @@
+---
+"hephaestus": patch
+---
+
+A practice review no longer loses a whole practice when its model provider is briefly overloaded. A
+failed model turn is now repeated for just over two minutes before the review gives that practice up,
+where it previously stopped after about fourteen seconds and reported the practice as unevaluated.

--- a/docs/contributor/agent/workspace-abi.mdx
+++ b/docs/contributor/agent/workspace-abi.mdx
@@ -42,7 +42,7 @@ vs writable is decided by *where* a file lives, not by convention. Three top-lev
 ├── task.json                        # TaskEnvelope<…> — runtime contract between handler and runner.
 ├── .pi/                             # Pi SDK agent dir — $PI_CODING_AGENT_DIR resolves here.
 │   ├── AGENTS.md                    #   Orchestrator instructions
-│   └── settings.json                #   Pi SDK config (provider, model, compaction)
+│   └── settings.json                #   Pi SDK config (provider, model, compaction, retry)
 ├── .sessions/                       # Pi SDK session JSONL, one file per session.
 ├── pi-provider.json                 # Provider/model routing for the runner.
 ├── pi-provider.ts                   # Provider/model helper imported by both runners.

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/runtime/PiRuntimeFactory.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/runtime/PiRuntimeFactory.java
@@ -41,6 +41,12 @@ public class PiRuntimeFactory {
      */
     static final long MIN_BUDGET_MS = (TIMEOUT_BUFFER_SECONDS - 1) * 1000L;
 
+    /** Turns the SDK repeats before a provider failure ends the session that hit it. */
+    private static final int RETRY_MAX_ATTEMPTS = 5;
+
+    /** Wait before the first repeat; each further attempt doubles it. */
+    private static final int RETRY_BASE_DELAY_MS = 4000;
+
     static final String AGENT_RESOURCE_PREFIX = "agent/";
 
     private final ObjectMapper objectMapper;
@@ -158,6 +164,16 @@ public class PiRuntimeFactory {
         compaction.put("enabled", true);
         compaction.put("reserveTokens", 16384);
         settings.put("compaction", compaction);
+        // A provider that answers "overloaded" is answered by waiting. The SDK's own default gives up
+        // after 2+4+8 seconds, which ended whole practice lanes here while the review still had most of
+        // its budget left, and a lane that dies takes its practice out of the review's coverage. Five
+        // attempts four seconds apart, doubling, ride out just over two minutes of provider trouble,
+        // and a review that spends that on every turn still ends inside its own watchdog.
+        Map<String, Object> retry = new LinkedHashMap<>();
+        retry.put("enabled", true);
+        retry.put("maxRetries", RETRY_MAX_ATTEMPTS);
+        retry.put("baseDelayMs", RETRY_BASE_DELAY_MS);
+        settings.put("retry", retry);
         try {
             return objectMapper.writerWithDefaultPrettyPrinter().writeValueAsBytes(settings);
         } catch (JacksonException e) {

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/runtime/PiRuntimeFactoryTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/runtime/PiRuntimeFactoryTest.java
@@ -167,6 +167,23 @@ class PiRuntimeFactoryTest extends BaseUnitTest {
             assertThat(root.path("compaction").path("enabled").asBoolean()).isTrue();
             assertThat(root.path("compaction").path("reserveTokens").asInt()).isEqualTo(16384);
         }
+
+        @Test
+        @DisplayName("a session waits out a provider blip rather than ending on the SDK's 14-second default")
+        void ridesOutAProviderBlip() throws Exception {
+            byte[] json = factory.buildPiSettingsJson(null);
+            JsonNode root = objectMapper.readTree(new String(json, StandardCharsets.UTF_8));
+            assertThat(root.path("retry").path("enabled").asBoolean()).isTrue();
+            int attempts = root.path("retry").path("maxRetries").asInt();
+            int baseDelayMs = root.path("retry").path("baseDelayMs").asInt();
+            // What the settings buy, in seconds of provider trouble: the doubling waits before each
+            // repeat. Two minutes is the floor this exists for; the review's own budget is the ceiling.
+            long ridesOutMs = 0;
+            for (int attempt = 1; attempt <= attempts; attempt++) {
+                ridesOutMs += (long) baseDelayMs << (attempt - 1);
+            }
+            assertThat(ridesOutMs).isBetween(120_000L, 600_000L);
+        }
     }
 
     @Nested


### PR DESCRIPTION
## Problem

Two Artemis reviews on staging in a row lost every practice lane to the model provider. One reported
`evaluated=0, eligible=4` and delivered nothing after five and a half minutes, with a 90-minute budget
still unspent. Its debug file counted eight errored turns; the lane died 14 seconds after the first
one, which is exactly the SDK's default retry budget of 2+4+8 seconds.

A lane that dies takes its practice out of the review's coverage, so a provider hiccup measured in
seconds costs a practice, or a whole review.

## Solution

The staged `settings.json` now sets the SDK's retry budget to five attempts four seconds apart,
doubling, so a session waits out just over two minutes of provider trouble before giving the practice
up as unevaluated. The review's own watchdog still bounds the run.

## Verification

`PiRuntimeFactoryTest` asserts what the settings buy in seconds of provider trouble, rather than
restating the two constants. All 24 tests in that class pass.
