### PR TITLE
fix(server): accept Hibernate's batched keyed fetch in the tenancy check

### DIFF
--- a/.changeset/tenancy-batched-collection-fetch.md
+++ b/.changeset/tenancy-batched-collection-fetch.md
@@ -1,0 +1,5 @@
+---
+"hephaestus": patch
+---
+
+Fixes teams and leaderboard pages failing to load on instances with synced labels. The tenancy self-check treats a keyed fetch as safe, but did not recognise the batched form Hibernate emits when it fills several repositories' label collections in one round trip, so it rejected the query and the request failed. Workspace isolation is unchanged — the rejected query was already pinned to keys the caller held.

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/tenancy/WorkspaceStatementInspector.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/tenancy/WorkspaceStatementInspector.java
@@ -135,9 +135,14 @@ public class WorkspaceStatementInspector implements StatementInspector {
      *       (or the discriminator appears first).</li>
      *   <li>Lazy {@code @OneToMany}/{@code @ManyToMany} collection initialisation →
      *       {@code FROM join_or_child_table alias … WHERE alias.<parent>_id = ?}</li>
+     *   <li>That same initialisation under {@code @BatchSize}, where Hibernate fills several
+     *       parents' collections in one round trip →
+     *       {@code FROM child_table alias … WHERE alias.<parent>_id = ANY(?)}</li>
      * </ul>
      *
-     * <p>Safe by construction: the caller already had the surrogate key. Surrogate keys are
+     * <p>Safe by construction: the caller already had the surrogate key — or, in the batched form,
+     * every key in the bound array, each obtained the same way. {@code ANY(?)} takes a single array
+     * parameter, so the predicate stays pinned to those keys. Surrogate keys are
      * opaque to URL inputs and only come into existence via a workspace-scoped path
      * ({@code findByWorkspaceIdAndSlug} → {@code entity.getRelation()} → lazy fetch).
      *
@@ -151,7 +156,7 @@ public class WorkspaceStatementInspector implements StatementInspector {
             "^\\s*SELECT\\b.+?\\bFROM\\s+\"?[A-Za-z_][A-Za-z0-9_]*\"?\\s+([A-Za-z_][A-Za-z0-9_]*)\\b" + ".*?"
                     + "\\bWHERE\\b"
                     + ".*?"
-                    + "\\b\\1\\s*\\.\\s*\"?(?:id|[A-Za-z_][A-Za-z0-9_]*_id)\"?\\s*=\\s*\\?"
+                    + "\\b\\1\\s*\\.\\s*\"?(?:id|[A-Za-z_][A-Za-z0-9_]*_id)\"?\\s*=\\s*(?:\\?|ANY\\s*\\(\\s*\\?\\s*\\))"
                     + ".*?$",
             Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
 

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/tenancy/WorkspaceStatementInspectorTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/tenancy/WorkspaceStatementInspectorTest.java
@@ -280,6 +280,29 @@ class WorkspaceStatementInspectorTest extends BaseUnitTest {
     }
 
     @Test
+    void hibernateBatchedCollectionLoadByParentFkIsAllowed() {
+        // The query that took production down: Repository.labels carries @BatchSize, so Hibernate
+        // fills several repositories' label collections in one round trip and writes the parent FK
+        // predicate as "= any(?)" rather than "= ?". Same safety argument as the unbatched form —
+        // the caller already held every key in the array — so it stays on the fast path.
+        WorkspaceStatementInspector inspector = newInspector(TenancyEnforcement.THROW);
+        inspector.inspect("select l1_0.repository_id,l1_0.id,l1_0.color,l1_0.name "
+                + "from label l1_0 where l1_0.repository_id=any(?)");
+        verifyNoInteractions(reporter, scopedTables);
+    }
+
+    @Test
+    void batchedParentFkDisjoinedWithOrStillEnforced() {
+        // The batched form earns the fast path only while the array predicate is what pins the
+        // result set. A disjunction widens it past those keys exactly as it does for "= ?".
+        WorkspaceStatementInspector inspector = newInspector(TenancyEnforcement.LOG);
+        when(scopedTables.isScoped("label")).thenReturn(true);
+        String sql = "select l1_0.id from label l1_0 where l1_0.repository_id=any(?) or l1_0.is_public=true";
+        inspector.inspect(sql);
+        verify(reporter).report(sql, Set.of("label"), TenancyEnforcement.LOG);
+    }
+
+    @Test
     void pkPredicateDisjoinedWithOrStillEnforced() {
         // The PK-only fast path tolerates extra CONJUNCTIVE predicates, but a DISJUNCTION broadens the
         // result set past the single keyed row — "WHERE id = ? OR is_public = true" returns every public


### PR DESCRIPTION
## Problem

Every authenticated request to the teams and leaderboard pages returned an error on production immediately after upgrading. The cause was the workspace tenancy self-check, not authorization:

```
Tenancy violation: scoped tables [label] queried without workspace_id predicate
SQL: select l1_0.repository_id,l1_0.id,... from label l1_0 where l1_0.repository_id = any(?)
```

`WorkspaceStatementInspector` has a fast path for a load pinned by a surrogate key — including a lazy collection filtered by its parent FK — on the argument that the caller already held that key. `Repository.labels` carries `@BatchSize(size = 50)`, added to avoid a Cartesian product in the team query, so Hibernate fills several repositories' collections in one round trip and writes the predicate as `= any(?)` instead of `= ?`. The pattern only matched the single-key form, so the query fell through to the `workspace_id` check — and `label` has no `workspace_id` column, inheriting its tenancy from `repository`. Result: a guaranteed throw on any instance whose teams have repositories with labels.

Staging did not surface it because no one loads those pages there with that data shape.

## Fix

Accept the batched form on the same fast path. `ANY(?)` binds a single array parameter, so the predicate stays pinned to keys the caller already held — the identical safety argument, which the Javadoc now states. The existing disqualifiers are unchanged: a disjunction still forces the full `workspace_id` check, in the batched form as in the single-key one.

Workspace isolation is not weakened. The inspector is a SQL-shape defect detector that complements, not replaces, workspace authorization (ADR 0004), and the query it was rejecting was already bounded to caller-held keys.

## Verification

`WorkspaceStatementInspectorTest` — 30 tests, all passing — with two added cases: the exact production query is accepted, and the same query with a disjunction is still reported.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed teams and leaderboard pages failing to load when labels are synchronized and fetched in batches.
  * Preserved workspace isolation checks for batched data requests, including cases combined with additional filter conditions.

* **Documentation**
  * Updated safety documentation to cover batched parent-key loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->