### PR TITLE
fix(server): a review that never reached its provider runs again

### DIFF
--- a/.changeset/a-review-that-never-reached-its-provider-runs-again.md
+++ b/.changeset/a-review-that-never-reached-its-provider-runs-again.md
@@ -2,6 +2,7 @@
 "hephaestus": patch
 ---
 
-A practice review that could not reach the model at all now runs again instead of being recorded as a
-review that found nothing. A restart or a provider outage during a review costs a delay rather than
-the review, and the run says how many calls went unanswered.
+A practice review that recorded nothing because the model stopped answering now runs again, instead
+of being recorded as a review that found nothing. A restart or a provider outage then costs a delay
+rather than the review, and the run says how many calls went unanswered. A review that reached some
+of its practices still delivers what it reached, as before.

--- a/.changeset/a-review-that-never-reached-its-provider-runs-again.md
+++ b/.changeset/a-review-that-never-reached-its-provider-runs-again.md
@@ -1,0 +1,7 @@
+---
+"hephaestus": patch
+---
+
+A practice review that could not reach the model at all now runs again instead of being recorded as a
+review that found nothing. A restart or a provider outage during a review costs a delay rather than
+the review, and the run says how many calls went unanswered.

--- a/docs/contributor/agent/workspace-abi.mdx
+++ b/docs/contributor/agent/workspace-abi.mdx
@@ -129,9 +129,10 @@ worker filesystem.
 | 3    | Watchdog hard-kill (budget + grace exceeded); writes `out/watchdog-killed.json` first |
 | 42   | Envelope mismatch (unsupported `schemaVersion` or unknown `kind`) — image/server drift |
 | 75   | The review finished, but the call admitting its observations never reached the server |
+| 76   | No practice was reached, and every model call the run made went unanswered |
 
 `137` is a container SIGKILL from the runtime, not a runner code. The server treats `0` as success,
-`42` as drift and `75` as an attempt to repeat; every other non-zero code is a generic failure.
+`42` as drift, and `75` and `76` as attempts to repeat; every other non-zero code is a generic failure.
 
 A sandbox reaches the server at the address the app server held when the container started, so a
 server that came back somewhere else — a deploy, a restart that moved the container — is unreachable
@@ -142,6 +143,11 @@ job whose observations did reach the server — the admission committed and only
 is never repeated: a second payload against a digest the job already carries is refused. That decision
 is taken under the row lock the admission itself takes, and governs every requeue, including the one a
 classified infrastructure failure asks for.
+
+`76` says the same thing about the other end of the run. A review that reached no practice because
+every model call went unanswered measured nothing, so there is nothing to record about the work and
+nothing a second attempt would repeat; the runner counts the calls the provider never answered and
+names them in the transcript, and the server queues the work again on the same terms as `75`.
 
 ## Versioning policy
 

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobExecutor.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobExecutor.java
@@ -619,17 +619,19 @@ public class AgentJobExecutor {
             SandboxResult result = sandboxManager.execute(sandboxSpec);
             AgentResult agentResult = practiceAgent.parseResult(result);
 
-            // The review itself succeeded and only the call carrying it home did not arrive, so there is
-            // nothing to deliver and nothing to learn from ending it here: the sandbox holds an address
-            // the server has since moved away from, which no further attempt inside that container can
-            // reach. Another attempt runs the same review against a server it can reach. Past the retry
-            // cap this falls through and terminalizes exactly as it did before.
-            if (result.exitCode() == SandboxLayout.EXIT_SERVER_UNREACHABLE
-                    && requeueForAnotherAttempt(jobId, job, "server-unreachable", true, result.logs())) {
+            // Two exits say the run could not reach something it needed, rather than anything about the
+            // reviewed work: the review finished and could not admit it, because the sandbox holds an
+            // address the server has since moved away from; or no practice was reached at all because
+            // every model call went unanswered. Neither leaves anything to deliver, and neither is a
+            // fact a second attempt would repeat. Past the retry cap both fall through and terminalize
+            // exactly as they did before.
+            String unreachable = unreachableReason(result.exitCode());
+            if (unreachable != null && requeueForAnotherAttempt(jobId, job, unreachable, true, result.logs())) {
                 metricOutcome = "REQUEUED";
                 log.warn(
-                        "Requeuing job {}: the review finished but could not reach this server to admit its observations (attempt {})",
+                        "Requeuing job {} ({}): nothing it measured can be delivered from here (attempt {})",
                         jobId,
+                        unreachable,
                         job.getRetryCount() + 1);
                 return;
             }
@@ -948,6 +950,20 @@ public class AgentJobExecutor {
      */
     static boolean isRetryableInfraFailure(Exception e) {
         return e instanceof SandboxInfrastructureException || e instanceof IOException;
+    }
+
+    /**
+     * Which unreachable service this exit names, or null when the exit says something about the work.
+     * The name is what the usage ledger records the attempt under.
+     */
+    private static @Nullable String unreachableReason(int exitCode) {
+        if (exitCode == SandboxLayout.EXIT_SERVER_UNREACHABLE) {
+            return "server-unreachable";
+        }
+        if (exitCode == SandboxLayout.EXIT_PROVIDER_UNREACHABLE) {
+            return "provider-unreachable";
+        }
+        return null;
     }
 
     /**

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/runtime/SandboxLayout.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/runtime/SandboxLayout.java
@@ -150,6 +150,13 @@ public final class SandboxLayout {
      */
     public static final int EXIT_SERVER_UNREACHABLE = 75;
 
+    /**
+     * Exit code emitted by the Pi runner when it reached no practice and every model call it made went
+     * unanswered. Nothing about the reviewed work was measured, so there is nothing to record and
+     * nothing a second attempt would repeat — the work is requeued, like an unreachable server.
+     */
+    public static final int EXIT_PROVIDER_UNREACHABLE = 76;
+
     /** OCI label declaring the agent image runtime contract. */
     public static final String RUNTIME_CONTRACT_LABEL = "hephaestus.agent.runtime-contract";
 

--- a/server/application/src/main/resources/agent/pi-runner.ts
+++ b/server/application/src/main/resources/agent/pi-runner.ts
@@ -750,6 +750,12 @@ const SERVER_UNREACHABLE_EXIT = 75;
  * as one that found nothing.
  */
 const PROVIDER_UNREACHABLE_EXIT = 76;
+
+/**
+ * The session labels whose turns are the ones that record observations — the per-practice observers
+ * and their retry lane. A practice is reached from one of these or not at all.
+ */
+const RECORDING_LANE = /^(observer|retry):/;
 const SUPPORTED_SCHEMA_VERSION = 1;
 const SUPPORTED_KIND = "practice_review";
 const TASK_PATH = `${CWD}/task.json`;
@@ -1763,10 +1769,11 @@ async function main() {
 			}
 			if (event.type === "auto_retry_end" && !event.success) {
 				const finalError = event.finalError ?? "no error given";
-				// A call the provider never answered, after the SDK spent its whole budget on it. Counted
-				// because a review that reached no practice needs to say whether it was never told
-				// anything or measured nothing.
-				providerFailures++;
+				// A call the provider never answered, after the SDK spent its whole budget on it. Only the
+				// lanes that record observations are counted: reconnaissance and composition can fail
+				// without costing a practice, and what this number decides is whether a review that
+				// recorded nothing was cut off or simply had nothing to record.
+				if (RECORDING_LANE.test(label)) providerFailures++;
 				console.error(
 					`[pi-runner] ${label} provider call failed for good after ${event.attempt} retries: ${finalError}`,
 				);

--- a/server/application/src/main/resources/agent/pi-runner.ts
+++ b/server/application/src/main/resources/agent/pi-runner.ts
@@ -743,6 +743,13 @@ const ENVELOPE_MISMATCH_EXIT = 42;
  * server the next sandbox can reach rather than recorded as a review that produced nothing.
  */
 const SERVER_UNREACHABLE_EXIT = 75;
+/**
+ * No practice was reached, and every model call this run made failed. That is the same kind of fact
+ * as an unreachable server — nothing about the reviewed work was measured, and nothing was learned
+ * that a second attempt would repeat — so the server queues the review again rather than recording it
+ * as one that found nothing.
+ */
+const PROVIDER_UNREACHABLE_EXIT = 76;
 const SUPPORTED_SCHEMA_VERSION = 1;
 const SUPPORTED_KIND = "practice_review";
 const TASK_PATH = `${CWD}/task.json`;
@@ -1736,6 +1743,7 @@ async function main() {
 		: null;
 	const events: { type: string; timestamp: number }[] = [];
 	const streamUsage = newUsageLedger();
+	let providerFailures = 0;
 	const subscribeSession = (
 		trackedSession: AgentSession,
 		label: string,
@@ -1755,6 +1763,10 @@ async function main() {
 			}
 			if (event.type === "auto_retry_end" && !event.success) {
 				const finalError = event.finalError ?? "no error given";
+				// A call the provider never answered, after the SDK spent its whole budget on it. Counted
+				// because a review that reached no practice needs to say whether it was never told
+				// anything or measured nothing.
+				providerFailures++;
 				console.error(
 					`[pi-runner] ${label} provider call failed for good after ${event.attempt} retries: ${finalError}`,
 				);
@@ -2186,6 +2198,13 @@ async function main() {
 		process.exit(0);
 	}
 
+	if (providerFailures > 0) {
+		console.error(
+			`[pi-runner] UNREACHABLE: this review reached no practice, and ${providerFailures} model call(s) ` +
+				`went unanswered — the provider, not the work, is what this run could not read`,
+		);
+		process.exit(PROVIDER_UNREACHABLE_EXIT);
+	}
 	console.error(`[pi-runner] FAILED: this review reached no practice at all`);
 	process.exit(1);
 }

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobExecutorTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobExecutorTest.java
@@ -1149,6 +1149,60 @@ class AgentJobExecutorTest extends BaseUnitTest {
         }
 
         @Test
+        @DisplayName("a review that reached no practice because the provider never answered is run again (exit 76)")
+        void unansweredProviderIsRequeued() {
+            executor = new AgentJobExecutor(
+                    AGENT_PROPS,
+                    jobRepository,
+                    bindingRepository,
+                    handlerRegistry,
+                    practiceAgent,
+                    workerJwtIssuer,
+                    sandboxManager,
+                    sandboxExecutor,
+                    transactionTemplate,
+                    objectMapper,
+                    meterRegistry,
+                    new PracticeReviewRefusalMetrics(meterRegistry),
+                    new AgentJobTelemetry(meterRegistry),
+                    usageRecorder,
+                    llmBudgetService,
+                    NO_LIVE_ADMISSION,
+                    Optional.empty(),
+                    Optional.of(workerProps("unreachable-worker")));
+            when(jobRepository.findByIdQueuedForUpdateSkipLocked(eq(jobId), any()))
+                    .thenReturn(Optional.of(job));
+            when(bindingRepository.findByWorkspaceIdAndPurpose(99L, AgentPurpose.PRACTICE_REVIEW))
+                    .thenReturn(Optional.of(binding));
+            when(jobRepository.countByWorkspaceIdAndPurposeAndStatusIn(
+                            eq(99L), eq(AgentPurpose.PRACTICE_REVIEW), any()))
+                    .thenReturn(0L);
+            when(jobRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+            when(jobRepository.requeueOrphan(
+                            eq(jobId), eq("unreachable-worker"), eq(AGENT_PROPS.maxRetries()), any(), any(), any()))
+                    .thenReturn(1);
+
+            String transcript = "[pi-runner] UNREACHABLE: this review reached no practice, and 4 model call(s)"
+                    + " went unanswered";
+            JobTypeHandler handler = setupFullExecution(new SandboxResult(
+                    SandboxLayout.EXIT_PROVIDER_UNREACHABLE, Map.of(), transcript, false, Duration.ofMinutes(11)));
+            AgentJob runningJob = freshJob();
+            when(jobRepository.findByIdWithWorkspaceForUpdate(jobId)).thenReturn(Optional.of(runningJob));
+            when(jobRepository.findById(any(UUID.class))).thenReturn(Optional.of(runningJob));
+
+            executor.processJob(jobId);
+
+            verify(jobRepository)
+                    .requeueOrphan(
+                            eq(jobId), eq("unreachable-worker"), eq(AGENT_PROPS.maxRetries()), any(), any(), any());
+            // Nothing was measured, so there is nothing to deliver and no terminal state to record.
+            assertThat(runningJob.getContainerLogs()).isEqualTo(transcript);
+            verify(handler, never()).deliver(any());
+            verify(jobRepository, never()).transitionStatus(any(), any(), any(), any(), any());
+            verify(jobRepository, never()).transitionStatusOwnedBy(any(), any(), any(), any(), any(), any());
+        }
+
+        @Test
         @DisplayName("a review whose observations did reach the server is NOT run again (exit 75, digest on the row)")
         void unreachableServerDoesNotRepeatAnAdmittedReview() {
             executor = new AgentJobExecutor(

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/runtime/SandboxLayoutSyncTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/runtime/SandboxLayoutSyncTest.java
@@ -46,6 +46,10 @@ class SandboxLayoutSyncTest extends BaseUnitTest {
                 .contains("SERVER_UNREACHABLE_EXIT = " + SandboxLayout.EXIT_SERVER_UNREACHABLE);
 
         assertThat(body)
+                .as("runner pins PROVIDER_UNREACHABLE_EXIT to SandboxLayout.EXIT_PROVIDER_UNREACHABLE")
+                .contains("PROVIDER_UNREACHABLE_EXIT = " + SandboxLayout.EXIT_PROVIDER_UNREACHABLE);
+
+        assertThat(body)
                 .as("runner writes its output under SandboxLayout.OUTPUT_PATH")
                 .contains(SandboxLayout.OUTPUT_PATH.substring(SandboxLayout.WORKSPACE_ROOT.length()));
 


### PR DESCRIPTION
## Problem

Staging lost a review this afternoon to a provider that answered nothing:

```
[pi-runner] retry:code-1 assistant msg: stopReason=error, toolCalls=0, types=[], error=Connection error.
[pi-runner] retry:code-1 provider call failed for good after 5 retries: Connection error.
[pi-runner] Retry: 124.2s, resultFile=false, reviewState=false
[pi-runner] Practice coverage: evaluated=0, eligible=4, ratio=0.0000
[pi-runner] FAILED: this review reached no practice at all
```

692 seconds, four practices, nothing measured — recorded as a review that reached nothing, which is
terminal. But nothing about the reviewed work was learned, and nothing a second attempt would repeat:
this is the same kind of fact as an unreachable server, which #1945 already queues again.

(The transcript above is only legible because of #1946 and #1947, which landed earlier today.)

## Solution

The runner counts the calls the provider never answered — the SDK's own `auto_retry_end` with
`success: false`, after it has spent its whole retry budget — and exits `76` when it reached no
practice and at least one such call happened. The server maps `76` alongside `75` onto the requeue
path: rotated token, usual backoff, transcript kept, and past the retry cap it terminalizes exactly as
before.

A review that reached *some* practices is untouched: partial coverage is delivered as it is today.

## Verification

`AgentJobExecutorTest` covers the requeue for exit 76 with its transcript and no delivery;
`SandboxLayoutSyncTest` pins the runner's constant to the ABI's. The unit tier passes (7206), and the
agent tree type-checks and lints clean. The ABI table and its prose carry the new code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Practice reviews that cannot reach the model are retried instead of being recorded as empty reviews.
  - Runs now report unanswered provider calls and preserve their transcripts.
  - Unreachable-provider runs are requeued without delivering results or marking the review as complete.

- **Documentation**
  - Documented the new run status and retry behavior for provider-unreachable reviews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->