### PR TITLE
fix(server): an all-clear says what it found, not how it looked

### DIFF
--- a/.changeset/an-all-clear-says-what-it-found.md
+++ b/.changeset/an-all-clear-says-what-it-found.md
@@ -1,0 +1,8 @@
+---
+"hephaestus": patch
+---
+
+Feedback on a change with nothing to fix now says what the review saw, rather than how it searched.
+Where a line used to read "I walked all six sink classes across every added line", it now reads
+"Added lines reduce external values to booleans; none reach a sink". The reasoning behind each
+observation is still recorded with the review.

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/handler/DeliveryComposer.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/handler/DeliveryComposer.java
@@ -314,11 +314,12 @@ class DeliveryComposer {
         String opening = openingOf(rendering);
         // Already ranked most-certain first by the caller. A strength earns a bullet when there is
         // something to say about it — the composed message where the stage wrote one, and the
-        // measurement's own reasoning where it did not.
+        // observation's own summary where it did not. Never the evidence rationale: that is written
+        // for whoever audits the review, in the first person and about the search ("I walked all six
+        // sink classes"), and a developer reading their own pull request is owed what was found about
+        // their work rather than how the instrument looked for it.
         List<ValidatedObservation> withSomethingToSay = observed.stream()
-                .filter(f -> rendering.noteFor(f) != null
-                        || (f.evidenceRationale() != null
-                                && !f.evidenceRationale().isBlank()))
+                .filter(f -> rendering.noteFor(f) != null || !f.summary().isBlank())
                 .toList();
 
         if (withSomethingToSay.isEmpty()) {
@@ -331,7 +332,7 @@ class DeliveryComposer {
             if (shown >= MAX_STRENGTH_REINFORCEMENTS) break;
             ComposedNote note = rendering.noteFor(f);
             String summary = clampToSentenceBudget(
-                    note == null ? sanitizeStudentText(f.evidenceRationale()).strip() : note.title(), STRENGTH_BUDGET);
+                    note == null ? sanitizeStudentText(f.summary()).strip() : note.title(), STRENGTH_BUDGET);
             if (summary.isBlank()) {
                 // Reasoning was entirely grading-meta and scrubbed to nothing — skip rather than emit a
                 // bare bullet with no observation behind it.

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/handler/DeliveryComposerTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/handler/DeliveryComposerTest.java
@@ -366,29 +366,32 @@ class DeliveryComposerTest extends BaseUnitTest {
         DeliveryContent result = DeliveryComposer.compose(observations);
 
         assertThat(result).isNotNull();
-        assertThat(result.mrNote()).contains("Reviewed against the active practices");
+        // Each observation says what it observed, so each earns a bullet; none of it is praise.
+        assertThat(result.mrNote()).contains("Error state handling").contains("View decomposition");
         assertThat(result.mrNote()).doesNotContain("stood out");
         assertThat(result.diffNotes()).isEmpty();
     }
 
     @Test
-    void compose_withAllPositiveAndReasoning_listsEvidenceAnchoredObservations() {
-        ValidatedObservation withReasoning = new ValidatedObservation(
+    void compose_withAllPositive_bulletsSayWhatWasObservedNotHowItWasChecked() {
+        ValidatedObservation observed = new ValidatedObservation(
                 "error-state-handling",
-                "Error state handling (positive)",
+                "Network errors are surfaced to the user via an alert",
                 Presence.PRESENT,
                 Assessment.GOOD,
                 Severity.INFO,
                 null,
-                "Network errors are surfaced to the user via an alert.");
+                // The warrant is written for whoever audits the review: first person, about the search.
+                "I walked every added subscribe block and followed each error callback to its sink.");
 
-        DeliveryContent result = DeliveryComposer.compose(List.of(withReasoning));
+        DeliveryContent result = DeliveryComposer.compose(List.of(observed));
 
         assertThat(result).isNotNull();
         assertThat(result.mrNote())
                 .contains("What's working well here")
                 .contains("Error state handling")
                 .contains("Network errors are surfaced")
+                .doesNotContain("I walked")
                 .doesNotContain("No issues found");
         assertThat(result.diffNotes()).isEmpty();
     }
@@ -768,7 +771,8 @@ class DeliveryComposerTest extends BaseUnitTest {
     void compose_noIssuesNote_skipsObservationWhoseReasoningScrubsToBlank() {
         ValidatedObservation scrubbed = new ValidatedObservation(
                 "issue-has-checkable-outcome",
-                "Checkable outcome",
+                // Grading vocabulary rather than an observation: scrubbed to nothing for a developer.
+                "The practice requires a checkable outcome for a POSITIVE observation",
                 Presence.PRESENT,
                 Assessment.GOOD,
                 Severity.INFO,
@@ -776,12 +780,12 @@ class DeliveryComposerTest extends BaseUnitTest {
                 "The practice requires a checkable outcome for a POSITIVE observation.");
         ValidatedObservation real = new ValidatedObservation(
                 "issue-scoped-to-single-concern",
-                "Single concern",
+                "The issue describes one deliverable and stays within that single concern",
                 Presence.PRESENT,
                 Assessment.GOOD,
                 Severity.INFO,
                 null,
-                "The issue describes one deliverable and stays within that single concern.");
+                "Its body names one outcome and the diff touches only that area.");
 
         DeliveryContent dc = DeliveryComposer.compose(List.of(scrubbed, real), ArtifactKinds.ISSUE);
 
@@ -795,7 +799,8 @@ class DeliveryComposerTest extends BaseUnitTest {
     void compose_noIssuesNote_allReasoningScrubbed_fallsBackToNothingToChange() {
         ValidatedObservation scrubbed = new ValidatedObservation(
                 "issue-has-checkable-outcome",
-                "Checkable outcome",
+                // Grading vocabulary rather than an observation: scrubbed to nothing for a developer.
+                "The practice requires a checkable outcome for a POSITIVE observation",
                 Presence.PRESENT,
                 Assessment.GOOD,
                 Severity.INFO,


### PR DESCRIPTION
## Problem

Nearly every Artemis review is an all-clear, so its note is what most developers will ever read from
this product. On staging it reads like this:

> - **Avoids insecure defaults and over broad permissions:** I walked all six sink classes across every added line. No added line toggles transport or certificate verification…
> - **Handles errors instead of swallowing them:** I enumerated every failure-relevant construct this change adds.

That is the evidence rationale — the warrant, addressed to whoever audits the review, written in the
first person and about the search. `composeNoIssuesNote` falls back to it whenever the composer wrote
no message of its own, which is the common case for a strength.

The report contract already distinguishes the two fields:

- `summary` — "A short phrase naming **what you observed**, such as 'Debug print left in the request handler'."
- `evidenceRationale` — "A concise explanation of **how the cited evidence warrants this outcome**."

## Solution

The bullet carries the summary. The rationale is untouched and still recorded with the review, where
an auditor reads it.

The same review, from the summaries staging already recorded for it:

> - **Handles errors instead of swallowing them:** New async paths propagate failures; no catch-and-drop added
> - **Ships tests with the change:** New guard and gating logic ship with specs that exercise each
> - **Validates and escapes untrusted input:** Added lines reduce external values to booleans; none reach a sink

## Verification

`DeliveryComposerTest` (87) and the unit tier (7206) pass. Four tests pinned the old shape with the
fields reversed — a bare label in the summary and the observation in the rationale — and now follow
the contract, including the case where a developer-facing line scrubs to nothing and earns no bullet.