### PR TITLE
fix(server): a citation may carry the coordinate it was shown

### DIFF
--- a/.changeset/a-citation-may-carry-the-coordinate-it-was-shown.md
+++ b/.changeset/a-citation-may-carry-the-coordinate-it-was-shown.md
@@ -1,0 +1,8 @@
+---
+"hephaestus": patch
+---
+
+A review no longer discards its own finding for copying a line exactly as the change displays it. The
+diff a review reads prints a line number in front of every line, and quoting that back was the most
+common reason an observation was thrown away — on one repository, a median of three per review, and
+up to fourteen. The quote still has to be the line the citation names.

--- a/server/application/src/main/resources/agent/pi-observation-normalize.ts
+++ b/server/application/src/main/resources/agent/pi-observation-normalize.ts
@@ -705,11 +705,23 @@ export function describeCitationMismatch(
 		if (diffLine === undefined) {
 			return `the diff has no [L${lineNumber}] on the ${citation.side ?? "NEW"} side of ${citation.path}`;
 		}
-		if (diffLine !== quoteLine && diffLine.slice(1) !== quoteLine) {
+		const quoted = withoutOwnCoordinate(quoteLine, lineNumber);
+		if (diffLine !== quoted && diffLine.slice(1) !== quoted) {
 			return `[L${lineNumber}] reads ${excerpt(diffLine)}, not ${excerpt(quoteLine)}`;
 		}
 	}
 	return null;
+}
+
+/**
+ * The line as the artifact shows it, when the quote copied the coordinate the artifact prints in
+ * front of it. Reading a diff line as `[L39] +public class Foo {` and quoting it back whole is the
+ * commonest refusal there is, and it proves the same thing an unprefixed quote proves: the coordinate
+ * has to be the one being matched, so a quote cannot claim a line it did not read.
+ */
+function withoutOwnCoordinate(quoteLine: string, lineNumber: number): string {
+	const [, quotedNumber, quotedText] = quoteLine.match(/^\[L(\d+)] (.*)$/) ?? [];
+	return quotedText !== undefined && quotedNumber === String(lineNumber) ? quotedText : quoteLine;
 }
 
 /** One line as evidence in a refusal: quoted, and cut where a reader has already seen the difference. */

--- a/server/application/src/test/resources/agent/pi-observation-normalize.spec.ts
+++ b/server/application/src/test/resources/agent/pi-observation-normalize.spec.ts
@@ -291,6 +291,21 @@ void test("diff citations bind the quote to the claimed file and line", () => {
 	assert.equal(citationMatchesArtifact({ ...citation, endLine: 12 }, diff), false);
 });
 
+void test("a quote may carry the coordinate the diff printed in front of it", () => {
+	const citation = onlyCitation(normalizeObservation(baseObservation()).evidence.citations);
+	const diff =
+		"diff --git a/src/Auth.java b/src/Auth.java\n+++ b/src/Auth.java\n@@ -10 +10 @@\n[L10] + insecure();\n";
+
+	// What the observer actually read, copied back whole. The commonest refusal on staging.
+	assert.equal(describeCitationMismatch({ ...citation, quote: "[L10] + insecure();" }, diff), null);
+	// The coordinate still has to be the one being matched, so a quote cannot claim a line it did
+	// not read — even when that line's text is in the diff somewhere else.
+	assert.match(
+		describeCitationMismatch({ ...citation, quote: "[L11] + insecure();" }, diff) ?? "",
+		/\[L10] reads/,
+	);
+});
+
 void test("a refused citation says which of the coordinate, the side and the text was wrong", () => {
 	const citation = onlyCitation(normalizeObservation(baseObservation()).evidence.citations);
 	const diff =


### PR DESCRIPTION
## Problem

The refusal reasons from #1951 reached staging an hour ago and named one cause behind nearly every
refused observation:

```
[pi-runner] observation refused for ships-tests-with-the-change: citation does not match
src/main/java/de/tum/cit/aet/artemis/exam/service/StudentExamAthenaFeedbackService.java:39-39 (NEW):
[L39] reads "+public class StudentExamAthenaFeedbackService {",
   not "[L39] +public class StudentExamAthenaFeedbackService {"
```

The diff a review reads prints `[L<n>] ` in front of every line. The observer quotes the line as it
read it — coordinate included — and the match compared against the line with the annotation stripped.
So a correct citation of a line the review had genuinely read was refused, and the observation with
it. On Artemis that is a median of three per review, with runs at thirteen and fourteen; each costs a
turn, and sometimes the practice.

## Solution

A quote may carry the coordinate it was shown, and only its own: the number in the prefix must be the
line being matched, so a quote still cannot claim a line it did not read. Every other rule is
untouched — the text must still be that line's, on that side of that file.

## Verification

A new spec covers both halves: the annotated quote matches, and the same text under a different
coordinate is still refused. Agent specs (150), type-check and lint pass.