### PR TITLE
fix(docker): keep the proxy's TLS certificates across releases

### DIFF
--- a/.changeset/proxy-acme-volume.md
+++ b/.changeset/proxy-acme-volume.md
@@ -1,0 +1,7 @@
+---
+"hephaestus": patch
+---
+
+Keeps the edge proxy's TLS certificates across deployments. They were stored next to the Compose file, which on a pull-based host is replaced with every release, so each deployment re-issued every certificate and a few deployments in one week were enough for Let's Encrypt to start refusing — leaving the site on an untrusted certificate. Certificates now live in their own volume and survive upgrades.
+
+**Operators:** a host that already serves TLS from the bundled proxy issues its certificates once more on the first start after this upgrade. To keep the ones it has, copy `acme.json` from the `letsencrypt` directory beside your `compose.proxy.yaml` into the new `proxy_letsencrypt` volume before starting.

--- a/.changeset/proxy-acme-volume.md
+++ b/.changeset/proxy-acme-volume.md
@@ -2,6 +2,6 @@
 "hephaestus": patch
 ---
 
-Keeps the edge proxy's TLS certificates across deployments. They were stored next to the Compose file, which on a pull-based host is replaced with every release, so each deployment re-issued every certificate and a few deployments in one week were enough for Let's Encrypt to start refusing — leaving the site on an untrusted certificate. Certificates now live in their own volume and survive upgrades.
+Keeps the edge proxy's TLS certificates across deployments. They were stored next to the Compose file, which on a pull-based host is replaced with every release, so each deployment re-issued every certificate and a handful of deployments in one week were enough for Let's Encrypt to start refusing — leaving the site on an untrusted certificate. Certificates now live in their own volume and survive upgrades.
 
-**Operators:** a host that already serves TLS from the bundled proxy issues its certificates once more on the first start after this upgrade. To keep the ones it has, copy `acme.json` from the `letsencrypt` directory beside your `compose.proxy.yaml` into the new `proxy_letsencrypt` volume before starting.
+An instance that already serves TLS from the bundled proxy issues its certificates once more on the first start after this upgrade, which needs nothing from you. To skip even that, copy `acme.json` out of the `letsencrypt` directory beside your Compose files into the new `proxy_letsencrypt` volume before starting.

--- a/docker/compose.proxy.yaml
+++ b/docker/compose.proxy.yaml
@@ -11,7 +11,11 @@ services:
       - "443:443"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
-      - ./letsencrypt:/letsencrypt
+      # A named volume, not a path beside this file: under the reconciler this file lives in a
+      # per-release worktree, so a relative bind would put the ACME account and certificates in
+      # state that a release replaces. Traefik would then re-issue on every deployment and Let's
+      # Encrypt would rate-limit the domain into serving an untrusted certificate.
+      - letsencrypt:/letsencrypt
     command:
       - "--ping=true"
       - "--ping.entrypoint=http"
@@ -173,3 +177,6 @@ configs:
           </div>
       </article>
       </html>
+
+volumes:
+  letsencrypt:

--- a/docs/admin/pull-based-deployment.mdx
+++ b/docs/admin/pull-based-deployment.mdx
@@ -104,6 +104,17 @@ reconcile:
 | `WEBHOOK_SECRET` | what the providers were registered to sign with |
 | `HEPHAESTUS_AUTH_STATE_COOKIE_KEY` | optional; a new one only invalidates sign-ins that are in flight at the moment of the switch |
 
+A host that also brings its own edge keeps its certificates in the `proxy_letsencrypt` volume. Copy
+the previous deployment's `acme.json` into it before the first reconcile, or Traefik issues the
+certificates again on first start:
+
+```bash
+sudo docker volume create proxy_letsencrypt
+sudo cp <previous>/letsencrypt/acme.json \
+  /var/lib/docker/volumes/proxy_letsencrypt/_data/acme.json
+sudo chmod 600 /var/lib/docker/volumes/proxy_letsencrypt/_data/acme.json
+```
+
 The pull-based stacks use the bundled database with its fixed credentials, so there is no
 database password to carry. On the Compose installer, `docker/self-host/setup.sh` refuses to
 generate an encryption key while the volume `hephaestus_postgresql-data` exists, and stops rather


### PR DESCRIPTION
## Problem

The `proxy` stack stored Traefik's ACME account and issued certificates in `./letsencrypt`, which Compose resolves against the directory holding the compose file. Under the reconciler that directory is a **per-release worktree** (`releases/<tag>/docker/`), so every release starts the proxy against an empty ACME store and Traefik re-issues every certificate. Let's Encrypt allows five duplicate certificates per week; past that the renewal fails and the site serves an untrusted certificate.

Nothing had hit this because no host runs the proxy stack under the reconciler yet — staging's `HEPHAESTUS_STACKS` is `"core app"`, and the production host is being moved onto pull-based deployment now, which is how it surfaced.

## Fix

ACME storage becomes a named volume, so it is host state like every other durable thing in these stacks and outlives the worktree a release replaces.

The changeset tells operators of an existing bundled-proxy install that their next start re-issues once, and how to carry `acme.json` over instead. `docs/admin/pull-based-deployment.mdx` gains the same step for a host being moved.

## Verification

`docker compose -f docker/compose.proxy.yaml config` renders the mount as `('volume', 'letsencrypt', '/letsencrypt')` and declares the top-level `letsencrypt` volume; before the change it rendered a bind to a path under the compose file's directory.
