### PR TITLE
fix(server): an upgrade with mentor history completes unattended

### DIFF
--- a/.changeset/an-upgrade-with-mentor-history-completes.md
+++ b/.changeset/an-upgrade-with-mentor-history-completes.md
@@ -1,0 +1,9 @@
+---
+"hephaestus": patch
+---
+
+An instance that used the mentor before its chat storage changed can now upgrade without a
+hand-run migration. The upgrade previously stopped at a step that refuses to remove the old
+chat-parts table while it still holds rows, and nothing ever emptied it, so the application stayed
+down on exactly the installations that had chat history. The history itself is carried onto the
+message, as that step always intended.

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/database/ChatMessagePartUpgradeRepair.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/database/ChatMessagePartUpgradeRepair.java
@@ -1,0 +1,101 @@
+package de.tum.cit.aet.hephaestus.core.database;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import javax.sql.DataSource;
+import liquibase.integration.spring.SpringLiquibase;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.stereotype.Component;
+
+/**
+ * Lets an installation that still holds mentor chat history upgrade without a hand-run migration.
+ *
+ * <p>Changelog {@code 1778756946278} adds {@code chat_message.parts}, backfills it by reading
+ * {@code chat_message_part}, and then drops that table behind a guard that raises unless it is
+ * empty. Nothing ever empties it: no changeset deletes those rows, and the follow-up changelog its
+ * own comment names ({@code 1778800000000}) was never written. The guard therefore fails for every
+ * database that used the mentor before that release — the application exits at boot and stays down —
+ * while a fresh install and an already-upgraded instance pass, because the table is empty or gone.
+ * A released changelog is immutable, so the chain cannot repair itself: the drop is reached before
+ * any changelog appended after it.
+ *
+ * <p>This performs, before Liquibase opens the chain, exactly what changesets 1 and 2 of that
+ * changelog do — add the column, reconstruct each message's parts — and then removes the rows the
+ * backfill has just copied. Those two changesets carry preconditions that mark them as run when
+ * their work is already present, so the chain proceeds and the drop finds the empty table it
+ * expects. Every statement is idempotent and the whole thing is a no-op once
+ * {@code chat_message_part} is gone, which is every installation from the next release onward.
+ */
+@Component
+class ChatMessagePartUpgradeRepair implements BeanPostProcessor {
+
+    private static final Logger log = LoggerFactory.getLogger(ChatMessagePartUpgradeRepair.class);
+
+    /** Mirrors changeset {@code mentor-1071-add-parts-column}: JSONB, defaulted so reads stay non-null. */
+    private static final String ADD_PARTS_COLUMN =
+            "ALTER TABLE chat_message ADD COLUMN IF NOT EXISTS parts JSONB DEFAULT '[]'::jsonb";
+
+    /** Verbatim from changeset {@code mentor-1071-backfill-parts}, so both write the same shape. */
+    private static final String BACKFILL_PARTS = """
+            UPDATE chat_message m
+               SET parts = COALESCE(sub.parts_array, '[]'::jsonb)
+              FROM (
+                SELECT
+                    p.message_id,
+                    jsonb_agg(
+                        COALESCE(p.content, '{}'::jsonb)
+                            || jsonb_build_object(
+                                'type',
+                                COALESCE(p.original_type, REPLACE(LOWER(p.type), '_', '-'))
+                            )
+                        ORDER BY p.order_index
+                    ) AS parts_array
+                  FROM chat_message_part p
+                 GROUP BY p.message_id
+              ) sub
+             WHERE m.id = sub.message_id
+               AND (m.parts IS NULL OR m.parts = '[]'::jsonb)
+            """;
+
+    @Override
+    public Object postProcessBeforeInitialization(Object bean, String beanName) throws BeansException {
+        if (bean instanceof SpringLiquibase liquibase) {
+            DataSource dataSource = liquibase.getDataSource();
+            if (dataSource != null) {
+                repair(dataSource);
+            }
+        }
+        return bean;
+    }
+
+    private void repair(DataSource dataSource) {
+        try (Connection connection = dataSource.getConnection();
+                Statement statement = connection.createStatement()) {
+            if (!legacyPartsTableExists(statement)) {
+                return;
+            }
+            statement.execute(ADD_PARTS_COLUMN);
+            int reconstructed = statement.executeUpdate(BACKFILL_PARTS);
+            int removed = statement.executeUpdate("DELETE FROM chat_message_part");
+            log.warn(
+                    "Repaired the mentor chat-parts upgrade before Liquibase: reconstructed {} message(s) "
+                            + "and cleared {} legacy part row(s) the drop guard would have refused to pass.",
+                    reconstructed,
+                    removed);
+        } catch (SQLException e) {
+            // Loud, but never fatal: an installation this does not apply to must still boot, and the
+            // changelog's own guard remains the backstop for one this failed to prepare.
+            log.error("Could not prepare the mentor chat-parts upgrade; Liquibase will report what it finds", e);
+        }
+    }
+
+    private static boolean legacyPartsTableExists(Statement statement) throws SQLException {
+        try (var rows = statement.executeQuery("SELECT to_regclass('public.chat_message_part') IS NOT NULL")) {
+            return rows.next() && rows.getBoolean(1);
+        }
+    }
+}

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/database/ChatMessagePartUpgradeRepair.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/database/ChatMessagePartUpgradeRepair.java
@@ -61,6 +61,34 @@ class ChatMessagePartUpgradeRepair implements BeanPostProcessor {
                AND (m.parts IS NULL OR m.parts = '[]'::jsonb)
             """;
 
+    /**
+     * Removes only the rows whose reconstruction is demonstrably already on the message: the group's
+     * computed array has to equal what {@code chat_message.parts} now holds. A group whose message no
+     * longer exists, or whose message carries something else, is left where it is — the backfill did
+     * not copy it, and the changelog's guard then stops the upgrade rather than letting this delete
+     * history nobody has a second copy of.
+     */
+    private static final String DELETE_REPRESENTED_PARTS =
+            """
+            DELETE FROM chat_message_part p
+             USING (
+                    SELECT g.message_id,
+                           jsonb_agg(
+                               COALESCE(g.content, '{}'::jsonb)
+                                   || jsonb_build_object(
+                                       'type',
+                                       COALESCE(g.original_type, REPLACE(LOWER(g.type), '_', '-'))
+                                   )
+                               ORDER BY g.order_index
+                           ) AS parts_array
+                      FROM chat_message_part g
+                     GROUP BY g.message_id
+                   ) sub
+                   JOIN chat_message m ON m.id = sub.message_id
+             WHERE p.message_id = sub.message_id
+               AND m.parts = sub.parts_array
+            """;
+
     @Override
     public Object postProcessBeforeInitialization(Object bean, String beanName) throws BeansException {
         if (bean instanceof SpringLiquibase liquibase) {
@@ -80,16 +108,32 @@ class ChatMessagePartUpgradeRepair implements BeanPostProcessor {
             }
             statement.execute(ADD_PARTS_COLUMN);
             int reconstructed = statement.executeUpdate(BACKFILL_PARTS);
-            int removed = statement.executeUpdate("DELETE FROM chat_message_part");
-            log.warn(
-                    "Repaired the mentor chat-parts upgrade before Liquibase: reconstructed {} message(s) "
-                            + "and cleared {} legacy part row(s) the drop guard would have refused to pass.",
-                    reconstructed,
-                    removed);
+            int removed = statement.executeUpdate(DELETE_REPRESENTED_PARTS);
+            long remaining = countRemainingParts(statement);
+            if (remaining == 0) {
+                log.warn(
+                        "Repaired the mentor chat-parts upgrade before Liquibase: reconstructed {} message(s) "
+                                + "and cleared {} legacy part row(s) the drop guard would have refused to pass.",
+                        reconstructed,
+                        removed);
+            } else {
+                log.error(
+                        "The mentor chat-parts upgrade cannot be prepared: {} legacy part row(s) are not "
+                                + "represented on any message — they belong to a message that no longer exists, or "
+                                + "to one that already carries different parts. They are left untouched and the "
+                                + "migration will stop rather than discard them.",
+                        remaining);
+            }
         } catch (SQLException e) {
             // Loud, but never fatal: an installation this does not apply to must still boot, and the
             // changelog's own guard remains the backstop for one this failed to prepare.
             log.error("Could not prepare the mentor chat-parts upgrade; Liquibase will report what it finds", e);
+        }
+    }
+
+    private static long countRemainingParts(Statement statement) throws SQLException {
+        try (var rows = statement.executeQuery("SELECT count(*) FROM chat_message_part")) {
+            return rows.next() ? rows.getLong(1) : 0L;
         }
     }
 

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/database/ChatMessagePartUpgradeRepair.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/database/ChatMessagePartUpgradeRepair.java
@@ -68,8 +68,7 @@ class ChatMessagePartUpgradeRepair implements BeanPostProcessor {
      * not copy it, and the changelog's guard then stops the upgrade rather than letting this delete
      * history nobody has a second copy of.
      */
-    private static final String DELETE_REPRESENTED_PARTS =
-            """
+    private static final String DELETE_REPRESENTED_PARTS = """
             DELETE FROM chat_message_part p
              USING (
                     SELECT g.message_id,

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/database/package-info.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/database/package-info.java
@@ -1,0 +1,2 @@
+@org.jspecify.annotations.NullMarked
+package de.tum.cit.aet.hephaestus.core.database;

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/database/ChatMessagePartUpgradeRepairIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/database/ChatMessagePartUpgradeRepairIntegrationTest.java
@@ -2,7 +2,6 @@ package de.tum.cit.aet.hephaestus.core.database;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import de.tum.cit.aet.hephaestus.testconfig.PostgreSQLTestContainer;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
@@ -10,6 +9,8 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import javax.sql.DataSource;
 import liquibase.integration.spring.SpringLiquibase;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
@@ -21,12 +22,31 @@ import org.testcontainers.containers.PostgreSQLContainer;
  * The shape this repairs no longer exists in the schema, so the fixture builds the legacy tables the
  * way the release that shipped them did. What is asserted is the state changeset
  * {@code mentor-1071-drop-chat-message-part} demands before it will drop the table.
+ *
+ * <p>On a database of its own, never the shared one: the fixture owns tables named after real ones
+ * and drops them between cases, which against the migrated schema every other integration test reads
+ * would be destructive.
  */
 @Tag("integration")
 class ChatMessagePartUpgradeRepairIntegrationTest {
 
     private final ChatMessagePartUpgradeRepair repair = new ChatMessagePartUpgradeRepair();
-    private final PostgreSQLContainer<?> postgres = PostgreSQLTestContainer.getInstance();
+
+    @SuppressWarnings("resource")
+    private static final PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:18")
+            .withDatabaseName("chat_parts_repair")
+            .withUsername("test")
+            .withPassword("test");
+
+    @BeforeAll
+    static void startDatabase() {
+        postgres.start();
+    }
+
+    @AfterAll
+    static void stopDatabase() {
+        postgres.stop();
+    }
 
     private Connection open() throws SQLException {
         return DriverManager.getConnection(postgres.getJdbcUrl(), postgres.getUsername(), postgres.getPassword());

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/database/ChatMessagePartUpgradeRepairIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/database/ChatMessagePartUpgradeRepairIntegrationTest.java
@@ -1,0 +1,109 @@
+package de.tum.cit.aet.hephaestus.core.database;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import de.tum.cit.aet.hephaestus.testconfig.PostgreSQLTestContainer;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import javax.sql.DataSource;
+import liquibase.integration.spring.SpringLiquibase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.datasource.SimpleDriverDataSource;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+/**
+ * The shape this repairs no longer exists in the schema, so the fixture builds the legacy tables the
+ * way the release that shipped them did. What is asserted is the state changeset
+ * {@code mentor-1071-drop-chat-message-part} demands before it will drop the table.
+ */
+@Tag("integration")
+class ChatMessagePartUpgradeRepairIntegrationTest {
+
+    private final ChatMessagePartUpgradeRepair repair = new ChatMessagePartUpgradeRepair();
+    private final PostgreSQLContainer<?> postgres = PostgreSQLTestContainer.getInstance();
+
+    private Connection open() throws SQLException {
+        return DriverManager.getConnection(postgres.getJdbcUrl(), postgres.getUsername(), postgres.getPassword());
+    }
+
+    private void runRepair() {
+        DataSource dataSource = new SimpleDriverDataSource(
+                new org.postgresql.Driver(), postgres.getJdbcUrl(), postgres.getUsername(), postgres.getPassword());
+        SpringLiquibase liquibase = new SpringLiquibase();
+        liquibase.setDataSource(dataSource);
+        repair.postProcessBeforeInitialization(liquibase, "liquibase");
+    }
+
+    @BeforeEach
+    void resetLegacyShape() throws SQLException {
+        try (Connection connection = open();
+                Statement statement = connection.createStatement()) {
+            statement.execute("DROP TABLE IF EXISTS chat_message_part");
+            statement.execute("DROP TABLE IF EXISTS chat_message");
+        }
+    }
+
+    @Test
+    @DisplayName("a database with mentor history is left in the state the drop guard requires")
+    void repairsAnInstallationThatStillHasParts() throws SQLException {
+        try (Connection connection = open();
+                Statement statement = connection.createStatement()) {
+            statement.execute("CREATE TABLE chat_message (id UUID PRIMARY KEY)");
+            statement.execute("CREATE TABLE chat_message_part (message_id UUID NOT NULL, order_index INT NOT NULL,"
+                    + " content JSONB, original_type VARCHAR(64), type VARCHAR(32) NOT NULL)");
+            statement.execute("INSERT INTO chat_message (id) VALUES ('11111111-1111-1111-1111-111111111111')");
+            statement.execute(
+                    "INSERT INTO chat_message_part (message_id, order_index, content, original_type, type) VALUES"
+                            + " ('11111111-1111-1111-1111-111111111111', 1, '{\"text\":\"second\"}', NULL, 'TEXT'),"
+                            + " ('11111111-1111-1111-1111-111111111111', 0, '{\"text\":\"first\"}', 'reasoning',"
+                            + " 'REASONING')");
+        }
+
+        runRepair();
+
+        try (Connection connection = open();
+                Statement statement = connection.createStatement()) {
+            // The guard counts rows in this table and raises on any; the drop proceeds only at zero.
+            try (ResultSet rows = statement.executeQuery("SELECT count(*) FROM chat_message_part")) {
+                assertThat(rows.next()).isTrue();
+                assertThat(rows.getInt(1)).isZero();
+            }
+            // What those rows carried survives on the message, ordered and typed the way the
+            // changelog's own backfill writes it.
+            try (ResultSet rows = statement.executeQuery("SELECT parts::text FROM chat_message")) {
+                assertThat(rows.next()).isTrue();
+                String parts = rows.getString(1);
+                assertThat(parts).contains("first").contains("second").contains("reasoning");
+                assertThat(parts.indexOf("first")).isLessThan(parts.indexOf("second"));
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("an installation without the legacy table is untouched")
+    void doesNothingWhenThereIsNoLegacyTable() throws SQLException {
+        try (Connection connection = open();
+                Statement statement = connection.createStatement()) {
+            statement.execute("CREATE TABLE chat_message (id UUID PRIMARY KEY)");
+        }
+
+        runRepair();
+
+        try (Connection connection = open();
+                Statement statement = connection.createStatement();
+                ResultSet rows = statement.executeQuery(
+                        "SELECT count(*) FROM information_schema.columns WHERE table_name = 'chat_message'"
+                                + " AND column_name = 'parts'")) {
+            // Nothing is added where there was nothing to migrate: a fresh install takes its schema
+            // from the changelog alone.
+            assertThat(rows.next()).isTrue();
+            assertThat(rows.getInt(1)).isZero();
+        }
+    }
+}

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/database/ChatMessagePartUpgradeRepairIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/database/ChatMessagePartUpgradeRepairIntegrationTest.java
@@ -134,8 +134,8 @@ class ChatMessagePartUpgradeRepairIntegrationTest {
                 Statement statement = connection.createStatement()) {
             // Only the group that is now demonstrably on its message is gone. Deleting either of the
             // others would have destroyed the sole copy of that history.
-            try (ResultSet rows = statement.executeQuery(
-                    "SELECT message_id::text FROM chat_message_part ORDER BY message_id")) {
+            try (ResultSet rows =
+                    statement.executeQuery("SELECT message_id::text FROM chat_message_part ORDER BY message_id")) {
                 assertThat(rows.next()).isTrue();
                 assertThat(rows.getString(1)).isEqualTo("22222222-2222-2222-2222-222222222222");
                 assertThat(rows.next()).isTrue();
@@ -143,8 +143,8 @@ class ChatMessagePartUpgradeRepairIntegrationTest {
                 assertThat(rows.next()).isFalse();
             }
             // The message that already had parts keeps the ones it had.
-            try (ResultSet rows = statement.executeQuery("SELECT parts::text FROM chat_message WHERE id = 
-                    + " '22222222-2222-2222-2222-222222222222'")) {
+            try (ResultSet rows = statement.executeQuery(
+                    "SELECT parts::text FROM chat_message WHERE id = '22222222-2222-2222-2222-222222222222'")) {
                 assertThat(rows.next()).isTrue();
                 assertThat(rows.getString(1)).contains("kept").doesNotContain("other");
             }

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/database/ChatMessagePartUpgradeRepairIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/database/ChatMessagePartUpgradeRepairIntegrationTest.java
@@ -143,7 +143,7 @@ class ChatMessagePartUpgradeRepairIntegrationTest {
                 assertThat(rows.next()).isFalse();
             }
             // The message that already had parts keeps the ones it had.
-            try (ResultSet rows = statement.executeQuery("SELECT parts::text FROM chat_message WHERE id ="
+            try (ResultSet rows = statement.executeQuery("SELECT parts::text FROM chat_message WHERE id = 
                     + " '22222222-2222-2222-2222-222222222222'")) {
                 assertThat(rows.next()).isTrue();
                 assertThat(rows.getString(1)).contains("kept").doesNotContain("other");

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/database/ChatMessagePartUpgradeRepairIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/database/ChatMessagePartUpgradeRepairIntegrationTest.java
@@ -106,6 +106,52 @@ class ChatMessagePartUpgradeRepairIntegrationTest {
     }
 
     @Test
+    @DisplayName("rows the backfill does not copy are kept, so the guard stops the upgrade")
+    void keepsRowsTheBackfillCannotCopy() throws SQLException {
+        try (Connection connection = open();
+                Statement statement = connection.createStatement()) {
+            statement.execute("CREATE TABLE chat_message (id UUID PRIMARY KEY, parts JSONB)");
+            statement.execute("CREATE TABLE chat_message_part (message_id UUID NOT NULL, order_index INT NOT NULL,"
+                    + " content JSONB, original_type VARCHAR(64), type VARCHAR(32) NOT NULL)");
+            // Copied: an empty message whose group the backfill reconstructs.
+            statement.execute("INSERT INTO chat_message (id, parts) VALUES"
+                    + " ('11111111-1111-1111-1111-111111111111', '[]'::jsonb)");
+            // Not copied: the backfill only writes a message whose parts are still empty.
+            statement.execute("INSERT INTO chat_message (id, parts) VALUES"
+                    + " ('22222222-2222-2222-2222-222222222222', '[{\"type\":\"text\",\"text\":\"kept\"}]')");
+            statement.execute(
+                    "INSERT INTO chat_message_part (message_id, order_index, content, original_type, type) VALUES"
+                            + " ('11111111-1111-1111-1111-111111111111', 0, '{\"text\":\"copied\"}', NULL, 'TEXT'),"
+                            + " ('22222222-2222-2222-2222-222222222222', 0, '{\"text\":\"other\"}', NULL, 'TEXT'),"
+                            // Not copied: no chat_message carries this id, and the legacy table has no
+                            // foreign key that would have prevented it.
+                            + " ('33333333-3333-3333-3333-333333333333', 0, '{\"text\":\"orphan\"}', NULL, 'TEXT')");
+        }
+
+        runRepair();
+
+        try (Connection connection = open();
+                Statement statement = connection.createStatement()) {
+            // Only the group that is now demonstrably on its message is gone. Deleting either of the
+            // others would have destroyed the sole copy of that history.
+            try (ResultSet rows = statement.executeQuery(
+                    "SELECT message_id::text FROM chat_message_part ORDER BY message_id")) {
+                assertThat(rows.next()).isTrue();
+                assertThat(rows.getString(1)).isEqualTo("22222222-2222-2222-2222-222222222222");
+                assertThat(rows.next()).isTrue();
+                assertThat(rows.getString(1)).isEqualTo("33333333-3333-3333-3333-333333333333");
+                assertThat(rows.next()).isFalse();
+            }
+            // The message that already had parts keeps the ones it had.
+            try (ResultSet rows = statement.executeQuery("SELECT parts::text FROM chat_message WHERE id ="
+                    + " '22222222-2222-2222-2222-222222222222'")) {
+                assertThat(rows.next()).isTrue();
+                assertThat(rows.getString(1)).contains("kept").doesNotContain("other");
+            }
+        }
+    }
+
+    @Test
     @DisplayName("an installation without the legacy table is untouched")
     void doesNothingWhenThereIsNoLegacyTable() throws SQLException {
         try (Connection connection = open();


### PR DESCRIPTION
Fixes #1960. This is the blocker for upgrading production, found by rehearsing the upgrade against a restored copy of the production database.

## Root cause

`db/changelog/1778756946278_changelog.xml` does three things in one release: adds `chat_message.parts`, backfills it **by reading** `chat_message_part`, and then drops that table behind a guard that raises unless it is empty.

Nothing ever empties it. No changeset deletes those rows — `grep -rl "DELETE FROM chat_message_part" db/changelog/` is empty — and the follow-up changelog its own step-1 comment names does not exist:

> chat_message_part itself is dropped in the **1778800000000** changelog

So the guard is unsatisfiable for any database with chat history: the backfill copies the rows, the rows remain, the drop raises, and the application exits at boot in a crash loop. Fresh installs and already-upgraded instances pass because the table is empty or already gone — which is why CI, staging, and the seeded upgrade gate all stayed green. It is the deprecate-then-remove rule in `database-migration.mdx` § 3 being collapsed into a single release.

## Why the fix is not a new changelog

Released changelogs are immutable, and the drop is reached **before** anything appended after it, so the chain cannot repair itself. The repair has to happen before Liquibase opens the chain.

## The fix

A `BeanPostProcessor` on the `SpringLiquibase` bean performs, idempotently, exactly what changesets 1 and 2 of that changelog do — add the column, reconstruct each message's parts with the changelog's own SQL — and then clears the rows the backfill has copied. Those two changesets carry preconditions (`not columnExists`, and a `sqlCheck` for messages still needing a backfill) that mark them as run when their work is already present, so the chain proceeds and the drop finds the empty table it expects.

It is a no-op wherever `chat_message_part` does not exist, which is every fresh install and every instance from the next release onward.

## Verification

- **Against a restored copy of production** (1,236 users, 38,811 issues, 43,218 commits): all 76 pending changelogs applied, 1,020 → 1,461 changesets, every row preserved, `practice_finding` → `observation` carried, and the three workspace tokens became 3 GitHub + 3 GitLab connections.
- New integration test builds the legacy two-table shape and asserts both what the guard demands (zero rows) and that the history survives on the message, ordered and typed as the changelog's backfill writes it. Also asserts the no-op path.
- Unit tier 7206 passes.

## Follow-up worth its own issue

The seeded upgrade gate (`scripts/release-upgrade-test.ts`) seeds a user and a workspace through the API, so tables outside that path are empty in the gate. Any migration whose behaviour depends on rows in a less-travelled table escapes it, exactly as this one did.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed upgrades for installations with existing mentor chat history.
  * Chat history is now preserved and transferred automatically during the upgrade.
  * Upgrades no longer require a manual database migration when legacy chat-part data is present.
  * Upgrade safeguards now prevent incomplete or unmatched historical data from being discarded, allowing the upgrade to stop safely for corrective action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->