### PR TITLE
fix(scripts): a renamed settings path is not a missing package

### DIFF
--- a/scripts/check-agent-instructions.test.ts
+++ b/scripts/check-agent-instructions.test.ts
@@ -224,6 +224,33 @@ await test("contributor docs reject missing repository paths and npm packages", 
 	assert.match(failures[2] ?? "", /@missing\/package/);
 });
 
+await test("a renamed settings path is not read as a missing package", () => {
+	// A release note names both halves of a rename, and the old half is what a shape test bites on:
+	// `hephaestus.mentor.docker-cli` ends the way an npm CLI package does. It blocked a release.
+	assert.deepEqual(
+		analyse(
+			snapshot({
+				"package.json": JSON.stringify({ dependencies: {} }),
+				"MIGRATION.md":
+					"Rename `hephaestus.mentor.docker-cli` to `hephaestus.sandbox.docker.cli`.\n",
+			}),
+		),
+		[],
+	);
+	// A package name is still a package name: one dot is what npm's own dotted names have.
+	assert.match(
+		only(
+			analyse(
+				snapshot({
+					"package.json": JSON.stringify({ dependencies: {} }),
+					"docs/contributor/setup.md": "Install `lodash.merge-cli`.\n",
+				}),
+			),
+		),
+		/lodash\.merge-cli/,
+	);
+});
+
 await test("an intentional non-checkout path is allowed only in the document that owns it", () => {
 	assert.deepEqual(
 		analyse(

--- a/scripts/check-agent-instructions.ts
+++ b/scripts/check-agent-instructions.ts
@@ -207,6 +207,13 @@ const INTENTIONALLY_MISSING_PATHS = [
 
 const PACKAGE_NAME = /^(?:@[a-z0-9][a-z0-9._-]*\/[a-z0-9][a-z0-9._-]*|[a-z0-9][a-z0-9._-]*)$/;
 const PACKAGE_SHAPED = /-(?:cli|config|core|js|node|package|plugin|react|sdk|test|ts)$/;
+/**
+ * A settings path this product owns, which the release notes name whenever one is renamed —
+ * `hephaestus.mentor.docker-cli` reads as a package to the shape test above, and blocked a release
+ * for it. An npm name reaches two dots about as often as a Spring property reaches none, so the
+ * dotted depth is what separates them; a declared dependency is still recognised as itself.
+ */
+const SETTINGS_PATH = /^[a-z0-9-]+(?:\.[a-z0-9-]+){2,}$/;
 const FILE_SHAPED = /\.(?:java|js|jsonc?|mdx?|mjs|sh|ts|tsx|xml|ya?ml)$/;
 const exists = (repo: Repo, path: string): boolean =>
 	repo.present.has(path) || repo.paths.some((present) => present.startsWith(`${path}/`));
@@ -240,7 +247,9 @@ function declaredPackages(repo: Repo): ReadonlySet<string> {
 
 const looksLikePackage = (value: string, packages: ReadonlySet<string>): boolean =>
 	PACKAGE_NAME.test(value) &&
-	(value.startsWith("@") || packages.has(value) || PACKAGE_SHAPED.test(value));
+	(value.startsWith("@") ||
+		packages.has(value) ||
+		(PACKAGE_SHAPED.test(value) && !SETTINGS_PATH.test(value)));
 
 function looksLikePath(value: string, roots: ReadonlySet<string>): boolean {
 	if (value.startsWith("@") || value.startsWith("~/") || value.includes(":")) return false;


### PR DESCRIPTION
This is what has been holding the release, and with it production.

## Problem

The Version PR (#1824) has failed CI since the release notes picked up the Docker sandbox rename.
`gate:instructions` scans a contributor document's inline code for stale references, and the
assembled `MIGRATION.md` says:

| Old Spring property | Replacement |
| --- | --- |
| `hephaestus.mentor.docker-cli` | `hephaestus.sandbox.docker.cli` |

`PACKAGE_SHAPED` treats anything ending in `-cli` as an npm package, so the gate rejected the release
branch for naming a package no `package.json` declares. The sibling rows in the same table survive
only because they end in `-host`, `-path` or `-verify`. `main` is green because the fragment lives in
`.migration/`, which the gate does not scan; the name only becomes visible once a release assembles
it.

Three other tasks are reported failed in that run; they printed no failures of their own and were cut
short when this one failed.

## Solution

A name with two or more dots is a settings path this product owns, not a package — npm's own dotted
names (`lodash.merge`) have one. A declared dependency is still recognised as itself, and a one-dot
name that looks like a package still has to exist.

## Verification

Run against the exact `MIGRATION.md` the Version PR assembles: the gate fails without this change and
passes with it. Both directions are pinned by tests — the renamed property is accepted, and
`lodash.merge-cli` is still reported. `gate:instructions` passes (43).

The one failure in `test:tooling` here is the macOS bash 3.2 issue that #1957 fixes; this branch does
not carry it.