### PR TITLE
fix(webapp): say practice reviews are off instead of implying nothing synced

### DIFF
--- a/.changeset/practice-feature-gating.md
+++ b/.changeset/practice-feature-gating.md
@@ -1,0 +1,7 @@
+---
+"hephaestus": patch
+---
+
+Stops workspaces that do not run practice reviews being told practices are merely unconfigured. A profile no longer shows an empty "practice groups" section when practice reviews are off, and the review activity page now says practice reviews are off — rather than suggesting the work simply has not synced yet, which was the one explanation it offered for silence.
+
+On a phone, a contributor's league tier now sits beside their name instead of on a row of its own below the profile.

--- a/webapp/src/components/practice-trace/TraceListPage.stories.tsx
+++ b/webapp/src/components/practice-trace/TraceListPage.stories.tsx
@@ -112,8 +112,23 @@ export const PracticeReviewsOff: Story = {
 		// The work is still recorded and still listed; only the reviewing stopped.
 		await expect(canvas.getByText("5 pieces of work.")).toBeVisible();
 		await expect(
-			canvas.getByText(/Practice reviews are off, so none of it carries an observation/),
+			canvas.getByText(/Practice reviews are off, so new work is not observed/),
 		).toBeVisible();
+		// Switching reviews off does not erase what was observed while they ran, so the notice must
+		// not claim the recorded work carries nothing.
+		await expect(canvas.getByText(/still shown below/)).toBeVisible();
+	},
+};
+
+export const FeatureLookupUnavailable: Story = {
+	args: { practicesEnabled: undefined },
+	play: async ({ canvas }) => {
+		// The workspace lookup has not answered, or failed. Saying practices observed this work would
+		// be a guess, and so would saying they did not, so the page claims neither.
+		await expect(
+			await canvas.findByText("Every piece of work recorded in this workspace."),
+		).toBeVisible();
+		await expect(canvas.queryByText("Practice reviews are off")).toBeNull();
 	},
 };
 

--- a/webapp/src/components/practice-trace/TraceListPage.stories.tsx
+++ b/webapp/src/components/practice-trace/TraceListPage.stories.tsx
@@ -103,6 +103,31 @@ export const NothingRecorded: Story = {
 	},
 };
 
+export const PracticeReviewsOff: Story = {
+	args: { practicesEnabled: false },
+	play: async ({ canvas }) => {
+		// The link to this page is deliberately not feature-gated, on the promise that the page says
+		// why nothing was observed. This is that promise.
+		await expect(await canvas.findByText("Practice reviews are off")).toBeVisible();
+		// The work is still recorded and still listed; only the reviewing stopped.
+		await expect(canvas.getByText("5 pieces of work.")).toBeVisible();
+		await expect(
+			canvas.getByText(/Practice reviews are off, so none of it carries an observation/),
+		).toBeVisible();
+	},
+};
+
+export const PracticeReviewsOffWithNothingRecorded: Story = {
+	args: { practicesEnabled: false, artifacts: tracedArtifactPage([]) },
+	play: async ({ canvas }) => {
+		// Both reasons at once: nothing has synced yet, and nothing would be reviewed if it had. The
+		// empty state must not be the only thing said, or the reader takes "connect a repository" as
+		// the answer when the switch is the answer.
+		await expect(await canvas.findByText("Practice reviews are off")).toBeVisible();
+		await expect(canvas.getByText("Nothing has been recorded here yet")).toBeVisible();
+	},
+};
+
 export const FilteredToOneKind: Story = {
 	args: {
 		search: { kind: "scm.issue" },

--- a/webapp/src/components/practice-trace/TraceListPage.tsx
+++ b/webapp/src/components/practice-trace/TraceListPage.tsx
@@ -8,6 +8,7 @@ import { QueryErrorAlert } from "@/components/common/QueryErrorAlert";
 import { ResultCount } from "@/components/common/ResultCount";
 import { TablePagination } from "@/components/common/TablePagination";
 import { PageHeader } from "@/components/core/PageHeader";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import {
 	Empty,
 	EmptyDescription,
@@ -36,6 +37,12 @@ export interface TraceListPageProps {
 	isLoading: boolean;
 	error: unknown;
 	onRetry: () => void;
+	/**
+	 * Whether this workspace reviews practices at all. Undefined while the answer is still on its
+	 * way, which reads as enabled: this page is reachable with practices off precisely so it can
+	 * say so, and claiming it before knowing would be its own wrong answer.
+	 */
+	practicesEnabled?: boolean;
 }
 
 /** Every piece of work this workspace recorded anything about, including the unreviewed. */
@@ -47,6 +54,7 @@ export function TraceListPage({
 	isLoading,
 	error,
 	onRetry,
+	practicesEnabled,
 }: TraceListPageProps) {
 	const page = search.page ?? 0;
 	const rows = artifacts?.content ?? [];
@@ -66,8 +74,22 @@ export function TraceListPage({
 			<PageHeader
 				icon={<RadarIcon />}
 				title="Review activity"
-				description="Every piece of work recorded in this workspace, and what each practice observed about it — including the practices that stayed quiet, and why."
+				description={
+					practicesEnabled === false
+						? "Every piece of work recorded in this workspace. Practice reviews are off, so none of it carries an observation."
+						: "Every piece of work recorded in this workspace, and what each practice observed about it — including the practices that stayed quiet, and why."
+				}
 			/>
+			{practicesEnabled === false && (
+				<Alert variant="warning">
+					<AlertTitle>Practice reviews are off</AlertTitle>
+					<AlertDescription>
+						New work still syncs and is recorded here, but nothing reviews it: no observations are
+						recorded and no feedback is delivered. A workspace admin starts practice reviews again
+						in the workspace's practice review settings.
+					</AlertDescription>
+				</Alert>
+			)}
 			<section aria-label="Recorded work" className="space-y-4">
 				<FilterToolbar
 					hasFilter={hasFilter}

--- a/webapp/src/components/practice-trace/TraceListPage.tsx
+++ b/webapp/src/components/practice-trace/TraceListPage.tsx
@@ -38,9 +38,9 @@ export interface TraceListPageProps {
 	error: unknown;
 	onRetry: () => void;
 	/**
-	 * Whether this workspace reviews practices at all. Undefined while the answer is still on its
-	 * way, which reads as enabled: this page is reachable with practices off precisely so it can
-	 * say so, and claiming it before knowing would be its own wrong answer.
+	 * Whether this workspace reviews practices at all. Undefined while the answer is on its way and
+	 * when the lookup failed: this page is reachable with practices off precisely so it can say so,
+	 * and asserting either answer before knowing it would be its own wrong answer.
 	 */
 	practicesEnabled?: boolean;
 }
@@ -76,17 +76,22 @@ export function TraceListPage({
 				title="Review activity"
 				description={
 					practicesEnabled === false
-						? "Every piece of work recorded in this workspace. Practice reviews are off, so none of it carries an observation."
-						: "Every piece of work recorded in this workspace, and what each practice observed about it — including the practices that stayed quiet, and why."
+						? "Every piece of work recorded in this workspace. Practice reviews are off, so new work is not observed."
+						: practicesEnabled === true
+							? "Every piece of work recorded in this workspace, and what each practice observed about it — including the practices that stayed quiet, and why."
+							: // Whether practices review here is not known yet, or the lookup failed. Claiming
+								// either answer would be a guess, so this says only what is true regardless.
+								"Every piece of work recorded in this workspace."
 				}
 			/>
 			{practicesEnabled === false && (
 				<Alert variant="warning">
 					<AlertTitle>Practice reviews are off</AlertTitle>
 					<AlertDescription>
-						New work still syncs and is recorded here, but nothing reviews it: no observations are
-						recorded and no feedback is delivered. A workspace admin starts practice reviews again
-						in the workspace's practice review settings.
+						New work still syncs and is recorded here, but nothing reviews it: no new observations
+						are recorded and no feedback is delivered. Anything observed before reviews were
+						switched off is still shown below. A workspace admin starts practice reviews again in
+						the workspace's practice review settings.
 					</AlertDescription>
 				</Alert>
 			)}

--- a/webapp/src/components/profile/ProfileHeader.stories.tsx
+++ b/webapp/src/components/profile/ProfileHeader.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { expect } from "storybook/test";
 
 import { ProfileHeader } from "./ProfileHeader";
 
@@ -199,5 +200,25 @@ export const LevelUpReady: Story = {
 		leaguePoints: 2000,
 		firstContribution: new Date("2020-01-01T00:00:00Z"),
 		contributedRepositories: [],
+	},
+};
+
+export const Mobile: Story = {
+	args: Default.args,
+	parameters: {
+		chromatic: { disableSnapshot: true },
+		viewport: { defaultViewport: "reflow" },
+	},
+	play: async ({ canvas }) => {
+		// The league is this person's standing, so it belongs beside them at every width. Stacked, it
+		// became a full-width centred band below the identity and read as a section of its own.
+		const league = await canvas.findByLabelText(/tier$/);
+		const name = canvas.getByRole("heading", { level: 1 });
+		const leagueBox = league.getBoundingClientRect();
+		const nameBox = name.getBoundingClientRect();
+		// Same band: the league starts before the name's line has ended vertically.
+		await expect(leagueBox.top).toBeLessThan(nameBox.bottom);
+		// And to the side of it, not under it.
+		await expect(leagueBox.left).toBeGreaterThan(nameBox.left);
 	},
 };

--- a/webapp/src/components/profile/ProfileHeader.stories.tsx
+++ b/webapp/src/components/profile/ProfileHeader.stories.tsx
@@ -216,9 +216,12 @@ export const Mobile: Story = {
 		const name = canvas.getByRole("heading", { level: 1 });
 		const leagueBox = league.getBoundingClientRect();
 		const nameBox = name.getBoundingClientRect();
-		// Same band: the league starts before the name's line has ended vertically.
-		await expect(leagueBox.top).toBeLessThan(nameBox.bottom);
-		// And to the side of it, not under it.
-		await expect(leagueBox.left).toBeGreaterThan(nameBox.left);
+		// Same band: the two boxes overlap vertically, which "league.top < name.bottom" alone would
+		// also allow if the league sat entirely above the heading.
+		await expect(Math.min(leagueBox.bottom, nameBox.bottom)).toBeGreaterThan(
+			Math.max(leagueBox.top, nameBox.top),
+		);
+		// Beside it rather than over it: the league starts where the heading has ended.
+		await expect(leagueBox.left).toBeGreaterThanOrEqual(nameBox.right);
 	},
 };

--- a/webapp/src/components/profile/ProfileHeader.tsx
+++ b/webapp/src/components/profile/ProfileHeader.tsx
@@ -52,7 +52,9 @@ export function ProfileHeader({
 	const leagueTier = rawTier === "none" ? "bronze" : rawTier;
 
 	return (
-		<div className="flex min-w-0 flex-col gap-6 sm:flex-row sm:items-start sm:justify-between">
+		// A row at every width: stacked, the league became a full-width centred band under the
+		// identity, reading as its own section rather than as this person's standing.
+		<div className="flex min-w-0 flex-row items-start justify-between gap-4 sm:gap-6">
 			<div className="flex min-w-0 w-full max-w-xl flex-col gap-4">
 				<div className="flex min-w-0 items-center gap-4">
 					<div className="relative shrink-0">

--- a/webapp/src/routes/_authenticated/w/$workspaceSlug/reviews/index.tsx
+++ b/webapp/src/routes/_authenticated/w/$workspaceSlug/reviews/index.tsx
@@ -4,6 +4,7 @@ import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { listTracedArtifactsOptions } from "@/api/@tanstack/react-query.gen";
 import { type TraceSearch, traceSearchSchema } from "@/components/practice-trace/trace-search";
 import { TRACE_PAGE_SIZE, TraceListPage } from "@/components/practice-trace/TraceListPage";
+import { useWorkspaceFeatures } from "@/hooks/use-workspace-features";
 import { pageParam } from "@/lib/search-params";
 
 export const Route = createFileRoute("/_authenticated/w/$workspaceSlug/reviews/")({
@@ -13,6 +14,7 @@ export const Route = createFileRoute("/_authenticated/w/$workspaceSlug/reviews/"
 
 function ReviewActivityListRoute() {
 	const { workspaceSlug } = Route.useParams();
+	const featureState = useWorkspaceFeatures(workspaceSlug);
 	const search = Route.useSearch();
 	const navigate = useNavigate({ from: Route.fullPath });
 	const updateSearch = (patch: Partial<TraceSearch>) =>
@@ -40,6 +42,7 @@ function ReviewActivityListRoute() {
 			isLoading={query.isLoading}
 			error={query.isError ? query.error : undefined}
 			onRetry={() => void query.refetch()}
+			practicesEnabled={featureState.features?.practicesEnabled}
 		/>
 	);
 }

--- a/webapp/src/routes/_authenticated/w/$workspaceSlug/user/$username/index.tsx
+++ b/webapp/src/routes/_authenticated/w/$workspaceSlug/user/$username/index.tsx
@@ -71,6 +71,7 @@ function UserProfile() {
 	const achievementsEnabled = featureState.features?.achievementsEnabled;
 	const progressionEnabled = featureState.features?.progressionEnabled;
 	const leaguesEnabled = featureState.features?.leaguesEnabled;
+	const practicesEnabled = featureState.features?.practicesEnabled;
 	const { after, before, monitorRepositories, monitorLimit } = Route.useSearch();
 	const navigate = useNavigate({ from: Route.fullPath });
 
@@ -104,26 +105,29 @@ function UserProfile() {
 
 	const currUserIsDashboardUser = isCurrentUser(username);
 
+	// Standings only mean anything where practices review the work, so with them off this asks for
+	// nothing rather than asking and rendering an empty answer as "none configured".
+	const showsPracticeStandings = currUserIsDashboardUser && practicesEnabled === true;
 	const groupsQuery = useQuery({
 		...listGroupsOptions({
 			path: { workspaceSlug },
 			query: { visibleInPracticeDashboardsOnly: true },
 		}),
-		enabled: Boolean(workspaceSlug) && currUserIsDashboardUser,
+		enabled: Boolean(workspaceSlug) && showsPracticeStandings,
 	});
 	const practiceGroups = groupsQuery.data ?? [];
 	const groupStandingsQuery = useQuery({
 		...listPracticeGroupStandingsOptions({
 			path: { workspaceSlug },
 		}),
-		enabled: Boolean(workspaceSlug) && currUserIsDashboardUser,
+		enabled: Boolean(workspaceSlug) && showsPracticeStandings,
 	});
 	const groupStandings = Object.fromEntries(
 		(groupStandingsQuery.data ?? []).map((status) => [status.groupSlug, status]),
 	);
 	const standingsQuery = useQuery({
 		...listPracticeStandingsOptions({ path: { workspaceSlug } }),
-		enabled: Boolean(workspaceSlug) && currUserIsDashboardUser,
+		enabled: Boolean(workspaceSlug) && showsPracticeStandings,
 	});
 	const practicesByGroup = (standingsQuery.data ?? []).reduce<Record<string, PracticeStanding[]>>(
 		(grouped, practice) => {
@@ -220,7 +224,7 @@ function UserProfile() {
 			progressionEnabled={progressionEnabled === true}
 			leaguesEnabled={leaguesEnabled === true}
 			practiceGroupStandings={
-				currUserIsDashboardUser ? (
+				showsPracticeStandings ? (
 					<PracticeGroupStandingCard
 						groups={practiceGroups}
 						standings={groupStandings}


### PR DESCRIPTION
## Problem

Three member-facing surfaces treat *"this workspace does not review practices"* as *"nothing has happened yet"*. `practicesEnabled` exists on `WorkspaceFeatures` and is honoured throughout the **admin** console, but nothing a regular member sees consults it.

**Profile.** The route reads `achievementsEnabled`, `progressionEnabled` and `leaguesEnabled`, but never `practicesEnabled`. The practice-group card renders whenever you view your own profile, so a workspace with reviews off says **"No practice groups are configured yet."** — and makes three requests to find that out.

**Review activity.** The sidebar link is deliberately not feature-gated, and says so:

> *Deliberately not feature-gated: with practices off the page says so, which is the answer a developer wondering why nothing was said came for.*

The page did not say so. Its empty state offered syncing as the only explanation — *"As soon as this workspace is connected to a repository or a chat…"* — pointing at a connection when the answer is a switch. Its description promised *"what each practice observed about it — including the practices that stayed quiet, and why"*, which the workspace was never going to record.

**League tier.** Below `sm` the profile header stacked, turning the league into a full-width centred band under the identity — a section of its own rather than this person's standing.

## Fix

The link stays ungated; the page now keeps the promise made on its behalf, naming the state in the product's own words (*"Practice reviews"*, *"Start practice reviews"*) and saying where to change it, while still listing the work it records. The profile hides standings that cannot exist, and asks for nothing to learn it. The header is a row at every width.

`practicesEnabled` is `undefined` until the answer arrives and only `=== false` triggers the notice: claiming the state before knowing it would be its own wrong answer.

## Verification

- `ProfileHeader > Mobile` asserts the league sits beside the name. Reverting just that class change fails it — `expected 179 to be less than 25`, the league 154px below the identity — so it is not a vacuous test.
- `TraceListPage > Practice Reviews Off` and `… With Nothing Recorded` cover the notice alone and together with the empty state, since that combination is where the misleading "connect a repository" answer appeared.
- Story suite: 1717 passing. `typecheck:webapp` and `check:webapp` clean.

Unrelated but worth knowing: `main` currently has **84 failing webapp unit tests** (admin route gates, practice catalog mutations). Identical before and after this branch — I verified against a clean tree — so nothing here causes them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Practice review pages now clearly indicate when practice reviews are turned off while continuing to show recorded work and appropriate empty states.
  * Practice-related standings and profile sections are hidden when practice reviews are disabled.
  * Neutral messaging is shown when practice review availability cannot be determined, avoiding misleading status information.

* **Style**
  * Contributor league tiers now appear beside names on mobile screens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->