### PR TITLE
fix(server): an unfinished review is not an all-clear

### DIFF
--- a/.changeset/an-unfinished-review-is-not-an-all-clear.md
+++ b/.changeset/an-unfinished-review-is-not-an-all-clear.md
@@ -1,0 +1,7 @@
+---
+"hephaestus": patch
+---
+
+A practice page no longer reports a practice as assessed and clean while its review is still running,
+or after that review has died. Both now say what is actually true of the run: one is under way, the
+other did not finish.

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/practices/trace/PracticeTraceDeriver.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/practices/trace/PracticeTraceDeriver.java
@@ -5,6 +5,7 @@ import de.tum.cit.aet.hephaestus.practices.model.PracticeAutonomy;
 import de.tum.cit.aet.hephaestus.practices.spi.ReviewOutcomeLookup.PracticeCoverageOutcome;
 import de.tum.cit.aet.hephaestus.practices.spi.ReviewOutcomeLookup.PracticeReadinessOutcome;
 import de.tum.cit.aet.hephaestus.practices.spi.ReviewOutcomeLookup.ReviewOutcome;
+import de.tum.cit.aet.hephaestus.practices.spi.ReviewOutcomeLookup.ReviewRunState;
 import de.tum.cit.aet.hephaestus.practices.trace.TraceInputs.PracticeOutput;
 import de.tum.cit.aet.hephaestus.practices.trace.TraceInputs.SignalOccurrence;
 import de.tum.cit.aet.hephaestus.practices.trace.TraceInputs.TracedPractice;
@@ -90,6 +91,13 @@ final class PracticeTraceDeriver {
         for (SignalOccurrence occurrence : matched) {
             ReviewOutcome review = occurrence.reviewId() == null ? null : reviews.get(occurrence.reviewId());
             if (review == null) {
+                continue;
+            }
+            // Readiness is recorded before the sandbox starts, so a review that is still running or that
+            // never finished carries one too. Answering from it would tell a developer their practice was
+            // assessed and clean while the review was still under way, or after it had died — the run's
+            // own state is the only thing that makes an all-clear a statement about their work.
+            if (review.state() != ReviewRunState.COMPLETED) {
                 continue;
             }
             PracticeReadinessOutcome readiness =

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/practices/trace/PracticeTraceDeriverTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/practices/trace/PracticeTraceDeriverTest.java
@@ -77,6 +77,46 @@ class PracticeTraceDeriverTest extends BaseUnitTest {
         }
 
         @Test
+        @DisplayName("a review still under way is not an all-clear, however ready the practice was")
+        void doesNotReportAnAllClearWhileTheReviewIsStillRunning() {
+            var running = new ReviewOutcome(
+                    ReviewRunState.IN_PROGRESS,
+                    false,
+                    AT,
+                    Map.of("slug", new PracticeReadinessOutcome(true, List.of(), null)),
+                    Map.of());
+
+            var entry = only(
+                    practice(PracticeAutonomy.AUTOMATIC, READY),
+                    List.of(triggered(READY, RUN)),
+                    Map.of(RUN, running),
+                    Map.of());
+
+            // Readiness is written before the sandbox starts, so it says nothing about what was assessed.
+            assertThat(entry.outcome()).isEqualTo(PracticeTraceOutcome.RUNNING);
+        }
+
+        @Test
+        @DisplayName("a review that died is not an all-clear either")
+        void doesNotReportAnAllClearForAReviewThatFailed() {
+            var failed = new ReviewOutcome(
+                    ReviewRunState.FAILED,
+                    false,
+                    AT,
+                    Map.of("slug", new PracticeReadinessOutcome(true, List.of(), null)),
+                    Map.of());
+
+            var entry = only(
+                    practice(PracticeAutonomy.AUTOMATIC, READY),
+                    List.of(triggered(READY, RUN)),
+                    Map.of(RUN, failed),
+                    Map.of());
+
+            assertThat(entry.outcome()).isEqualTo(PracticeTraceOutcome.FAILED);
+            assertThat(entry.explanation()).contains("did not finish");
+        }
+
+        @Test
         void keepsMeasurementAndDeliveryOnSeparateAxes() {
             var entry = only(
                     practice(PracticeAutonomy.HUMAN_APPROVAL, READY),


### PR DESCRIPTION
## Problem

`PracticeTraceDeriver` answers from `review_readiness`, which is written before the sandbox starts. A
practice that was ready and produced no observations therefore reads as

> Assessed on this artifact; nothing to report.

while its review is still running, and again after that review has failed. Both are claims about
someone's work made from a run that never made them. The states already exist — the same deriver
reports `RUNNING` and `FAILED` further down — they were simply unreachable for a practice whose
readiness had been recorded.

## Solution

The all-clear branch requires `ReviewRunState.COMPLETED`. A running or failed review falls through to
the answer that already exists for it.

## Verification

Two new cases in `PracticeTraceDeriverTest` cover a running and a failed review with ready readiness.
The whole class passes (22), and the unit tier (7198).

## Not this

A completed run whose coverage ledger names no outcome for the practice still reads as an all-clear.
That is the older default, and flipping it would change how past runs read on every practice page, so
it wants a maintainer's decision rather than a rider on this fix.