### PR TITLE
fix(webapp): take review activity away where practices are not reviewed

### DIFF
--- a/.changeset/gate-review-activity.md
+++ b/.changeset/gate-review-activity.md
@@ -1,0 +1,5 @@
+---
+"hephaestus": patch
+---
+
+Removes the review activity surface from workspaces that do not run practice reviews. The sidebar entry no longer appears, and a link kept from before — or from another workspace — lands on the workspace home instead of a page whose only content would be an explanation of its own emptiness.

--- a/webapp/src/components/core/sidebar/AppSidebar.tsx
+++ b/webapp/src/components/core/sidebar/AppSidebar.tsx
@@ -136,6 +136,7 @@ export function AppSidebar({
 					workspaceSlug={activeWorkspace.workspaceSlug}
 					achievementsEnabled={activeWorkspace.achievementsEnabled}
 					leaderboardEnabled={activeWorkspace.leaderboardEnabled}
+					practicesEnabled={activeWorkspace.practicesEnabled}
 				/>
 				{hasMentorAccess && activeWorkspace.mentorEnabled && (
 					<NavMentor workspaceSlug={activeWorkspace.workspaceSlug} />

--- a/webapp/src/components/core/sidebar/NavDashboards.stories.tsx
+++ b/webapp/src/components/core/sidebar/NavDashboards.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { expect } from "storybook/test";
 
 import { SidebarProvider } from "@/components/ui/sidebar";
 
@@ -15,6 +16,7 @@ const meta = {
 		workspaceSlug: "aet",
 		achievementsEnabled: true,
 		leaderboardEnabled: true,
+		practicesEnabled: true,
 	},
 	decorators: [
 		(Story) => (
@@ -41,5 +43,23 @@ export const AllFeaturesDisabled: Story = {
 	args: {
 		achievementsEnabled: false,
 		leaderboardEnabled: false,
+		practicesEnabled: false,
+	},
+	play: async ({ canvas }) => {
+		// Profile and Teams are not workspace capabilities, so they stay whatever else is off.
+		await expect(await canvas.findByRole("link", { name: "Profile" })).toBeVisible();
+		await expect(canvas.getByRole("link", { name: "Teams" })).toBeVisible();
+		for (const gated of ["Achievements", "Leaderboard", "Review activity"])
+			await expect(canvas.queryByRole("link", { name: gated })).toBeNull();
+	},
+};
+
+export const PracticeReviewsOff: Story = {
+	args: { practicesEnabled: false },
+	play: async ({ canvas }) => {
+		// A workspace that does not review practices has no review activity to show, so the entry is
+		// gone rather than leading to a page that could only explain itself.
+		await expect(await canvas.findByRole("link", { name: "Leaderboard" })).toBeVisible();
+		await expect(canvas.queryByRole("link", { name: "Review activity" })).toBeNull();
 	},
 };

--- a/webapp/src/components/core/sidebar/NavDashboards.tsx
+++ b/webapp/src/components/core/sidebar/NavDashboards.tsx
@@ -14,11 +14,13 @@ export function NavDashboards({
 	workspaceSlug,
 	achievementsEnabled,
 	leaderboardEnabled,
+	practicesEnabled,
 }: {
 	username: string;
 	workspaceSlug: string;
 	achievementsEnabled: boolean;
 	leaderboardEnabled: boolean;
+	practicesEnabled: boolean;
 }) {
 	const matchRoute = useMatchRoute();
 	const onProfile = Boolean(matchRoute({ to: "/w/$workspaceSlug/user/$username", fuzzy: true }));
@@ -67,18 +69,18 @@ export function NavDashboards({
 						</SidebarMenuButton>
 					</SidebarMenuItem>
 				)}
-				{/* Deliberately not feature-gated: with practices off the page says so, which is the answer
-				    a developer wondering why nothing was said came for. */}
-				<SidebarMenuItem>
-					<SidebarMenuButton
-						tooltip="Review activity"
-						isActive={onReviews}
-						render={<Link to="/w/$workspaceSlug/reviews" params={{ workspaceSlug }} />}
-					>
-						<Radar />
-						<span>Review activity</span>
-					</SidebarMenuButton>
-				</SidebarMenuItem>
+				{practicesEnabled && (
+					<SidebarMenuItem>
+						<SidebarMenuButton
+							tooltip="Review activity"
+							isActive={onReviews}
+							render={<Link to="/w/$workspaceSlug/reviews" params={{ workspaceSlug }} />}
+						>
+							<Radar />
+							<span>Review activity</span>
+						</SidebarMenuButton>
+					</SidebarMenuItem>
+				)}
 				<SidebarMenuItem>
 					<SidebarMenuButton
 						tooltip="Teams"

--- a/webapp/src/components/practice-trace/TraceListPage.stories.tsx
+++ b/webapp/src/components/practice-trace/TraceListPage.stories.tsx
@@ -103,46 +103,6 @@ export const NothingRecorded: Story = {
 	},
 };
 
-export const PracticeReviewsOff: Story = {
-	args: { practicesEnabled: false },
-	play: async ({ canvas }) => {
-		// The link to this page is deliberately not feature-gated, on the promise that the page says
-		// why nothing was observed. This is that promise.
-		await expect(await canvas.findByText("Practice reviews are off")).toBeVisible();
-		// The work is still recorded and still listed; only the reviewing stopped.
-		await expect(canvas.getByText("5 pieces of work.")).toBeVisible();
-		await expect(
-			canvas.getByText(/Practice reviews are off, so new work is not observed/),
-		).toBeVisible();
-		// Switching reviews off does not erase what was observed while they ran, so the notice must
-		// not claim the recorded work carries nothing.
-		await expect(canvas.getByText(/still shown below/)).toBeVisible();
-	},
-};
-
-export const FeatureLookupUnavailable: Story = {
-	args: { practicesEnabled: undefined },
-	play: async ({ canvas }) => {
-		// The workspace lookup has not answered, or failed. Saying practices observed this work would
-		// be a guess, and so would saying they did not, so the page claims neither.
-		await expect(
-			await canvas.findByText("Every piece of work recorded in this workspace."),
-		).toBeVisible();
-		await expect(canvas.queryByText("Practice reviews are off")).toBeNull();
-	},
-};
-
-export const PracticeReviewsOffWithNothingRecorded: Story = {
-	args: { practicesEnabled: false, artifacts: tracedArtifactPage([]) },
-	play: async ({ canvas }) => {
-		// Both reasons at once: nothing has synced yet, and nothing would be reviewed if it had. The
-		// empty state must not be the only thing said, or the reader takes "connect a repository" as
-		// the answer when the switch is the answer.
-		await expect(await canvas.findByText("Practice reviews are off")).toBeVisible();
-		await expect(canvas.getByText("Nothing has been recorded here yet")).toBeVisible();
-	},
-};
-
 export const FilteredToOneKind: Story = {
 	args: {
 		search: { kind: "scm.issue" },

--- a/webapp/src/components/practice-trace/TraceListPage.tsx
+++ b/webapp/src/components/practice-trace/TraceListPage.tsx
@@ -8,7 +8,6 @@ import { QueryErrorAlert } from "@/components/common/QueryErrorAlert";
 import { ResultCount } from "@/components/common/ResultCount";
 import { TablePagination } from "@/components/common/TablePagination";
 import { PageHeader } from "@/components/core/PageHeader";
-import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import {
 	Empty,
 	EmptyDescription,
@@ -37,12 +36,6 @@ export interface TraceListPageProps {
 	isLoading: boolean;
 	error: unknown;
 	onRetry: () => void;
-	/**
-	 * Whether this workspace reviews practices at all. Undefined while the answer is on its way and
-	 * when the lookup failed: this page is reachable with practices off precisely so it can say so,
-	 * and asserting either answer before knowing it would be its own wrong answer.
-	 */
-	practicesEnabled?: boolean;
 }
 
 /** Every piece of work this workspace recorded anything about, including the unreviewed. */
@@ -54,7 +47,6 @@ export function TraceListPage({
 	isLoading,
 	error,
 	onRetry,
-	practicesEnabled,
 }: TraceListPageProps) {
 	const page = search.page ?? 0;
 	const rows = artifacts?.content ?? [];
@@ -74,27 +66,8 @@ export function TraceListPage({
 			<PageHeader
 				icon={<RadarIcon />}
 				title="Review activity"
-				description={
-					practicesEnabled === false
-						? "Every piece of work recorded in this workspace. Practice reviews are off, so new work is not observed."
-						: practicesEnabled === true
-							? "Every piece of work recorded in this workspace, and what each practice observed about it — including the practices that stayed quiet, and why."
-							: // Whether practices review here is not known yet, or the lookup failed. Claiming
-								// either answer would be a guess, so this says only what is true regardless.
-								"Every piece of work recorded in this workspace."
-				}
+				description="Every piece of work recorded in this workspace, and what each practice observed about it — including the practices that stayed quiet, and why."
 			/>
-			{practicesEnabled === false && (
-				<Alert variant="warning">
-					<AlertTitle>Practice reviews are off</AlertTitle>
-					<AlertDescription>
-						New work still syncs and is recorded here, but nothing reviews it: no new observations
-						are recorded and no feedback is delivered. Anything observed before reviews were
-						switched off is still shown below. A workspace admin starts practice reviews again in
-						the workspace's practice review settings.
-					</AlertDescription>
-				</Alert>
-			)}
 			<section aria-label="Recorded work" className="space-y-4">
 				<FilterToolbar
 					hasFilter={hasFilter}

--- a/webapp/src/routeTree.gen.ts
+++ b/webapp/src/routeTree.gen.ts
@@ -39,6 +39,7 @@ import { Route as AuthenticatedWWorkspaceSlugIndexRouteImport } from './routes/_
 import { Route as AuthenticatedWWorkspaceSlugAchievementsRouteImport } from './routes/_authenticated/w/$workspaceSlug/achievements'
 import { Route as AuthenticatedWWorkspaceSlugAdminRouteRouteImport } from './routes/_authenticated/w/$workspaceSlug/admin/route'
 import { Route as AuthenticatedWWorkspaceSlugMentorRouteImport } from './routes/_authenticated/w/$workspaceSlug/mentor'
+import { Route as AuthenticatedWWorkspaceSlugReviewsRouteImport } from './routes/_authenticated/w/$workspaceSlug/reviews'
 import { Route as AuthenticatedWorkspacesNewIndexRouteImport } from './routes/_authenticated/workspaces/new/index'
 import { Route as AuthenticatedWorkspacesNewGithubRouteImport } from './routes/_authenticated/workspaces/new/github'
 import { Route as AuthenticatedWorkspacesNewGitlabRouteImport } from './routes/_authenticated/workspaces/new/gitlab'
@@ -254,6 +255,12 @@ const AuthenticatedWWorkspaceSlugMentorRoute =
     path: '/mentor',
     getParentRoute: () => AuthenticatedWWorkspaceSlugRouteRoute,
   } as any)
+const AuthenticatedWWorkspaceSlugReviewsRoute =
+  AuthenticatedWWorkspaceSlugReviewsRouteImport.update({
+    id: '/reviews',
+    path: '/reviews',
+    getParentRoute: () => AuthenticatedWWorkspaceSlugRouteRoute,
+  } as any)
 const AuthenticatedWorkspacesNewIndexRoute =
   AuthenticatedWorkspacesNewIndexRouteImport.update({
     id: '/workspaces/new/',
@@ -370,9 +377,9 @@ const AuthenticatedWWorkspaceSlugMentorThreadIdRoute =
   } as any)
 const AuthenticatedWWorkspaceSlugReviewsIndexRoute =
   AuthenticatedWWorkspaceSlugReviewsIndexRouteImport.update({
-    id: '/reviews/',
-    path: '/reviews/',
-    getParentRoute: () => AuthenticatedWWorkspaceSlugRouteRoute,
+    id: '/',
+    path: '/',
+    getParentRoute: () => AuthenticatedWWorkspaceSlugReviewsRoute,
   } as any)
 const AuthenticatedWWorkspaceSlugTeamsIndexRoute =
   AuthenticatedWWorkspaceSlugTeamsIndexRouteImport.update({
@@ -460,9 +467,9 @@ const AuthenticatedWWorkspaceSlugAdminPracticesSettingsRoute =
   } as any)
 const AuthenticatedWWorkspaceSlugReviewsArtifactKindArtifactIdRoute =
   AuthenticatedWWorkspaceSlugReviewsArtifactKindArtifactIdRouteImport.update({
-    id: '/reviews/$artifactKind/$artifactId',
-    path: '/reviews/$artifactKind/$artifactId',
-    getParentRoute: () => AuthenticatedWWorkspaceSlugRouteRoute,
+    id: '/$artifactKind/$artifactId',
+    path: '/$artifactKind/$artifactId',
+    getParentRoute: () => AuthenticatedWWorkspaceSlugReviewsRoute,
   } as any)
 const AuthenticatedWWorkspaceSlugUserUsernameIndexRoute =
   AuthenticatedWWorkspaceSlugUserUsernameIndexRouteImport.update({
@@ -623,6 +630,7 @@ export interface FileRoutesByFullPath {
   '/w/$workspaceSlug/admin': typeof AuthenticatedWWorkspaceSlugAdminRouteRouteWithChildren
   '/w/$workspaceSlug/achievements': typeof AuthenticatedWWorkspaceSlugAchievementsRoute
   '/w/$workspaceSlug/mentor': typeof AuthenticatedWWorkspaceSlugMentorRouteWithChildren
+  '/w/$workspaceSlug/reviews': typeof AuthenticatedWWorkspaceSlugReviewsRouteWithChildren
   '/workspaces/new/github': typeof AuthenticatedWorkspacesNewGithubRoute
   '/workspaces/new/gitlab': typeof AuthenticatedWorkspacesNewGitlabRoute
   '/admin/catalog/': typeof AuthenticatedAdminCatalogIndexRoute
@@ -781,6 +789,7 @@ export interface FileRoutesById {
   '/_authenticated/w/$workspaceSlug/admin': typeof AuthenticatedWWorkspaceSlugAdminRouteRouteWithChildren
   '/_authenticated/w/$workspaceSlug/achievements': typeof AuthenticatedWWorkspaceSlugAchievementsRoute
   '/_authenticated/w/$workspaceSlug/mentor': typeof AuthenticatedWWorkspaceSlugMentorRouteWithChildren
+  '/_authenticated/w/$workspaceSlug/reviews': typeof AuthenticatedWWorkspaceSlugReviewsRouteWithChildren
   '/_authenticated/workspaces/new/github': typeof AuthenticatedWorkspacesNewGithubRoute
   '/_authenticated/workspaces/new/gitlab': typeof AuthenticatedWorkspacesNewGitlabRoute
   '/_authenticated/admin/catalog/': typeof AuthenticatedAdminCatalogIndexRoute
@@ -866,6 +875,7 @@ export interface FileRouteTypes {
     | '/w/$workspaceSlug/admin'
     | '/w/$workspaceSlug/achievements'
     | '/w/$workspaceSlug/mentor'
+    | '/w/$workspaceSlug/reviews'
     | '/workspaces/new/github'
     | '/workspaces/new/gitlab'
     | '/admin/catalog/'
@@ -1023,6 +1033,7 @@ export interface FileRouteTypes {
     | '/_authenticated/w/$workspaceSlug/admin'
     | '/_authenticated/w/$workspaceSlug/achievements'
     | '/_authenticated/w/$workspaceSlug/mentor'
+    | '/_authenticated/w/$workspaceSlug/reviews'
     | '/_authenticated/workspaces/new/github'
     | '/_authenticated/workspaces/new/gitlab'
     | '/_authenticated/admin/catalog/'
@@ -1305,6 +1316,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedWWorkspaceSlugMentorRouteImport
       parentRoute: typeof AuthenticatedWWorkspaceSlugRouteRoute
     }
+    '/_authenticated/w/$workspaceSlug/reviews': {
+      id: '/_authenticated/w/$workspaceSlug/reviews'
+      path: '/reviews'
+      fullPath: '/w/$workspaceSlug/reviews'
+      preLoaderRoute: typeof AuthenticatedWWorkspaceSlugReviewsRouteImport
+      parentRoute: typeof AuthenticatedWWorkspaceSlugRouteRoute
+    }
     '/_authenticated/workspaces/new/': {
       id: '/_authenticated/workspaces/new/'
       path: '/workspaces/new'
@@ -1440,10 +1458,10 @@ declare module '@tanstack/react-router' {
     }
     '/_authenticated/w/$workspaceSlug/reviews/': {
       id: '/_authenticated/w/$workspaceSlug/reviews/'
-      path: '/reviews'
+      path: '/'
       fullPath: '/w/$workspaceSlug/reviews/'
       preLoaderRoute: typeof AuthenticatedWWorkspaceSlugReviewsIndexRouteImport
-      parentRoute: typeof AuthenticatedWWorkspaceSlugRouteRoute
+      parentRoute: typeof AuthenticatedWWorkspaceSlugReviewsRoute
     }
     '/_authenticated/w/$workspaceSlug/teams/': {
       id: '/_authenticated/w/$workspaceSlug/teams/'
@@ -1545,10 +1563,10 @@ declare module '@tanstack/react-router' {
     }
     '/_authenticated/w/$workspaceSlug/reviews/$artifactKind/$artifactId': {
       id: '/_authenticated/w/$workspaceSlug/reviews/$artifactKind/$artifactId'
-      path: '/reviews/$artifactKind/$artifactId'
+      path: '/$artifactKind/$artifactId'
       fullPath: '/w/$workspaceSlug/reviews/$artifactKind/$artifactId'
       preLoaderRoute: typeof AuthenticatedWWorkspaceSlugReviewsArtifactKindArtifactIdRouteImport
-      parentRoute: typeof AuthenticatedWWorkspaceSlugRouteRoute
+      parentRoute: typeof AuthenticatedWWorkspaceSlugReviewsRoute
     }
     '/_authenticated/w/$workspaceSlug/user/$username/': {
       id: '/_authenticated/w/$workspaceSlug/user/$username/'
@@ -1940,14 +1958,31 @@ const AuthenticatedWWorkspaceSlugMentorRouteWithChildren =
     AuthenticatedWWorkspaceSlugMentorRouteChildren,
   )
 
+interface AuthenticatedWWorkspaceSlugReviewsRouteChildren {
+  AuthenticatedWWorkspaceSlugReviewsIndexRoute: typeof AuthenticatedWWorkspaceSlugReviewsIndexRoute
+  AuthenticatedWWorkspaceSlugReviewsArtifactKindArtifactIdRoute: typeof AuthenticatedWWorkspaceSlugReviewsArtifactKindArtifactIdRoute
+}
+
+const AuthenticatedWWorkspaceSlugReviewsRouteChildren: AuthenticatedWWorkspaceSlugReviewsRouteChildren =
+  {
+    AuthenticatedWWorkspaceSlugReviewsIndexRoute:
+      AuthenticatedWWorkspaceSlugReviewsIndexRoute,
+    AuthenticatedWWorkspaceSlugReviewsArtifactKindArtifactIdRoute:
+      AuthenticatedWWorkspaceSlugReviewsArtifactKindArtifactIdRoute,
+  }
+
+const AuthenticatedWWorkspaceSlugReviewsRouteWithChildren =
+  AuthenticatedWWorkspaceSlugReviewsRoute._addFileChildren(
+    AuthenticatedWWorkspaceSlugReviewsRouteChildren,
+  )
+
 interface AuthenticatedWWorkspaceSlugRouteRouteChildren {
   AuthenticatedWWorkspaceSlugAdminRouteRoute: typeof AuthenticatedWWorkspaceSlugAdminRouteRouteWithChildren
   AuthenticatedWWorkspaceSlugAchievementsRoute: typeof AuthenticatedWWorkspaceSlugAchievementsRoute
   AuthenticatedWWorkspaceSlugMentorRoute: typeof AuthenticatedWWorkspaceSlugMentorRouteWithChildren
+  AuthenticatedWWorkspaceSlugReviewsRoute: typeof AuthenticatedWWorkspaceSlugReviewsRouteWithChildren
   AuthenticatedWWorkspaceSlugIndexRoute: typeof AuthenticatedWWorkspaceSlugIndexRoute
-  AuthenticatedWWorkspaceSlugReviewsIndexRoute: typeof AuthenticatedWWorkspaceSlugReviewsIndexRoute
   AuthenticatedWWorkspaceSlugTeamsIndexRoute: typeof AuthenticatedWWorkspaceSlugTeamsIndexRoute
-  AuthenticatedWWorkspaceSlugReviewsArtifactKindArtifactIdRoute: typeof AuthenticatedWWorkspaceSlugReviewsArtifactKindArtifactIdRoute
   AuthenticatedWWorkspaceSlugUserUsernameAchievementsRoute: typeof AuthenticatedWWorkspaceSlugUserUsernameAchievementsRoute
   AuthenticatedWWorkspaceSlugUserUsernameIndexRoute: typeof AuthenticatedWWorkspaceSlugUserUsernameIndexRoute
   AuthenticatedWWorkspaceSlugUserUsernamePracticeGroupsGroupSlugRoute: typeof AuthenticatedWWorkspaceSlugUserUsernamePracticeGroupsGroupSlugRoute
@@ -1961,14 +1996,12 @@ const AuthenticatedWWorkspaceSlugRouteRouteChildren: AuthenticatedWWorkspaceSlug
       AuthenticatedWWorkspaceSlugAchievementsRoute,
     AuthenticatedWWorkspaceSlugMentorRoute:
       AuthenticatedWWorkspaceSlugMentorRouteWithChildren,
+    AuthenticatedWWorkspaceSlugReviewsRoute:
+      AuthenticatedWWorkspaceSlugReviewsRouteWithChildren,
     AuthenticatedWWorkspaceSlugIndexRoute:
       AuthenticatedWWorkspaceSlugIndexRoute,
-    AuthenticatedWWorkspaceSlugReviewsIndexRoute:
-      AuthenticatedWWorkspaceSlugReviewsIndexRoute,
     AuthenticatedWWorkspaceSlugTeamsIndexRoute:
       AuthenticatedWWorkspaceSlugTeamsIndexRoute,
-    AuthenticatedWWorkspaceSlugReviewsArtifactKindArtifactIdRoute:
-      AuthenticatedWWorkspaceSlugReviewsArtifactKindArtifactIdRoute,
     AuthenticatedWWorkspaceSlugUserUsernameAchievementsRoute:
       AuthenticatedWWorkspaceSlugUserUsernameAchievementsRoute,
     AuthenticatedWWorkspaceSlugUserUsernameIndexRoute:

--- a/webapp/src/routes/_authenticated/w/$workspaceSlug/reviews.tsx
+++ b/webapp/src/routes/_authenticated/w/$workspaceSlug/reviews.tsx
@@ -1,0 +1,47 @@
+import { createFileRoute, Navigate, Outlet } from "@tanstack/react-router";
+
+import { QueryErrorAlert } from "@/components/common/QueryErrorAlert";
+import { Spinner } from "@/components/ui/spinner";
+import { useWorkspaceFeatures } from "@/hooks/use-workspace-features";
+
+export const Route = createFileRoute("/_authenticated/w/$workspaceSlug/reviews")({
+	component: ReviewActivityLayout,
+});
+
+/**
+ * Review activity exists only where practices review the work, so a workspace with practice reviews
+ * off does not have this surface at all — the sidebar drops the entry and a link kept from before,
+ * or from another workspace, lands on the workspace home rather than on a page that can only
+ * explain itself.
+ */
+function ReviewActivityLayout() {
+	const { workspaceSlug } = Route.useParams();
+	const featureState = useWorkspaceFeatures(workspaceSlug);
+	const practicesEnabled = featureState.features?.practicesEnabled;
+
+	if (featureState.isError) {
+		return (
+			<QueryErrorAlert
+				error={featureState.error}
+				title="Couldn't load workspace features"
+				onRetry={featureState.refetch}
+			/>
+		);
+	}
+
+	// Only a definite "off" redirects: sending someone away before the answer arrives would bounce
+	// them out of a workspace that does review practices.
+	if (practicesEnabled === false) {
+		return <Navigate to="/w/$workspaceSlug" params={{ workspaceSlug }} replace />;
+	}
+
+	if (featureState.isLoading || practicesEnabled !== true) {
+		return (
+			<div className="flex min-h-0 flex-1 items-center justify-center">
+				<Spinner className="h-8 w-8" />
+			</div>
+		);
+	}
+
+	return <Outlet />;
+}

--- a/webapp/src/routes/_authenticated/w/$workspaceSlug/reviews/-route.test.tsx
+++ b/webapp/src/routes/_authenticated/w/$workspaceSlug/reviews/-route.test.tsx
@@ -7,8 +7,9 @@ import {
 	tracedArtifactPage,
 	tracedArtifacts,
 } from "@/components/practice-trace/story-mock-data";
+import { workspaceListItem } from "@/mocks/fixtures/workspaces";
 import { server } from "@/mocks/server";
-import { ROUTE_RENDER_WAIT, renderRouteAt } from "@/test/router-harness";
+import { ROUTE_RENDER_WAIT, renderRouteAt, renderRouteAtWithRouter } from "@/test/router-harness";
 
 // Mounting the real route pulls in the whole app shell and its lazy modules.
 vi.setConfig({ testTimeout: 15_000 });
@@ -18,6 +19,11 @@ beforeEach(() => {
 		// A plain MEMBER: this surface is deliberately not behind the admin layout's role guard.
 		http.get("*/workspaces/:workspaceSlug/members/me", () =>
 			HttpResponse.json({ role: "MEMBER", userId: 1, userLogin: "ada", userName: "Ada" }),
+		),
+		// The surface exists only where practices review the work, and the shared fixture has them
+		// off, so every case below has to say that this workspace reviews.
+		http.get("*/workspaces", () =>
+			HttpResponse.json([workspaceListItem("acme", { practicesEnabled: true })]),
 		),
 		http.get("*/workspaces/:workspaceSlug/practices/trace", () =>
 			HttpResponse.json(tracedArtifactPage()),
@@ -29,6 +35,22 @@ beforeEach(() => {
 });
 
 describe("review activity routes", () => {
+	it("sends a reader away when this workspace does not review practices", async () => {
+		server.use(
+			http.get("*/workspaces", () =>
+				HttpResponse.json([workspaceListItem("acme", { practicesEnabled: false })]),
+			),
+		);
+		const { router } = renderRouteAtWithRouter("/w/acme/reviews");
+
+		// With practices off the surface does not exist here, so the reader ends up on the workspace
+		// home rather than on a page whose only content could be an explanation of its own emptiness.
+		await vi.waitFor(
+			() => expect(router.state.location.pathname).toBe("/w/acme"),
+			ROUTE_RENDER_WAIT,
+		);
+	});
+
 	it("lists recorded work for a member", async () => {
 		renderRouteAt("/w/acme/reviews");
 

--- a/webapp/src/routes/_authenticated/w/$workspaceSlug/reviews/-trace-detail-route.test.tsx
+++ b/webapp/src/routes/_authenticated/w/$workspaceSlug/reviews/-trace-detail-route.test.tsx
@@ -4,6 +4,7 @@ import { HttpResponse, http } from "msw";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { artifactTrace } from "@/components/practice-trace/story-mock-data";
+import { workspaceListItem } from "@/mocks/fixtures/workspaces";
 import { server } from "@/mocks/server";
 import { ROUTE_RENDER_WAIT, renderRouteAt } from "@/test/router-harness";
 
@@ -27,6 +28,10 @@ beforeEach(() => {
 		// A plain MEMBER: this surface is deliberately not behind the admin layout's role guard.
 		http.get("*/workspaces/:workspaceSlug/members/me", () =>
 			HttpResponse.json({ role: "MEMBER", userId: 1, userLogin: "ada", userName: "Ada" }),
+		),
+		// This surface exists only where practices review the work; the shared fixture has them off.
+		http.get("*/workspaces", () =>
+			HttpResponse.json([workspaceListItem("acme", { practicesEnabled: true })]),
 		),
 		http.get(TRACE_PATH, () => {
 			traceReads += 1;

--- a/webapp/src/routes/_authenticated/w/$workspaceSlug/reviews/index.tsx
+++ b/webapp/src/routes/_authenticated/w/$workspaceSlug/reviews/index.tsx
@@ -4,7 +4,6 @@ import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { listTracedArtifactsOptions } from "@/api/@tanstack/react-query.gen";
 import { type TraceSearch, traceSearchSchema } from "@/components/practice-trace/trace-search";
 import { TRACE_PAGE_SIZE, TraceListPage } from "@/components/practice-trace/TraceListPage";
-import { useWorkspaceFeatures } from "@/hooks/use-workspace-features";
 import { pageParam } from "@/lib/search-params";
 
 export const Route = createFileRoute("/_authenticated/w/$workspaceSlug/reviews/")({
@@ -14,7 +13,6 @@ export const Route = createFileRoute("/_authenticated/w/$workspaceSlug/reviews/"
 
 function ReviewActivityListRoute() {
 	const { workspaceSlug } = Route.useParams();
-	const featureState = useWorkspaceFeatures(workspaceSlug);
 	const search = Route.useSearch();
 	const navigate = useNavigate({ from: Route.fullPath });
 	const updateSearch = (patch: Partial<TraceSearch>) =>
@@ -42,7 +40,6 @@ function ReviewActivityListRoute() {
 			isLoading={query.isLoading}
 			error={query.isError ? query.error : undefined}
 			onRetry={() => void query.refetch()}
-			practicesEnabled={featureState.features?.practicesEnabled}
 		/>
 	);
 }


### PR DESCRIPTION
## Problem

The Review activity sidebar entry and its pages were reachable whatever the workspace was configured to do. That was deliberate, and the code said so:

> *Deliberately not feature-gated: with practices off the page says so, which is the answer a developer wondering why nothing was said came for.*

The maintainer's call is the other way: a workspace that does not review practices should not offer the surface at all.

## Change

- The sidebar entry is gated on `practicesEnabled`, and the comment asserting the opposite is gone.
- A `reviews.tsx` layout route guards the list **and** the trace detail beneath it, mirroring `mentor.tsx`:
  - a definite `false` redirects to the workspace home,
  - an unresolved answer waits, so nobody is bounced out of a workspace that *does* review while the lookup is in flight,
  - a failed lookup reports itself rather than silently choosing a side.
- The disabled-state notice from #1975 is removed. It explained a state the page can no longer be reached in, so keeping it would have left unreachable copy behind.

## Verification

- `reviews/-route.test.tsx` — 5 passing, including a new case asserting the redirect by **destination** (`router.state.location.pathname` is `/w/acme`) rather than by the absence of a heading.
- `NavDashboards.stories.tsx` — 4 passing; `PracticeReviewsOff` and `AllFeaturesDisabled` assert the entry is gone while Profile and Teams, which are not workspace capabilities, stay.
- The shared workspace fixture has `practicesEnabled: false`, so both reviews route test files now state that the workspace reviews — which is what surfaced the guard working.
- `typecheck:webapp` and `check:webapp` clean.

Three cases in `-trace-detail-route.test.tsx` fail on my machine, and fail identically on a clean `origin/main` checkout — part of a local-only divergence from CI I am tracking separately. CI runs them green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Review activity is now shown in the workspace sidebar only when practice reviews are enabled.
  - Direct links to review activity in workspaces without practice reviews now redirect to the workspace home.
  - Review activity routes are organized under a dedicated workspace path.

- **Bug Fixes**
  - Prevented users from landing on an empty review activity page when the feature is unavailable.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->