### PR TITLE
fix(ci): an unapproved production deploy no longer blocks every release

### DIFF
--- a/.changeset/an-unapproved-deploy-does-not-block-releases.md
+++ b/.changeset/an-unapproved-deploy-does-not-block-releases.md
@@ -1,0 +1,9 @@
+---
+"hephaestus": patch
+---
+
+A release no longer waits behind an unapproved production deployment. The approval for production
+used to sit inside the same run that serialises tag promotion, so a release nobody approved held
+that lock and every later release queued behind it without starting — for two days, in a state the
+default run listing does not show. The lock now covers only the promotion of the version, series and
+latest tags.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,11 +8,12 @@ on:
     types: [completed]
     branches: [main]
 
-# Serialize promotion of the moving series and latest tags.
-concurrency:
-  group: release
-  cancel-in-progress: false
-
+# Serialising the whole run would put the production approval inside the lock: `deploy-production`
+# waits for a required reviewer, and a release nobody approves then holds the group for as long as
+# the approval is outstanding — every later release queues behind it and never starts a job. One
+# unapproved deploy stalled every release for two days that way, invisibly, because a run waiting on
+# an environment does not appear in the default run listing. The lock therefore sits on the jobs it
+# is actually for: promotion of the moving series and latest tags.
 permissions: {}
 
 jobs:
@@ -80,6 +81,10 @@ jobs:
   tag-images:
     needs: release
     if: needs.release.outputs.released == 'true'
+    # Moves `X.Y`, `latest` and the version tags; two releases must never interleave here.
+    concurrency:
+      group: release-promotion
+      cancel-in-progress: false
     timeout-minutes: 30
     runs-on: ubuntu-latest
     permissions:
@@ -400,6 +405,10 @@ jobs:
   publish-release:
     needs: [release, tag-images, upgrade-test, supported-host-smoke]
     if: needs.release.outputs.released == 'true'
+    # Same lock as the tag moves: publication is the other half of that promotion.
+    concurrency:
+      group: release-promotion
+      cancel-in-progress: false
     timeout-minutes: 20
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Problem

`release.yml` serialises the **whole run** under `concurrency: group: release`, and its
`deploy-production` job waits inside that run for the Production environment's required reviewer. So
a release that nobody approves holds the group for as long as the approval is outstanding, and every
later release queues behind it without ever scheduling a job.

This happened. The v0.76.0 release run sat in status `waiting` from **4 September**. The 0.77.0
release created when the Version PR merged stayed `pending` with zero jobs for over an hour;
cancelling it, re-running it, and re-running its triggering CI/CD all changed nothing, while every
other workflow in the repository scheduled normally. A run waiting on an environment does not appear
in `gh run list`, so nothing pointed at it — it took `actions/runs?status=waiting` to find:

```
33865199779  Release  waiting  2026-09-04T10:51:28Z   → pending_deployments: Production
```

Cancelling that run started the queued release within seconds, and v0.77.0 published.

## Solution

The lock moves to the jobs it was written for — "serialize promotion of the moving series and latest
tags" — namely `tag-images` and `publish-release`, under `release-promotion`. The deploy leg already
carries its own `deploy-production` concurrency group, so an approval nobody grants now delays only
that deployment.

## Verification

`test:tooling` (574) and actionlint pass. The behaviour is exercised the moment two releases are cut
with an approval outstanding, which is the situation that produced the outage.