### PR TITLE
test(ci): stop driving the Linux-only buildpack step on Windows

### DIFF
--- a/scripts/ci-contract.test.ts
+++ b/scripts/ci-contract.test.ts
@@ -277,10 +277,19 @@ function bashRunsRunnerSteps(): boolean {
 	return probe.error === undefined && probe.status === 0;
 }
 
-const runnerBashOnly = {
-	skip: bashRunsRunnerSteps()
-		? false
-		: "this bash has no mapfile; runner steps need bash 4 or later",
+/**
+ * The buildpack step this guards is driven by replacing `pack` and `docker` with executable stubs
+ * on PATH. That needs a bash new enough for the runner's own steps, and a platform where an
+ * extensionless stub is executable: on Windows the exec goes through Git Bash and fails
+ * intermittently, which is a property of the harness rather than of the step — the job that runs
+ * this shell is pinned to the ubuntu-24.04 runners and never executes on Windows at all.
+ */
+const runnerStepsOnly = {
+	skip: !bashRunsRunnerSteps()
+		? "this bash has no mapfile; runner steps need bash 4 or later"
+		: process.platform === "win32"
+			? "the buildpack step runs only on Linux runners; PATH stubs are not reliably executable here"
+			: false,
 };
 
 /**
@@ -908,7 +917,7 @@ void describe("CI contract", () => {
 
 	void test(
 		"a fork's buildpack build produces an image without contacting the registry",
-		runnerBashOnly,
+		runnerStepsOnly,
 		async () => {
 			const reusable = parseDocument(
 				await readFile(".github/workflows/reusable-docker-build.yml", "utf8"),


### PR DESCRIPTION
## Problem

`a fork's buildpack build produces an image without contacting the registry` fails intermittently on `Quality / Windows` with `AssertionError: exit 2147483652`. It failed CI/CD on `main` tonight, and because `Release` is conditioned on CI/CD succeeding, the release was **skipped** — v0.77.1 only published after a re-run of the failed jobs. The same test previously failed every run on macOS, which is why the `mapfile` guard exists.

## Cause

The test proves the step's behaviour by putting executable stubs for `pack` and `docker` on `PATH` and running the workflow's shell. On Windows those extensionless stubs are executed through Git Bash, and that exec is not reliable under the runner — the failure is a property of the harness, not of the step under test.

The job whose shell this drives is pinned to `ubuntu-24.04` / `ubuntu-24.04-arm`:

```yaml
matrix: … {"platform":"linux/amd64","runner":"ubuntu-24.04"} …
runs-on: ${{ matrix.runner }}
```

So Windows was asserting against an environment the step never runs in.

## Fix

The existing `mapfile` guard becomes `runnerStepsOnly`, which also skips on `win32` and says why. Coverage is unchanged where the step actually runs; the guard is the only consumer, and this is the only test that writes executable PATH stubs.

## Verification

`vp run test:tooling` — 575 tests, 574 passing, 1 skipped, 0 failing.