### PR TITLE
fix(server): a citation is the line, not its indentation

### DIFF
--- a/.changeset/a-citation-is-the-line-not-its-indentation.md
+++ b/.changeset/a-citation-is-the-line-not-its-indentation.md
@@ -1,0 +1,7 @@
+---
+"hephaestus": patch
+---
+
+A review no longer discards a finding for writing a quoted line without the change marker or the
+indentation in front of it. The line it names still has to be the line it read, on the same side of
+the change; only the leading whitespace is forgiven.

--- a/server/application/src/main/resources/agent/pi-observation-normalize.ts
+++ b/server/application/src/main/resources/agent/pi-observation-normalize.ts
@@ -705,12 +705,33 @@ export function describeCitationMismatch(
 		if (diffLine === undefined) {
 			return `the diff has no [L${lineNumber}] on the ${citation.side ?? "NEW"} side of ${citation.path}`;
 		}
-		const quoted = withoutOwnCoordinate(quoteLine, lineNumber);
-		if (diffLine !== quoted && diffLine.slice(1) !== quoted) {
+		if (!quotesDiffLine(diffLine, withoutOwnCoordinate(quoteLine, lineNumber))) {
 			return `[L${lineNumber}] reads ${excerpt(diffLine)}, not ${excerpt(quoteLine)}`;
 		}
 	}
 	return null;
+}
+
+/**
+ * Whether a quote is the diff line it claims — as displayed, without the +/- marker, or without the
+ * indentation the diff shows in front of the code. What a citation proves is that the observer read
+ * the line at that coordinate on that side, and the coordinate has already pinned which line is being
+ * compared: two lines cannot be confused by trimming, because only one is ever a candidate. A quote
+ * whose text differs, or that belongs to the other side of the change, still fails.
+ */
+function quotesDiffLine(diffLine: string, quoted: string): boolean {
+	if (diffLine === quoted || diffLine.slice(1) === quoted) {
+		return true;
+	}
+	const shown = diffLine.slice(1).trimStart();
+	return shown.length > 0 && shown === withoutMarker(quoted).trimStart();
+}
+
+/** A quote that dropped the diff's own +/- or context marker along with the indentation. */
+function withoutMarker(quoted: string): string {
+	return quoted.startsWith("+") || quoted.startsWith("-") || quoted.startsWith(" ")
+		? quoted.slice(1)
+		: quoted;
 }
 
 /**

--- a/server/application/src/main/resources/agent/pi-observation-normalize.ts
+++ b/server/application/src/main/resources/agent/pi-observation-normalize.ts
@@ -724,7 +724,13 @@ function quotesDiffLine(diffLine: string, quoted: string): boolean {
 		return true;
 	}
 	const shown = diffLine.slice(1).trimStart();
-	return shown.length > 0 && shown === withoutMarker(quoted).trimStart();
+	if (shown.length === 0) {
+		return false;
+	}
+	// As written first, so a line of code that begins with a `-` or a `+` keeps it; only then as a
+	// quote that dropped the diff's own marker along with the indentation.
+	const trimmed = quoted.trimStart();
+	return shown === trimmed || shown === withoutMarker(trimmed).trimStart();
 }
 
 /** A quote that dropped the diff's own +/- or context marker along with the indentation. */

--- a/server/application/src/test/resources/agent/pi-observation-normalize.spec.ts
+++ b/server/application/src/test/resources/agent/pi-observation-normalize.spec.ts
@@ -304,6 +304,18 @@ void test("a quote may drop the diff's marker and the indentation in front of th
 		describeCitationMismatch({ ...citation, quote: "secure();" }, diff) ?? "",
 		/\[L10] reads/,
 	);
+
+	// Code that begins with the same character the diff uses as a marker keeps it.
+	const flagDiff =
+		"diff --git a/run.sh b/run.sh\n+++ b/run.sh\n@@ -10 +10 @@\n[L10] +    -flag --now\n";
+	assert.equal(
+		describeCitationMismatch({ ...citation, path: "run.sh", quote: "-flag --now" }, flagDiff),
+		null,
+	);
+	assert.equal(
+		describeCitationMismatch({ ...citation, path: "run.sh", quote: "+    -flag --now" }, flagDiff),
+		null,
+	);
 });
 
 void test("a quote from the other side of the change is refused, however it is written", () => {

--- a/server/application/src/test/resources/agent/pi-observation-normalize.spec.ts
+++ b/server/application/src/test/resources/agent/pi-observation-normalize.spec.ts
@@ -291,6 +291,36 @@ void test("diff citations bind the quote to the claimed file and line", () => {
 	assert.equal(citationMatchesArtifact({ ...citation, endLine: 12 }, diff), false);
 });
 
+void test("a quote may drop the diff's marker and the indentation in front of the code", () => {
+	const citation = onlyCitation(normalizeObservation(baseObservation()).evidence.citations);
+	const diff =
+		"diff --git a/src/Auth.java b/src/Auth.java\n+++ b/src/Auth.java\n@@ -10 +10 @@\n[L10] +    insecure();\n";
+
+	// The code as a reader would write it down, without the marker or the diff's indentation.
+	assert.equal(describeCitationMismatch({ ...citation, quote: "insecure();" }, diff), null);
+	assert.equal(describeCitationMismatch({ ...citation, quote: "+    insecure();" }, diff), null);
+	// Different text at that coordinate is still refused, trimmed or not.
+	assert.match(
+		describeCitationMismatch({ ...citation, quote: "secure();" }, diff) ?? "",
+		/\[L10] reads/,
+	);
+});
+
+void test("a quote from the other side of the change is refused, however it is written", () => {
+	const citation: NormalizedCitation = {
+		...onlyCitation(normalizeObservation(baseObservation()).evidence.citations),
+		side: "NEW",
+		startLine: 47,
+		endLine: 47,
+		quote: '-@RequestMapping({ "api/legacy/" })',
+	};
+	const diff =
+		"--- a/src/Auth.java\n+++ b/src/Auth.java\n@@ -47 +47 @@\n" +
+		'[L47] -@RequestMapping({ "api/legacy/" })\n[L47] +@RequestMapping("api/passkeys/")\n';
+
+	assert.match(describeCitationMismatch(citation, diff) ?? "", /\[L47] reads/);
+});
+
 void test("a quote may carry the coordinate the diff printed in front of it", () => {
 	const citation = onlyCitation(normalizeObservation(baseObservation()).evidence.citations);
 	const diff =


### PR DESCRIPTION
## Problem

With #1955 in, staging's refusals name a second way an observer loses a finding it had read
correctly. It writes the line down as code — without the diff's marker and without the indentation
the diff prints in front of it:

```
[L279] reads "+            throw new IllegalArgumentException(\"At least one sub-path has to be provided…\")",
   not "throw new IllegalArgumentException(\"At least one sub-path has to be provided…\")"
```

Two of five refusals in one review were this; the run still delivered, but each one costs a turn and
can cost the practice. The match already forgave the `+`/`-` marker. It did not forgive the leading
whitespace that comes with it.

## Solution

The comparison falls back to the line's text with leading whitespace trimmed on both sides. That is
what a citation proves — the observer read *this* line — and the coordinate has already pinned which
line is a candidate, so trimming cannot confuse two lines with each other.

Both refusals that should stay refused are pinned by new specs: different text at the coordinate, and
a quote taken from the other side of the change (the `-` line quoted against a `NEW` citation, which
also appeared on staging).

## Verification

Agent specs (152), type-check and lint pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Reviews now accept findings that quote a changed line without diff markers or matching indentation.
  - Citations must still reference the correct line and side of the change.
  - Text mismatches and citations from the wrong side of a change continue to be rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->