### PR TITLE
fix(server): an admission refusal is a decision, not an internal error

### DIFF
--- a/.changeset/an-admission-refusal-is-a-decision.md
+++ b/.changeset/an-admission-refusal-is-a-decision.md
@@ -1,0 +1,8 @@
+---
+"hephaestus": patch
+---
+
+A review whose observations Hephaestus will not record now ends with that reason on the run, instead
+of failing as an internal error with nothing to show. The reason appears in the run's transcript and
+on the run itself, and the review stops rather than re-submitting what the server has already
+declined.

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/handler/IssueReviewHandler.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/handler/IssueReviewHandler.java
@@ -18,6 +18,7 @@ import de.tum.cit.aet.hephaestus.agent.handler.spi.JobPreparationException;
 import de.tum.cit.aet.hephaestus.agent.handler.spi.JobSubmission;
 import de.tum.cit.aet.hephaestus.agent.handler.spi.JobSubmissionRequest;
 import de.tum.cit.aet.hephaestus.agent.handler.spi.JobTypeHandler;
+import de.tum.cit.aet.hephaestus.agent.handler.spi.ObservationsRefusedException;
 import de.tum.cit.aet.hephaestus.agent.handler.spi.PreparedJobInputs;
 import de.tum.cit.aet.hephaestus.agent.job.AgentJob;
 import de.tum.cit.aet.hephaestus.agent.runtime.SandboxLayout;
@@ -301,7 +302,8 @@ public class IssueReviewHandler implements JobTypeHandler {
         output.put("rawOutput", raw.toString());
         var parsed = resultParser.parse(output);
         if (parsed.validObservations().isEmpty()) {
-            throw new JobDeliveryException("No valid observations in agent output: jobId=" + job.getId());
+            throw new ObservationsRefusedException(
+                    "no_valid_observations", "No valid observations in agent output: jobId=" + job.getId());
         }
         var admitted = new ArrayList<>(PracticeDetectionResultParser.coerceCoherence(
                 parsed.validObservations(), practiceCatalogInjector.defectDetectorSlugs(job)));

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/handler/ObservationAdmissionService.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/handler/ObservationAdmissionService.java
@@ -11,6 +11,7 @@ import de.tum.cit.aet.hephaestus.practices.observation.ObservationRepository;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.json.JsonMapper;
@@ -21,6 +22,9 @@ import tools.jackson.databind.node.ObjectNode;
 public class ObservationAdmissionService {
 
     public static final String DIGEST_METADATA_KEY = "observation_admission_digest";
+
+    /** Where a refusal's reason is kept, so the run says what happened to it after the sandbox is gone. */
+    public static final String REFUSAL_METADATA_KEY = "observation_admission_refusal";
 
     static void requireMatchingCompositionDigest(AgentJob job) {
         String admitted = job.getMetadata() == null
@@ -86,6 +90,26 @@ public class ObservationAdmissionService {
                 job,
                 digest,
                 observations.findByAgentJobId(jobId, job.getWorkspace().getId()));
+    }
+
+    /**
+     * Records why this review's observations were refused, in its own transaction: the admission that
+     * refused them rolls back, and the reason must outlive that rollback — it is all the practice page
+     * and the administration surface have to explain a run that recorded nothing.
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void recordRefusal(UUID jobId, String reasonCode, String reason) {
+        jobs.findById(jobId).ifPresent(job -> {
+            ObjectNode metadata = job.getMetadata() instanceof ObjectNode object
+                    ? (ObjectNode) object.deepCopy()
+                    : mapper.createObjectNode();
+            ObjectNode refusal = mapper.createObjectNode();
+            refusal.put("reasonCode", reasonCode);
+            refusal.put("reason", reason);
+            metadata.set(REFUSAL_METADATA_KEY, refusal);
+            job.setMetadata(metadata);
+            jobs.save(job);
+        });
     }
 
     private byte[] serializedPayload(JsonNode submitted) {

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/handler/PullRequestReviewHandler.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/handler/PullRequestReviewHandler.java
@@ -20,6 +20,7 @@ import de.tum.cit.aet.hephaestus.agent.handler.spi.JobPreparationException;
 import de.tum.cit.aet.hephaestus.agent.handler.spi.JobSubmission;
 import de.tum.cit.aet.hephaestus.agent.handler.spi.JobSubmissionRequest;
 import de.tum.cit.aet.hephaestus.agent.handler.spi.JobTypeHandler;
+import de.tum.cit.aet.hephaestus.agent.handler.spi.ObservationsRefusedException;
 import de.tum.cit.aet.hephaestus.agent.handler.spi.PreparedJobInputs;
 import de.tum.cit.aet.hephaestus.agent.job.AgentJob;
 import de.tum.cit.aet.hephaestus.agent.runtime.ProvenanceDigest;
@@ -351,9 +352,11 @@ public class PullRequestReviewHandler implements JobTypeHandler {
                     parsed.discarded());
         }
         if (parsed.validObservations().isEmpty()) {
-            throw new JobDeliveryException("No valid observations in agent output: jobId=" + job.getId()
-                    + ", discarded="
-                    + parsed.discarded().size());
+            throw new ObservationsRefusedException(
+                    "no_valid_observations",
+                    "No valid observations in agent output: jobId=" + job.getId()
+                            + ", discarded="
+                            + parsed.discarded().size());
         }
 
         String unifiedDiff = capturedDiff(job);
@@ -380,11 +383,13 @@ public class PullRequestReviewHandler implements JobTypeHandler {
                 && secretObservations.isEmpty()
                 && !diffFiles.isEmpty()
                 && !readTheDiff(parsed.validObservations())) {
-            throw new JobDeliveryException("No observation decided anything or quoted the diff, and the diff contains "
-                    + diffFiles.size()
-                    + " files — the review answered without reading the change. "
-                    + "Refusing to deliver. jobId="
-                    + job.getId());
+            throw new ObservationsRefusedException(
+                    "did_not_read_the_diff",
+                    "No observation decided anything or quoted the diff, and the diff contains "
+                            + diffFiles.size()
+                            + " files — the review answered without reading the change. "
+                            + "Refusing to deliver. jobId="
+                            + job.getId());
         }
 
         var scopedObservations = new ArrayList<>(filterByDiffScope(parsed.validObservations(), diffFiles));
@@ -426,11 +431,13 @@ public class PullRequestReviewHandler implements JobTypeHandler {
                     job.getId());
         }
         if (scopedObservations.isEmpty()) {
-            throw new JobDeliveryException("All observations were filtered by diff scope: jobId=" + job.getId()
-                    + ", before="
-                    + parsed.validObservations().size()
-                    + ", diffFiles="
-                    + diffFiles.size());
+            throw new ObservationsRefusedException(
+                    "out_of_diff_scope",
+                    "All observations were filtered by diff scope: jobId=" + job.getId()
+                            + ", before="
+                            + parsed.validObservations().size()
+                            + ", diffFiles="
+                            + diffFiles.size());
         }
 
         // Coherence coercion: a defect-detector practice's GOOD assessment becomes NOT_APPLICABLE (no false

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/handler/spi/ObservationsRefusedException.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/handler/spi/ObservationsRefusedException.java
@@ -1,0 +1,31 @@
+package de.tum.cit.aet.hephaestus.agent.handler.spi;
+
+/**
+ * A review whose observations the server will not record: the run finished, and what it submitted
+ * does not support a claim about anyone's work. This is a decision the review stage took, not a
+ * failure of the machinery around it, so the sandbox is told so and stops rather than repeating the
+ * submission against a server that will refuse it again for the same reason.
+ *
+ * @param reasonCode a stable, lowercase name for the refusal, for metrics and logs — never the
+ *     message, which names one job
+ */
+public class ObservationsRefusedException extends JobDeliveryException {
+
+    private final String reasonCode;
+    private final String reason;
+
+    public ObservationsRefusedException(String reasonCode, String reason) {
+        super(reason);
+        this.reasonCode = reasonCode;
+        this.reason = reason;
+    }
+
+    public String reasonCode() {
+        return reasonCode;
+    }
+
+    /** The refusal in words, always present — unlike {@code getMessage()}, which a caller must null-check. */
+    public String reason() {
+        return reason;
+    }
+}

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/handler/spi/ObservationsRefusedException.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/handler/spi/ObservationsRefusedException.java
@@ -6,8 +6,8 @@ package de.tum.cit.aet.hephaestus.agent.handler.spi;
  * failure of the machinery around it, so the sandbox is told so and stops rather than repeating the
  * submission against a server that will refuse it again for the same reason.
  *
- * @param reasonCode a stable, lowercase name for the refusal, for metrics and logs — never the
- *     message, which names one job
+ * <p>The reason code is a stable, lowercase name for the refusal, for metrics and logs — never the
+ * message, which names one job.
  */
 public class ObservationsRefusedException extends JobDeliveryException {
 

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/proxy/ObservationAdmissionController.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/proxy/ObservationAdmissionController.java
@@ -1,10 +1,14 @@
 package de.tum.cit.aet.hephaestus.agent.proxy;
 
 import de.tum.cit.aet.hephaestus.agent.handler.ObservationAdmissionService;
+import de.tum.cit.aet.hephaestus.agent.handler.spi.ObservationsRefusedException;
 import de.tum.cit.aet.hephaestus.agent.usage.LlmUsageSourceType;
 import de.tum.cit.aet.hephaestus.core.WorkspaceAgnostic;
+import de.tum.cit.aet.hephaestus.integration.core.signal.PracticeReviewRefusalMetrics;
 import io.swagger.v3.oas.annotations.Hidden;
 import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
@@ -22,10 +26,15 @@ import tools.jackson.databind.node.ObjectNode;
 @PreAuthorize("isAuthenticated()")
 public class ObservationAdmissionController {
 
-    private final ObservationAdmissionService admission;
+    private static final Logger log = LoggerFactory.getLogger(ObservationAdmissionController.class);
 
-    public ObservationAdmissionController(ObservationAdmissionService admission) {
+    private final ObservationAdmissionService admission;
+    private final PracticeReviewRefusalMetrics refusals;
+
+    public ObservationAdmissionController(
+            ObservationAdmissionService admission, PracticeReviewRefusalMetrics refusals) {
         this.admission = admission;
+        this.refusals = refusals;
     }
 
     @PostMapping("/admit-observations")
@@ -49,6 +58,14 @@ public class ObservationAdmissionController {
             return admission.admit(jobId, request.path("observations"));
         } catch (ObservationAdmissionService.AdmissionConflictException e) {
             throw new ResponseStatusException(HttpStatus.CONFLICT, "Observations differ from the admitted payload", e);
+        } catch (ObservationsRefusedException e) {
+            // A decision, not a defect: the review ran and what it submitted does not support a claim
+            // about anyone's work. Answering 5xx would have the sandbox repeat a submission this server
+            // refuses for the same reason every time, and would file the refusal as an internal error.
+            refusals.recordExecutionRefusal(e.reasonCode());
+            admission.recordRefusal(jobId, e.reasonCode(), e.reason());
+            log.info("Refused this review's observations ({}): jobId={}, {}", e.reasonCode(), jobId, e.reason());
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, e.reason(), e);
         }
     }
 }

--- a/server/application/src/main/resources/agent/pi-runner.ts
+++ b/server/application/src/main/resources/agent/pi-runner.ts
@@ -1504,6 +1504,21 @@ const ADMISSION_ATTEMPTS = 4;
  */
 const ADMISSION_ATTEMPT_TIMEOUT_MS = 5_000;
 
+/**
+ * What the server said about an answer it refused, as text a reader can act on. A body that cannot be
+ * read is not worth failing over twice: the status alone still says a refusal happened.
+ */
+async function answerText(response: Response): Promise<string> {
+	try {
+		const body = await response.text();
+		const problem: unknown = body.trim().startsWith("{") ? parseJson(body) : null;
+		const detail = isRecord(problem) ? problem.detail : null;
+		return typeof detail === "string" && detail.length > 0 ? detail : body.slice(0, 500);
+	} catch {
+		return "the server gave no readable reason";
+	}
+}
+
 /** One admission attempt: the answer it returns is the parsed body, unvalidated. */
 async function postAdmission(): Promise<unknown> {
 	let response: Response;
@@ -1528,7 +1543,13 @@ async function postAdmission(): Promise<unknown> {
 	if (isRetryableStatus(response.status)) {
 		throw new AdmissionUnreachable(`observation admission failed: HTTP ${response.status}`);
 	}
-	if (!response.ok) throw new Error(`observation admission failed: HTTP ${response.status}`);
+	if (!response.ok) {
+		// The server has decided, and it said why. Asking again puts the same question, so the run ends
+		// here — with the reason in the transcript, which is the only place a reader can find it.
+		throw new Error(
+			`observation admission was refused: HTTP ${response.status} — ${await answerText(response)}`,
+		);
+	}
 	try {
 		return await response.json();
 	} catch (error) {

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/proxy/ObservationAdmissionControllerTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/proxy/ObservationAdmissionControllerTest.java
@@ -5,7 +5,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.*;
 
 import de.tum.cit.aet.hephaestus.agent.handler.ObservationAdmissionService;
+import de.tum.cit.aet.hephaestus.agent.handler.spi.ObservationsRefusedException;
 import de.tum.cit.aet.hephaestus.agent.usage.LlmUsageSourceType;
+import de.tum.cit.aet.hephaestus.integration.core.signal.PracticeReviewRefusalMetrics;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.math.BigDecimal;
 import java.util.UUID;
 import org.junit.jupiter.api.Tag;
@@ -20,7 +23,9 @@ import tools.jackson.databind.node.ObjectNode;
 class ObservationAdmissionControllerTest {
 
     private final ObservationAdmissionService service = mock(ObservationAdmissionService.class);
-    private final ObservationAdmissionController controller = new ObservationAdmissionController(service);
+    private final SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+    private final ObservationAdmissionController controller =
+            new ObservationAdmissionController(service, new PracticeReviewRefusalMetrics(meterRegistry));
     private final JsonMapper mapper = JsonMapper.builder().build();
 
     @Test
@@ -40,6 +45,28 @@ class ObservationAdmissionControllerTest {
 
         assertThat(actual).isSameAs(response);
         verify(service).admit(id, validRequest().path("observations"));
+    }
+
+    @Test
+    void aRefusedReviewIsAnsweredAsADecisionAndCounted() {
+        UUID id = UUID.randomUUID();
+        when(service.admit(eq(id), any()))
+                .thenThrow(new ObservationsRefusedException(
+                        "did_not_read_the_diff", "No observation decided anything or quoted the diff"));
+
+        assertThatThrownBy(() -> controller.admit(validRequest(), authentication(LlmUsageSourceType.AGENT_JOB, id)))
+                .isInstanceOfSatisfying(ResponseStatusException.class, e -> {
+                    // Not 5xx: a 5xx is what the sandbox repeats, and repeating puts the same question.
+                    assertThat(e.getStatusCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY);
+                    assertThat(e.getReason()).contains("quoted the diff");
+                });
+        assertThat(meterRegistry
+                        .counter("practice.review.refused", "phase", "execution", "reason", "did_not_read_the_diff")
+                        .count())
+                .isEqualTo(1d);
+        // The sandbox is gone once it reads this answer, so the reason has to outlive it on the job.
+        verify(service)
+                .recordRefusal(id, "did_not_read_the_diff", "No observation decided anything or quoted the diff");
     }
 
     @Test


### PR DESCRIPTION
Closes #1934.

## Problem

A review refuses its own observations when what it submitted cannot support a claim about someone's
work: no valid observations, nothing decided and no diff quoted, or everything filtered out as
outside the change. All four sites threw `JobDeliveryException`, and the admission endpoint mapped
only `AdmissionConflictException`, so a deliberate refusal reached the sandbox as HTTP 500:

```
[pi-runner] FATAL: observation admission failed: HTTP 500
```

The runner read that as a server having trouble and retried it, the run exited 2 with everything
discarded, and the refusal was recorded as an unhandled exception. Nothing anywhere said why the
developer's practice page stayed empty. Since a 500 is also what the runner now treats as a server it
could not reach, a refusal would have been answered by running the whole review again.

## Solution

The four refusals throw `ObservationsRefusedException`, which carries a stable reason code. The
endpoint answers 422 with the reason, counts an execution refusal, and records the reason on the job
in its own transaction, so it outlives the rollback of the admission that refused. The runner reads
the server's reason into its transcript and stops.

## Verification

`ObservationAdmissionControllerTest` covers the refusal across the controller boundary: the status,
the reason, the metric and the recording. The unit tier (7196) passes, and the agent tree type-checks
and lints clean.