### PR TITLE
perf(server): a job listing leaves the transcript in the database

### DIFF
--- a/.changeset/a-job-listing-leaves-the-transcript-behind.md
+++ b/.changeset/a-job-listing-leaves-the-transcript-behind.md
@@ -1,0 +1,8 @@
+---
+"hephaestus": patch
+---
+
+Listing a workspace's agent jobs no longer reads every review transcript into the server's memory to
+throw it away. A page of a hundred jobs cost tens of megabytes of heap per request and grew with how
+much each review had to say; it now reads only what the listing shows. The delivery-recovery sweep
+reads a job whole only for the delivery it actually re-attempts.

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobDTO.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobDTO.java
@@ -22,7 +22,8 @@ public record AgentJobDTO(
         @Schema(description = "Job metadata (routing/display info)") @Nullable
         Object metadata,
 
-        @Schema(description = "Job output (agent results)") Object output,
+        @Schema(description = "Job output (agent results)") @Nullable
+        Object output,
 
         @NonNull
         @Schema(
@@ -45,14 +46,16 @@ public record AgentJobDTO(
         @Nullable
         String model,
 
-        @Schema(description = "Container exit code") Integer exitCode,
+        @Schema(description = "Container exit code") @Nullable
+        Integer exitCode,
 
-        @Schema(description = "Human-readable error message")
+        @Schema(description = "Human-readable error message") @Nullable
         String errorMessage,
 
         @Schema(
                 description =
                         "Delivery status: null = not applicable, PENDING = awaiting delivery, DELIVERED = posted, FAILED = delivery error")
+        @Nullable
         DeliveryStatus deliveryStatus,
 
         @Schema(description = "Git provider comment/note ID for posted feedback") @Nullable
@@ -79,10 +82,10 @@ public record AgentJobDTO(
         @NonNull @Schema(description = "Timestamp when the job was created")
         Instant createdAt,
 
-        @Schema(description = "Timestamp when the job started running")
+        @Schema(description = "Timestamp when the job started running") @Nullable
         Instant startedAt,
 
-        @Schema(description = "Timestamp when the job completed")
+        @Schema(description = "Timestamp when the job completed") @Nullable
         Instant completedAt,
 
         @Schema(description = "LLM model used (e.g. gpt-5.4-mini, openai/gpt-oss-120b)") @Nullable

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobDTO.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobDTO.java
@@ -144,6 +144,42 @@ public record AgentJobDTO(
     }
 
     /**
+     * The listing's row, which carries every column this record renders and no transcript — the one
+     * thing an entity page would have read per row and thrown away.
+     */
+    public static AgentJobDTO from(AgentJobRepository.AgentJobListRow row) {
+        JsonNode snapshot = row.getConfigSnapshot();
+        return new AgentJobDTO(
+                row.getId(),
+                row.getJobType(),
+                row.getStatus(),
+                ReviewRunTargetDTO.from(row),
+                row.getMetadata(),
+                row.getOutput(),
+                ReviewRunOutcome.fromJobOutput(row.getOutput()),
+                redactInstanceBaseUrl(snapshot),
+                snapshotString(snapshot, "upstreamModelId"),
+                row.getExitCode(),
+                row.getErrorMessage(),
+                row.getDeliveryStatus(),
+                row.getDeliveryCommentId(),
+                row.getRetryCount(),
+                row.getAvailableAt(),
+                row.getHoldReason(),
+                row.getCreatedAt(),
+                row.getStartedAt(),
+                row.getCompletedAt(),
+                row.getLlmModel(),
+                row.getLlmModelVersion(),
+                row.getLlmTotalCalls(),
+                row.getLlmTotalInputTokens(),
+                row.getLlmTotalOutputTokens(),
+                row.getLlmTotalReasoningTokens(),
+                row.getLlmCacheReadTokens(),
+                row.getLlmCacheWriteTokens());
+    }
+
+    /**
      * The audience here is a workspace admin, who may see the full {@code baseUrl} only of a
      * {@code WORKSPACE}-scoped connection they configured themselves. Anything else — an INSTANCE
      * connection, or a scope-less snapshot from a rolling upgrade — is cut back to {@code scheme://host}

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobRepository.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobRepository.java
@@ -27,9 +27,29 @@ public interface AgentJobRepository extends JpaRepository<AgentJob, UUID> {
     @Query("DELETE FROM AgentJob j WHERE j.workspace.id = :workspaceId")
     int deleteAllByWorkspaceId(@Param("workspaceId") Long workspaceId);
 
-    Page<AgentJob> findByWorkspaceId(Long workspaceId, Pageable pageable);
-
-    Page<AgentJob> findByWorkspaceIdAndStatus(Long workspaceId, AgentJobStatus status, Pageable pageable);
+    /**
+     * One page of a workspace's jobs, with an optional status filter, selecting only what the listing
+     * renders. An entity page would carry {@code container_logs} — a whole review transcript per row,
+     * which no listing reads — into heap and throw it away. {@code output} stays: the listing renders
+     * it and derives each run's outcome from it, and it is bounded by the agent's result contract
+     * rather than by how much a review had to say.
+     */
+    @Query("SELECT j.id AS id, j.jobType AS jobType, j.status AS status, j.integrationKind AS integrationKind, "
+            + "j.metadata AS metadata, j.output AS output, j.configSnapshot AS configSnapshot, "
+            + "j.exitCode AS exitCode, j.errorMessage AS errorMessage, j.deliveryStatus AS deliveryStatus, "
+            + "j.deliveryCommentId AS deliveryCommentId, j.retryCount AS retryCount, "
+            + "j.availableAt AS availableAt, j.holdReason AS holdReason, j.createdAt AS createdAt, "
+            + "j.startedAt AS startedAt, j.completedAt AS completedAt, j.llmModel AS llmModel, "
+            + "j.llmModelVersion AS llmModelVersion, j.llmTotalCalls AS llmTotalCalls, "
+            + "j.llmTotalInputTokens AS llmTotalInputTokens, j.llmTotalOutputTokens AS llmTotalOutputTokens, "
+            + "j.llmTotalReasoningTokens AS llmTotalReasoningTokens, j.llmCacheReadTokens AS llmCacheReadTokens, "
+            + "j.llmCacheWriteTokens AS llmCacheWriteTokens "
+            + "FROM AgentJob j WHERE j.workspace.id = :workspaceId "
+            + "AND (:status IS NULL OR j.status = :status)")
+    Page<AgentJobListRow> findListRows(
+            @Param("workspaceId") Long workspaceId,
+            @Param("status") @Nullable AgentJobStatus status,
+            Pageable pageable);
 
     @Query("SELECT j.id AS id, j.jobType AS jobType, j.integrationKind AS integrationKind, j.metadata AS metadata "
             + "FROM AgentJob j WHERE j.workspace.id = :workspaceId AND j.id IN :ids")
@@ -543,11 +563,25 @@ public interface AgentJobRepository extends JpaRepository<AgentJob, UUID> {
             @Param("newStatus") DeliveryStatus newStatus,
             @Param("fromStatuses") Collection<DeliveryStatus> fromStatuses);
 
-    /** Bounded by {@code pageable} so one sweep pass never loads an unbounded backlog. */
+    /**
+     * Bounded by {@code pageable} so one sweep pass never loads an unbounded backlog, and narrowed to
+     * what the sweep decides on: most candidates are skipped or exhausted, and only the one that wins
+     * its attempt is worth reading whole.
+     */
     @WorkspaceAgnostic("Cross-workspace delivery-recovery sweep; caller is @WorkspaceAgnostic sweeper")
-    @Query("SELECT j FROM AgentJob j WHERE j.status = 'COMPLETED' AND j.deliveryStatus = 'PENDING' "
+    @Query("SELECT j.id AS id, j.deliveryAttempts AS deliveryAttempts, j.deliveryCommentId AS deliveryCommentId "
+            + "FROM AgentJob j WHERE j.status = 'COMPLETED' AND j.deliveryStatus = 'PENDING' "
             + "AND j.completedAt < :cutoff ORDER BY j.completedAt ASC")
-    List<AgentJob> findStuckPendingDeliveries(@Param("cutoff") Instant cutoff, Pageable pageable);
+    List<StuckDeliveryRow> findStuckPendingDeliveries(@Param("cutoff") Instant cutoff, Pageable pageable);
+
+    /**
+     * The one candidate a sweep pass won its attempt on, read whole because the delivery needs the
+     * output the review produced. The status and delivery predicates repeat the sweep's own, so a row
+     * that finished or failed in between is simply not there.
+     */
+    @WorkspaceAgnostic("ID-based read of a delivery-recovery candidate; job ID from the @WorkspaceAgnostic sweep")
+    @Query("SELECT j FROM AgentJob j WHERE j.id = :id AND j.status = 'COMPLETED' " + "AND j.deliveryStatus = 'PENDING'")
+    Optional<AgentJob> findDeliveryRecoveryCandidate(@Param("id") UUID id);
 
     /**
      * Increments {@code delivery_attempts} only if it still matches {@code expectedAttempts}, so two
@@ -718,6 +752,75 @@ public interface AgentJobRepository extends JpaRepository<AgentJob, UUID> {
 
         /** A JSON array of blockers, aggregated by the query so one row is one practice. */
         String getBlockersObserved();
+    }
+
+    /**
+     * One row of the workspace job listing: every column {@code AgentJobDTO} renders, and no other.
+     * Each getter carries the nullness {@link AgentJob} declares for the same field, so a row and an
+     * entity say the same thing about what may be absent.
+     */
+    interface AgentJobListRow extends ReviewRunTargetRow {
+        AgentJobStatus getStatus();
+
+        JsonNode getOutput();
+
+        JsonNode getConfigSnapshot();
+
+        Integer getExitCode();
+
+        String getErrorMessage();
+
+        DeliveryStatus getDeliveryStatus();
+
+        @Nullable
+        String getDeliveryCommentId();
+
+        int getRetryCount();
+
+        Instant getAvailableAt();
+
+        @Nullable
+        String getHoldReason();
+
+        Instant getCreatedAt();
+
+        Instant getStartedAt();
+
+        Instant getCompletedAt();
+
+        @Nullable
+        String getLlmModel();
+
+        @Nullable
+        String getLlmModelVersion();
+
+        @Nullable
+        Integer getLlmTotalCalls();
+
+        @Nullable
+        Integer getLlmTotalInputTokens();
+
+        @Nullable
+        Integer getLlmTotalOutputTokens();
+
+        @Nullable
+        Integer getLlmTotalReasoningTokens();
+
+        @Nullable
+        Integer getLlmCacheReadTokens();
+
+        @Nullable
+        Integer getLlmCacheWriteTokens();
+    }
+
+    /** What one delivery-recovery pass decides on before it reads a job whole. */
+    interface StuckDeliveryRow {
+        UUID getId();
+
+        short getDeliveryAttempts();
+
+        @Nullable
+        String getDeliveryCommentId();
     }
 
     interface ReviewRunTargetRow {

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobRepository.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobRepository.java
@@ -762,14 +762,18 @@ public interface AgentJobRepository extends JpaRepository<AgentJob, UUID> {
     interface AgentJobListRow extends ReviewRunTargetRow {
         AgentJobStatus getStatus();
 
+        @Nullable
         JsonNode getOutput();
 
         JsonNode getConfigSnapshot();
 
+        @Nullable
         Integer getExitCode();
 
+        @Nullable
         String getErrorMessage();
 
+        @Nullable
         DeliveryStatus getDeliveryStatus();
 
         @Nullable
@@ -784,8 +788,10 @@ public interface AgentJobRepository extends JpaRepository<AgentJob, UUID> {
 
         Instant getCreatedAt();
 
+        @Nullable
         Instant getStartedAt();
 
+        @Nullable
         Instant getCompletedAt();
 
         @Nullable

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobService.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobService.java
@@ -12,6 +12,7 @@ import de.tum.cit.aet.hephaestus.agent.handler.PullRequestReviewSubmissionReques
 import de.tum.cit.aet.hephaestus.agent.handler.spi.JobSubmission;
 import de.tum.cit.aet.hephaestus.agent.handler.spi.JobSubmissionRequest;
 import de.tum.cit.aet.hephaestus.agent.handler.spi.JobTypeHandler;
+import de.tum.cit.aet.hephaestus.agent.job.AgentJobRepository.AgentJobListRow;
 import de.tum.cit.aet.hephaestus.agent.usage.LlmBudgetService;
 import de.tum.cit.aet.hephaestus.core.TransactionCallbacks;
 import de.tum.cit.aet.hephaestus.core.exception.EntityNotFoundException;
@@ -102,11 +103,8 @@ public class AgentJobService {
     }
 
     @Transactional(readOnly = true)
-    public Page<AgentJob> getJobs(Long workspaceId, AgentJobStatus status, Pageable pageable) {
-        if (status != null) {
-            return agentJobRepository.findByWorkspaceIdAndStatus(workspaceId, status, pageable);
-        }
-        return agentJobRepository.findByWorkspaceId(workspaceId, pageable);
+    public Page<AgentJobListRow> getJobs(Long workspaceId, @Nullable AgentJobStatus status, Pageable pageable) {
+        return agentJobRepository.findListRows(workspaceId, status, pageable);
     }
 
     @Transactional(readOnly = true)

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobZombieSweeper.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobZombieSweeper.java
@@ -1,6 +1,7 @@
 package de.tum.cit.aet.hephaestus.agent.job;
 
 import de.tum.cit.aet.hephaestus.agent.config.ConfigSnapshot;
+import de.tum.cit.aet.hephaestus.agent.job.AgentJobRepository.StuckDeliveryRow;
 import de.tum.cit.aet.hephaestus.agent.metrics.AgentMetrics;
 import de.tum.cit.aet.hephaestus.agent.usage.LlmPriceSnapshot;
 import de.tum.cit.aet.hephaestus.agent.usage.LlmUsageRecorder;
@@ -257,28 +258,36 @@ public class AgentJobZombieSweeper {
     @Scheduled(fixedDelay = 5, initialDelay = 3, timeUnit = TimeUnit.MINUTES)
     public void recoverStuckDeliveries() {
         Instant cutoff = Instant.now().minus(DELIVERY_PENDING_STUCK_THRESHOLD);
-        List<AgentJob> stuck =
+        List<StuckDeliveryRow> stuck =
                 jobRepository.findStuckPendingDeliveries(cutoff, PageRequest.of(0, DELIVERY_RECOVERY_BATCH_SIZE));
         if (stuck.isEmpty()) {
             return;
         }
         log.warn("Found {} agent job(s) stuck at delivery_status=PENDING; attempting recovery", stuck.size());
-        for (AgentJob job : stuck) {
+        for (StuckDeliveryRow candidate : stuck) {
             try {
-                if (job.getDeliveryAttempts() >= MAX_DELIVERY_RECOVERY_ATTEMPTS) {
+                if (candidate.getDeliveryAttempts() >= MAX_DELIVERY_RECOVERY_ATTEMPTS) {
                     transactionTemplate.executeWithoutResult(s -> jobRepository.updateDeliveryStatus(
-                            job.getId(), DeliveryStatus.FAILED, job.getDeliveryCommentId()));
+                            candidate.getId(), DeliveryStatus.FAILED, candidate.getDeliveryCommentId()));
                     log.warn(
                             "Delivery recovery exhausted after {} attempt(s); marking FAILED: jobId={}",
-                            job.getDeliveryAttempts(),
-                            job.getId());
+                            candidate.getDeliveryAttempts(),
+                            candidate.getId());
                     continue;
                 }
-                short expectedAttempts = job.getDeliveryAttempts();
+                short expectedAttempts = candidate.getDeliveryAttempts();
                 Integer claimed = transactionTemplate.execute(
-                        s -> jobRepository.claimDeliveryRecoveryAttempt(job.getId(), expectedAttempts));
+                        s -> jobRepository.claimDeliveryRecoveryAttempt(candidate.getId(), expectedAttempts));
                 if (claimed == null || claimed == 0) {
                     continue; // a concurrent sweeper replica already claimed this pass's attempt
+                }
+                // Only now is the job worth reading whole: everything above decided from three columns,
+                // and the delivery itself needs the output the review produced.
+                AgentJob job = jobRepository
+                        .findDeliveryRecoveryCandidate(candidate.getId())
+                        .orElse(null);
+                if (job == null) {
+                    continue; // it finished, failed or was removed between the sweep and this attempt
                 }
                 // The CAS's post-increment value is THIS attempt's fence token for its terminal write.
                 short claimedAttempts = (short) (expectedAttempts + 1);
@@ -287,7 +296,7 @@ public class AgentJobZombieSweeper {
                     deliveryRecovered.increment();
                 }
             } catch (Exception e) {
-                log.warn("Delivery recovery pass failed for job {}: {}", job.getId(), e.getMessage());
+                log.warn("Delivery recovery pass failed for job {}: {}", candidate.getId(), e.getMessage());
             }
         }
     }

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/job/ReviewRunOutcome.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/job/ReviewRunOutcome.java
@@ -1,5 +1,8 @@
 package de.tum.cit.aet.hephaestus.agent.job;
 
+import org.jspecify.annotations.Nullable;
+import tools.jackson.databind.JsonNode;
+
 /**
  * Why a run that reached {@link AgentJobStatus#COMPLETED} produced the observations it did.
  *
@@ -20,7 +23,7 @@ public enum ReviewRunOutcome {
     static final String OUTPUT_FIELD = "outcome";
 
     /** Reads the outcome an executor recorded on {@code agent_job.output}; defaults to {@link #REVIEWED}. */
-    static ReviewRunOutcome fromJobOutput(tools.jackson.databind.JsonNode output) {
+    static ReviewRunOutcome fromJobOutput(@Nullable JsonNode output) {
         if (output == null || !output.has(OUTPUT_FIELD)) {
             return REVIEWED;
         }

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/AgentWorkspacePurgeIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/AgentWorkspacePurgeIntegrationTest.java
@@ -95,7 +95,7 @@ class AgentWorkspacePurgeIntegrationTest extends BaseIntegrationTest {
 
         lifecycleService.purgeWorkspace(purgedWorkspace.getWorkspaceSlug());
 
-        assertThat(jobRepository.findByWorkspaceId(purgedWorkspace.getId(), Pageable.unpaged()))
+        assertThat(jobRepository.findListRows(purgedWorkspace.getId(), null, Pageable.unpaged()))
                 .isEmpty();
         assertThat(bindingRepository.findByWorkspaceId(purgedWorkspace.getId())).isEmpty();
         assertThat(modelRepository.findByWorkspaceId(purgedWorkspace.getId())).isEmpty();

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobListingContractTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobListingContractTest.java
@@ -1,0 +1,63 @@
+package de.tum.cit.aet.hephaestus.agent.job;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import de.tum.cit.aet.hephaestus.agent.job.AgentJobRepository.AgentJobListRow;
+import de.tum.cit.aet.hephaestus.agent.job.AgentJobRepository.StuckDeliveryRow;
+import de.tum.cit.aet.hephaestus.testconfig.BaseUnitTest;
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.time.Instant;
+import java.util.Arrays;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Query;
+
+/**
+ * A review's whole transcript lives on the job row and can run to megabytes. Nothing renders it, so
+ * the queries that page over jobs must never read it — a page of entities would, one transcript per
+ * row, and the reading is invisible from the endpoint that pays for it.
+ */
+class AgentJobListingContractTest extends BaseUnitTest {
+
+    @Test
+    @DisplayName("the workspace job listing reads rows, not entities, and no row carries the transcript")
+    void theListingNeverReadsATranscript() throws NoSuchMethodException {
+        Method listing =
+                AgentJobRepository.class.getMethod("findListRows", Long.class, AgentJobStatus.class, Pageable.class);
+
+        assertThat(listing.getReturnType()).isEqualTo(Page.class);
+        assertThat(((ParameterizedType) listing.getGenericReturnType()).getActualTypeArguments()[0])
+                .as("an entity page would select every column, transcript included")
+                .isEqualTo(AgentJobListRow.class);
+        assertThat(getterNames(AgentJobListRow.class)).doesNotContain("getContainerLogs");
+        assertThat(selectClauseOf(listing)).doesNotContain("containerLogs");
+    }
+
+    @Test
+    @DisplayName("the delivery-recovery sweep reads only what it decides on")
+    void theDeliverySweepReadsOnlyWhatItDecidesOn() throws NoSuchMethodException {
+        Method sweep = AgentJobRepository.class.getMethod("findStuckPendingDeliveries", Instant.class, Pageable.class);
+
+        assertThat(((ParameterizedType) sweep.getGenericReturnType()).getActualTypeArguments()[0])
+                .isEqualTo(StuckDeliveryRow.class);
+        assertThat(getterNames(StuckDeliveryRow.class))
+                .containsExactlyInAnyOrder("getId", "getDeliveryAttempts", "getDeliveryCommentId");
+        assertThat(selectClauseOf(sweep)).doesNotContain("containerLogs");
+    }
+
+    /** The query's own text, which is what decides the columns Postgres sends. */
+    private static String selectClauseOf(Method method) {
+        Query query = method.getAnnotation(Query.class);
+        assertThat(query)
+                .as("%s must state its own select list", method.getName())
+                .isNotNull();
+        return query == null ? "" : query.value();
+    }
+
+    private static Iterable<String> getterNames(Class<?> projection) {
+        return Arrays.stream(projection.getMethods()).map(Method::getName).toList();
+    }
+}

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobZombieSweeperTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobZombieSweeperTest.java
@@ -22,8 +22,10 @@ import de.tum.cit.aet.hephaestus.workspace.Workspace;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -325,11 +327,41 @@ class AgentJobZombieSweeperTest extends BaseUnitTest {
             return job;
         }
 
+        /**
+         * The sweep decides from three columns and reads the job itself only for the attempt it wins,
+         * so a candidate is staged as the row the query returns plus the job behind it.
+         */
+        private void stagedAsStuck(AgentJob job) {
+            when(jobRepository.findStuckPendingDeliveries(any(), any())).thenReturn(List.of(rowFor(job)));
+            lenient()
+                    .when(jobRepository.findDeliveryRecoveryCandidate(job.getId()))
+                    .thenReturn(Optional.of(job));
+        }
+
+        private AgentJobRepository.StuckDeliveryRow rowFor(AgentJob job) {
+            return new AgentJobRepository.StuckDeliveryRow() {
+                @Override
+                public UUID getId() {
+                    return job.getId();
+                }
+
+                @Override
+                public short getDeliveryAttempts() {
+                    return job.getDeliveryAttempts();
+                }
+
+                @Override
+                public @Nullable String getDeliveryCommentId() {
+                    return job.getDeliveryCommentId();
+                }
+            };
+        }
+
         @Test
         @DisplayName("claims the attempt CAS, delegates to the lifecycle service, and counts a successful recovery")
         void claimsAndDelegatesOnSuccess() {
             AgentJob job = stuckJob((short) 0);
-            when(jobRepository.findStuckPendingDeliveries(any(), any())).thenReturn(List.of(job));
+            stagedAsStuck(job);
             when(jobRepository.claimDeliveryRecoveryAttempt(job.getId(), (short) 0))
                     .thenReturn(1);
             when(lifecycleService.recoverStuckDelivery(job, (short) 1)).thenReturn(true);
@@ -348,7 +380,7 @@ class AgentJobZombieSweeperTest extends BaseUnitTest {
                 "a lost attempt-CAS (a concurrent sweeper replica already claimed it) skips the delivery attempt entirely")
         void skipsWhenAttemptCasLost() {
             AgentJob job = stuckJob((short) 0);
-            when(jobRepository.findStuckPendingDeliveries(any(), any())).thenReturn(List.of(job));
+            stagedAsStuck(job);
             when(jobRepository.claimDeliveryRecoveryAttempt(job.getId(), (short) 0))
                     .thenReturn(0);
 
@@ -363,7 +395,7 @@ class AgentJobZombieSweeperTest extends BaseUnitTest {
         @DisplayName("a delivery attempt that itself fails is not counted as recovered")
         void failedAttemptIsNotCounted() {
             AgentJob job = stuckJob((short) 1);
-            when(jobRepository.findStuckPendingDeliveries(any(), any())).thenReturn(List.of(job));
+            stagedAsStuck(job);
             when(jobRepository.claimDeliveryRecoveryAttempt(job.getId(), (short) 1))
                     .thenReturn(1);
             when(lifecycleService.recoverStuckDelivery(job, (short) 2)).thenReturn(false);
@@ -380,7 +412,7 @@ class AgentJobZombieSweeperTest extends BaseUnitTest {
         void exhaustedAttemptsMarksFailedDirectlyKeepingTheCommentId() {
             AgentJob job = stuckJob((short) AgentJobZombieSweeper.MAX_DELIVERY_RECOVERY_ATTEMPTS);
             job.setDeliveryCommentId("comment-1");
-            when(jobRepository.findStuckPendingDeliveries(any(), any())).thenReturn(List.of(job));
+            stagedAsStuck(job);
 
             sweeper.recoverStuckDeliveries();
 

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/job/IssueUpdateCoalescerIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/job/IssueUpdateCoalescerIntegrationTest.java
@@ -185,9 +185,9 @@ class IssueUpdateCoalescerIntegrationTest extends BaseIntegrationTest {
 
         transactions.executeWithoutResult(status -> coalescer.drain(workspace.getId(), current.artifactId(), NOW));
 
-        assertThat(jobs.findByWorkspaceId(workspace.getId(), Pageable.unpaged()))
+        assertThat(jobs.findListRows(workspace.getId(), null, Pageable.unpaged()))
                 .isEmpty();
-        assertThat(jobs.findByWorkspaceId(other.getId(), Pageable.unpaged())).isEmpty();
+        assertThat(jobs.findListRows(other.getId(), null, Pageable.unpaged())).isEmpty();
         assertThat(signals.findForArtifact(workspace.getId(), ScmSignals.ISSUE.value(), current.artifactId()))
                 .hasSize(2)
                 .allSatisfy(signal -> {
@@ -203,7 +203,7 @@ class IssueUpdateCoalescerIntegrationTest extends BaseIntegrationTest {
 
         transactions.executeWithoutResult(status -> coalescer.drain(workspace.getId(), current.artifactId(), NOW));
 
-        assertThat(jobs.findByWorkspaceId(workspace.getId(), Pageable.unpaged()))
+        assertThat(jobs.findListRows(workspace.getId(), null, Pageable.unpaged()))
                 .isEmpty();
         assertThat(signals.findForArtifact(workspace.getId(), ScmSignals.ISSUE.value(), current.artifactId()))
                 .hasSize(2)
@@ -217,14 +217,14 @@ class IssueUpdateCoalescerIntegrationTest extends BaseIntegrationTest {
     void shouldRollBackTheWholeBurstWhenSettlementFailsAfterSubmissionReturns(CapturedOutput output) {
         assertThatThrownBy(() -> transactions.executeWithoutResult(status -> {
                     coalescer.drain(workspace.getId(), current.artifactId(), NOW);
-                    assertThat(jobs.findByWorkspaceId(workspace.getId(), Pageable.unpaged()))
+                    assertThat(jobs.findListRows(workspace.getId(), null, Pageable.unpaged()))
                             .hasSize(1);
                     throw new IllegalStateException("Settlement failed after admission");
                 }))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessage("Settlement failed after admission");
         assertThat(output).doesNotContain("agent.job.queued");
-        assertThat(jobs.findByWorkspaceId(workspace.getId(), Pageable.unpaged()))
+        assertThat(jobs.findListRows(workspace.getId(), null, Pageable.unpaged()))
                 .isEmpty();
 
         assertThat(signals.findForArtifact(workspace.getId(), ScmSignals.ISSUE.value(), current.artifactId()))
@@ -238,7 +238,7 @@ class IssueUpdateCoalescerIntegrationTest extends BaseIntegrationTest {
         transactions.executeWithoutResult(status -> coalescer.drain(workspace.getId(), current.artifactId(), NOW));
         transactions.executeWithoutResult(status -> coalescer.drain(workspace.getId(), current.artifactId(), NOW));
         assertThat(output).containsOnlyOnce("agent.job.queued");
-        assertThat(jobs.findByWorkspaceId(workspace.getId(), Pageable.unpaged()))
+        assertThat(jobs.findListRows(workspace.getId(), null, Pageable.unpaged()))
                 .singleElement()
                 .satisfies(job -> assertThat(signals.findForArtifact(
                                 workspace.getId(), ScmSignals.ISSUE.value(), current.artifactId()))


### PR DESCRIPTION
Closes #1944.

## Problem

`AgentJobService.getJobs` returned `Page<AgentJob>`, so listing a workspace's jobs selected every
column of every row, including `container_logs`. `AgentJobDTO::from` then discarded the transcript
entirely — `getContainerLogs()` has no production call site anywhere. With a page size of 100 and
whole transcripts now kept rather than a 64 KB tail, one request pulls tens of megabytes into heap
and throws nearly all of it away. The delivery-recovery sweep loaded whole entities for the same
reason, most of which it only skips.

## Solution

The listing reads an interface projection of exactly the columns `AgentJobDTO` renders. The sweep
reads three columns per candidate and loads a job whole only for the attempt it wins, through a
purpose-named finder rather than `findById`, which the scheduled-context architecture rule bans.

`output` stays in the listing, and that is the decision the issue asks for: the page renders it and
each run's outcome is derived from it, and it is bounded by the agent's result contract rather than
by how much a review had to say.

## Verification

- `AgentJobListingContractTest` pins that both queries return projections rather than entities, that
  neither projection exposes the transcript, and that neither query names it.
- Unit tier (7197) and architecture tier (304) pass.
- `AgentWorkspacePurgeIntegrationTest` exercises the new listing query against a real database.