### PR TITLE
fix(server): a refused citation says what mismatched

### DIFF
--- a/.changeset/a-refused-citation-says-what-mismatched.md
+++ b/.changeset/a-refused-citation-says-what-mismatched.md
@@ -1,0 +1,8 @@
+---
+"hephaestus": patch
+---
+
+When a review quotes a line that is not in the change it is reviewing, the run now records which part
+was wrong: the line number, the side of the diff, or the text itself. The quote is still checked
+against the change exactly as before; only the explanation is new, and it is what lets a review
+correct itself instead of dropping the practice.

--- a/server/application/src/main/resources/agent/pi-observation-normalize.ts
+++ b/server/application/src/main/resources/agent/pi-observation-normalize.ts
@@ -647,12 +647,29 @@ function foldConfusables(text: string): string {
 	return out;
 }
 
+/** How much of a diff line a refusal quotes back; enough to see the difference, not the whole line. */
+const MISMATCH_EXCERPT_CHARS = 160;
+
+/** Whether an observation's citation is really in the artifact it names. */
 export function citationMatchesArtifact(citation: NormalizedCitation, content: string): boolean {
+	return describeCitationMismatch(citation, content) === null;
+}
+
+/**
+ * Why a citation does not match, in one phrase, or null when it does. A refusal that only says "does
+ * not match" leaves the session guessing at which of the coordinate, the side and the text was wrong,
+ * and leaves a reader of the transcript guessing at the same thing. The rule itself is unchanged:
+ * every quote is still read out of the artifact it names.
+ */
+export function describeCitationMismatch(
+	citation: NormalizedCitation,
+	content: string,
+): string | null {
 	if (citation.sourceKind !== "scm.pull-request.diff") {
-		return (
+		const found =
 			content.includes(citation.quote) ||
-			foldConfusables(content).includes(foldConfusables(citation.quote))
-		);
+			foldConfusables(content).includes(foldConfusables(citation.quote));
+		return found ? null : "that text is not in the artifact";
 	}
 	let oldPath: string | null = null;
 	let newPath: string | null = null;
@@ -678,11 +695,28 @@ export function citationMatchesArtifact(citation: NormalizedCitation, content: s
 		}
 	}
 	const quoteLines = citation.quote.split("\n");
-	if (quoteLines.length !== citation.endLine - citation.startLine + 1) return false;
-	return quoteLines.every((quoteLine, index) => {
-		const diffLine = citedLines.get(citation.startLine + index);
-		return diffLine === quoteLine || diffLine?.slice(1) === quoteLine;
-	});
+	const citedLineCount = citation.endLine - citation.startLine + 1;
+	if (quoteLines.length !== citedLineCount) {
+		return `the quote is ${quoteLines.length} line(s) and the citation covers ${citedLineCount}`;
+	}
+	for (const [index, quoteLine] of quoteLines.entries()) {
+		const lineNumber = citation.startLine + index;
+		const diffLine = citedLines.get(lineNumber);
+		if (diffLine === undefined) {
+			return `the diff has no [L${lineNumber}] on the ${citation.side ?? "NEW"} side of ${citation.path}`;
+		}
+		if (diffLine !== quoteLine && diffLine.slice(1) !== quoteLine) {
+			return `[L${lineNumber}] reads ${excerpt(diffLine)}, not ${excerpt(quoteLine)}`;
+		}
+	}
+	return null;
+}
+
+/** One line as evidence in a refusal: quoted, and cut where a reader has already seen the difference. */
+function excerpt(line: string): string {
+	const cut =
+		line.length > MISMATCH_EXCERPT_CHARS ? `${line.slice(0, MISMATCH_EXCERPT_CHARS)}…` : line;
+	return JSON.stringify(cut);
 }
 
 function diffPath(rawPath: string): string | null {

--- a/server/application/src/main/resources/agent/pi-runner.ts
+++ b/server/application/src/main/resources/agent/pi-runner.ts
@@ -20,7 +20,7 @@ import {
 import { errorText } from "./pi-error-text.ts";
 import { buildGrepTool } from "./pi-grep-tool.ts";
 import {
-	citationMatchesArtifact,
+	describeCitationMismatch,
 	dedupeKeyForObservation,
 	isRecord,
 	type NormalizedObservation,
@@ -572,11 +572,12 @@ function normalizeAndValidateObservation(rawObservation: unknown): NormalizedObs
 	validateInapplicabilityScope(observation, availableSourceKinds);
 	for (const citation of observation.evidence.citations) {
 		const content = readFileSync(`${CWD}/${citation.artifactPath}`, "utf8");
-		if (!citationMatchesArtifact(citation, content)) {
+		const mismatch = describeCitationMismatch(citation, content);
+		if (mismatch !== null) {
 			throw new Error(
 				`citation does not match ${citation.path}:${citation.startLine}-${citation.endLine} ` +
-					`(${citation.side ?? "text"}) in '${citation.artifactPath}'; copy the exact artifact text ` +
-					`and, for a diff, use its [L<n>] coordinates and OLD/NEW side`,
+					`(${citation.side ?? "text"}) in '${citation.artifactPath}': ${mismatch}. Copy the exact ` +
+					`artifact text and, for a diff, use its [L<n>] coordinates and OLD/NEW side`,
 			);
 		}
 	}

--- a/server/application/src/test/resources/agent/pi-observation-normalize.spec.ts
+++ b/server/application/src/test/resources/agent/pi-observation-normalize.spec.ts
@@ -6,6 +6,7 @@ import {
 	ASSESSMENT_VALUES,
 	carriesValence,
 	citationMatchesArtifact,
+	describeCitationMismatch,
 	dedupeKeyForObservation,
 	describeVocabulary,
 	type NormalizedCitation,
@@ -288,6 +289,29 @@ void test("diff citations bind the quote to the claimed file and line", () => {
 	assert.equal(citationMatchesArtifact({ ...citation, path: "src/Other.java" }, diff), false);
 	assert.equal(citationMatchesArtifact({ ...citation, startLine: 11 }, diff), false);
 	assert.equal(citationMatchesArtifact({ ...citation, endLine: 12 }, diff), false);
+});
+
+void test("a refused citation says which of the coordinate, the side and the text was wrong", () => {
+	const citation = onlyCitation(normalizeObservation(baseObservation()).evidence.citations);
+	const diff =
+		"diff --git a/src/Auth.java b/src/Auth.java\n+++ b/src/Auth.java\n@@ -10 +10 @@\n[L10] + insecure();\n";
+
+	assert.equal(describeCitationMismatch(citation, diff), null);
+	// The coordinate is not in the diff at all.
+	assert.match(
+		describeCitationMismatch({ ...citation, startLine: 11, endLine: 11 }, diff) ?? "",
+		/no \[L11] on the NEW side of src\/Auth\.java/,
+	);
+	// The coordinate is there and says something else, so the refusal shows both.
+	assert.match(
+		describeCitationMismatch({ ...citation, quote: "+ secure();" }, diff) ?? "",
+		/\[L10] reads "\+ insecure\(\);", not "\+ secure\(\);"/,
+	);
+	// The quote and the line span disagree.
+	assert.match(
+		describeCitationMismatch({ ...citation, endLine: 12 }, diff) ?? "",
+		/quote is 1 line\(s\) and the citation covers 3/,
+	);
 });
 
 void test("removed-line citations use old-side coordinates", () => {


### PR DESCRIPTION
## Problem

An observation whose citation cannot be produced from the artifact it names is refused, and the
refusal said only that it "does not match":

```
[pi-runner] observation refused for ships-tests-with-the-change: citation does not match
src/main/java/de/tum/cit/aet/artemis/account/security/SAML2Service.java:233-233 (NEW) in
'inputs/context/diff.patch'; copy the exact artifact text and, for a diff, use its [L<n>]
coordinates and OLD/NEW side
```

The session cannot tell which of the coordinate, the side and the text was wrong, so its next attempt
is a guess; and a reader of the transcript cannot tell either. Staging's Artemis reviews carry a
median of three of these each, with two recent runs at thirteen and fourteen, and each one costs a
turn — sometimes the practice.

## Solution

`describeCitationMismatch` returns the reason in a phrase, and the refusal carries it: the diff has no
such coordinate on that side of that file, the coordinate reads something else (both lines quoted,
cut at 160 characters), or the quote and the cited span disagree in length.
`citationMatchesArtifact` stays as the boolean and is now that function's answer, so the rule is
unchanged: every quote is still read out of the artifact it names.

## Verification

A new spec covers all three shapes plus the matching case. The agent specs (149), the type-check and
the lint pass.