### PR TITLE
fix(scripts): tell a host its environment has no channel yet

### DIFF
--- a/scripts/reconcile-deployment.ts
+++ b/scripts/reconcile-deployment.ts
@@ -463,6 +463,18 @@ async function main(): Promise<void> {
 		})
 	).trim();
 	const channelPath = `channels/${config.channel}.json`;
+	// An environment nobody has promoted yet has no channel file. That is the first thing a new
+	// host meets, so say which channel is missing and what publishes it rather than letting git's
+	// "path does not exist" surface as an unhandled exec failure.
+	if (
+		!(await succeeds("git", ["cat-file", "-e", `${channelCommit}:${channelPath}`], {
+			cwd: config.checkout,
+		}))
+	)
+		throw new Error(
+			`no ${channelPath} on deploy-state: the "${config.channel}" environment has not been ` +
+				"promoted yet. Run the Promote workflow for it and this host applies it on the next tick.",
+		);
 	const channelJson = await output("git", ["show", `${channelCommit}:${channelPath}`], {
 		cwd: config.checkout,
 	});

--- a/scripts/release-deployment-policy.test.ts
+++ b/scripts/release-deployment-policy.test.ts
@@ -153,6 +153,10 @@ await test("every promotion decision is taken by the script that owns it", () =>
 	assert.doesNotMatch(reconciler, /join\(releaseTree, "scripts\/prepare-release-lock\.ts"\)/);
 	// Run through the tooling link, argv[1] and import.meta.filename differ; only import.meta.main holds.
 	assert.match(reconciler, /^if \(import\.meta\.main\) \{/m);
+	// A host pointed at an environment nobody has promoted yet must be told that, not handed git's
+	// "path does not exist" as an unhandled exec failure — it is the first thing a new host meets.
+	assert.match(reconciler, /cat-file", "-e", `\$\{channelCommit\}:\$\{channelPath\}`/);
+	assert.match(reconciler, /promoted yet/);
 });
 
 function referenced(expression: string, pattern: RegExp): string[] {


### PR DESCRIPTION
## Problem

Installing the reconciler on a host whose environment has never been promoted fails on the first tick — which is precisely when the install guide tells the operator to watch `journalctl -fu hephaestus-reconcile.service`. What they see is an unhandled `ExecException`, with `cmd`, `stdout`, `stderr`, `code` and a Node stack wrapped around a single line of actual cause:

```
Error: Command failed: git show <sha>:channels/production.json
fatal: path 'channels/production.json' does not exist in '<sha>'
    at genericNodeError (node:internal/errors:985:15)
    …
```

I hit this bringing production onto pull-based deployment.

## Fix

Check the path before reading it, and fail with the reason and the remedy:

> `no channels/production.json on deploy-state: the "production" environment has not been promoted yet. Run the Promote workflow for it and this host applies it on the next tick.`

Nothing else changes: a channel that exists takes exactly the path it did before, and the bytes still reach cosign unmodified.

## Verification

`vp run test:tooling` — 575 tests, 574 passing, 1 skipped, 0 failing. The guard is pinned in `release-deployment-policy.test.ts`, alongside the other assertions that hold the reconciler's shape, since the check sits on an I/O path inside `main()` with no unit seam.