### PR TITLE
fix: harden review execution, credential recovery, and navigation

### DIFF
--- a/.changeset/account-export-failure-recovery.md
+++ b/.changeset/account-export-failure-recovery.md
@@ -1,0 +1,5 @@
+---
+"hephaestus": patch
+---
+
+Account exports now record a failed attempt after a database transaction rolls back, instead of remaining queued or processing when generation fails. Successful exports are counted only after their data commits.

--- a/.changeset/custom-gitlab-signin-icon.md
+++ b/.changeset/custom-gitlab-signin-icon.md
@@ -1,0 +1,5 @@
+---
+"hephaestus": patch
+---
+
+GitLab sign-in options show the GitLab icon even when their login provider has a custom registration name.

--- a/.changeset/issue-title-echo-classification.md
+++ b/.changeset/issue-title-echo-classification.md
@@ -1,0 +1,5 @@
+---
+"hephaestus": patch
+---
+
+Practice reviews no longer treat a substantive issue body as a repetition of its title solely because the title is missing, empty, or contains no Latin letters or digits.

--- a/.changeset/keep-short-review-timeouts-bounded.md
+++ b/.changeset/keep-short-review-timeouts-bounded.md
@@ -1,0 +1,5 @@
+---
+"hephaestus": patch
+---
+
+Short practice-review timeouts now reserve time for the review to finish and save its result before the sandbox deadline, instead of extending the work budget beyond the available shutdown time.

--- a/.changeset/post-merge-internal-cleanup.md
+++ b/.changeset/post-merge-internal-cleanup.md
@@ -1,0 +1,4 @@
+---
+---
+
+Remove unreachable landing-page states, redundant query defaults and workspace lookups, duplicated issue classification, unused sandbox configuration, and a test-only credential setter. These internal cleanups preserve reachable UI behavior and practice-review guidance.

--- a/.changeset/practice-review-setup-recovery.md
+++ b/.changeset/practice-review-setup-recovery.md
@@ -1,0 +1,5 @@
+---
+"hephaestus": patch
+---
+
+Practice reviews continue when a preparation step fails. Completed observations are preserved, and practices that could not be reviewed remain explicitly unevaluated.

--- a/.changeset/profile-activity-recovery.md
+++ b/.changeset/profile-activity-recovery.md
@@ -3,3 +3,5 @@
 ---
 
 Profiles now show a retry action when workspace settings or activity cannot load, instead of silently showing missing activity. The loaded developer profile remains visible.
+
+Changing an activity filter now shows loading placeholders instead of presenting the previous range’s results under the new selection.

--- a/.changeset/profile-activity-recovery.md
+++ b/.changeset/profile-activity-recovery.md
@@ -1,0 +1,5 @@
+---
+"hephaestus": patch
+---
+
+Profiles now show a retry action when workspace settings or activity cannot load, instead of silently showing missing activity. The loaded developer profile remains visible.

--- a/.changeset/replace-unreadable-scm-tokens.md
+++ b/.changeset/replace-unreadable-scm-tokens.md
@@ -1,0 +1,5 @@
+---
+"hephaestus": patch
+---
+
+Workspace administrators can replace GitHub and GitLab personal access tokens directly from the integration page, restoring connections whose stored token can no longer be read without removing repositories or synced work.

--- a/.changeset/reset-outline-connection-drafts.md
+++ b/.changeset/reset-outline-connection-drafts.md
@@ -1,0 +1,5 @@
+---
+"hephaestus": patch
+---
+
+Outline connection forms no longer carry a previously entered server URL or token into another workspace or a new connection.

--- a/.changeset/retry-keeps-its-reserved-slice.md
+++ b/.changeset/retry-keeps-its-reserved-slice.md
@@ -1,0 +1,5 @@
+---
+"hephaestus": patch
+---
+
+Keeps the recovery pass for practices nothing observed when the first pass runs long. The pass that retries them was being given the review time left unspent, which is none after an overrun — so on exactly the slow reviews where practices are most likely still unobserved, no retry ran at all, even with minutes left before the review's deadline. It now keeps the share reserved for it whenever that time genuinely exists, and is skipped only when it does not.

--- a/.changeset/review-deadline-preservation.md
+++ b/.changeset/review-deadline-preservation.md
@@ -1,0 +1,5 @@
+---
+"hephaestus": patch
+---
+
+Practice reviews no longer start another analysis or composition turn after its available time has expired. Admitted observations remain available for delivery if feedback composition cannot start or finish.

--- a/.changeset/review-output-paths.md
+++ b/.changeset/review-output-paths.md
@@ -1,0 +1,5 @@
+---
+"hephaestus": patch
+---
+
+Practice review output archives reject nested path traversal and ambiguous file paths.

--- a/.changeset/review-profile-navigation.md
+++ b/.changeset/review-profile-navigation.md
@@ -1,0 +1,5 @@
+---
+"hephaestus": patch
+---
+
+Keep review requests and profile data tied to the work and developer currently open, even when you navigate while a request is running. Bookmarked practice-group pages now respect disabled practice reviews, filters preserve your scroll position and bookmarked custom dates survive Back navigation, and responding to feedback refreshes the group's cached review filters.

--- a/.changeset/session-activity-renewal.md
+++ b/.changeset/session-activity-renewal.md
@@ -1,0 +1,5 @@
+---
+"hephaestus": patch
+---
+
+Active sessions renew reliably when you resume activity after an idle renewal check. Inactive sessions still expire normally.

--- a/.changeset/timeframe-bookmark-preservation.md
+++ b/.changeset/timeframe-bookmark-preservation.md
@@ -1,0 +1,5 @@
+---
+"hephaestus": patch
+---
+
+Opening a bookmarked leaderboard interval or using Back preserves its exact dates instead of silently resetting them. Custom dates near weekly and monthly boundaries remain editable, and All time is recognized consistently across time zones.

--- a/.changeset/trace-requires-recorded-coverage.md
+++ b/.changeset/trace-requires-recorded-coverage.md
@@ -1,0 +1,5 @@
+---
+"hephaestus": patch
+---
+
+Practice review activity no longer reports an all-clear when a completed review has no record of whether it reached a practice. Existing observations remain visible, and missing coverage is explained separately from practices the review explicitly did not reach.

--- a/.changeset/workspace-integration-state-isolation.md
+++ b/.changeset/workspace-integration-state-isolation.md
@@ -1,0 +1,5 @@
+---
+"hephaestus": patch
+---
+
+Switching workspaces now resets integration job-history pages and pending form state. A token replacement still refreshes the workspace it was submitted for, without disabling another workspace's token form or showing its previous job history.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -242,7 +242,6 @@ Oxlint lints; oxfmt formats and sorts imports. Each tree states its rule set in 
   attribution to pull request titles or bodies.
 - UI changes need before/after images; motion or timing needs a short video. Never commit PR-only
   evidence; `/land-pr` owns its preparation and upload.
-- One concern per PR. If the description says "also", split it.
 - A PR that changes shipped code ships a changeset — `.changeset/README.md` is the contract. With no
   TTY, hand-write `.changeset/<slug>.md` in the shape shown there; `verify-changesets` fails the PR
   without one and rejects `major` before 1.0. The summary is a release note in the operator's or
@@ -281,8 +280,7 @@ change that ships, never a measurement or a verdict alone.
 - Comments say what the code cannot — a constraint, a platform behaviour, a rejected alternative —
   and move when the code moves. Nothing in them is a run number, a measured duration or an
   incident. Deleting one of these needs the same justification as adding one: either the code now
-  says it, or it moved to its one home. A pass that strips comments across files is its own pull
-  request, never a rider on a fix.
+  says it, or it moved to its one home.
 - Our users read feedback about their own work. A wrong claim, a stale label or a lying spinner
   costs trust that a fast fix does not buy back.
 

--- a/docker/agents/precompute/lib/issue-classification.ts
+++ b/docker/agents/precompute/lib/issue-classification.ts
@@ -1,0 +1,30 @@
+export interface IssueMetadata {
+	title?: string;
+	body?: string;
+	issue_type?: string | null;
+	labels?: string[];
+}
+
+export function classifyIssue(metadata: IssueMetadata) {
+	const body = (metadata.body ?? "").trim();
+	const title = (metadata.title ?? "").trim();
+	const issueType = (metadata.issue_type ?? "").toLowerCase();
+	const labels = (metadata.labels ?? []).map((label) => label.toLowerCase());
+
+	const norm = (s: string) => s.toLowerCase().replace(/[^a-z0-9]/g, "");
+	const titleNorm = norm(title);
+	const bodyNorm = norm(body);
+	const titleEcho =
+		bodyNorm.length > 0 &&
+		(bodyNorm === titleNorm || titleNorm.includes(bodyNorm) || bodyNorm.includes(titleNorm));
+	const emptyOrTitleEcho = body.length < 25 || titleEcho;
+	const deliverableType =
+		/\b(user ?story|story|bug|defect|feature|enhancement|task|chore|requirement|artifact|epic|spike)\b/;
+	const hasDeliverableType =
+		deliverableType.test(issueType) || labels.some((l) => deliverableType.test(l));
+	const looksUmbrella =
+		labels.some((l) => /\b(epic|umbrella|meta|initiative|requirement)\b/.test(l)) ||
+		/\b(epic|umbrella|initiative)\b/i.test(title);
+
+	return { body, title, issueType, labels, emptyOrTitleEcho, hasDeliverableType, looksUmbrella };
+}

--- a/docker/agents/precompute/lib/issue-classification.ts
+++ b/docker/agents/precompute/lib/issue-classification.ts
@@ -15,6 +15,7 @@ export function classifyIssue(metadata: IssueMetadata) {
 	const titleNorm = norm(title);
 	const bodyNorm = norm(body);
 	const titleEcho =
+		titleNorm.length > 0 &&
 		bodyNorm.length > 0 &&
 		(bodyNorm === titleNorm || titleNorm.includes(bodyNorm) || bodyNorm.includes(titleNorm));
 	const emptyOrTitleEcho = body.length < 25 || titleEcho;

--- a/docker/agents/precompute/scripts.test.ts
+++ b/docker/agents/precompute/scripts.test.ts
@@ -145,6 +145,38 @@ void describe("issue classification across practices", () => {
 			looksUmbrella: 1,
 		},
 		{
+			name: "substantive body with an omitted title",
+			metadata: {
+				body: "The PDF contains overlapping text when a customer's address spans more than three lines.",
+				labels: ["BUG"],
+			},
+			emptyOrTitleEcho: 0,
+			hasDeliverableType: 1,
+			looksUmbrella: 0,
+		},
+		{
+			name: "substantive body with an empty title",
+			metadata: {
+				title: "",
+				body: "The PDF contains overlapping text when a customer's address spans more than three lines.",
+				labels: ["BUG"],
+			},
+			emptyOrTitleEcho: 0,
+			hasDeliverableType: 1,
+			looksUmbrella: 0,
+		},
+		{
+			name: "substantive body with a non-Latin title",
+			metadata: {
+				title: "报告",
+				body: "The PDF contains overlapping text when a customer's address spans more than three lines.",
+				labels: ["BUG"],
+			},
+			emptyOrTitleEcho: 0,
+			hasDeliverableType: 1,
+			looksUmbrella: 0,
+		},
+		{
 			name: "substantive untyped issue",
 			metadata: {
 				title: "Unreadable invoice",

--- a/docker/agents/precompute/scripts.test.ts
+++ b/docker/agents/precompute/scripts.test.ts
@@ -106,3 +106,77 @@ void describe("ships-tests-with-the-change", () => {
 		assert.ok(result.directions.join(" ").includes("WORKTREE NOT VISIBLE"));
 	});
 });
+
+void describe("issue classification across practices", () => {
+	const names = [
+		"issue-has-checkable-outcome",
+		"issue-states-an-actionable-problem",
+		"issue-scoped-to-single-concern",
+	];
+
+	for (const { name, metadata, emptyOrTitleEcho, hasDeliverableType, looksUmbrella } of [
+		{
+			name: "empty deliverable",
+			metadata: { title: "Export billing reports", labels: ["FEATURE"] },
+			emptyOrTitleEcho: 1,
+			hasDeliverableType: 1,
+			looksUmbrella: 0,
+		},
+		{
+			name: "title repeated with different punctuation",
+			metadata: {
+				title: "Export billing reports to CSV",
+				body: "EXPORT billing reports: to CSV!",
+				issue_type: "Task",
+			},
+			emptyOrTitleEcho: 1,
+			hasDeliverableType: 1,
+			looksUmbrella: 0,
+		},
+		{
+			name: "substantive umbrella",
+			metadata: {
+				title: "Billing improvements",
+				body: "Split the invoice work into independently deliverable child issues with their own acceptance criteria.",
+				labels: ["REQUIREMENT"],
+			},
+			emptyOrTitleEcho: 0,
+			hasDeliverableType: 1,
+			looksUmbrella: 1,
+		},
+		{
+			name: "substantive untyped issue",
+			metadata: {
+				title: "Unreadable invoice",
+				body: "The PDF contains overlapping text when a customer's address spans more than three lines.",
+			},
+			emptyOrTitleEcho: 0,
+			hasDeliverableType: 0,
+			looksUmbrella: 0,
+		},
+	]) {
+		void it(`preserves shared facts for a ${name}`, async () => {
+			for (const scriptName of names) {
+				const run = await loadScript(scriptName);
+				const result = await run("", new Map(), metadata);
+				assert.equal(result.metrics.emptyOrTitleEcho, emptyOrTitleEcho, scriptName);
+				assert.deepEqual(result.hints, [], scriptName);
+				if (scriptName !== "issue-scoped-to-single-concern") {
+					assert.equal(result.metrics.hasDeliverableType, hasDeliverableType, scriptName);
+					assert.equal(result.metrics.looksUmbrella, looksUmbrella, scriptName);
+				}
+				if (
+					scriptName === "issue-states-an-actionable-problem" &&
+					emptyOrTitleEcho &&
+					hasDeliverableType
+				) {
+					assert.ok(
+						result.directions.some((direction) =>
+							direction.includes("investigate whether a maintainer can actually act on it."),
+						),
+					);
+				}
+			}
+		});
+	}
+});

--- a/docs/admin/credential-key-rotation.mdx
+++ b/docs/admin/credential-key-rotation.mdx
@@ -50,6 +50,7 @@ Stop if the result contains an unexpected version.
 
    Rotation is complete when `pending` is zero. Do not remove the prior key while `undecryptable` is
    nonzero unless every affected integration credential has been replaced.
+
 6. Disable rotation and repeat the provider checks. Deploy every runtime without the prior key and
    version.
 
@@ -98,7 +99,9 @@ Re-enable rotation only after the update is applied.
 
 If the ciphertext is corrupt or its key is permanently unavailable, replace the credential. For Slack
 and Outline, disconnect the integration in workspace administration and connect it again. For a
-GitHub or GitLab personal access token, submit the replacement as a workspace administrator to
+GitHub or GitLab personal access token, open **Workspace administration → Integrations**, choose **GitHub** or **GitLab**,
+and use **Personal access token → Replace token**. This keeps the monitored repositories and synced
+work. The same operation is available to workspace administrators through
 `PATCH /api/workspaces/{workspaceSlug}/token`. Writing a replacement clears the marker. Confirm the
 provider request succeeds and rerun the verification query before removing the prior key. Never clear
 the marker repeatedly without correcting the credential: that recreates a retry loop and alert noise.

--- a/docs/admin/observability.mdx
+++ b/docs/admin/observability.mdx
@@ -51,6 +51,10 @@ deployment that reports it every day never finishes deleting. Account, workspace
 identifiers are not labels. The erasure and retention paths these cover are listed in the
 [personal-data map](./dsms/personal-data-map.md).
 
+For export generation, `success` and the affected count are published only after the export commits.
+A failed attempt reports `failure` even if the database is unavailable and cannot save the failed
+status; consult the server log when an export remains queued or processing after a reported failure.
+
 ## Correlating a request
 
 Every HTTP response carries an `X-Request-Id` header whose value is the request's W3C trace ID — a

--- a/docs/admin/pull-based-deployment.mdx
+++ b/docs/admin/pull-based-deployment.mdx
@@ -11,10 +11,10 @@ digest-pinned Compose stacks. Deployment needs no inbound administration connect
 
 For a release deployment, the host verifies two signatures:
 
-| Artifact | Signed by | Answers |
-| --- | --- | --- |
-| The channel (`channels/<env>.json`) | the promotion workflow | *may this host move, and who said so* |
-| The release lock (`release-<version>.json`) | the release workflow | *which source commit and image digests are this release* |
+| Artifact                                    | Signed by              | Answers                                                  |
+| ------------------------------------------- | ---------------------- | -------------------------------------------------------- |
+| The channel (`channels/<env>.json`)         | the promotion workflow | *may this host move, and who said so*                    |
+| The release lock (`release-<version>.json`) | the release workflow   | *which source commit and image digests are this release* |
 
 The host rejects a new channel commit that does not descend from its last accepted channel commit.
 It also rejects lower release versions and older commits unless `allowRollback` is set. These checks
@@ -26,11 +26,11 @@ do not order manual transitions between releases and commits; choose those targe
 { "release": "v1.2.3", "allowRollback": false, "freeze": false }
 ```
 
-| Field | Effect |
-| --- | --- |
-| `release` | the `vX.Y.Z` release to apply when not frozen |
-| `allowRollback` | permits one deliberate move backwards |
-| `freeze` | holds the environment where it is, for an incident |
+| Field           | Effect                                             |
+| --------------- | -------------------------------------------------- |
+| `release`       | the `vX.Y.Z` release to apply when not frozen      |
+| `allowRollback` | permits one deliberate move backwards              |
+| `freeze`        | holds the environment where it is, for an incident |
 
 Staging can follow successful builds of `main` instead of releases. Its channel names a full
 `commit` SHA instead of `release`, plus an `images` map of digest-pinned references and a
@@ -96,24 +96,32 @@ nothing about pull-based deployment changes them. The per-stack files in `/etc/h
 to the Compose installer — so carry these over from the previous deployment before the first
 reconcile:
 
-| Setting | What it must be |
-| --- | --- |
-| `HEPHAESTUS_SECURITY_ENCRYPTION_KEY` | the previous deployment's value: what the server encrypts at rest other than integration credentials was written with it |
-| `HEPHAESTUS_SECURITY_CREDENTIAL_ENCRYPTION_KEY` | the previous deployment's value, or the master key on an installation that never set it separately: integration credentials were written with it, and a different key makes them unreadable without a word of warning |
+| Setting                                                                                                                                                                                                                          | What it must be                                                                                                                                                                                                             |
+| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `HEPHAESTUS_SECURITY_ENCRYPTION_KEY`                                                                                                                                                                                             | the previous deployment's value: what the server encrypts at rest other than integration credentials was written with it                                                                                                    |
+| `HEPHAESTUS_SECURITY_CREDENTIAL_ENCRYPTION_KEY`                                                                                                                                                                                  | the previous deployment's value, or the master key on an installation that never set it separately: integration credentials were written with it, and a different key makes them unreadable without a word of warning       |
 | `HEPHAESTUS_SECURITY_CREDENTIAL_ROTATION_ENABLED`, `HEPHAESTUS_SECURITY_CREDENTIAL_ENCRYPTION_KEY_VERSION`, `HEPHAESTUS_SECURITY_PRIOR_CREDENTIAL_ENCRYPTION_KEY`, `HEPHAESTUS_SECURITY_PRIOR_CREDENTIAL_ENCRYPTION_KEY_VERSION` | whatever the previous deployment set, if it rotated credential keys: each stored credential names the key version that wrote it, and a credential written under the prior key is readable only while that key is configured |
-| `WEBHOOK_SECRET` | what the providers were registered to sign with |
-| `HEPHAESTUS_AUTH_STATE_COOKIE_KEY` | optional; a new one only invalidates sign-ins that are in flight at the moment of the switch |
+| `WEBHOOK_SECRET`                                                                                                                                                                                                                 | what the providers were registered to sign with                                                                                                                                                                             |
+| `HEPHAESTUS_AUTH_STATE_COOKIE_KEY`                                                                                                                                                                                               | optional; a new one only invalidates sign-ins that are in flight at the moment of the switch                                                                                                                                |
 
-A host that also brings its own edge keeps its certificates in the `proxy_letsencrypt` volume. Copy
-the previous deployment's `acme.json` into it before the first reconcile, or Traefik issues the
-certificates again on first start:
+A host that also brings its own edge keeps its certificates in the `proxy_letsencrypt` volume. Before
+reconciling a host that used the old bind mount, pause the timer and stop its existing Traefik container
+so the ACME store cannot change during the copy. Back up that `acme.json` first; in a release worktree
+it is under `docker/letsencrypt/`. Copy it into the volume before starting the new proxy, or Traefik
+issues the certificates again.
+
+On the Docker Engine host, use the volume's actual mountpoint rather than assuming Docker's data root:
 
 ```bash
 sudo docker volume create proxy_letsencrypt
-sudo cp <previous>/letsencrypt/acme.json \
-  /var/lib/docker/volumes/proxy_letsencrypt/_data/acme.json
-sudo chmod 600 /var/lib/docker/volumes/proxy_letsencrypt/_data/acme.json
+volume_path=$(sudo docker volume inspect --format '{{ .Mountpoint }}' proxy_letsencrypt)
+sudo install -m 600 /path/to/previous/acme.json "$volume_path/acme.json"
 ```
+
+Do not overwrite a populated volume with an older copy. Keep the backup until the new proxy serves
+the existing certificates successfully, then re-enable reconciliation. A rollback to a release whose
+proxy still uses the bind mount needs the current ACME store copied back while Traefik is stopped;
+retaining the old release tree alone does not keep that copy current.
 
 The pull-based stacks use the bundled database with its fixed credentials, so there is no
 database password to carry. On the Compose installer, `docker/self-host/setup.sh` refuses to
@@ -162,16 +170,16 @@ ingress, omit `proxy` and use `core app`.
 
 ## Operating it
 
-| You want to | Do this |
-| --- | --- |
-| Move an environment | Run the **Promote** workflow: pick the environment and release or commit |
-| Roll back | Promote the older release with **allow-rollback** |
-| Hold an environment | Promote with **freeze** |
-| Resume a held environment | Manually promote the desired release or commit with **freeze** cleared |
-| Reapply Compose configuration | Promote the release or commit the host already runs |
-| Move a following host onto the commit's database image | Promote the commit with **refresh-database-image** |
-| Prevent new reconciliation runs | `sudo systemctl disable --now hephaestus-reconcile.timer` |
-| See what a host runs | `cat /var/lib/hephaestus/applied.json` |
+| You want to                                            | Do this                                                                  |
+| ------------------------------------------------------ | ------------------------------------------------------------------------ |
+| Move an environment                                    | Run the **Promote** workflow: pick the environment and release or commit |
+| Roll back                                              | Promote the older release with **allow-rollback**                        |
+| Hold an environment                                    | Promote with **freeze**                                                  |
+| Resume a held environment                              | Manually promote the desired release or commit with **freeze** cleared   |
+| Reapply Compose configuration                          | Promote the release or commit the host already runs                      |
+| Move a following host onto the commit's database image | Promote the commit with **refresh-database-image**                       |
+| Prevent new reconciliation runs                        | `sudo systemctl disable --now hephaestus-reconcile.timer`                |
+| See what a host runs                                   | `cat /var/lib/hephaestus/applied.json`                                   |
 
 :::warning Pause reconciliation before manual changes
 Disable the timer and confirm the service is no longer running with

--- a/scripts/reconcile-deployment.test.ts
+++ b/scripts/reconcile-deployment.test.ts
@@ -1,9 +1,18 @@
 import assert from "node:assert/strict";
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import { readFileSync } from "node:fs";
-import { mkdir, mkdtemp, readFile, readlink, rm, symlink, writeFile } from "node:fs/promises";
+import {
+	copyFile,
+	mkdir,
+	mkdtemp,
+	readFile,
+	readlink,
+	rm,
+	symlink,
+	writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { delimiter, join } from "node:path";
 import { test } from "node:test";
 
 import { parseDocument } from "yaml";
@@ -597,3 +606,265 @@ await test("only a record that kept its commit, or names one, says what tooling 
 		/hephaestus_deploy_tooling_pending 1\n/,
 	);
 });
+
+const reconcilerSubprocess = {
+	skip: process.platform === "win32" && "the systemd host uses POSIX executable stubs",
+};
+
+async function reconcilerFixture(directory: string) {
+	const checkout = join(directory, "checkout");
+	const bootstrap = join(directory, "bootstrap");
+	const units = join(directory, "units");
+	const bin = join(directory, "bin");
+	const callsFile = join(directory, "calls");
+	const metricsFile = join(directory, "deploy.prom");
+	const image = `example.invalid/app@sha256:${"a".repeat(64)}`;
+	const git = (...args: string[]) =>
+		execFileSync("git", args, {
+			cwd: checkout,
+			encoding: "utf8",
+			env: environmentForGitFixture(),
+		}).trim();
+	await Promise.all([checkout, units, bin].map((path) => mkdir(path, { recursive: true })));
+	for (const tree of [checkout, bootstrap]) {
+		await mkdir(join(tree, "scripts/lib"), { recursive: true });
+		await writeFile(join(tree, "package.json"), '{"type":"module"}\n');
+		for (const file of ["reconcile-deployment.ts", "lib/env.ts", "lib/json.ts", "lib/process.ts"])
+			await copyFile(join(import.meta.dirname, file), join(tree, "scripts", file));
+	}
+	const sourceUnits = join(checkout, "docker/self-host/systemd");
+	await mkdir(sourceUnits, { recursive: true });
+	await writeFile(
+		join(sourceUnits, "hephaestus-reconcile.service"),
+		"[Service]\nExecStart=/usr/bin/env node /var/lib/hephaestus/tooling/scripts/reconcile-deployment.ts\n",
+	);
+	await writeFile(
+		join(sourceUnits, "hephaestus-reconcile.timer"),
+		"[Timer]\nOnUnitActiveSec=1min\n",
+	);
+	await writeFile(
+		join(checkout, "scripts/prepare-release-lock.ts"),
+		'throw new Error("candidate release must not verify itself");\n',
+	);
+	git("init", "--quiet", "--initial-branch=main");
+	git("config", "user.email", "host@example.invalid");
+	git("config", "user.name", "host");
+	git("config", "core.autocrlf", "false");
+	git("add", ".");
+	git("commit", "--quiet", "-m", "release");
+	const releaseCommit = git("rev-parse", "HEAD");
+	git("tag", "v1.0.0");
+	git("checkout", "--quiet", "-b", "deploy-state");
+	await mkdir(join(checkout, "channels"));
+	await writeFile(join(checkout, "channels/test.json"), JSON.stringify({ release: "v1.0.0" }));
+	await writeFile(join(checkout, "channels/test.json.sigstore.json"), "{}\n");
+	git("add", "channels");
+	git("commit", "--quiet", "-m", "promotion");
+	const channelCommit = git("rev-parse", "HEAD");
+	const origin = join(directory, "origin.git");
+	git("clone", "--quiet", "--bare", checkout, origin);
+	git("remote", "add", "origin", origin);
+	git("checkout", "--quiet", "main");
+	await symlink(bootstrap, join(directory, "tooling"));
+	await writeFile(metricsFile, "previous metrics\n");
+	await writeFile(callsFile, "");
+	const realGit = execFileSync("which", ["git"], { encoding: "utf8" }).trim();
+	const recordCall = `import { appendFileSync } from "node:fs";
+const args = process.argv.slice(2);
+appendFileSync(${JSON.stringify(callsFile)}, [NAME, ...args].join(" ") + "\\n");\n`;
+	// `--` keeps Node from interpreting Docker's --env-file as its own startup option.
+	for (const [name, body] of Object.entries({
+		git: `import { spawnSync } from "node:child_process";
+const result = spawnSync(${JSON.stringify(realGit)}, args, { stdio: "inherit" });
+process.exit(result.status ?? 1);`,
+		cosign: 'process.exit(process.env.FAIL_VERIFICATION === "1" ? 1 : 0);',
+		systemctl: 'if (args[0] === "show") console.log("yes");',
+		docker: `if (args.includes("config")) console.log(${JSON.stringify(JSON.stringify({ services: { app: { image } } }))});`,
+	})) {
+		await writeFile(
+			join(bin, name),
+			`#!/usr/bin/env -S node --\n${recordCall.replace("NAME", JSON.stringify(name))}${body}\n`,
+			{
+				mode: 0o755,
+			},
+		);
+	}
+	await writeFile(
+		join(bootstrap, "scripts/prepare-release-lock.ts"),
+		`import { appendFileSync, writeFileSync } from "node:fs";
+appendFileSync(${JSON.stringify(callsFile)}, "trusted verifier\\n");
+writeFileSync(process.argv[3], ${JSON.stringify(`HEPHAESTUS_RELEASE_COMMIT=${releaseCommit}\nHEPHAESTUS_IMAGE_APP=${image}\n`)});\n`,
+	);
+	await writeFile(
+		join(directory, "run.mjs"),
+		`import { main } from "./tooling/scripts/reconcile-deployment.ts";
+await main(${JSON.stringify(units)});\n`,
+	);
+	const record = { release: "v1.0.0", channelCommit, appliedAt: applied.appliedAt };
+	return {
+		bootstrap,
+		units,
+		releaseCommit,
+		record,
+		metricsFile,
+		calls: () => readFile(callsFile, "utf8"),
+		run: ({
+			cli = false,
+			failVerification = false,
+			channel = "test",
+		}: { cli?: boolean; failVerification?: boolean; channel?: string } = {}) =>
+			spawnSync(
+				process.execPath,
+				[join(directory, cli ? "tooling/scripts/reconcile-deployment.ts" : "run.mjs")],
+				{
+					encoding: "utf8",
+					timeout: 30_000,
+					env: environmentForGitFixture({
+						PATH: `${bin}${delimiter}${process.env.PATH ?? ""}`,
+						STATE_DIRECTORY: directory,
+						HEPHAESTUS_CHANNEL: channel,
+						HEPHAESTUS_STACKS: "proxy core app",
+						HEPHAESTUS_PROMOTE_IDENTITY: "https://example.invalid/promote",
+						HEPHAESTUS_METRICS_FILE: metricsFile,
+						FAIL_VERIFICATION: failVerification ? "1" : "0",
+					}),
+				},
+			),
+	};
+}
+
+await test(
+	"startup adopts the recorded release before attempting to read the channel",
+	reconcilerSubprocess,
+	async () => {
+		const directory = await mkdtemp(join(tmpdir(), "reconcile-startup-"));
+		try {
+			const fixture = await reconcilerFixture(directory);
+			const record = { ...fixture.record, commit: fixture.releaseCommit };
+			await writeFile(join(directory, "applied.json"), JSON.stringify(record));
+			const result = fixture.run();
+			assert.equal(result.status, 0, result.stderr);
+			const tree = join(directory, "releases", record.release);
+			assert.equal(await readlink(join(directory, "tooling")), tree);
+			assert.deepEqual(await readApplied(join(directory, "applied.json")), record);
+			assert.equal(await readFile(fixture.metricsFile, "utf8"), "previous metrics\n");
+			assert.equal(
+				await readFile(join(fixture.units, "hephaestus-reconcile.service"), "utf8"),
+				await readFile(join(tree, "docker/self-host/systemd/hephaestus-reconcile.service"), "utf8"),
+			);
+			const calls = await fixture.calls();
+			assert.match(calls, /git worktree add/);
+			assert.match(calls, /git status[\s\S]*systemctl show[\s\S]*systemctl daemon-reload/);
+			assert.doesNotMatch(calls, /git fetch|cosign|docker/);
+		} finally {
+			await rm(directory, { recursive: true, force: true });
+		}
+	},
+);
+
+await test(
+	"the symlinked CLI preserves pending tooling after a no-op and a failure",
+	reconcilerSubprocess,
+	async () => {
+		const directory = await mkdtemp(join(tmpdir(), "reconcile-cli-"));
+		try {
+			const fixture = await reconcilerFixture(directory);
+			await writeFile(join(directory, "applied.json"), JSON.stringify(fixture.record));
+			const noop = fixture.run({ cli: true });
+			assert.equal(noop.status, 0, noop.stderr);
+			assert.match(noop.stdout, /No change: already running v1\.0\.0/);
+			assert.match(
+				await readFile(fixture.metricsFile, "utf8"),
+				/^hephaestus_deploy_reconcile_success 1$/m,
+			);
+			assert.match(
+				await readFile(fixture.metricsFile, "utf8"),
+				/^hephaestus_deploy_tooling_pending 1$/m,
+			);
+			const failed = fixture.run({ cli: true, failVerification: true });
+			assert.notEqual(failed.status, 0);
+			assert.match(failed.stderr, /cosign exited with code 1/);
+			assert.match(
+				await readFile(fixture.metricsFile, "utf8"),
+				/^hephaestus_deploy_reconcile_success 0$/m,
+			);
+			assert.match(
+				await readFile(fixture.metricsFile, "utf8"),
+				/^hephaestus_deploy_tooling_pending 1$/m,
+			);
+			assert.equal(await readlink(join(directory, "tooling")), fixture.bootstrap);
+			assert.deepEqual(await readApplied(join(directory, "applied.json")), fixture.record);
+			assert.doesNotMatch(await fixture.calls(), /docker|systemctl/);
+		} finally {
+			await rm(directory, { recursive: true, force: true });
+		}
+	},
+);
+
+await test(
+	"an apply verifies with the running tooling before starting stacks and adopting the release",
+	reconcilerSubprocess,
+	async () => {
+		const directory = await mkdtemp(join(tmpdir(), "reconcile-apply-"));
+		try {
+			const fixture = await reconcilerFixture(directory);
+			const result = fixture.run();
+			assert.equal(result.status, 0, result.stderr);
+			const record = await readApplied(join(directory, "applied.json"));
+			assert.equal(record?.release, fixture.record.release);
+			assert.equal(record.commit, fixture.releaseCommit);
+			assert.equal(record.channelCommit, fixture.record.channelCommit);
+			assert.equal(await readlink(join(directory, "tooling")), join(directory, "releases/v1.0.0"));
+			assert.match(
+				await readFile(fixture.metricsFile, "utf8"),
+				/^hephaestus_deploy_reconcile_success 1$/m,
+			);
+			const calls = (await fixture.calls())
+				.split("\n")
+				.filter((line) => /^(cosign|trusted verifier|docker|systemctl)/.test(line));
+			assert.match(calls[0] ?? "", /^cosign verify-blob/);
+			assert.equal(calls[1], "trusted verifier");
+			const docker = calls.filter((line) => line.startsWith("docker"));
+			assert.equal(docker.length, 7);
+			for (const [index, stack] of ["app", "core", "proxy"].entries())
+				assert.match(
+					docker[index] ?? "",
+					new RegExp(`--project-name ${stack} .* config --format json$`),
+				);
+			assert.match(docker[3] ?? "", /--project-name core .* up .* nats-server$/);
+			for (const [index, stack] of ["app", "core", "proxy"].entries())
+				assert.match(
+					docker[index + 4] ?? "",
+					new RegExp(`--project-name ${stack} .* up .* --remove-orphans$`),
+				);
+			assert.match(calls.at(-2) ?? "", /^systemctl show/);
+			assert.equal(calls.at(-1), "systemctl daemon-reload");
+		} finally {
+			await rm(directory, { recursive: true, force: true });
+		}
+	},
+);
+
+await test(
+	"the CLI explains an unpromoted channel without starting any stack",
+	reconcilerSubprocess,
+	async () => {
+		const directory = await mkdtemp(join(tmpdir(), "reconcile-missing-channel-"));
+		try {
+			const fixture = await reconcilerFixture(directory);
+			const result = fixture.run({ cli: true, channel: "unpromoted" });
+			assert.notEqual(result.status, 0);
+			assert.match(result.stderr, /no channels\/unpromoted\.json on deploy-state/);
+			assert.match(result.stderr, /Run the Promote workflow/);
+			assert.equal(await readApplied(join(directory, "applied.json")), undefined);
+			assert.equal(await readlink(join(directory, "tooling")), fixture.bootstrap);
+			assert.match(
+				await readFile(fixture.metricsFile, "utf8"),
+				/^hephaestus_deploy_reconcile_success 0$/m,
+			);
+			assert.doesNotMatch(await fixture.calls(), /cosign|docker|systemctl/);
+		} finally {
+			await rm(directory, { recursive: true, force: true });
+		}
+	},
+);

--- a/scripts/reconcile-deployment.test.ts
+++ b/scripts/reconcile-deployment.test.ts
@@ -679,7 +679,11 @@ const result = spawnSync(${JSON.stringify(realGit)}, args, { stdio: "inherit" })
 process.exit(result.status ?? 1);`,
 		cosign: 'process.exit(process.env.FAIL_VERIFICATION === "1" ? 1 : 0);',
 		systemctl: 'if (args[0] === "show") console.log("yes");',
-		docker: `if (args.includes("config")) console.log(${JSON.stringify(JSON.stringify({ services: { app: { image } } }))});`,
+		docker: `if (args.includes("config")) {
+const stack = args[args.indexOf("--project-name") + 1];
+const image = stack === process.env.UNLOCKED_STACK ? "example.invalid/unverified:latest" : ${JSON.stringify(image)};
+console.log(JSON.stringify({ services: { app: { image } } }));
+}`,
 	})) {
 		await writeFile(
 			join(bin, name),
@@ -711,8 +715,14 @@ await main(${JSON.stringify(units)});\n`,
 		run: ({
 			cli = false,
 			failVerification = false,
+			unlockedStack,
 			channel = "test",
-		}: { cli?: boolean; failVerification?: boolean; channel?: string } = {}) =>
+		}: {
+			cli?: boolean;
+			failVerification?: boolean;
+			channel?: string;
+			unlockedStack?: string;
+		} = {}) =>
 			spawnSync(
 				process.execPath,
 				[join(directory, cli ? "tooling/scripts/reconcile-deployment.ts" : "run.mjs")],
@@ -727,6 +737,7 @@ await main(${JSON.stringify(units)});\n`,
 						HEPHAESTUS_PROMOTE_IDENTITY: "https://example.invalid/promote",
 						HEPHAESTUS_METRICS_FILE: metricsFile,
 						FAIL_VERIFICATION: failVerification ? "1" : "0",
+						UNLOCKED_STACK: unlockedStack,
 					}),
 				},
 			),
@@ -863,6 +874,29 @@ await test(
 				/^hephaestus_deploy_reconcile_success 0$/m,
 			);
 			assert.doesNotMatch(await fixture.calls(), /cosign|docker|systemctl/);
+		} finally {
+			await rm(directory, { recursive: true, force: true });
+		}
+	},
+);
+
+await test(
+	"an unlocked image in a later stack leaves the applied release and every container untouched",
+	reconcilerSubprocess,
+	async () => {
+		const directory = await mkdtemp(join(tmpdir(), "reconcile-unlocked-image-"));
+		try {
+			const fixture = await reconcilerFixture(directory);
+			const previous = { ...fixture.record, release: "v0.9.0" };
+			await writeFile(join(directory, "applied.json"), JSON.stringify(previous));
+
+			const result = fixture.run({ unlockedStack: "proxy" });
+
+			assert.notEqual(result.status, 0);
+			assert.match(result.stderr, /proxy renders images outside the release lock/);
+			assert.deepEqual(await readApplied(join(directory, "applied.json")), previous);
+			assert.equal(await readlink(join(directory, "tooling")), fixture.bootstrap);
+			assert.doesNotMatch(await fixture.calls(), / up |systemctl/);
 		} finally {
 			await rm(directory, { recursive: true, force: true });
 		}

--- a/scripts/reconcile-deployment.ts
+++ b/scripts/reconcile-deployment.ts
@@ -413,7 +413,7 @@ function fetchOptions(config: HostConfig): { cwd: string; signal: AbortSignal } 
 	return { cwd: config.checkout, signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) };
 }
 
-async function main(): Promise<void> {
+export async function main(unitsDirectory = SYSTEMD_UNITS): Promise<void> {
 	const config = hostConfig(process.env);
 	const appliedFile = join(config.stateDirectory, "applied.json");
 	const applied = await readApplied(appliedFile);
@@ -442,7 +442,7 @@ async function main(): Promise<void> {
 				applied.release,
 				commit,
 			);
-			if (await followTooling(config, tree)) {
+			if (await followTooling(config, tree, unitsDirectory)) {
 				console.log(`Adopted the tooling of ${applied.release}; the next run uses it`);
 				return;
 			}
@@ -698,7 +698,7 @@ async function main(): Promise<void> {
 		);
 	console.log(`Applied ${decision.release} to ${config.stacks.join(", ")}`);
 	// Only now, with the release verified and running, does the host run that release's tooling.
-	await followTooling(config, releaseTree);
+	await followTooling(config, releaseTree, unitsDirectory);
 }
 
 const DAY_SECONDS = 24 * 60 * 60;
@@ -775,13 +775,17 @@ export async function commitImages(
  * and its reconciler could not read a current channel — so a rollback to one keeps the tooling the
  * host has. Every step is idempotent, because a tick can stop between any two of them.
  */
-async function followTooling(config: HostConfig, tree: string): Promise<boolean> {
+async function followTooling(
+	config: HostConfig,
+	tree: string,
+	unitsDirectory: string,
+): Promise<boolean> {
 	if (!(await carriesToolingLink(tree))) {
 		console.log(`Keeping the current tooling: ${tree} predates the tooling link`);
 		return false;
 	}
 	const moved = await adoptTooling(config.tooling, tree);
-	const changed = await syncUnits(tree, SYSTEMD_UNITS);
+	const changed = await syncUnits(tree, unitsDirectory);
 	if (changed.length > 0) console.log(`Updated ${changed.join(", ")}`);
 	// systemd itself knows whether the units it loaded match the files, so a tick that stopped
 	// between writing a unit and reloading is finished by the next one.

--- a/scripts/release-deployment-policy.test.ts
+++ b/scripts/release-deployment-policy.test.ts
@@ -101,16 +101,6 @@ await test("every promotion decision is taken by the script that owns it", () =>
 		);
 	// Rollback must support releases predating immutable tags; the signed lock binds their digests.
 	assert.doesNotMatch(resolver, /isImmutable/);
-	// The verifier is the tooling this tick runs — resolved from the running script, which Node pins
-	// to the tree it loaded — never the release under review.
-	assert.match(reconciler, /join\(import\.meta\.dirname, "prepare-release-lock\.ts"\)/);
-	assert.doesNotMatch(reconciler, /join\(releaseTree, "scripts\/prepare-release-lock\.ts"\)/);
-	// Run through the tooling link, argv[1] and import.meta.filename differ; only import.meta.main holds.
-	assert.match(reconciler, /^if \(import\.meta\.main\) \{/m);
-	// A host pointed at an environment nobody has promoted yet must be told that, not handed git's
-	// "path does not exist" as an unhandled exec failure — it is the first thing a new host meets.
-	assert.match(reconciler, /cat-file", "-e", `\$\{channelCommit\}:\$\{channelPath\}`/);
-	assert.match(reconciler, /promoted yet/);
 });
 
 function referenced(expression: string, pattern: RegExp): string[] {

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/gateway/SandboxGatewayConfiguration.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/gateway/SandboxGatewayConfiguration.java
@@ -43,9 +43,10 @@ public class SandboxGatewayConfiguration {
 
     /**
      * Buckets for the gateway's rate limit on a pod that runs no server role, where the worker overlay
-     * drops {@code core.auth} and with it the instance's shared resolver. Per JVM, so per worker
-     * replica — but a job token is only ever presented to the worker that issued it, so a job's budget
-     * is whole either way. A pod that does run the server role shares that resolver instead.
+     * drops {@code core.auth} and with it the instance's shared resolver. Limits are per worker:
+     * sandbox adapters route to their worker's address on the job network, not a load balancer.
+     * This is local flood protection, not a fleet-wide quota. A pod running the server role shares
+     * its auth resolver instead.
      */
     @Bean
     @ConditionalOnProperty(name = RuntimeRole.SERVER_PROPERTY, havingValue = "false")

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/runtime/PiRuntimeFactory.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/runtime/PiRuntimeFactory.java
@@ -31,15 +31,8 @@ public class PiRuntimeFactory {
 
     private static final Logger log = LoggerFactory.getLogger(PiRuntimeFactory.class);
 
-    /** Grace window before the sandbox hard-kills the runner — must fire before that deadline. */
+    /** Time reserved for runner shutdown and sandbox teardown, outside the model's work budget. */
     public static final int TIMEOUT_BUFFER_SECONDS = 60;
-
-    /**
-     * Floor for the self-watchdog budget, so a spec just above the minimum timeout does not compute an
-     * effectively-zero one. Must stay below {@code TIMEOUT_BUFFER_SECONDS * 1000}: the watchdog has to
-     * fire before the sandbox hard kill.
-     */
-    static final long MIN_BUDGET_MS = (TIMEOUT_BUFFER_SECONDS - 1) * 1000L;
 
     /** Turns the SDK repeats before a provider failure ends the session that hit it. */
     private static final int RETRY_MAX_ATTEMPTS = 5;
@@ -83,7 +76,7 @@ public class PiRuntimeFactory {
         inputFiles.putAll(promptScaffolding);
         inputFiles.putAll(spec.extraInputs());
 
-        long agentTimeoutMs = Math.max(MIN_BUDGET_MS, (long) (spec.timeoutSeconds() - TIMEOUT_BUFFER_SECONDS) * 1000);
+        long agentTimeoutMs = (spec.timeoutSeconds() - TIMEOUT_BUFFER_SECONDS) * 1000L;
         env.put("AGENT_BUDGET_MS", Long.toString(agentTimeoutMs));
 
         env.put("HOME", "/home/agent");

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/DockerSandboxAdapter.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/DockerSandboxAdapter.java
@@ -348,17 +348,14 @@ public class DockerSandboxAdapter implements SandboxManager {
         env.put("GIT_ATTR_NOSYSTEM", "1");
 
         if (spec.networkPolicy() != null) {
-            String gatewayUrl = appServerIp != null ? "http://" + appServerIp + ":" + gatewayPort : null;
-            if (gatewayUrl != null) {
-                env.put("GATEWAY_URL", gatewayUrl);
-            }
+            String gatewayUrl = "http://" + appServerIp + ":" + gatewayPort;
             if (spec.networkPolicy().llmProxyUrl() != null) {
                 String proxyUrl = spec.networkPolicy().llmProxyUrl();
-                if (proxyUrl.contains(PROXY_URL_PLACEHOLDER) && appServerIp != null) {
+                if (proxyUrl.contains(PROXY_URL_PLACEHOLDER)) {
                     proxyUrl = proxyUrl.replace(PROXY_URL_PLACEHOLDER, appServerIp);
                 }
                 env.put("LLM_PROXY_URL", proxyUrl);
-            } else if (gatewayUrl != null) {
+            } else {
                 // One route for every provider: the proxy identifies the connection from the
                 // authenticated job token, not the URL.
                 env.put("LLM_PROXY_URL", gatewayUrl + "/internal/llm");

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/interactive/DockerInteractiveSandboxAdapter.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/interactive/DockerInteractiveSandboxAdapter.java
@@ -284,18 +284,14 @@ public class DockerInteractiveSandboxAdapter implements InteractiveSandboxServic
             env.put("TRACE_ID", traceId);
             env.put("TRACEPARENT", "00-" + traceId + "-" + spanId + "-00");
         }
-        String gatewayUrl = appServerIp != null ? "http://" + appServerIp + ":" + gatewayPort : null;
-        if (spec.networkPolicy() != null && gatewayUrl != null) {
-            env.put("GATEWAY_URL", gatewayUrl);
-        }
         if (spec.networkPolicy() != null && spec.networkPolicy().llmProxyUrl() != null) {
             String url = spec.networkPolicy().llmProxyUrl();
             if (url.contains(PROXY_URL_PLACEHOLDER)) {
                 url = url.replace(PROXY_URL_PLACEHOLDER, appServerIp);
             }
             env.put("LLM_PROXY_URL", url);
-        } else if (spec.networkPolicy() != null && gatewayUrl != null) {
-            env.put("LLM_PROXY_URL", gatewayUrl + "/internal/llm");
+        } else if (spec.networkPolicy() != null) {
+            env.put("LLM_PROXY_URL", "http://" + appServerIp + ":" + gatewayPort + "/internal/llm");
         }
         if (spec.networkPolicy() != null && spec.networkPolicy().llmProxyToken() != null) {
             env.put("LLM_PROXY_TOKEN", spec.networkPolicy().llmProxyToken());

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/auth/export/ExportGenerationWorker.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/auth/export/ExportGenerationWorker.java
@@ -3,7 +3,6 @@ package de.tum.cit.aet.hephaestus.core.auth.export;
 import de.tum.cit.aet.hephaestus.core.PrivacyJobMetrics;
 import de.tum.cit.aet.hephaestus.core.PrivacyJobMetrics.Job;
 import de.tum.cit.aet.hephaestus.core.PrivacyJobMetrics.Outcome;
-import de.tum.cit.aet.hephaestus.core.TransactionCallbacks;
 import de.tum.cit.aet.hephaestus.core.WorkspaceAgnostic;
 import de.tum.cit.aet.hephaestus.core.runtime.ConditionalOnServerRole;
 import java.time.Clock;
@@ -13,7 +12,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
 import tools.jackson.core.JacksonException;
 import tools.jackson.databind.ObjectMapper;
 
@@ -36,60 +36,81 @@ public class ExportGenerationWorker {
     private final ObjectMapper objectMapper;
     private final Clock clock;
     private final PrivacyJobMetrics metrics;
+    private final TransactionTemplate transaction;
 
     public ExportGenerationWorker(
             AccountExportRepository accountExportRepository,
             ExportBundleAssembler assembler,
             ObjectMapper objectMapper,
             Clock clock,
-            PrivacyJobMetrics metrics) {
+            PrivacyJobMetrics metrics,
+            PlatformTransactionManager transactionManager) {
         this.accountExportRepository = accountExportRepository;
         this.assembler = assembler;
         this.objectMapper = objectMapper;
         this.clock = clock;
         this.metrics = metrics;
+        this.transaction = new TransactionTemplate(transactionManager);
     }
 
-    /**
-     * Generate the bundle for {@code exportId} (owned by {@code accountId}) and persist the outcome.
-     * PROCESSING → READY on success (payload + expiry set), → FAILED on any error. Never throws to the
-     * caller (it's fire-and-forget); failures are recorded on the row and on the privacy-job counters.
-     */
+    /** Generate the export atomically; record a failure only after the failed transaction rolls back. */
     @Async
-    @Transactional
     public void generate(Long exportId, Long accountId) {
+        boolean generated;
+        try {
+            generated = Boolean.TRUE.equals(transaction.execute(status -> assemble(exportId, accountId)));
+        } catch (JacksonException e) {
+            recordFailure(exportId, accountId, "serialization_failed", e);
+            return;
+        } catch (RuntimeException e) {
+            recordFailure(exportId, accountId, "assembly_failed", e);
+            return;
+        }
+        metrics.record(Job.EXPORT_GENERATION, generated ? Outcome.SUCCESS : Outcome.FAILURE);
+        if (generated) {
+            metrics.recordAffected(Job.EXPORT_GENERATION, 1);
+            log.info("auth.export: export {} for account {} READY", exportId, accountId);
+        }
+    }
+
+    private boolean assemble(Long exportId, Long accountId) {
         AccountExport export = accountExportRepository
                 .findByIdAndAccountId(exportId, accountId)
                 .orElse(null);
         if (export == null) {
-            // Row vanished (e.g. account hard-deleted between request and pickup). Nothing to do.
             log.warn("auth.export: generation skipped, export {} for account {} not found", exportId, accountId);
-            recordAfterCommit(Outcome.FAILURE);
-            return;
+            return false;
         }
         export.setStatus(AccountExport.Status.PROCESSING);
         accountExportRepository.save(export);
 
+        ExportBundle bundle = assembler.assemble(accountId);
+        byte[] payload = objectMapper.writeValueAsBytes(bundle);
+        Instant now = Instant.now(clock);
+        export.setPayload(payload);
+        export.setCompletedAt(now);
+        export.setExpiresAt(now.plus(RETENTION));
+        export.setStatus(AccountExport.Status.READY);
+        accountExportRepository.save(export);
+        return true;
+    }
+
+    private void recordFailure(Long exportId, Long accountId, String reason, RuntimeException failure) {
+        log.error("auth.export: generation failed for export {} account {}", exportId, accountId, failure);
+        metrics.record(Job.EXPORT_GENERATION, Outcome.FAILURE);
         try {
-            ExportBundle bundle = assembler.assemble(accountId);
-            byte[] payload = objectMapper.writeValueAsBytes(bundle);
-            Instant now = Instant.now(clock);
-            export.setPayload(payload);
-            export.setCompletedAt(now);
-            export.setExpiresAt(now.plus(RETENTION));
-            export.setStatus(AccountExport.Status.READY);
-            accountExportRepository.save(export);
-            TransactionCallbacks.afterCommit(() -> {
-                metrics.record(Job.EXPORT_GENERATION, Outcome.SUCCESS);
-                metrics.recordAffected(Job.EXPORT_GENERATION, 1);
+            // Repository errors can mark a transaction rollback-only; recovery needs a fresh transaction.
+            transaction.executeWithoutResult(status -> {
+                accountExportRepository
+                        .findByIdAndAccountId(exportId, accountId)
+                        .ifPresent(export -> fail(export, reason));
             });
-            log.info("auth.export: export {} for account {} READY ({} bytes)", exportId, accountId, payload.length);
-        } catch (JacksonException e) {
-            fail(export, "serialization_failed");
-            log.error("auth.export: serialization failed for export {} account {}", exportId, accountId, e);
-        } catch (RuntimeException e) {
-            fail(export, "assembly_failed");
-            log.error("auth.export: assembly failed for export {} account {}", exportId, accountId, e);
+        } catch (RuntimeException recoveryFailure) {
+            log.error(
+                    "auth.export: could not record failure for export {} account {}",
+                    exportId,
+                    accountId,
+                    recoveryFailure);
         }
     }
 
@@ -97,12 +118,8 @@ public class ExportGenerationWorker {
         export.setStatus(AccountExport.Status.FAILED);
         export.setFailureReason(reason);
         export.setPayload(null);
+        export.setCompletedAt(null);
+        export.setExpiresAt(null);
         accountExportRepository.save(export);
-        recordAfterCommit(Outcome.FAILURE);
-    }
-
-    /** A counter an operator alerts on must not claim an outcome for a row the commit could still lose. */
-    private void recordAfterCommit(Outcome outcome) {
-        TransactionCallbacks.afterCommit(() -> metrics.record(Job.EXPORT_GENERATION, outcome));
     }
 }

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/auth/ratelimit/AuthRateLimitConfig.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/auth/ratelimit/AuthRateLimitConfig.java
@@ -33,10 +33,12 @@ import tools.jackson.databind.ObjectMapper;
  * (otherwise context startup fails on the unsatisfied {@code DataSource} dependency).
  *
  * <p><strong>Trade-off / fallback:</strong> when {@code postgres-backed=false} (the {@code specs}
- * profile, worker-only pods, the H2 test context, and any DataSource-less boot set it),
+ * profile, the H2 test context, and any DataSource-less server boot set it),
  * an in-JVM {@code ConcurrentHashMap}-backed resolver is used instead. In that mode the limits are
- * <strong>per-replica</strong>: N replicas allow up to N× the configured rate cluster-wide. This is
- * acceptable for those non-production contexts but would be a regression in a multi-replica
+ * <strong>per-replica</strong>: N replicas allow up to N× the configured rate cluster-wide.
+ * Worker-only pods exclude this configuration; their gateway resolver lives in
+ * {@link de.tum.cit.aet.hephaestus.agent.gateway.SandboxGatewayConfiguration}. This fallback is
+ * acceptable for non-production server contexts but would be a regression in a multi-replica
  * production deployment — production MUST run Postgres-backed. The active mode is logged at startup.
  */
 @ConditionalOnServerRole
@@ -97,14 +99,14 @@ public class AuthRateLimitConfig {
      * In-JVM fallback. PER-REPLICA limits — see the class Javadoc trade-off. Activated only when
      * {@code postgres-backed=false} (the Postgres beans above require a DataSource and do not back off
      * on their own). Bounded by
-     * {@link #IN_MEMORY_MAX_BUCKETS}: this mode is dev / specs / worker-only and short-lived, so a
+     * {@link #IN_MEMORY_MAX_BUCKETS}: this mode is dev / specs and short-lived, so a
      * coarse clear-on-overflow is sufficient to keep memory bounded without per-entry eviction.
      */
     @Bean
     @ConditionalOnMissingBean(BucketResolver.class)
     BucketResolver inMemoryBucketResolver() {
         log.warn("Auth rate limiting: in-JVM fallback — limits are PER-REPLICA, NOT shared across the "
-                + "cluster. Acceptable for dev / specs / worker-only pods; production must run "
+                + "cluster. Acceptable for dev / specs; production must run "
                 + "Postgres-backed (hephaestus.auth.rate-limit.postgres-backed=true with a DataSource).");
         var store = new ConcurrentHashMap<String, io.github.bucket4j.Bucket>();
         return (key, config) -> {

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/core/connection/Connection.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/core/connection/Connection.java
@@ -239,10 +239,6 @@ public class Connection {
         this.config = config;
     }
 
-    void setCredentialsEncrypted(byte @Nullable [] credentialsEncrypted) {
-        this.credentialsEncrypted = credentialsEncrypted;
-    }
-
     /** Encrypts or clears this connection's credentials. */
     public void setCredentials(@Nullable CredentialBundle bundle, CredentialBundleConverter converter) {
         if (bundle == null) {

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/practices/trace/PracticeTraceDeriver.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/practices/trace/PracticeTraceDeriver.java
@@ -105,12 +105,14 @@ final class PracticeTraceDeriver {
             if (readiness == null) {
                 continue;
             }
-            if (readiness.ready()
-                    && review.coverageByPracticeSlug().get(practice.slug()) == PracticeCoverageOutcome.NOT_REACHED) {
+            PracticeCoverageOutcome coverage = review.coverageByPracticeSlug().get(practice.slug());
+            if (readiness.ready() && coverage != PracticeCoverageOutcome.EVALUATED) {
                 return entry(
                         practice,
                         PracticeTraceOutcome.NOT_REACHED,
-                        "The review ended before reaching this practice.",
+                        coverage == PracticeCoverageOutcome.NOT_REACHED
+                                ? "The review ended before reaching this practice."
+                                : "The review did not record whether it reached this practice.",
                         occurrence,
                         review.decidedAt(),
                         occurrence.reviewId(),

--- a/server/application/src/main/resources/agent/pi-runner-output.ts
+++ b/server/application/src/main/resources/agent/pi-runner-output.ts
@@ -18,6 +18,11 @@ export function outputPath(outputDir: string, name: string): string {
 			`Output file name must start with an ASCII letter or digit and hold only letters, digits, '.', '_', '-' and '/': ${name}`,
 		);
 	}
+	if (name.split("/").some((segment) => segment === "" || segment === "." || segment === "..")) {
+		throw new Error(
+			`Output file name must contain only non-empty, relative path segments: ${name}`,
+		);
+	}
 	// ASCII by the test above, so one character is one byte.
 	if (member.length > MAX_MEMBER_BYTES) {
 		throw new Error(

--- a/server/application/src/main/resources/agent/pi-runner-timings.ts
+++ b/server/application/src/main/resources/agent/pi-runner-timings.ts
@@ -13,16 +13,7 @@ export function deriveTimeouts(agentBudgetMs: number, compositionEnabled = false
 	};
 }
 
-/**
- * How long the shared reconnaissance may take before the groups start without it.
- *
- * <p>It is one model turn over the whole change, so it is bounded below by what a turn needs rather
- * than by a share of the review: a budget that expires before the first answer buys nothing and costs
- * every group the shared reading. The cap keeps a large review from spending its observers' time here.
- * The reconnaissance is paid for out of the first pass, so the floor is bounded by a quarter of it:
- * a deadline longer than the pass that funds it can never expire, and the whole review would run out
- * of time before any group heard that it was starting alone.
- */
+/** Shared reconnaissance uses at most a quarter of a short review and four minutes of a long one. */
 export function deriveReconBudget(initialMs: number) {
 	if (!Number.isFinite(initialMs) || initialMs <= 0) {
 		throw new Error(`initialMs must be a positive number, got: ${initialMs}`);
@@ -37,18 +28,7 @@ export interface StageTimeouts {
 	compositionMs: number;
 }
 
-/**
- * The retry's wall clock: whatever is left of the review budget when the initial pass ends, and never
- * less than the slice the split reserved for it. That reservation guards against an initial pass that
- * runs long; it is not a cap, because a pass that returned early has not spent the rest and the retry
- * is the last stage that can still close a practice nobody observed.
- *
- * <p>What is left of the process bounds it from above. The review budget is measured from the first
- * pass, the process budget from module load, and the watchdog's grace is all that covers the two
- * stretches inside neither: the SDK and model runtime the run builds before the first pass, and the
- * composition session it builds after the last one. So the retry stops early enough to leave
- * composition its own slice of what remains.
- */
+/** The retry uses unspent review time, bounded by the process deadline and composition reservation. */
 export function deriveRetryWindow(
 	timeouts: StageTimeouts,
 	initialElapsedMs: number,
@@ -59,12 +39,12 @@ export function deriveRetryWindow(
 			throw new Error(`${name} must be a non-negative number, got: ${value}`);
 		}
 	}
-	// remainingProcessMs is the one argument that may be negative: a process already past its budget
-	// has a negative remainder, and the reservation below is what keeps that from arming a timer in
-	// the past.
+	if (!Number.isFinite(remainingProcessMs)) {
+		throw new TypeError(`remainingProcessMs must be finite, got: ${remainingProcessMs}`);
+	}
 	const unspentReviewMs = timeouts.initialMs + timeouts.retryMs - initialElapsedMs;
 	const beforeCompositionMs = remainingProcessMs - timeouts.compositionMs;
-	return Math.max(timeouts.retryMs, Math.floor(Math.min(unspentReviewMs, beforeCompositionMs)));
+	return Math.max(0, Math.floor(Math.min(unspentReviewMs, beforeCompositionMs)));
 }
 
 /**
@@ -78,7 +58,19 @@ export function armRetryWindow(
 	onExpire: () => void,
 ) {
 	const windowMs = deriveRetryWindow(timeouts, initialElapsedMs, remainingProcessMs);
-	return { windowMs, timer: setTimeout(onExpire, windowMs) };
+	if (windowMs === 0) onExpire();
+	return { windowMs, timer: windowMs > 0 ? setTimeout(onExpire, windowMs) : undefined };
+}
+
+export function deriveCompositionWindow(compositionMs: number, remainingProcessMs: number): number {
+	if (
+		!Number.isFinite(compositionMs) ||
+		compositionMs < 0 ||
+		!Number.isFinite(remainingProcessMs)
+	) {
+		throw new Error("compositionMs must be non-negative and both budgets must be finite");
+	}
+	return Math.max(0, Math.floor(Math.min(compositionMs, remainingProcessMs)));
 }
 
 export function deriveTurnTiming(remainingMs: number, remainingTurns: number) {

--- a/server/application/src/main/resources/agent/pi-runner-timings.ts
+++ b/server/application/src/main/resources/agent/pi-runner-timings.ts
@@ -28,7 +28,17 @@ export interface StageTimeouts {
 	compositionMs: number;
 }
 
-/** The retry uses unspent review time, bounded by the process deadline and composition reservation. */
+/**
+ * The retry's wall clock: what the initial pass did not spend, and never less than the slice the
+ * split reserved for it. That floor is the point of the reservation — an initial pass that ran long
+ * is exactly when a practice is still unobserved, and the retry is the last stage that can close
+ * one. Taking the unspent time alone would hand that case zero.
+ *
+ * <p>The process deadline is the only hard cap, and composition is subtracted from it first: the
+ * review budget is measured from the first pass and the process budget from module load, so the
+ * stretches inside neither — building the runtime before, composing after — come out of what is
+ * left. A window of zero means there is genuinely nothing left to spend.
+ */
 export function deriveRetryWindow(
 	timeouts: StageTimeouts,
 	initialElapsedMs: number,
@@ -44,7 +54,8 @@ export function deriveRetryWindow(
 	}
 	const unspentReviewMs = timeouts.initialMs + timeouts.retryMs - initialElapsedMs;
 	const beforeCompositionMs = remainingProcessMs - timeouts.compositionMs;
-	return Math.max(0, Math.floor(Math.min(unspentReviewMs, beforeCompositionMs)));
+	const wantedMs = Math.max(unspentReviewMs, timeouts.retryMs);
+	return Math.max(0, Math.floor(Math.min(wantedMs, beforeCompositionMs)));
 }
 
 /**

--- a/server/application/src/main/resources/agent/pi-runner.ts
+++ b/server/application/src/main/resources/agent/pi-runner.ts
@@ -1929,61 +1929,63 @@ async function main() {
 	const groupSessionFiles = new Map<string, string>();
 	const groupSeedFiles = new Map<string, string>();
 	if (!hardAborted) {
-		const manager = SessionManager.create(CWD, sessionDir);
-		const { session: reconSession } = await createAgentSession({
-			cwd: CWD,
-			agentDir: AGENT_DIR,
-			tools: [...EVIDENCE_TOOLS],
-			customTools: [grepTool],
-			sessionManager: manager,
-			settingsManager,
-			resourceLoader: await loadResources(),
-			modelRuntime,
-			model,
-		});
-		if (hardAbort.signal.aborted || Date.now() >= reviewDeadline) {
-			hardAborted = true;
-			hardAbort.abort();
-			stopSession(reconSession);
-		} else {
-			const unsubscribeRecon = subscribeSession(reconSession, "recon:shared");
-			activeSessions.add(reconSession);
-			const reconBudgetMs = Math.min(
-				deriveReconBudget(INITIAL_TIMEOUT_MS),
-				reviewDeadline - Date.now(),
-			);
-			const reconDeadline = scheduleDeadline(reconBudgetMs, () => stopSession(reconSession));
-			try {
-				const groupScope = tree.groups
-					.map((group) => `${group.id} [${group.practiceSlugs.join(", ")}]`)
-					.join("; ");
-				await Promise.race([
-					reconSession.prompt(
-						`Build one factual reconnaissance map for this review. Read the manifest and the artifact summary first, then inspect only enough shared evidence to identify changed surfaces, review activity, linked work, tests, and likely code paths. Record exact artifact paths and diff coordinates. Do not evaluate a practice or claim GOOD/BAD. The following group sessions will continue from this checkpoint: ${groupScope}`,
-					),
-					reconDeadline.elapsed,
-				]);
-				const { seedSessionFile, checkpointEntryId } = reconnaissanceSeed(
-					reconSession.sessionManager,
-					reconDeadline.state,
-					reconBudgetMs,
-				);
-				for (const fork of forkSessions({
-					seedSessionFile,
-					checkpointEntryId,
-					keys: tree.groups.map((group) => group.id),
-					sessionDir,
-				})) {
-					groupSeedFiles.set(fork.key, fork.sessionFile);
-				}
-			} catch (error) {
-				console.error(`[pi-runner] shared reconnaissance failed: ${errorText(error)}`);
-			} finally {
-				clearTimeout(reconDeadline.timer);
-				activeSessions.delete(reconSession);
-				unsubscribeRecon();
+		try {
+			const manager = SessionManager.create(CWD, sessionDir);
+			const { session: reconSession } = await createAgentSession({
+				cwd: CWD,
+				agentDir: AGENT_DIR,
+				tools: [...EVIDENCE_TOOLS],
+				customTools: [grepTool],
+				sessionManager: manager,
+				settingsManager,
+				resourceLoader: await loadResources(),
+				modelRuntime,
+				model,
+			});
+			if (hardAbort.signal.aborted || Date.now() >= reviewDeadline) {
+				hardAborted = true;
+				hardAbort.abort();
 				stopSession(reconSession);
+			} else {
+				const unsubscribeRecon = subscribeSession(reconSession, "recon:shared");
+				activeSessions.add(reconSession);
+				const reconBudgetMs = Math.min(
+					deriveReconBudget(INITIAL_TIMEOUT_MS),
+					reviewDeadline - Date.now(),
+				);
+				const reconDeadline = scheduleDeadline(reconBudgetMs, () => stopSession(reconSession));
+				try {
+					const groupScope = tree.groups
+						.map((group) => `${group.id} [${group.practiceSlugs.join(", ")}]`)
+						.join("; ");
+					await Promise.race([
+						reconSession.prompt(
+							`Build one factual reconnaissance map for this review. Read the manifest and the artifact summary first, then inspect only enough shared evidence to identify changed surfaces, review activity, linked work, tests, and likely code paths. Record exact artifact paths and diff coordinates. Do not evaluate a practice or claim GOOD/BAD. The following group sessions will continue from this checkpoint: ${groupScope}`,
+						),
+						reconDeadline.elapsed,
+					]);
+					const { seedSessionFile, checkpointEntryId } = reconnaissanceSeed(
+						reconSession.sessionManager,
+						reconDeadline.state,
+						reconBudgetMs,
+					);
+					for (const fork of forkSessions({
+						seedSessionFile,
+						checkpointEntryId,
+						keys: tree.groups.map((group) => group.id),
+						sessionDir,
+					})) {
+						groupSeedFiles.set(fork.key, fork.sessionFile);
+					}
+				} finally {
+					clearTimeout(reconDeadline.timer);
+					activeSessions.delete(reconSession);
+					unsubscribeRecon();
+					stopSession(reconSession);
+				}
 			}
+		} catch (error) {
+			console.error(`[pi-runner] shared reconnaissance failed: ${errorText(error)}`);
 		}
 	}
 
@@ -1993,70 +1995,73 @@ async function main() {
 			tree.groups,
 			concurrency,
 			async (group, index) => {
-				const seedFile = groupSeedFiles.get(group.id);
-				const manager = seedFile
-					? SessionManager.open(seedFile, sessionDir)
-					: SessionManager.create(CWD, sessionDir);
-				const scopedTool = buildReportObservationTool(group.practiceSlugs);
-				const { session: observerSession } = await createAgentSession({
-					cwd: CWD,
-					agentDir: AGENT_DIR,
-					tools: [...EVIDENCE_TOOLS, "report_observation"],
-					customTools: [grepTool, scopedTool],
-					sessionManager: manager,
-					settingsManager,
-					resourceLoader: await loadResources(),
-					modelRuntime,
-					model,
-				});
-				if (hardAbort.signal.aborted || Date.now() >= reviewDeadline) {
-					hardAborted = true;
-					hardAbort.abort();
-					stopSession(observerSession);
-					return;
-				}
-				const unsubscribeObserver = subscribeSession(
-					observerSession,
-					`observer:${group.id}`,
-					createRecordingPace(contextWindow, seedFile !== undefined),
-				);
-				activeSessions.add(observerSession);
-				const remainingMs = Math.max(1, reviewDeadline - Date.now());
-				const activeSlots = Math.min(concurrency, remainingGroups);
-				const groupBudgetMs = deriveWorkstreamBudget(remainingMs, activeSlots, remainingGroups);
-				const timing = deriveTurnTiming(groupBudgetMs, 1);
-				const timers = scheduleTurnTimers(
-					observerSession,
-					index + 1,
-					tree.groups.length,
-					timing.softNudgeMs,
-					timing.fairShareMs,
-				);
 				try {
-					await Promise.race([
-						observerSession.prompt(
-							`${prompt}\n\n## Practice group: ${group.id}\nEvaluate exactly these practices: ${group.practiceSlugs.join(", ")}. ` +
-								`Read their files under inputs/practices/, then start with the cheapest decisive practice. Persist each ` +
-								`observation as soon as it is supported; do not finish a group-wide evidence map first. Reuse evidence ` +
-								`already gathered when investigating the remaining practices. Persist at least one disposition for ` +
-								`every listed practice, plus any distinct material problems a practice exposes. Use ` +
-								`NO_REVIEW_OCCASION only after complete evidence proves the practice's explicit prerequisite did not ` +
-								`occur; missing evidence is not an occasion that failed to happen. Do not skip a practice because its ` +
-								`behavior is absent.`,
-						),
-						timers.hardDeadline,
-					]);
+					const seedFile = groupSeedFiles.get(group.id);
+					const manager = seedFile
+						? SessionManager.open(seedFile, sessionDir)
+						: SessionManager.create(CWD, sessionDir);
+					const scopedTool = buildReportObservationTool(group.practiceSlugs);
+					const { session: observerSession } = await createAgentSession({
+						cwd: CWD,
+						agentDir: AGENT_DIR,
+						tools: [...EVIDENCE_TOOLS, "report_observation"],
+						customTools: [grepTool, scopedTool],
+						sessionManager: manager,
+						settingsManager,
+						resourceLoader: await loadResources(),
+						modelRuntime,
+						model,
+					});
+					if (hardAbort.signal.aborted || Date.now() >= reviewDeadline) {
+						hardAborted = true;
+						hardAbort.abort();
+						stopSession(observerSession);
+						return;
+					}
+					const unsubscribeObserver = subscribeSession(
+						observerSession,
+						`observer:${group.id}`,
+						createRecordingPace(contextWindow, seedFile !== undefined),
+					);
+					activeSessions.add(observerSession);
+					const remainingMs = Math.max(1, reviewDeadline - Date.now());
+					const activeSlots = Math.min(concurrency, remainingGroups);
+					const groupBudgetMs = deriveWorkstreamBudget(remainingMs, activeSlots, remainingGroups);
+					const timing = deriveTurnTiming(groupBudgetMs, 1);
+					const timers = scheduleTurnTimers(
+						observerSession,
+						index + 1,
+						tree.groups.length,
+						timing.softNudgeMs,
+						timing.fairShareMs,
+					);
+					try {
+						await Promise.race([
+							observerSession.prompt(
+								`${prompt}\n\n## Practice group: ${group.id}\nEvaluate exactly these practices: ${group.practiceSlugs.join(", ")}. ` +
+									`Read their files under inputs/practices/, then start with the cheapest decisive practice. Persist each ` +
+									`observation as soon as it is supported; do not finish a group-wide evidence map first. Reuse evidence ` +
+									`already gathered when investigating the remaining practices. Persist at least one disposition for ` +
+									`every listed practice, plus any distinct material problems a practice exposes. Use ` +
+									`NO_REVIEW_OCCASION only after complete evidence proves the practice's explicit prerequisite did not ` +
+									`occur; missing evidence is not an occasion that failed to happen. Do not skip a practice because its ` +
+									`behavior is absent.`,
+							),
+							timers.hardDeadline,
+						]);
+					} finally {
+						const sessionFile = observerSession.sessionManager.getSessionFile();
+						if (sessionFile) groupSessionFiles.set(group.id, sessionFile);
+						softTimeoutFired ||= timers.state.softTimedOut;
+						clearTimeout(timers.softTimer);
+						clearTimeout(timers.hardTimer);
+						activeSessions.delete(observerSession);
+						unsubscribeObserver();
+						stopSession(observerSession);
+					}
 				} catch (error) {
 					console.error(`[pi-runner] observer ${group.id} failed: ${errorText(error)}`);
 				} finally {
-					const sessionFile = observerSession.sessionManager.getSessionFile();
-					if (sessionFile) groupSessionFiles.set(group.id, sessionFile);
-					softTimeoutFired ||= timers.state.softTimedOut;
-					clearTimeout(timers.softTimer);
-					clearTimeout(timers.hardTimer);
-					activeSessions.delete(observerSession);
-					unsubscribeObserver();
-					stopSession(observerSession);
 					remainingGroups--;
 				}
 			},
@@ -2138,60 +2143,63 @@ async function main() {
 			retryGroups,
 			concurrency,
 			async (group) => {
-				const retryTool = buildReportObservationTool(group.practiceSlugs);
-				const priorSessionFile = groupSessionFiles.get(group.id);
-				const { session: retrySession } = await createAgentSession({
-					cwd: CWD,
-					agentDir: AGENT_DIR,
-					tools: [...EVIDENCE_TOOLS, "report_observation"],
-					customTools: [grepTool, retryTool],
-					sessionManager: priorSessionFile
-						? SessionManager.open(priorSessionFile, sessionDir)
-						: SessionManager.inMemory(),
-					settingsManager,
-					resourceLoader: await loadResources(),
-					modelRuntime,
-					model,
-				});
-				const remainingRetryMs = Math.max(0, retryStartMs + retry.windowMs - Date.now());
-				if (retryAbort.signal.aborted || remainingRetryMs === 0) {
-					retryAborted = true;
-					retryAbort.abort();
-					stopSession(retrySession);
-					return;
-				}
-				const unsubscribeRetry = subscribeSession(
-					retrySession,
-					`retry:${group.id}`,
-					createRecordingPace(contextWindow, priorSessionFile !== undefined),
-				);
-				activeSessions.add(retrySession);
-				const activeSlots = Math.min(concurrency, retriesRemaining);
-				const retryBudgetMs = deriveWorkstreamBudget(
-					remainingRetryMs,
-					activeSlots,
-					retriesRemaining,
-				);
-				const retryDeadline = scheduleDeadline(retryBudgetMs, () => {
-					stopSession(retrySession);
-				});
 				try {
-					await Promise.race([
-						retrySession.prompt(
-							`${prompt}\n\n## Recovery practice group\nThe earlier group did not persist: ${group.practiceSlugs.join(", ")}. ` +
-								`Continue from its evidence and tool feedback. Persist one best-justified outcome for each missing ` +
-								`practice now; read more only to resolve a specific validation failure or genuinely open evidence ` +
-								`question. Evaluate no other practice. ${PERSIST_DISCIPLINE}`,
-						),
-						retryDeadline.elapsed,
-					]);
+					const retryTool = buildReportObservationTool(group.practiceSlugs);
+					const priorSessionFile = groupSessionFiles.get(group.id);
+					const { session: retrySession } = await createAgentSession({
+						cwd: CWD,
+						agentDir: AGENT_DIR,
+						tools: [...EVIDENCE_TOOLS, "report_observation"],
+						customTools: [grepTool, retryTool],
+						sessionManager: priorSessionFile
+							? SessionManager.open(priorSessionFile, sessionDir)
+							: SessionManager.inMemory(),
+						settingsManager,
+						resourceLoader: await loadResources(),
+						modelRuntime,
+						model,
+					});
+					const remainingRetryMs = Math.max(0, retryStartMs + retry.windowMs - Date.now());
+					if (retryAbort.signal.aborted || remainingRetryMs === 0) {
+						retryAborted = true;
+						retryAbort.abort();
+						stopSession(retrySession);
+						return;
+					}
+					const unsubscribeRetry = subscribeSession(
+						retrySession,
+						`retry:${group.id}`,
+						createRecordingPace(contextWindow, priorSessionFile !== undefined),
+					);
+					activeSessions.add(retrySession);
+					const activeSlots = Math.min(concurrency, retriesRemaining);
+					const retryBudgetMs = deriveWorkstreamBudget(
+						remainingRetryMs,
+						activeSlots,
+						retriesRemaining,
+					);
+					const retryDeadline = scheduleDeadline(retryBudgetMs, () => {
+						stopSession(retrySession);
+					});
+					try {
+						await Promise.race([
+							retrySession.prompt(
+								`${prompt}\n\n## Recovery practice group\nThe earlier group did not persist: ${group.practiceSlugs.join(", ")}. ` +
+									`Continue from its evidence and tool feedback. Persist one best-justified outcome for each missing ` +
+									`practice now; read more only to resolve a specific validation failure or genuinely open evidence ` +
+									`question. Evaluate no other practice. ${PERSIST_DISCIPLINE}`,
+							),
+							retryDeadline.elapsed,
+						]);
+					} finally {
+						clearTimeout(retryDeadline.timer);
+						activeSessions.delete(retrySession);
+						unsubscribeRetry();
+						stopSession(retrySession);
+					}
 				} catch (error) {
 					console.error(`[pi-runner] retry ${group.id} failed: ${errorText(error)}`);
 				} finally {
-					clearTimeout(retryDeadline.timer);
-					activeSessions.delete(retrySession);
-					unsubscribeRetry();
-					stopSession(retrySession);
 					retriesRemaining--;
 				}
 			},

--- a/server/application/src/main/resources/agent/pi-runner.ts
+++ b/server/application/src/main/resources/agent/pi-runner.ts
@@ -2146,6 +2146,14 @@ async function main() {
 				try {
 					const retryTool = buildReportObservationTool(group.practiceSlugs);
 					const priorSessionFile = groupSessionFiles.get(group.id);
+					// Before building anything: a session costs the budget composition is about to need,
+					// and a window that is already gone would only have it stopped again. The same check
+					// runs after creation too, because building one takes time of its own.
+					if (retryAbort.signal.aborted || retryStartMs + retry.windowMs - Date.now() <= 0) {
+						retryAborted = true;
+						retryAbort.abort();
+						return;
+					}
 					const { session: retrySession } = await createAgentSession({
 						cwd: CWD,
 						agentDir: AGENT_DIR,

--- a/server/application/src/main/resources/agent/pi-runner.ts
+++ b/server/application/src/main/resources/agent/pi-runner.ts
@@ -2146,10 +2146,14 @@ async function main() {
 				try {
 					const retryTool = buildReportObservationTool(group.practiceSlugs);
 					const priorSessionFile = groupSessionFiles.get(group.id);
+					// Read through a call rather than inline: testing `signal.aborted` directly narrows it
+					// to false for the rest of the branch, which would make the identical check after
+					// the await dead to the type system while the signal can still abort during it.
+					const retryIsOver = () =>
+						retryAbort.signal.aborted || retryStartMs + retry.windowMs - Date.now() <= 0;
 					// Before building anything: a session costs the budget composition is about to need,
-					// and a window that is already gone would only have it stopped again. The same check
-					// runs after creation too, because building one takes time of its own.
-					if (retryAbort.signal.aborted || retryStartMs + retry.windowMs - Date.now() <= 0) {
+					// and a window that is already gone would only have it stopped again.
+					if (retryIsOver()) {
 						retryAborted = true;
 						retryAbort.abort();
 						return;
@@ -2167,13 +2171,15 @@ async function main() {
 						modelRuntime,
 						model,
 					});
-					const remainingRetryMs = Math.max(0, retryStartMs + retry.windowMs - Date.now());
-					if (retryAbort.signal.aborted || remainingRetryMs === 0) {
+					// Again after: building the session takes time of its own, and the window may have
+					// closed or the abort fired while it was being built.
+					if (retryIsOver()) {
 						retryAborted = true;
 						retryAbort.abort();
 						stopSession(retrySession);
 						return;
 					}
+					const remainingRetryMs = Math.max(0, retryStartMs + retry.windowMs - Date.now());
 					const unsubscribeRetry = subscribeSession(
 						retrySession,
 						`retry:${group.id}`,

--- a/server/application/src/main/resources/agent/pi-runner.ts
+++ b/server/application/src/main/resources/agent/pi-runner.ts
@@ -56,6 +56,7 @@ import {
 import { isRetryableStatus, retrying } from "./pi-runner-retry.ts";
 import {
 	armRetryWindow,
+	deriveCompositionWindow,
 	deriveReconBudget,
 	deriveTimeouts,
 	deriveTurnTiming,
@@ -1831,6 +1832,7 @@ async function main() {
 	async function completeWithAdmittedComposition(notReached: readonly string[]) {
 		measurementClosed = true;
 		await admitObservations();
+		persistComposedFeedback();
 		const parsed = parseJson(readFileSync(RESULT_PATH, "utf8"));
 		const result: Record<string, unknown> = isRecord(parsed) ? parsed : {};
 		result.admissionDigest = admissionDigest;
@@ -1853,7 +1855,18 @@ async function main() {
 		}
 		const unsubscribeComposer = subscribeSession(composerSession, "composer");
 		const instructions = readFileSync(COMPOSER_PROMPT_PATH, "utf8");
-		const compositionDeadline = scheduleDeadline(COMPOSITION_TIMEOUT_MS, () => {
+		const compositionMs = deriveCompositionWindow(
+			COMPOSITION_TIMEOUT_MS,
+			AGENT_BUDGET_MS - (Date.now() - PROCESS_START_MS),
+		);
+		if (compositionMs === 0) {
+			console.error("[pi-runner] Composition budget exhausted — preserving admitted observations");
+			unsubscribeComposer();
+			stopSession(composerSession);
+			persistComposedFeedback();
+			return;
+		}
+		const compositionDeadline = scheduleDeadline(compositionMs, () => {
 			console.error(
 				`[pi-runner] Composition timeout — preserving observations and composed units so far`,
 			);
@@ -1869,10 +1882,10 @@ async function main() {
 		} finally {
 			clearTimeout(compositionDeadline.timer);
 			unsubscribeComposer();
+			stopSession(composerSession);
+			persistComposedFeedback();
 		}
-		persistComposedFeedback();
 		const combinedUsage = extractUsageFromSession(composerSession.state, streamUsage);
-		stopSession(composerSession);
 		accumulateUsage(prevUsage, combinedUsage);
 		prevUsage = combinedUsage;
 		persistUsage();
@@ -1882,14 +1895,18 @@ async function main() {
 	const activeSessions = new Set<AgentSession>();
 	const hardAbort = new AbortController();
 
-	const hardTimer = setTimeout(() => {
+	const reviewDeadline = PROCESS_START_MS + INITIAL_TIMEOUT_MS;
+	const abortInitial = () => {
 		hardAborted = true;
 		hardAbort.abort();
 		console.error(`[pi-runner] Hard timeout — aborting ${activeSessions.size} active session(s)`);
 		for (const activeSession of activeSessions) {
 			stopSession(activeSession);
 		}
-	}, INITIAL_TIMEOUT_MS);
+	};
+	const initialWindowMs = Math.max(0, reviewDeadline - Date.now());
+	const hardTimer = initialWindowMs > 0 ? setTimeout(abortInitial, initialWindowMs) : undefined;
+	if (initialWindowMs === 0) abortInitial();
 
 	console.error(`[pi-runner] Starting initial analysis`);
 	const startMs = Date.now();
@@ -1905,7 +1922,6 @@ async function main() {
 		tree.practiceCount,
 	);
 	const sessionDir = `${CWD}/.sessions`;
-	const reviewDeadline = startMs + INITIAL_TIMEOUT_MS;
 	console.error(
 		`[pi-runner] Review tree: ${tree.practiceCount} practices, ${tree.groups.length} evidence group(s), concurrency=${concurrency}`,
 	);
@@ -1925,40 +1941,49 @@ async function main() {
 			modelRuntime,
 			model,
 		});
-		const unsubscribeRecon = subscribeSession(reconSession, "recon:shared");
-		activeSessions.add(reconSession);
-		const reconBudgetMs = deriveReconBudget(INITIAL_TIMEOUT_MS);
-		const reconDeadline = scheduleDeadline(reconBudgetMs, () => stopSession(reconSession));
-		try {
-			const groupScope = tree.groups
-				.map((group) => `${group.id} [${group.practiceSlugs.join(", ")}]`)
-				.join("; ");
-			await Promise.race([
-				reconSession.prompt(
-					`Build one factual reconnaissance map for this review. Read the manifest and the artifact summary first, then inspect only enough shared evidence to identify changed surfaces, review activity, linked work, tests, and likely code paths. Record exact artifact paths and diff coordinates. Do not evaluate a practice or claim GOOD/BAD. The following group sessions will continue from this checkpoint: ${groupScope}`,
-				),
-				reconDeadline.elapsed,
-			]);
-			const { seedSessionFile, checkpointEntryId } = reconnaissanceSeed(
-				reconSession.sessionManager,
-				reconDeadline.state,
-				reconBudgetMs,
-			);
-			for (const fork of forkSessions({
-				seedSessionFile,
-				checkpointEntryId,
-				keys: tree.groups.map((group) => group.id),
-				sessionDir,
-			})) {
-				groupSeedFiles.set(fork.key, fork.sessionFile);
-			}
-		} catch (error) {
-			console.error(`[pi-runner] shared reconnaissance failed: ${errorText(error)}`);
-		} finally {
-			clearTimeout(reconDeadline.timer);
-			activeSessions.delete(reconSession);
-			unsubscribeRecon();
+		if (hardAbort.signal.aborted || Date.now() >= reviewDeadline) {
+			hardAborted = true;
+			hardAbort.abort();
 			stopSession(reconSession);
+		} else {
+			const unsubscribeRecon = subscribeSession(reconSession, "recon:shared");
+			activeSessions.add(reconSession);
+			const reconBudgetMs = Math.min(
+				deriveReconBudget(INITIAL_TIMEOUT_MS),
+				reviewDeadline - Date.now(),
+			);
+			const reconDeadline = scheduleDeadline(reconBudgetMs, () => stopSession(reconSession));
+			try {
+				const groupScope = tree.groups
+					.map((group) => `${group.id} [${group.practiceSlugs.join(", ")}]`)
+					.join("; ");
+				await Promise.race([
+					reconSession.prompt(
+						`Build one factual reconnaissance map for this review. Read the manifest and the artifact summary first, then inspect only enough shared evidence to identify changed surfaces, review activity, linked work, tests, and likely code paths. Record exact artifact paths and diff coordinates. Do not evaluate a practice or claim GOOD/BAD. The following group sessions will continue from this checkpoint: ${groupScope}`,
+					),
+					reconDeadline.elapsed,
+				]);
+				const { seedSessionFile, checkpointEntryId } = reconnaissanceSeed(
+					reconSession.sessionManager,
+					reconDeadline.state,
+					reconBudgetMs,
+				);
+				for (const fork of forkSessions({
+					seedSessionFile,
+					checkpointEntryId,
+					keys: tree.groups.map((group) => group.id),
+					sessionDir,
+				})) {
+					groupSeedFiles.set(fork.key, fork.sessionFile);
+				}
+			} catch (error) {
+				console.error(`[pi-runner] shared reconnaissance failed: ${errorText(error)}`);
+			} finally {
+				clearTimeout(reconDeadline.timer);
+				activeSessions.delete(reconSession);
+				unsubscribeRecon();
+				stopSession(reconSession);
+			}
 		}
 	}
 
@@ -1984,6 +2009,12 @@ async function main() {
 					modelRuntime,
 					model,
 				});
+				if (hardAbort.signal.aborted || Date.now() >= reviewDeadline) {
+					hardAborted = true;
+					hardAbort.abort();
+					stopSession(observerSession);
+					return;
+				}
 				const unsubscribeObserver = subscribeSession(
 					observerSession,
 					`observer:${group.id}`,
@@ -2122,6 +2153,13 @@ async function main() {
 					modelRuntime,
 					model,
 				});
+				const remainingRetryMs = Math.max(0, retryStartMs + retry.windowMs - Date.now());
+				if (retryAbort.signal.aborted || remainingRetryMs === 0) {
+					retryAborted = true;
+					retryAbort.abort();
+					stopSession(retrySession);
+					return;
+				}
 				const unsubscribeRetry = subscribeSession(
 					retrySession,
 					`retry:${group.id}`,
@@ -2129,7 +2167,11 @@ async function main() {
 				);
 				activeSessions.add(retrySession);
 				const activeSlots = Math.min(concurrency, retriesRemaining);
-				const retryBudgetMs = deriveWorkstreamBudget(retry.windowMs, activeSlots, retriesRemaining);
+				const retryBudgetMs = deriveWorkstreamBudget(
+					remainingRetryMs,
+					activeSlots,
+					retriesRemaining,
+				);
 				const retryDeadline = scheduleDeadline(retryBudgetMs, () => {
 					stopSession(retrySession);
 				});

--- a/server/application/src/main/resources/practices/precompute/issue-has-checkable-outcome.ts
+++ b/server/application/src/main/resources/practices/precompute/issue-has-checkable-outcome.ts
@@ -1,21 +1,12 @@
+import { classifyIssue, type IssueMetadata } from "../lib/issue-classification.ts";
 import type { Hint } from "../lib/types.ts";
-
-interface IssueMeta {
-	title?: string;
-	body?: string;
-	issue_type?: string | null;
-	labels?: string[];
-}
 
 export default function issueHasCheckableOutcome(
 	_repo: string,
 	_diff: Map<string, unknown>,
-	m: IssueMeta,
+	m: IssueMetadata,
 ) {
-	const body = (m.body ?? "").trim();
-	const title = (m.title ?? "").trim();
-	const issueType = (m.issue_type ?? "").toLowerCase();
-	const labels = (m.labels ?? []).map((l) => l.toLowerCase());
+	const { body, emptyOrTitleEcho, hasDeliverableType, looksUmbrella } = classifyIssue(m);
 	const uncheckedBoxes = (body.match(/^[\s>]*[-*]\s+\[ \]/gm) ?? []).length;
 	const checkedBoxes = (body.match(/^[\s>]*[-*]\s+\[[xX]\]/gm) ?? []).length;
 	const totalBoxes = uncheckedBoxes + checkedBoxes;
@@ -27,21 +18,6 @@ export default function issueHasCheckableOutcome(
 	const valueClause =
 		/\bso that\b/i.test(body) || /\bas an?\b[\s\S]{0,60}\bi (want|need|would like)\b/i.test(body);
 	const isStub = body.length < 40;
-
-	const norm = (s: string) => s.toLowerCase().replace(/[^a-z0-9]/g, "");
-	const titleNorm = norm(title);
-	const bodyNorm = norm(body);
-	const titleEcho =
-		bodyNorm.length > 0 &&
-		(bodyNorm === titleNorm || titleNorm.includes(bodyNorm) || bodyNorm.includes(titleNorm));
-	const emptyOrTitleEcho = body.length < 25 || titleEcho;
-	const deliverableType =
-		/\b(user ?story|story|bug|defect|feature|enhancement|task|chore|requirement|artifact|epic|spike)\b/;
-	const hasDeliverableType =
-		deliverableType.test(issueType) || labels.some((l) => deliverableType.test(l));
-	const looksUmbrella =
-		labels.some((l) => /\b(epic|umbrella|meta|initiative|requirement)\b/.test(l)) ||
-		/\b(epic|umbrella|initiative)\b/i.test(title);
 
 	const directions: string[] = [];
 	if (emptyOrTitleEcho && hasDeliverableType) {

--- a/server/application/src/main/resources/practices/precompute/issue-scoped-to-single-concern.ts
+++ b/server/application/src/main/resources/practices/precompute/issue-scoped-to-single-concern.ts
@@ -1,3 +1,4 @@
+import { classifyIssue, type IssueMetadata } from "../lib/issue-classification.ts";
 // Precompute HINTS for issue-scoped-to-single-concern: surface signals that an issue may bundle more than
 // one independently-shippable deliverable — multiple distinct task sections, "and also"/enumerated asks,
 // many referenced child issues. FACTS only (counts + the sub-issue rollup); the LLM decides single vs
@@ -6,10 +7,7 @@
 import { readProjectInventory } from "../lib/context.ts";
 import type { Hint } from "../lib/types.ts";
 
-interface IssueMeta {
-	title?: string;
-	body?: string;
-	labels?: string[];
+interface IssueScopeMetadata extends IssueMetadata {
 	sub_issues_total?: number;
 	sub_issues_completed?: number;
 }
@@ -17,29 +15,15 @@ interface IssueMeta {
 export default async function issueScopedToSingleConcern(
 	_repo: string,
 	_diff: Map<string, unknown>,
-	m: IssueMeta,
+	m: IssueScopeMetadata,
 	contextDir?: string,
 ) {
-	const body = (m.body ?? "").trim();
-	const title = (m.title ?? "").trim();
-	const labels = (m.labels ?? []).map((l) => l.toLowerCase());
+	const { body, title, labels, emptyOrTitleEcho } = classifyIssue(m);
 
 	const isStub = body.length < 40;
 	const isDiscussion =
 		labels.some((l) => /support|question|discussion/.test(l)) ||
 		(/\?\s*$/.test(title) && body.length < 120);
-
-	// Empty-or-title-echo gate — the SAME classification fact issue-has-checkable-outcome keys its observation
-	// off. When the body carries no content of its own, there is NO deliverable to scope, so the practice is
-	// NOT_APPLICABLE — never a PRESENT, GOOD reading off the title alone. Kept byte-aligned with the sibling's
-	// computation on purpose (precompute scripts ship as standalone DB rows).
-	const norm = (s: string) => s.toLowerCase().replace(/[^a-z0-9]/g, "");
-	const titleNorm = norm(title);
-	const bodyNorm = norm(body);
-	const titleEcho =
-		bodyNorm.length > 0 &&
-		(bodyNorm === titleNorm || titleNorm.includes(bodyNorm) || bodyNorm.includes(titleNorm));
-	const emptyOrTitleEcho = body.length < 25 || titleEcho;
 
 	const checkboxes = (body.match(/^[\s>]*[-*]\s+\[[ xX]\]/gm) ?? []).length;
 	const childRefs = new Set((body.match(/(^|\s)#\d+\b/g) ?? []).map((s) => s.trim())).size;

--- a/server/application/src/main/resources/practices/precompute/issue-states-an-actionable-problem.ts
+++ b/server/application/src/main/resources/practices/precompute/issue-states-an-actionable-problem.ts
@@ -1,4 +1,5 @@
 import { type InventoryItem, readProjectInventory } from "../lib/context.ts";
+import { classifyIssue, type IssueMetadata } from "../lib/issue-classification.ts";
 import type { Hint } from "../lib/types.ts";
 
 /** Title-token overlap (Jaccard) — a coarse near-duplicate signal across the project inventory. */
@@ -20,26 +21,16 @@ function titleOverlap(a: string, b: string): number {
 	return inter / (x.size + y.size - inter);
 }
 
-interface IssueMeta {
-	title?: string;
-	body?: string;
-	issue_type?: string | null;
-	labels?: string[];
-	state?: string;
-}
-
 const has = (re: RegExp, s: string) => re.test(s);
 
 export default async function issueStatesAnActionableProblem(
 	_repo: string,
 	_diff: Map<string, unknown>,
-	m: IssueMeta,
+	m: IssueMetadata,
 	contextDir?: string,
 ) {
-	const body = (m.body ?? "").trim();
-	const title = (m.title ?? "").trim();
-	const issueType = (m.issue_type ?? "").toLowerCase();
-	const labels = (m.labels ?? []).map((l) => l.toLowerCase());
+	const { body, title, issueType, labels, emptyOrTitleEcho, hasDeliverableType, looksUmbrella } =
+		classifyIssue(m);
 
 	const bodyLen = body.length;
 	const isStub = bodyLen < 40 || /^_?no response_?$/i.test(body);
@@ -49,21 +40,6 @@ export default async function issueStatesAnActionableProblem(
 			.replace(/<!--[\s\S]*?-->/g, "")
 			.replace(/^#{1,3}.*$/gm, "")
 			.trim().length < 60;
-
-	const norm = (s: string) => s.toLowerCase().replace(/[^a-z0-9]/g, "");
-	const titleNorm = norm(title);
-	const bodyNorm = norm(body);
-	const titleEcho =
-		bodyNorm.length > 0 &&
-		(bodyNorm === titleNorm || titleNorm.includes(bodyNorm) || bodyNorm.includes(titleNorm));
-	const emptyOrTitleEcho = body.length < 25 || titleEcho;
-	const deliverableType =
-		/\b(user ?story|story|bug|defect|feature|enhancement|task|chore|requirement|artifact|epic|spike)\b/;
-	const hasDeliverableType =
-		deliverableType.test(issueType) || labels.some((l) => deliverableType.test(l));
-	const looksUmbrella =
-		labels.some((l) => /\b(epic|umbrella|meta|initiative|requirement)\b/.test(l)) ||
-		/\b(epic|umbrella|initiative)\b/i.test(title);
 
 	const typeBug = /bug|defect/.test(issueType) || labels.some((l) => /bug|defect|fix/.test(l));
 	const typeStory =

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/gateway/SandboxGatewayConfigurationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/gateway/SandboxGatewayConfigurationTest.java
@@ -2,14 +2,19 @@ package de.tum.cit.aet.hephaestus.agent.gateway;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import de.tum.cit.aet.hephaestus.core.auth.ratelimit.AuthRateLimitConfig;
 import de.tum.cit.aet.hephaestus.core.auth.ratelimit.AuthRateLimitProperties;
 import de.tum.cit.aet.hephaestus.core.auth.ratelimit.BucketResolver;
 import de.tum.cit.aet.hephaestus.testconfig.BaseUnitTest;
 import io.github.bucket4j.BucketConfiguration;
+import java.io.IOException;
 import java.net.InetAddress;
 import java.time.Duration;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.env.YamlPropertySourceLoader;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.boot.tomcat.servlet.TomcatServletWebServerFactory;
+import org.springframework.core.io.ClassPathResource;
 
 class SandboxGatewayConfigurationTest extends BaseUnitTest {
 
@@ -34,18 +39,22 @@ class SandboxGatewayConfigurationTest extends BaseUnitTest {
         assertThat(factory.getAddress()).isEqualTo(InetAddress.getLoopbackAddress());
     }
 
-    /**
-     * The fallback a worker-only pod runs on, where the instance's shared resolver is not wired. Two
-     * calls with one key have to reach one bucket, or the limit stops limiting.
-     */
     @Test
-    void givesOneBucketPerKeyWhenThePodHasNoSharedResolver() {
-        BucketResolver resolver = new SandboxGatewayConfiguration().sandboxGatewayBucketResolver();
-        BucketConfiguration onePerMinute =
-                new AuthRateLimitProperties.Limit(1, Duration.ofMinutes(1)).bucketConfiguration();
-
-        assertThat(resolver.resolve("job:1", onePerMinute).tryConsume(1)).isTrue();
-        assertThat(resolver.resolve("job:1", onePerMinute).tryConsume(1)).isFalse();
-        assertThat(resolver.resolve("job:2", onePerMinute).tryConsume(1)).isTrue();
+    void shouldProvideGatewayBucketsWithoutAuthInfrastructureWhenWorkerProfileIsLoaded() throws IOException {
+        var overlay = new YamlPropertySourceLoader().load("worker", new ClassPathResource("application-worker.yml"));
+        new ApplicationContextRunner()
+                .withUserConfiguration(SandboxGatewayConfiguration.class, AuthRateLimitConfig.class)
+                .withInitializer(context -> overlay.forEach(
+                        source -> context.getEnvironment().getPropertySources().addLast(source)))
+                .run(context -> {
+                    assertThat(context).hasNotFailed().hasSingleBean(BucketResolver.class);
+                    assertThat(context).doesNotHaveBean(AuthRateLimitConfig.class);
+                    BucketResolver resolver = context.getBean(BucketResolver.class);
+                    BucketConfiguration limit =
+                            new AuthRateLimitProperties.Limit(1, Duration.ofMinutes(1)).bucketConfiguration();
+                    assertThat(resolver.resolve("job:1", limit).tryConsume(1)).isTrue();
+                    assertThat(resolver.resolve("job:1", limit).tryConsume(1)).isFalse();
+                    assertThat(resolver.resolve("job:2", limit).tryConsume(1)).isTrue();
+                });
     }
 }

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/runtime/PiRuntimeFactoryTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/runtime/PiRuntimeFactoryTest.java
@@ -13,6 +13,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
@@ -233,26 +235,9 @@ class PiRuntimeFactoryTest extends BaseUnitTest {
     @Nested
     class Environment {
 
-        @Test
-        void budget_leavesGraceUnderSpecTimeout() {
-            var pspec = spec("azure-openai-responses", "gpt-5.4-mini", false);
-            String budget = factory.build(pspec).environment().get("AGENT_BUDGET_MS");
-            assertThat(budget).as("AGENT_BUDGET_MS must be present").isNotNull();
-            long budgetMs = Long.parseLong(budget);
-            long hardTimeoutMs = (long) pspec.timeoutSeconds() * 1_000L;
-            assertThat(budgetMs)
-                    .as("Pi's self-watchdog must fire strictly before the SPI hard kill — leaves grace")
-                    .isLessThan(hardTimeoutMs)
-                    .isPositive();
-        }
-
-        @Test
-        @DisplayName("budget floor applies just above the minimum timeout — stays positive and under the hard kill")
-        void budget_floorAppliesAtMinimumTimeout() {
-            // Smallest spec PiPlanSpec accepts (timeoutSeconds > TIMEOUT_BUFFER_SECONDS=60). The computed
-            // budget (1s) is below MIN_BUDGET_MS, so the floor branch fires — this exercises the otherwise
-            // untested Math.max floor. The floor must stay positive AND strictly under the hard-kill deadline.
-            int timeoutSeconds = PiRuntimeFactory.TIMEOUT_BUFFER_SECONDS + 1;
+        @ParameterizedTest
+        @CsvSource({"61, 1000", "90, 30000", "119, 59000", "600, 540000", "2147483647, 2147483587000"})
+        void shouldReserveShutdownTimeBeforeTheSandboxDeadline(int timeoutSeconds, long expectedBudgetMs) {
             PiPlanSpec spec = new PiPlanSpec(
                     "openai-completions",
                     "gpt-x",
@@ -265,12 +250,13 @@ class PiRuntimeFactoryTest extends BaseUnitTest {
                     PRACTICE,
                     Map.of(),
                     "");
+
             long budgetMs = Long.parseLong(factory.build(spec).environment().get("AGENT_BUDGET_MS"));
-            long hardTimeoutMs = (long) timeoutSeconds * 1_000L;
-            assertThat(budgetMs)
-                    .isEqualTo(PiRuntimeFactory.MIN_BUDGET_MS)
-                    .isPositive()
-                    .isLessThan(hardTimeoutMs);
+
+            assertThat(budgetMs).isEqualTo(expectedBudgetMs).isPositive();
+            assertThat(budgetMs + 30_000L)
+                    .as("the runner's watchdog includes a 30-second shutdown grace")
+                    .isLessThan(timeoutSeconds * 1000L);
         }
 
         @Test

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/DockerSandboxAdapterTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/DockerSandboxAdapterTest.java
@@ -188,7 +188,7 @@ class DockerSandboxAdapterTest extends BaseUnitTest {
             Map<String, String> env = captor.getValue().environment();
             // No per-provider path segment — the connection is identified from the authenticated token, not the URL.
             assertThat(env).containsEntry("LLM_PROXY_URL", "http://172.18.0.2:8081/internal/llm");
-            assertThat(env).containsEntry("GATEWAY_URL", "http://172.18.0.2:8081");
+            assertThat(env).doesNotContainKey("GATEWAY_URL");
             assertThat(env).containsEntry("LLM_PROXY_TOKEN", "token-123");
         }
 

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/auth/AccountHardDeleteSweeperTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/auth/AccountHardDeleteSweeperTest.java
@@ -11,10 +11,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import de.tum.cit.aet.hephaestus.core.PrivacyJobMetrics;
-import de.tum.cit.aet.hephaestus.core.PrivacyJobMetrics.Job;
-import de.tum.cit.aet.hephaestus.core.PrivacyJobMetrics.Outcome;
 import de.tum.cit.aet.hephaestus.core.auth.domain.AccountRepository;
 import de.tum.cit.aet.hephaestus.testconfig.BaseUnitTest;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
@@ -36,8 +35,8 @@ class AccountHardDeleteSweeperTest extends BaseUnitTest {
     @Mock
     private AuthProperties authProperties;
 
-    @Mock
-    private PrivacyJobMetrics metrics;
+    private final SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    private final PrivacyJobMetrics metrics = new PrivacyJobMetrics(registry);
 
     private final Clock clock = Clock.fixed(NOW, ZoneOffset.UTC);
 
@@ -73,8 +72,16 @@ class AccountHardDeleteSweeperTest extends BaseUnitTest {
 
         sweeper.sweep();
 
-        verify(metrics).record(Job.ACCOUNT_ERASURE, Outcome.SUCCESS);
-        verify(metrics).recordAffected(Job.ACCOUNT_ERASURE, 0);
+        assertThat(registry.get("privacy.job.completed")
+                        .tags("job", "account_erasure", "outcome", "success")
+                        .counter()
+                        .count())
+                .isEqualTo(1);
+        assertThat(registry.get("privacy.job.affected")
+                        .tag("job", "account_erasure")
+                        .counter()
+                        .count())
+                .isEqualTo(0);
     }
 
     @Test
@@ -86,6 +93,10 @@ class AccountHardDeleteSweeperTest extends BaseUnitTest {
 
         assertThatThrownBy(sweeper::sweep).isInstanceOf(IllegalStateException.class);
 
-        verify(metrics).record(Job.ACCOUNT_ERASURE, Outcome.FAILURE);
+        assertThat(registry.get("privacy.job.completed")
+                        .tags("job", "account_erasure", "outcome", "failure")
+                        .counter()
+                        .count())
+                .isEqualTo(1);
     }
 }

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/auth/export/ExportGenerationWorkerIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/auth/export/ExportGenerationWorkerIntegrationTest.java
@@ -1,0 +1,102 @@
+package de.tum.cit.aet.hephaestus.core.auth.export;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import de.tum.cit.aet.hephaestus.core.PrivacyJobMetrics;
+import de.tum.cit.aet.hephaestus.core.auth.domain.Account;
+import de.tum.cit.aet.hephaestus.core.auth.domain.AccountRepository;
+import de.tum.cit.aet.hephaestus.testconfig.BaseIntegrationTest;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Clock;
+import java.util.List;
+import java.util.Objects;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.PlatformTransactionManager;
+import tools.jackson.databind.ObjectMapper;
+
+class ExportGenerationWorkerIntegrationTest extends BaseIntegrationTest {
+
+    @Autowired
+    private AccountExportRepository repository;
+
+    @Autowired
+    private AccountRepository accountRepository;
+
+    @Autowired
+    private PlatformTransactionManager transactionManager;
+
+    @Autowired
+    private JdbcTemplate jdbc;
+
+    @Autowired
+    private Clock clock;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void shouldCommitFailureWhenTheAssemblyTransactionIsAborted() {
+        Long accountId = Objects.requireNonNull(
+                accountRepository.save(new Account("Failed export subject")).getId());
+        Long exportId = Objects.requireNonNull(
+                repository.save(new AccountExport(accountId)).getId());
+        ExportBundleAssembler assembler = mock(ExportBundleAssembler.class);
+        when(assembler.assemble(accountId)).thenAnswer(invocation -> {
+            jdbc.execute("SELECT 1 / 0");
+            throw new AssertionError("PostgreSQL must abort the transaction");
+        });
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        ExportGenerationWorker worker = new ExportGenerationWorker(
+                repository, assembler, objectMapper, clock, new PrivacyJobMetrics(registry), transactionManager);
+
+        worker.generate(exportId, accountId);
+
+        assertFailureCommitted(exportId, registry);
+    }
+
+    @Test
+    void shouldCommitFailureWithoutSuccessMetricsWhenGenerationCannotCommit() {
+        Long accountId = Objects.requireNonNull(accountRepository
+                .save(new Account("Export commit failure subject"))
+                .getId());
+        Long exportId = Objects.requireNonNull(
+                repository.save(new AccountExport(accountId)).getId());
+        ExportBundleAssembler assembler = mock(ExportBundleAssembler.class);
+        when(assembler.assemble(accountId)).thenAnswer(invocation -> {
+            // Dirty checking defers this constraint violation until the generation transaction commits.
+            repository.findByIdAndAccountId(exportId, accountId).orElseThrow().setFailureReason("x".repeat(129));
+            ExportBundle.Profile profile = new ExportBundle.Profile(accountId, "User", null, "ACTIVE", clock.instant());
+            return new ExportBundle("v1", clock.instant(), profile, List.of(), List.of(), List.of(), null, List.of());
+        });
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        ExportGenerationWorker worker = new ExportGenerationWorker(
+                repository, assembler, objectMapper, clock, new PrivacyJobMetrics(registry), transactionManager);
+
+        worker.generate(exportId, accountId);
+
+        assertFailureCommitted(exportId, registry);
+    }
+
+    private void assertFailureCommitted(Long exportId, SimpleMeterRegistry registry) {
+        AccountExport export = repository.findById(exportId).orElseThrow();
+        assertThat(export.getStatus()).isEqualTo(AccountExport.Status.FAILED);
+        assertThat(export.getFailureReason()).isEqualTo("assembly_failed");
+        assertThat(export.getPayload()).isNull();
+        assertThat(export.getCompletedAt()).isNull();
+        assertThat(export.getExpiresAt()).isNull();
+        assertThat(registry.get("privacy.job.completed")
+                        .tags("job", "export_generation", "outcome", "failure")
+                        .counter()
+                        .count())
+                .isEqualTo(1);
+        assertThat(registry.find("privacy.job.completed")
+                        .tags("job", "export_generation", "outcome", "success")
+                        .counter())
+                .isNull();
+        assertThat(registry.find("privacy.job.affected").counter()).isNull();
+    }
+}

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/auth/export/ExportGenerationWorkerTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/auth/export/ExportGenerationWorkerTest.java
@@ -9,9 +9,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import de.tum.cit.aet.hephaestus.core.PrivacyJobMetrics;
-import de.tum.cit.aet.hephaestus.core.PrivacyJobMetrics.Job;
-import de.tum.cit.aet.hephaestus.core.PrivacyJobMetrics.Outcome;
 import de.tum.cit.aet.hephaestus.testconfig.BaseUnitTest;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
@@ -20,15 +19,10 @@ import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.SimpleTransactionStatus;
 import tools.jackson.databind.ObjectMapper;
 
-/**
- * Pins {@link ExportGenerationWorker}'s outcome state machine: success sets payload + a 48h expiry
- * and flips to READY; an assembly error flips to FAILED with the payload nulled (never left
- * half-written); and a vanished row writes nothing. Guards against a failed export being stranded in
- * PROCESSING or a failure leaking a partial payload, and against any of the three paths ending
- * without the terminal outcome an operator alerts on.
- */
 class ExportGenerationWorkerTest extends BaseUnitTest {
 
     private static final long EXPORT_ID = 5L;
@@ -38,7 +32,8 @@ class ExportGenerationWorkerTest extends BaseUnitTest {
     private AccountExportRepository repository;
     private ExportBundleAssembler assembler;
     private ObjectMapper objectMapper;
-    private PrivacyJobMetrics metrics;
+    private final SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    private final PrivacyJobMetrics metrics = new PrivacyJobMetrics(registry);
     private ExportGenerationWorker worker;
 
     @BeforeEach
@@ -46,9 +41,10 @@ class ExportGenerationWorkerTest extends BaseUnitTest {
         repository = mock(AccountExportRepository.class);
         assembler = mock(ExportBundleAssembler.class);
         objectMapper = mock(ObjectMapper.class);
-        metrics = mock(PrivacyJobMetrics.class);
+        PlatformTransactionManager transactionManager = mock(PlatformTransactionManager.class);
+        when(transactionManager.getTransaction(any())).thenAnswer(invocation -> new SimpleTransactionStatus());
         worker = new ExportGenerationWorker(
-                repository, assembler, objectMapper, Clock.fixed(NOW, ZoneOffset.UTC), metrics);
+                repository, assembler, objectMapper, Clock.fixed(NOW, ZoneOffset.UTC), metrics, transactionManager);
     }
 
     private AccountExport existingExport() {
@@ -58,7 +54,7 @@ class ExportGenerationWorkerTest extends BaseUnitTest {
     }
 
     @Test
-    void generate_success_setsPayloadExpiryAndReady() {
+    void shouldSetPayloadExpiryAndReadyWhenGenerationSucceeds() {
         AccountExport export = existingExport();
         ExportBundle.Profile profile = new ExportBundle.Profile(ACCOUNT_ID, "User", null, "ACTIVE", NOW);
         ExportBundle bundle = new ExportBundle("v1", NOW, profile, List.of(), List.of(), List.of(), null, List.of());
@@ -71,12 +67,20 @@ class ExportGenerationWorkerTest extends BaseUnitTest {
         assertThat(export.getPayload()).containsExactly(1, 2, 3);
         assertThat(export.getCompletedAt()).isEqualTo(NOW);
         assertThat(export.getExpiresAt()).isEqualTo(NOW.plus(Duration.ofHours(48)));
-        verify(metrics).record(Job.EXPORT_GENERATION, Outcome.SUCCESS);
-        verify(metrics).recordAffected(Job.EXPORT_GENERATION, 1);
+        assertThat(registry.get("privacy.job.completed")
+                        .tags("job", "export_generation", "outcome", "success")
+                        .counter()
+                        .count())
+                .isEqualTo(1);
+        assertThat(registry.get("privacy.job.affected")
+                        .tag("job", "export_generation")
+                        .counter()
+                        .count())
+                .isEqualTo(1);
     }
 
     @Test
-    void generate_assemblyError_marksFailedAndNullsPayload() {
+    void shouldMarkFailedAndClearPayloadWhenAssemblyFails() {
         AccountExport export = existingExport();
         when(assembler.assemble(ACCOUNT_ID)).thenThrow(new RuntimeException("db unavailable"));
 
@@ -85,17 +89,79 @@ class ExportGenerationWorkerTest extends BaseUnitTest {
         assertThat(export.getStatus()).isEqualTo(AccountExport.Status.FAILED);
         assertThat(export.getFailureReason()).isEqualTo("assembly_failed");
         assertThat(export.getPayload()).isNull();
-        verify(metrics).record(Job.EXPORT_GENERATION, Outcome.FAILURE);
+        assertThat(registry.get("privacy.job.completed")
+                        .tags("job", "export_generation", "outcome", "failure")
+                        .counter()
+                        .count())
+                .isEqualTo(1);
     }
 
     @Test
-    void generate_missingRow_writesNothingAndReportsFailure() {
+    void shouldMarkFailedWhenTheInitialLookupFails() {
+        AccountExport export = new AccountExport(ACCOUNT_ID);
+        when(repository.findByIdAndAccountId(EXPORT_ID, ACCOUNT_ID))
+                .thenThrow(new IllegalStateException("lookup failed"))
+                .thenReturn(Optional.of(export));
+
+        worker.generate(EXPORT_ID, ACCOUNT_ID);
+
+        assertThat(export.getStatus()).isEqualTo(AccountExport.Status.FAILED);
+        assertThat(export.getFailureReason()).isEqualTo("assembly_failed");
+        assertThat(registry.get("privacy.job.completed")
+                        .tags("job", "export_generation", "outcome", "failure")
+                        .counter()
+                        .count())
+                .isEqualTo(1);
+    }
+
+    @Test
+    void shouldMarkFailedWhenSavingProcessingFails() {
+        AccountExport export = existingExport();
+        when(repository.save(export))
+                .thenThrow(new IllegalStateException("save failed"))
+                .thenReturn(export);
+
+        worker.generate(EXPORT_ID, ACCOUNT_ID);
+
+        assertThat(export.getStatus()).isEqualTo(AccountExport.Status.FAILED);
+        assertThat(export.getFailureReason()).isEqualTo("assembly_failed");
+        assertThat(registry.get("privacy.job.completed")
+                        .tags("job", "export_generation", "outcome", "failure")
+                        .counter()
+                        .count())
+                .isEqualTo(1);
+    }
+
+    @Test
+    void shouldReportFailureWhenTheDatabaseCannotRecordIt() {
+        when(repository.findByIdAndAccountId(EXPORT_ID, ACCOUNT_ID)).thenThrow(new IllegalStateException("db down"));
+
+        worker.generate(EXPORT_ID, ACCOUNT_ID);
+
+        assertThat(registry.get("privacy.job.completed")
+                        .tags("job", "export_generation", "outcome", "failure")
+                        .counter()
+                        .count())
+                .isEqualTo(1);
+        assertThat(registry.find("privacy.job.completed")
+                        .tags("job", "export_generation", "outcome", "success")
+                        .counter())
+                .isNull();
+        verify(repository, never()).save(any());
+    }
+
+    @Test
+    void shouldWriteNothingAndReportFailureWhenRowIsMissing() {
         when(repository.findByIdAndAccountId(EXPORT_ID, ACCOUNT_ID)).thenReturn(Optional.empty());
 
         worker.generate(EXPORT_ID, ACCOUNT_ID);
 
         verify(repository, never()).save(any());
         verify(assembler, never()).assemble(eq(ACCOUNT_ID));
-        verify(metrics).record(Job.EXPORT_GENERATION, Outcome.FAILURE);
+        assertThat(registry.get("privacy.job.completed")
+                        .tags("job", "export_generation", "outcome", "failure")
+                        .counter()
+                        .count())
+                .isEqualTo(1);
     }
 }

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/auth/export/ExportRetentionSweeperTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/auth/export/ExportRetentionSweeperTest.java
@@ -1,15 +1,14 @@
 package de.tum.cit.aet.hephaestus.core.auth.export;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import de.tum.cit.aet.hephaestus.core.PrivacyJobMetrics;
-import de.tum.cit.aet.hephaestus.core.PrivacyJobMetrics.Job;
-import de.tum.cit.aet.hephaestus.core.PrivacyJobMetrics.Outcome;
 import de.tum.cit.aet.hephaestus.testconfig.BaseUnitTest;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 
 class ExportRetentionSweeperTest extends BaseUnitTest {
@@ -17,11 +16,15 @@ class ExportRetentionSweeperTest extends BaseUnitTest {
     @Mock
     private AccountExportService accountExportService;
 
-    @Mock
-    private PrivacyJobMetrics metrics;
+    private final SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    private final PrivacyJobMetrics metrics = new PrivacyJobMetrics(registry);
 
-    @InjectMocks
     private ExportRetentionSweeper sweeper;
+
+    @BeforeEach
+    void setUp() {
+        sweeper = new ExportRetentionSweeper(accountExportService, metrics);
+    }
 
     @Test
     void shouldRecordSuccessAndTheExpiredCountWhenTheSweepRuns() {
@@ -29,8 +32,16 @@ class ExportRetentionSweeperTest extends BaseUnitTest {
 
         sweeper.sweep();
 
-        verify(metrics).record(Job.EXPORT_RETENTION, Outcome.SUCCESS);
-        verify(metrics).recordAffected(Job.EXPORT_RETENTION, 4);
+        assertThat(registry.get("privacy.job.completed")
+                        .tags("job", "export_retention", "outcome", "success")
+                        .counter()
+                        .count())
+                .isEqualTo(1);
+        assertThat(registry.get("privacy.job.affected")
+                        .tag("job", "export_retention")
+                        .counter()
+                        .count())
+                .isEqualTo(4);
     }
 
     @Test
@@ -39,8 +50,16 @@ class ExportRetentionSweeperTest extends BaseUnitTest {
 
         sweeper.sweep();
 
-        verify(metrics).record(Job.EXPORT_RETENTION, Outcome.SUCCESS);
-        verify(metrics).recordAffected(Job.EXPORT_RETENTION, 0);
+        assertThat(registry.get("privacy.job.completed")
+                        .tags("job", "export_retention", "outcome", "success")
+                        .counter()
+                        .count())
+                .isEqualTo(1);
+        assertThat(registry.get("privacy.job.affected")
+                        .tag("job", "export_retention")
+                        .counter()
+                        .count())
+                .isEqualTo(0);
     }
 
     @Test
@@ -49,6 +68,10 @@ class ExportRetentionSweeperTest extends BaseUnitTest {
 
         assertThatThrownBy(sweeper::sweep).isInstanceOf(IllegalStateException.class);
 
-        verify(metrics).record(Job.EXPORT_RETENTION, Outcome.FAILURE);
+        assertThat(registry.get("privacy.job.completed")
+                        .tags("job", "export_retention", "outcome", "failure")
+                        .counter()
+                        .count())
+                .isEqualTo(1);
     }
 }

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/core/connection/CredentialRotationServiceIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/core/connection/CredentialRotationServiceIntegrationTest.java
@@ -18,6 +18,7 @@ import java.util.Objects;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.transaction.support.TransactionTemplate;
 
 class CredentialRotationServiceIntegrationTest extends AbstractWorkspaceIntegrationTest {
@@ -46,7 +47,7 @@ class CredentialRotationServiceIntegrationTest extends AbstractWorkspaceIntegrat
         byte[] corrupted =
                 Objects.requireNonNull(corrupt.getCredentialsEncrypted()).clone();
         corrupted[corrupted.length - 1] ^= 1;
-        corrupt.setCredentialsEncrypted(corrupted);
+        ReflectionTestUtils.setField(corrupt, "credentialsEncrypted", corrupted);
         corrupt = connectionRepository.save(corrupt);
         Connection healthy = connectionRepository.save(connection(workspace, "healthy"));
         healthy.setCredentials(TOKEN, oldConverter);

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/core/connection/CredentialRotationServiceTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/core/connection/CredentialRotationServiceTest.java
@@ -18,7 +18,6 @@ import de.tum.cit.aet.hephaestus.integration.core.spi.IntegrationKind;
 import de.tum.cit.aet.hephaestus.testconfig.BaseUnitTest;
 import de.tum.cit.aet.hephaestus.workspace.Workspace;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import java.lang.reflect.Field;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -32,6 +31,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @Tag("unit")
 class CredentialRotationServiceTest extends BaseUnitTest {
@@ -111,7 +111,7 @@ class CredentialRotationServiceTest extends BaseUnitTest {
         byte[] corrupted =
                 Objects.requireNonNull(orphaned.getCredentialsEncrypted()).clone();
         corrupted[corrupted.length - 1] ^= 1;
-        orphaned.setCredentialsEncrypted(corrupted);
+        ReflectionTestUtils.setField(orphaned, "credentialsEncrypted", corrupted);
         Connection stale = connection(58L);
         stale.setCredentials(TOKEN, oldConverter);
         when(connectionRepository.lockCredentialRotationBatch(2, 25)).thenReturn(List.of(57L, 58L));
@@ -136,7 +136,7 @@ class CredentialRotationServiceTest extends BaseUnitTest {
         byte[] corrupted =
                 Objects.requireNonNull(orphaned.getCredentialsEncrypted()).clone();
         corrupted[corrupted.length - 1] ^= 1;
-        orphaned.setCredentialsEncrypted(corrupted);
+        ReflectionTestUtils.setField(orphaned, "credentialsEncrypted", corrupted);
         when(connectionRepository.lockCredentialRotationBatch(2, 25)).thenReturn(List.of(61L));
         when(connectionRepository.findAllById(List.of(61L))).thenReturn(List.of(orphaned));
 
@@ -197,21 +197,11 @@ class CredentialRotationServiceTest extends BaseUnitTest {
                 IntegrationKind.GITHUB,
                 "100",
                 new ConnectionConfig.GitHubAppConfig(100L, null, null, Set.of()));
-        setField(connection, "id", id);
+        ReflectionTestUtils.setField(connection, "id", id);
         return connection;
     }
 
     private static void setKeyVersion(Connection connection, @Nullable Integer version) {
-        setField(connection, "credentialsKeyVersion", version);
-    }
-
-    private static void setField(Connection connection, String name, @Nullable Object value) {
-        try {
-            Field field = Connection.class.getDeclaredField(name);
-            field.setAccessible(true);
-            field.set(connection, value);
-        } catch (ReflectiveOperationException e) {
-            throw new AssertionError(e);
-        }
+        ReflectionTestUtils.setField(connection, "credentialsKeyVersion", version);
     }
 }

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/practices/trace/PracticeTraceDeriverTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/practices/trace/PracticeTraceDeriverTest.java
@@ -64,11 +64,17 @@ class PracticeTraceDeriverTest extends BaseUnitTest {
         }
 
         @Test
-        void reportsAnAdmittedPracticeWithNoFindingsAsReviewedRatherThanSilent() {
+        void shouldReportAnExplicitlyEvaluatedPracticeWithoutObservationsAsReviewed() {
+            var review = new ReviewOutcome(
+                    ReviewRunState.COMPLETED,
+                    false,
+                    AT,
+                    Map.of("slug", new PracticeReadinessOutcome(true, List.of(), null)),
+                    Map.of("slug", PracticeCoverageOutcome.EVALUATED));
             var entry = only(
                     practice(PracticeAutonomy.AUTOMATIC, READY),
                     List.of(triggered(READY, RUN)),
-                    Map.of(RUN, completed(Map.of("slug", new PracticeReadinessOutcome(true, List.of(), null)))),
+                    Map.of(RUN, review),
                     Map.of());
 
             assertThat(entry.outcome()).isEqualTo(PracticeTraceOutcome.REVIEWED);
@@ -210,6 +216,19 @@ class PracticeTraceDeriverTest extends BaseUnitTest {
 
             assertThat(entry.outcome()).isEqualTo(PracticeTraceOutcome.NOT_REACHED);
             assertThat(entry.explanation()).contains("ended before reaching");
+        }
+
+        @Test
+        void shouldNotReportAnAllClearWhenACompletedReviewHasNoCoverageRecord() {
+            var entry = only(
+                    practice(PracticeAutonomy.AUTOMATIC, READY),
+                    List.of(triggered(READY, RUN)),
+                    Map.of(RUN, completed(Map.of("slug", new PracticeReadinessOutcome(true, List.of(), null)))),
+                    Map.of());
+
+            assertThat(entry.outcome()).isEqualTo(PracticeTraceOutcome.NOT_REACHED);
+            assertThat(entry.explanation()).isEqualTo("The review did not record whether it reached this practice.");
+            assertThat(entry.observationCount()).isZero();
         }
 
         @Test

--- a/server/application/src/test/resources/agent/pi-runner-orchestration.spec.ts
+++ b/server/application/src/test/resources/agent/pi-runner-orchestration.spec.ts
@@ -88,8 +88,8 @@ if (scenario) {
 							: "retry"
 						: "recon";
 				record(`create:${lane}`);
-				if (lane === "composer" && scenario === "composer")
-					throw new Error("Composer initialization failed");
+				if (scenario === `${lane}-init` || (lane === "composer" && scenario === "composer"))
+					throw new Error(`${lane} initialization failed`);
 				if (lane === "composer" && scenario === "composer-budget") now += 20_000;
 				if (scenario === lane) now += 20_000;
 				return Promise.resolve({
@@ -103,7 +103,13 @@ if (scenario) {
 						async prompt() {
 							record(`prompt:${lane}`);
 							if (lane === "recon") throw new Error("Reconnaissance unavailable");
-							if (scenario.startsWith("composer") && lane === "observer") {
+							if (
+								((scenario.startsWith("composer") ||
+									scenario === "recon-init" ||
+									scenario === "retry-init") &&
+									lane === "observer") ||
+								(scenario === "observer-init" && lane === "retry")
+							) {
 								const tool = options.customTools.find((item) => item.name === "report_observation");
 								assert.ok(tool);
 								await tool.execute("report-1", {
@@ -134,11 +140,23 @@ if (scenario) {
 	});
 	await import("../../../main/resources/agent/pi-runner.ts");
 } else {
-	for (const stage of ["setup", "recon", "observer", "retry", "composer", "composer-budget"]) {
+	for (const stage of [
+		"setup",
+		"recon",
+		"observer",
+		"retry",
+		"composer",
+		"composer-budget",
+		"recon-init",
+		"observer-init",
+		"retry-init",
+	]) {
 		void test(
-			stage === "composer"
-				? "preserves admitted observations when composer initialization fails"
-				: `does not prompt a session whose ${stage} initialization exhausts the budget`,
+			stage.endsWith("-init")
+				? `preserves review progress when ${stage} throws`
+				: stage === "composer"
+					? "preserves admitted observations when composer initialization fails"
+					: `does not prompt a session whose ${stage} initialization exhausts the budget`,
 			() => {
 				const cwd = mkdtempSync(join(tmpdir(), "pi-orchestration-"));
 				try {
@@ -173,7 +191,11 @@ if (scenario) {
 					);
 					writeFileSync(
 						join(cwd, "inputs/practices/index.json"),
-						JSON.stringify([{ slug: "test-practice" }]),
+						JSON.stringify(
+							stage === "retry-init"
+								? [{ slug: "test-practice" }, { slug: "missing-practice" }]
+								: [{ slug: "test-practice" }],
+						),
 					);
 					writeFileSync(
 						join(cwd, "pi-provider.json"),
@@ -206,7 +228,11 @@ if (scenario) {
 					assert.equal(child.error, undefined);
 					assert.equal(
 						child.status,
-						stage === "composer" ? 2 : stage === "composer-budget" ? 0 : 1,
+						stage === "composer"
+							? 2
+							: stage === "composer-budget" || stage.endsWith("-init")
+								? 0
+								: 1,
 						child.stderr,
 					);
 					const events = readFileSync(join(cwd, "events"), "utf8")
@@ -219,6 +245,19 @@ if (scenario) {
 						assert.ok(events.includes("create:composer"), child.stderr);
 						assert.ok(!events.includes("prompt:composer"));
 						if (stage === "composer-budget") assert.ok(events.includes("dispose:composer"));
+					} else if (stage.endsWith("-init")) {
+						const lane = stage.slice(0, -5);
+						assert.ok(events.includes(`create:${lane}`), child.stderr);
+						assert.ok(!events.includes(`prompt:${lane}`));
+						assert.ok(
+							events.includes(stage === "observer-init" ? "prompt:retry" : "prompt:observer"),
+						);
+					} else {
+						assert.ok(events.includes(`create:${stage}`), child.stderr);
+						assert.ok(events.includes(`dispose:${stage}`), child.stderr);
+						assert.ok(!events.includes(`prompt:${stage}`), events.join("\n"));
+					}
+					if (stage.startsWith("composer") || stage.endsWith("-init")) {
 						const feedback: unknown = JSON.parse(
 							readFileSync(join(cwd, "out/feedback.json"), "utf8"),
 						);
@@ -229,22 +268,24 @@ if (scenario) {
 							units: [],
 							lead: null,
 						});
-					} else {
-						assert.ok(events.includes(`create:${stage}`), child.stderr);
-						assert.ok(events.includes(`dispose:${stage}`), child.stderr);
-						assert.ok(!events.includes(`prompt:${stage}`), events.join("\n"));
 					}
 					const coverage: unknown = JSON.parse(
 						readFileSync(join(cwd, "out/practice-coverage.json"), "utf8"),
 					);
 					assert.deepEqual(coverage, {
-						eligible: 1,
-						evaluated: stage.startsWith("composer") ? 1 : 0,
+						eligible: stage === "retry-init" ? 2 : 1,
+						evaluated: stage.startsWith("composer") || stage.endsWith("-init") ? 1 : 0,
 						outcomes: [
 							{
 								practiceSlug: "test-practice",
-								outcome: stage.startsWith("composer") ? "EVALUATED" : "NOT_REACHED",
+								outcome:
+									stage.startsWith("composer") || stage.endsWith("-init")
+										? "EVALUATED"
+										: "NOT_REACHED",
 							},
+							...(stage === "retry-init"
+								? [{ practiceSlug: "missing-practice", outcome: "NOT_REACHED" }]
+								: []),
 						],
 					});
 				} finally {

--- a/server/application/src/test/resources/agent/pi-runner-orchestration.spec.ts
+++ b/server/application/src/test/resources/agent/pi-runner-orchestration.spec.ts
@@ -1,0 +1,256 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import {
+	appendFileSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { mock, test } from "node:test";
+
+const admittedObservation = {
+	id: "observation-1",
+	practiceSlug: "test-practice",
+	assessment: "BAD",
+	severity: "MAJOR",
+	anchorable: true,
+	citations: [
+		{
+			index: 0,
+			sourceKind: "scm.pull-request.diff",
+			path: "src/Auth.java",
+			side: "NEW",
+			startLine: 10,
+			endLine: 10,
+			anchorable: true,
+		},
+	],
+};
+
+const scenario = process.env.PI_ORCHESTRATION_SCENARIO;
+if (scenario) {
+	const cwd = process.env.PI_RUNNER_CWD;
+	assert.ok(cwd);
+	let now = 1_000_000;
+	mock.method(Date, "now", () => now);
+	const record = (event: string) => appendFileSync(join(cwd, "events"), `${event}\n`);
+	mock.method(globalThis, "fetch", () =>
+		Promise.resolve(
+			Response.json({
+				schemaVersion: 1,
+				admissionDigest: "admitted-digest",
+				observations: [admittedObservation],
+			}),
+		),
+	);
+	let observerCount = 0;
+	const manager = { getSessionFile: () => undefined };
+	mock.module("@earendil-works/pi-coding-agent", {
+		namedExports: {
+			defineTool: (tool: unknown) => tool,
+			getAgentDir: () => cwd,
+			DefaultResourceLoader: class {
+				reload() {
+					return Promise.resolve();
+				}
+			},
+			SettingsManager: { create: () => ({}) },
+			SessionManager: {
+				create: () => manager,
+				inMemory: () => manager,
+				open: () => manager,
+			},
+			ModelRuntime: {
+				create() {
+					if (scenario === "setup") now += 20_000;
+					return Promise.resolve({
+						registerProvider() {},
+						getModel: () => ({ contextWindow: 128_000 }),
+					});
+				},
+			},
+			createAgentSession(options: {
+				tools: string[];
+				customTools: Array<{
+					name: string;
+					execute: (id: string, input: unknown) => Promise<unknown>;
+				}>;
+			}) {
+				const lane = options.tools.includes("report_feedback")
+					? "composer"
+					: options.tools.includes("report_observation")
+						? ++observerCount === 1
+							? "observer"
+							: "retry"
+						: "recon";
+				record(`create:${lane}`);
+				if (lane === "composer" && scenario === "composer")
+					throw new Error("Composer initialization failed");
+				if (lane === "composer" && scenario === "composer-budget") now += 20_000;
+				if (scenario === lane) now += 20_000;
+				return Promise.resolve({
+					extensionsResult: { errors: [] },
+					session: {
+						state: { messages: [] },
+						sessionManager: manager,
+						subscribe: () => () => {},
+						clearQueue() {},
+						dispose: () => record(`dispose:${lane}`),
+						async prompt() {
+							record(`prompt:${lane}`);
+							if (lane === "recon") throw new Error("Reconnaissance unavailable");
+							if (scenario.startsWith("composer") && lane === "observer") {
+								const tool = options.customTools.find((item) => item.name === "report_observation");
+								assert.ok(tool);
+								await tool.execute("report-1", {
+									practiceSlug: "test-practice",
+									summary: "Unsafe authentication call",
+									outcome: "BEHAVIOR_PRESENT_BAD_MAJOR",
+									evidenceRationale: "The changed authentication code calls insecure().",
+									evidence: {
+										citations: [
+											{
+												sourceKind: "scm.pull-request.diff",
+												artifactPath: "inputs/diff.patch",
+												path: "src/Auth.java",
+												side: "NEW",
+												startLine: 10,
+												endLine: 10,
+												quote: "+ insecure();",
+											},
+										],
+									},
+								});
+							}
+						},
+					},
+				});
+			},
+		},
+	});
+	await import("../../../main/resources/agent/pi-runner.ts");
+} else {
+	for (const stage of ["setup", "recon", "observer", "retry", "composer", "composer-budget"]) {
+		void test(
+			stage === "composer"
+				? "preserves admitted observations when composer initialization fails"
+				: `does not prompt a session whose ${stage} initialization exhausts the budget`,
+			() => {
+				const cwd = mkdtempSync(join(tmpdir(), "pi-orchestration-"));
+				try {
+					mkdirSync(join(cwd, "inputs/practices"), { recursive: true });
+					writeFileSync(join(cwd, "AGENTS.md"), "Review the staged evidence.");
+					writeFileSync(join(cwd, "feedback-composer.md"), "Compose from admitted observations.");
+					writeFileSync(join(cwd, "events"), "");
+					writeFileSync(
+						join(cwd, "inputs/diff.patch"),
+						"diff --git a/src/Auth.java b/src/Auth.java\n--- a/src/Auth.java\n+++ b/src/Auth.java\n@@ -10,0 +10,1 @@\n[L10] + insecure();\n",
+					);
+					if (stage.startsWith("composer")) {
+						writeFileSync(
+							join(cwd, "inputs/feedback-composition.json"),
+							JSON.stringify({
+								enabled: true,
+								channels: { IN_APP: { enabled: true, maxUnits: 1 } },
+							}),
+						);
+					}
+					writeFileSync(
+						join(cwd, "inputs/manifest.json"),
+						JSON.stringify({
+							sources: [
+								{
+									kind: "scm.pull-request.diff",
+									state: { availability: "AVAILABLE" },
+									artifacts: [{ path: "inputs/diff.patch" }],
+								},
+							],
+						}),
+					);
+					writeFileSync(
+						join(cwd, "inputs/practices/index.json"),
+						JSON.stringify([{ slug: "test-practice" }]),
+					);
+					writeFileSync(
+						join(cwd, "pi-provider.json"),
+						JSON.stringify({ apiProtocol: "openai-completions", modelId: "test-model" }),
+					);
+					writeFileSync(
+						join(cwd, "task.json"),
+						JSON.stringify({
+							schemaVersion: 1,
+							task: { kind: "practice_review", prompt: "Review the practice." },
+						}),
+					);
+					const child = spawnSync(
+						process.execPath,
+						["--experimental-test-module-mocks", import.meta.filename],
+						{
+							env: {
+								...process.env,
+								PI_ORCHESTRATION_SCENARIO: stage,
+								PI_RUNNER_CWD: cwd,
+								PI_CODING_AGENT_DIR: cwd,
+								AGENT_BUDGET_MS: "10000",
+								LLM_PROXY_URL: "https://unused.invalid",
+								LLM_PROXY_TOKEN: "test-token",
+							},
+							encoding: "utf8",
+							timeout: 10_000,
+						},
+					);
+					assert.equal(child.error, undefined);
+					assert.equal(
+						child.status,
+						stage === "composer" ? 2 : stage === "composer-budget" ? 0 : 1,
+						child.stderr,
+					);
+					const events = readFileSync(join(cwd, "events"), "utf8")
+						.trim()
+						.split("\n")
+						.filter(Boolean);
+					if (stage === "setup") {
+						assert.deepEqual(events, []);
+					} else if (stage.startsWith("composer")) {
+						assert.ok(events.includes("create:composer"), child.stderr);
+						assert.ok(!events.includes("prompt:composer"));
+						if (stage === "composer-budget") assert.ok(events.includes("dispose:composer"));
+						const feedback: unknown = JSON.parse(
+							readFileSync(join(cwd, "out/feedback.json"), "utf8"),
+						);
+						assert.deepEqual(feedback, {
+							admissionDigest: "admitted-digest",
+							observations: [admittedObservation],
+							preparedTargets: [],
+							units: [],
+							lead: null,
+						});
+					} else {
+						assert.ok(events.includes(`create:${stage}`), child.stderr);
+						assert.ok(events.includes(`dispose:${stage}`), child.stderr);
+						assert.ok(!events.includes(`prompt:${stage}`), events.join("\n"));
+					}
+					const coverage: unknown = JSON.parse(
+						readFileSync(join(cwd, "out/practice-coverage.json"), "utf8"),
+					);
+					assert.deepEqual(coverage, {
+						eligible: 1,
+						evaluated: stage.startsWith("composer") ? 1 : 0,
+						outcomes: [
+							{
+								practiceSlug: "test-practice",
+								outcome: stage.startsWith("composer") ? "EVALUATED" : "NOT_REACHED",
+							},
+						],
+					});
+				} finally {
+					rmSync(cwd, { recursive: true, force: true });
+				}
+			},
+		);
+	}
+}

--- a/server/application/src/test/resources/agent/pi-runner-output.spec.ts
+++ b/server/application/src/test/resources/agent/pi-runner-output.spec.ts
@@ -43,3 +43,15 @@ void test("a name that would escape or hide itself is refused", () => {
 	);
 	assert.throws(() => outputPath("/workspace/out", ""), /must start with an ASCII letter or digit/);
 });
+
+void test("nested traversal and noncanonical member names are refused", () => {
+	for (const name of [
+		"group/../../result.json",
+		"group/../result.json",
+		"group/./result.json",
+		"group//result.json",
+		"group/",
+	]) {
+		assert.throws(() => outputPath("/workspace/out", name), /non-empty, relative path segments/);
+	}
+});

--- a/server/application/src/test/resources/agent/pi-runner-timings.spec.ts
+++ b/server/application/src/test/resources/agent/pi-runner-timings.spec.ts
@@ -43,6 +43,22 @@ void test("the retry inherits what the initial pass did not spend", () => {
 	assert.equal(deriveRetryWindow(timeouts, 900_000, 0), 0);
 });
 
+void test("an initial pass that overran still gets the retry slice the split reserved", () => {
+	const timeouts = { initialMs: 600_000, retryMs: 120_000, compositionMs: 60_000 };
+	// The pass ran 200s past its own budget, so nothing of the review is unspent — but the process
+	// clock still holds 400s and composition needs only 60s of it. Taking the unspent time alone
+	// would hand the retry zero while 340s sat there, and the retry is the last stage that can close
+	// a practice nobody observed.
+	assert.equal(deriveRetryWindow(timeouts, 800_000, 400_000), timeouts.retryMs);
+});
+
+void test("the reserved slice is still bounded by a process that really is out of time", () => {
+	const timeouts = { initialMs: 600_000, retryMs: 120_000, compositionMs: 60_000 };
+	// 30s left and composition alone wants 60s: there is nothing to reserve, so the floor does not
+	// invent any and the window is zero rather than a timer armed in the past.
+	assert.equal(deriveRetryWindow(timeouts, 800_000, 30_000), 0);
+});
+
 void test("the retry leaves composition its slice of what the process has left", () => {
 	const timeouts = deriveTimeouts(1_740_000, true);
 	// 18s of SDK and model runtime setup ran before the first pass, which returned after 736s of its

--- a/server/application/src/test/resources/agent/pi-runner-timings.spec.ts
+++ b/server/application/src/test/resources/agent/pi-runner-timings.spec.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
 	armRetryWindow,
+	deriveCompositionWindow,
 	deriveReconBudget,
 	deriveRetryWindow,
 	deriveTimeouts,
@@ -38,8 +39,8 @@ void test("the retry inherits what the initial pass did not spend", () => {
 	assert.equal(deriveRetryWindow(timeouts, 400_000, 900_000), 500_000);
 	// It used every second it was given: the retry gets exactly its reservation.
 	assert.equal(deriveRetryWindow(timeouts, timeouts.initialMs, 135_000), timeouts.retryMs);
-	// It overran (a hard abort lands late): the reservation is the floor, never a negative window.
-	assert.equal(deriveRetryWindow(timeouts, 900_000, 0), timeouts.retryMs);
+	// A reservation cannot create time after the process budget is exhausted.
+	assert.equal(deriveRetryWindow(timeouts, 900_000, 0), 0);
 });
 
 void test("the retry leaves composition its slice of what the process has left", () => {
@@ -134,4 +135,38 @@ void test("a workstream budget is not capped below its fair share", () => {
 void test("rejects invalid workstream capacity", () => {
 	assert.throws(() => deriveWorkstreamBudget(1_000, 0, 1), /activeSlots/);
 	assert.throws(() => deriveWorkstreamBudget(1_000, 1, 0), /remainingWorkstreams/);
+});
+
+void test("retry cannot consume composition time or exceed the remaining process budget", () => {
+	const timeouts = deriveTimeouts(900_000, true);
+	assert.equal(
+		deriveRetryWindow(timeouts, timeouts.initialMs, timeouts.compositionMs + 5_000),
+		5_000,
+	);
+	assert.equal(deriveRetryWindow(timeouts, timeouts.initialMs, timeouts.compositionMs), 0);
+	assert.equal(deriveRetryWindow(timeouts, timeouts.initialMs, -1), 0);
+	for (const remaining of [Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY]) {
+		assert.throws(
+			() => deriveRetryWindow(timeouts, 0, remaining),
+			/remainingProcessMs must be finite/,
+		);
+	}
+});
+
+void test("an exhausted retry window aborts before any work can start", () => {
+	let aborted = false;
+	const retry = armRetryWindow(deriveTimeouts(900_000), 900_000, 0, () => {
+		aborted = true;
+	});
+	assert.equal(aborted, true);
+	assert.equal(retry.windowMs, 0);
+	assert.equal(retry.timer, undefined);
+});
+
+void test("composition uses only the time left after admission and session setup", () => {
+	assert.equal(deriveCompositionWindow(135_000, 150_000), 135_000);
+	assert.equal(deriveCompositionWindow(135_000, 10_000), 10_000);
+	assert.equal(deriveCompositionWindow(135_000, 0), 0);
+	assert.equal(deriveCompositionWindow(135_000, -1), 0);
+	assert.throws(() => deriveCompositionWindow(135_000, Number.NaN), /finite/);
 });

--- a/webapp/src/components/admin/integrations/WorkspaceScmTokenSettings.stories.tsx
+++ b/webapp/src/components/admin/integrations/WorkspaceScmTokenSettings.stories.tsx
@@ -1,0 +1,73 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { expect, fn, userEvent } from "storybook/test";
+
+import { STORY_NOW } from "@/components/common/story-clock";
+
+import { ConnectionStateNotice } from "./ConnectionStateNotice";
+import { WorkspaceScmTokenSettings } from "./WorkspaceScmTokenSettings";
+
+const meta = {
+	component: WorkspaceScmTokenSettings,
+	parameters: { layout: "padded" },
+	tags: ["autodocs"],
+	args: {
+		providerLabel: "GitHub",
+		isSaving: false,
+		error: null,
+		onSave: fn().mockResolvedValue(true),
+	},
+} satisfies Meta<typeof WorkspaceScmTokenSettings>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Empty: Story = {
+	play: async ({ canvas }) => {
+		await expect(canvas.getByLabelText("New personal access token")).toHaveAttribute(
+			"type",
+			"password",
+		);
+		await expect(canvas.getByRole("button", { name: "Replace token" })).toBeDisabled();
+	},
+};
+
+export const Saving: Story = {
+	args: { isSaving: true },
+	play: async ({ canvas }) => {
+		await expect(canvas.getByRole("button", { name: "Saving token…" })).toBeDisabled();
+		await expect(canvas.getByLabelText("New personal access token")).toBeDisabled();
+	},
+};
+
+export const SaveError: Story = {
+	args: { error: new Error("The replacement could not be stored. Try again.") },
+};
+
+export const UnreadableGitLabToken: Story = {
+	args: { providerLabel: "GitLab" },
+	parameters: { viewport: { defaultViewport: "reflow" } },
+	render: (args) => (
+		<div className="space-y-4">
+			<ConnectionStateNotice
+				connectionState="ACTIVE"
+				displayName={args.providerLabel}
+				credentialsUnreadableSince={new Date(STORY_NOW)}
+				credentialRecovery="Replace it using the personal access token form below"
+			/>
+			<WorkspaceScmTokenSettings {...args} />
+		</div>
+	),
+	play: async ({ canvas }) => {
+		canvas.getByText("The stored token can't be read");
+		await expect(canvas.getByLabelText("New personal access token")).toBeEnabled();
+	},
+};
+
+export const SuccessfulReplacement: Story = {
+	play: async ({ canvas }) => {
+		const input = canvas.getByLabelText("New personal access token");
+		await userEvent.type(input, "replacement-token");
+		await userEvent.click(canvas.getByRole("button", { name: "Replace token" }));
+		await expect(input).toHaveValue("");
+	},
+};

--- a/webapp/src/components/admin/integrations/WorkspaceScmTokenSettings.stories.tsx
+++ b/webapp/src/components/admin/integrations/WorkspaceScmTokenSettings.stories.tsx
@@ -14,7 +14,7 @@ const meta = {
 		providerLabel: "GitHub",
 		isSaving: false,
 		error: null,
-		onSave: fn().mockResolvedValue(true),
+		onSave: fn(async () => true),
 	},
 } satisfies Meta<typeof WorkspaceScmTokenSettings>;
 

--- a/webapp/src/components/admin/integrations/WorkspaceScmTokenSettings.stories.tsx
+++ b/webapp/src/components/admin/integrations/WorkspaceScmTokenSettings.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { expect, fn, userEvent } from "storybook/test";
+import { expect, fn, userEvent, waitFor } from "storybook/test";
 
 import { STORY_NOW } from "@/components/common/story-clock";
 
@@ -68,6 +68,6 @@ export const SuccessfulReplacement: Story = {
 		const input = canvas.getByLabelText("New personal access token");
 		await userEvent.type(input, "replacement-token");
 		await userEvent.click(canvas.getByRole("button", { name: "Replace token" }));
-		await expect(input).toHaveValue("");
+		await waitFor(() => expect(input).toHaveValue(""));
 	},
 };

--- a/webapp/src/components/admin/integrations/WorkspaceScmTokenSettings.tsx
+++ b/webapp/src/components/admin/integrations/WorkspaceScmTokenSettings.tsx
@@ -1,0 +1,79 @@
+import { useId, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader } from "@/components/ui/card";
+import { Field, FieldDescription, FieldError, FieldLabel } from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
+import { Spinner } from "@/components/ui/spinner";
+import { problemDetailOf } from "@/lib/problem-detail";
+
+import { IntegrationCardHeading } from "./IntegrationCardHeading";
+
+interface WorkspaceScmTokenSettingsProps {
+	providerLabel: string;
+	isSaving: boolean;
+	error: unknown;
+	onSave: (token: string) => Promise<boolean>;
+}
+
+export function WorkspaceScmTokenSettings({
+	providerLabel,
+	isSaving,
+	error,
+	onSave,
+}: WorkspaceScmTokenSettingsProps) {
+	const id = useId();
+	const [token, setToken] = useState("");
+	const handleSave = async () => {
+		if (!token.trim() || isSaving) return;
+		if (await onSave(token.trim())) setToken("");
+	};
+
+	return (
+		<Card>
+			<CardHeader>
+				<IntegrationCardHeading>Personal access token</IntegrationCardHeading>
+				<CardDescription>
+					Replace the token used for this workspace's {providerLabel} connection. Existing
+					repositories and synced work are kept.
+				</CardDescription>
+			</CardHeader>
+			<CardContent>
+				<form
+					className="space-y-4"
+					onSubmit={(event) => {
+						event.preventDefault();
+						void handleSave();
+					}}
+				>
+					<Field>
+						<FieldLabel htmlFor={id}>New personal access token</FieldLabel>
+						<Input
+							id={id}
+							type="password"
+							autoComplete="new-password"
+							value={token}
+							onChange={(event) => setToken(event.target.value)}
+							disabled={isSaving}
+							required
+							aria-describedby={`${id}-description${error ? ` ${id}-error` : ""}`}
+						/>
+						<FieldDescription id={`${id}-description`}>
+							Use a token with access to the same repositories and the permissions required by your
+							integration. The current token is never displayed.
+						</FieldDescription>
+						{error != null && (
+							<FieldError id={`${id}-error`}>
+								{problemDetailOf(error, "Couldn't replace the token. Try again.")}
+							</FieldError>
+						)}
+					</Field>
+					<Button type="submit" disabled={!token.trim() || isSaving}>
+						{isSaving && <Spinner />}
+						{isSaving ? "Saving token…" : "Replace token"}
+					</Button>
+				</form>
+			</CardContent>
+		</Card>
+	);
+}

--- a/webapp/src/components/admin/integrations/outline/OutlineConnectCard.tsx
+++ b/webapp/src/components/admin/integrations/outline/OutlineConnectCard.tsx
@@ -103,7 +103,7 @@ export function OutlineConnectCard({
 					{!connected && (
 						<CardDescription>
 							Mirror Outline collections so their design docs and decision records reach practice
-							detection as context. Use a dedicated bot-user API token; after connecting you choose
+							reviews as context. Use a dedicated bot-user API token; after connecting you choose
 							exactly which collections are mirrored.
 						</CardDescription>
 					)}

--- a/webapp/src/components/auth/ConfirmAccessDialog.stories.tsx
+++ b/webapp/src/components/auth/ConfirmAccessDialog.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { expect, fn, screen, userEvent } from "storybook/test";
+import { expect, fn, screen, userEvent, within } from "storybook/test";
 
 import { Stateful } from "@/stories/stateful";
 import { expectSettledVisible } from "@/test/overlay";
@@ -135,5 +135,20 @@ export const Dismiss: Story = {
 		await screen.findByRole("dialog", { name: "Confirm access" });
 		await userEvent.keyboard("{Escape}");
 		await expect(args.onOpenChange).toHaveBeenCalledWith(false);
+	},
+};
+
+export const CustomGitLabRegistration: Story = {
+	args: {
+		providers: [
+			{ registrationId: "company-sso", providerType: "GITLAB", displayName: "Company GitLab" },
+		],
+	},
+	play: async () => {
+		const button = await screen.findByRole("button", { name: "Continue with Company GitLab" });
+		await expect(within(button).getByRole("img", { hidden: true })).toHaveAttribute(
+			"aria-hidden",
+			"true",
+		);
 	},
 };

--- a/webapp/src/components/auth/ConfirmAccessDialog.tsx
+++ b/webapp/src/components/auth/ConfirmAccessDialog.tsx
@@ -30,22 +30,10 @@ export interface ConfirmAccessDialogProps {
 	onRetry: () => void;
 }
 
-/**
- * The server states the window in seconds and a reader does not think in seconds, so 300 has to
- * reach the screen as "5 minutes". `formatDuration` picks the units the value lands on, which keeps
- * a 90-second window honest ("1 minute 30 seconds") instead of rounding it into a claim.
- */
 function signInWindow(maxAgeSeconds: number): string {
 	return formatDuration(intervalToDuration({ start: 0, end: maxAgeSeconds * 1000 }));
 }
 
-/**
- * Asks for a fresh sign-in when an instance-admin action refuses without one.
- *
- * The provider a reader picks here re-authenticates the session they are already in, so the choice
- * is not "how does this instance sign people in" but "which identity is this account". A
- * registration the account has never linked would quietly become a different account.
- */
 export function ConfirmAccessDialog({
 	open,
 	onOpenChange,

--- a/webapp/src/components/auth/LandingSignInCta.tsx
+++ b/webapp/src/components/auth/LandingSignInCta.tsx
@@ -10,9 +10,7 @@ import { cn } from "@/lib/utils";
 type ButtonSize = ComponentPropsWithoutRef<typeof Button>["size"];
 
 interface LandingSignInCtaProps {
-	isSignedIn: boolean;
 	onSignIn: (idpHint: string) => void;
-	onGoToDashboard?: () => void;
 	size?: ButtonSize;
 	className?: string;
 }
@@ -21,23 +19,9 @@ interface LandingSignInCtaProps {
  * One call-to-action instead of a wall of provider buttons repeated across every section: `/login`
  * stays the single place a provider is chosen, so a visitor never picks one twice.
  */
-export function LandingSignInCta({
-	isSignedIn,
-	onSignIn,
-	onGoToDashboard,
-	size = "lg",
-	className,
-}: LandingSignInCtaProps) {
+export function LandingSignInCta({ onSignIn, size = "lg", className }: LandingSignInCtaProps) {
 	const navigate = useNavigate();
 	const { data: providers } = useQuery(listIdentityProvidersOptions());
-
-	if (isSignedIn) {
-		return (
-			<Button size={size} className={cn("gap-2", className)} onClick={onGoToDashboard}>
-				Go to dashboard <ArrowRight className="h-4 w-4" />
-			</Button>
-		);
-	}
 
 	const handleSignIn = () => {
 		// One provider → straight to OAuth (no pointless picker). Several (or not yet known) → the

--- a/webapp/src/components/auth/SignInProviderButton.tsx
+++ b/webapp/src/components/auth/SignInProviderButton.tsx
@@ -1,40 +1,19 @@
-import type { ComponentPropsWithoutRef, SVGAttributes } from "react";
+import type { ComponentPropsWithoutRef } from "react";
 
 import type { IdentityProviderView } from "@/api/types.gen";
+import { GithubIcon, GitlabIcon } from "@/components/icons/brand";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
 type ButtonSize = ComponentPropsWithoutRef<typeof Button>["size"];
 
-/** GitHub mark SVG. Sized by the Button's `[&_svg]` rule; kept monochrome (currentColor). */
-function GitHubMark(props: SVGAttributes<SVGSVGElement>) {
-	return (
-		<svg viewBox="0 0 98 96" fill="currentColor" focusable="false" aria-hidden="true" {...props}>
-			<path
-				fillRule="evenodd"
-				clipRule="evenodd"
-				d="M49 0C21.914 0 0 22 0 49.2c0 21.754 14.026 40.187 33.492 46.73 2.45.455 3.356-1.067 3.356-2.374 0-1.175-.045-5.037-.073-9.127-13.632 2.965-16.516-5.718-16.516-5.718-2.23-5.734-5.45-7.26-5.45-7.26-4.457-3.047.334-2.99.334-2.99 4.934.35 7.526 5.156 7.526 5.156 4.377 7.496 11.486 5.327 14.29 4.073.443-3.206 1.712-5.327 3.11-6.553-10.885-1.25-22.323-5.485-22.323-24.409 0-5.393 1.918-9.8 5.063-13.25-.51-1.25-2.2-6.282.48-13.091 0 0 4.145-1.326 13.59 5.06a47.355 47.355 0 0 1 12.363-1.662c4.2.024 8.432.57 12.363 1.662 9.446-6.385 13.58-5.06 13.58-5.06 2.69 6.809.998 11.84.488 13.09 3.155 3.45 5.064 7.858 5.064 13.25 0 18.967-11.454 23.144-22.35 24.36 1.759 1.527 3.321 4.5 3.321 9.08 0 6.558-.058 11.85-.058 13.46 0 1.32.892 2.858 3.37 2.37C83.98 89.42 98 71 98 49.24 98 22 76.085 0 49 0Z"
-			/>
-		</svg>
-	);
-}
-
-/** GitLab tanuki mark SVG (monochrome, currentColor — recognisable on a neutral button). */
-function GitLabMark(props: SVGAttributes<SVGSVGElement>) {
-	return (
-		<svg viewBox="0 0 24 24" fill="currentColor" focusable="false" aria-hidden="true" {...props}>
-			<path d="m23.6004 9.5927-.0337-.0862L20.3.9814a.851.851 0 0 0-.3362-.405.8748.8748 0 0 0-.9997.0539.8748.8748 0 0 0-.29.4399l-2.2055 6.748H7.5375l-2.2057-6.748a.8573.8573 0 0 0-.29-.4412.8748.8748 0 0 0-.9997-.0537.8585.8585 0 0 0-.3362.4049L.4332 9.5015l-.0325.0862a6.0657 6.0657 0 0 0 2.0119 7.0105l.0113.0087.03.0213 4.976 3.7264 2.462 1.8633 1.4995 1.1321a1.0085 1.0085 0 0 0 1.2197 0l1.4995-1.1321 2.4619-1.8633 5.006-3.7489.0125-.01a6.0682 6.0682 0 0 0 2.0094-7.003z" />
-		</svg>
-	);
-}
-
 /** Recognisable provider mark (icon only — the button itself stays the stock shadcn style). */
 export function ProviderIcon({ provider }: { provider: IdentityProviderView }) {
 	if (provider.providerType?.toUpperCase() === "GITHUB") {
-		return <GitHubMark className="shrink-0" />;
+		return <GithubIcon className="shrink-0" aria-hidden="true" focusable="false" />;
 	}
-	if ((provider.registrationId ?? "").startsWith("gitlab")) {
-		return <GitLabMark className="shrink-0" />;
+	if (provider.providerType?.toUpperCase() === "GITLAB") {
+		return <GitlabIcon className="shrink-0" aria-hidden="true" focusable="false" />;
 	}
 	return null;
 }

--- a/webapp/src/components/info/landing/LandingCtaSection.stories.tsx
+++ b/webapp/src/components/info/landing/LandingCtaSection.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { expect, fn } from "storybook/test";
+import { fn } from "storybook/test";
 import { LandingCtaSection } from "./LandingCtaSection";
 
 const meta = {
@@ -8,32 +8,14 @@ const meta = {
 	tags: ["autodocs"],
 	args: {
 		onSignIn: fn(),
-		onGoToDashboard: fn(),
 	},
 } satisfies Meta<typeof LandingCtaSection>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
-	args: {
-		isSignedIn: false,
-	},
-};
-
-export const SignedIn: Story = {
-	args: {
-		isSignedIn: true,
-	},
-	play: async ({ canvas }) => {
-		await expect(canvas.queryByRole("link", { name: /Read the installation guide/ })).toBeNull();
-		await expect(canvas.getByRole("button", { name: /dashboard/i })).toBeVisible();
-	},
-};
+export const Default: Story = {};
 
 export const DarkMode: Story = {
-	args: {
-		isSignedIn: false,
-	},
 	globals: { theme: "dark" },
 };

--- a/webapp/src/components/info/landing/LandingCtaSection.tsx
+++ b/webapp/src/components/info/landing/LandingCtaSection.tsx
@@ -6,15 +6,9 @@ import styles from "./LandingVisuals.module.css";
 
 interface LandingCtaSectionProps {
 	onSignIn: (idpHint: string) => void;
-	onGoToDashboard?: () => void;
-	isSignedIn: boolean;
 }
 
-export function LandingCtaSection({
-	onSignIn,
-	onGoToDashboard,
-	isSignedIn,
-}: LandingCtaSectionProps) {
+export function LandingCtaSection({ onSignIn }: LandingCtaSectionProps) {
 	return (
 		<section
 			aria-labelledby="landing-cta-heading"
@@ -40,18 +34,10 @@ export function LandingCtaSection({
 						Start with the work in front of you
 					</h2>
 					<p className="mx-auto mt-4 max-w-2xl text-lg leading-relaxed text-muted-foreground lg:mx-0">
-						{isSignedIn
-							? "Open your workspace to read your feedback or ask about recent work."
-							: "Sign in to see feedback on the work you are already doing, and ask it anything about it."}
+						Sign in to see feedback on the work you are already doing, and ask it anything about it.
 					</p>
 					<div className="mt-6 flex w-full flex-col justify-center gap-3 sm:flex-row lg:justify-start">
-						<LandingSignInCta
-							isSignedIn={isSignedIn}
-							onSignIn={onSignIn}
-							onGoToDashboard={onGoToDashboard}
-							size="lg"
-							className="w-full sm:w-auto"
-						/>
+						<LandingSignInCta onSignIn={onSignIn} size="lg" className="w-full sm:w-auto" />
 						<a
 							href="https://docs.hephaestus.build/user/overview"
 							target="_blank"
@@ -64,21 +50,19 @@ export function LandingCtaSection({
 							<ArrowRight aria-hidden="true" />
 						</a>
 					</div>
-					{!isSignedIn && (
-						<p className="mt-5 text-sm text-muted-foreground">
-							Running your own deployment?{" "}
-							<a
-								className="font-medium text-foreground underline underline-offset-4"
-								href="https://docs.hephaestus.build/admin/install"
-								target="_blank"
-								rel="noopener noreferrer"
-							>
-								Read the installation guide
-								<span className="sr-only"> (opens in a new tab)</span>
-							</a>
-							.
-						</p>
-					)}
+					<p className="mt-5 text-sm text-muted-foreground">
+						Running your own deployment?{" "}
+						<a
+							className="font-medium text-foreground underline underline-offset-4"
+							href="https://docs.hephaestus.build/admin/install"
+							target="_blank"
+							rel="noopener noreferrer"
+						>
+							Read the installation guide
+							<span className="sr-only"> (opens in a new tab)</span>
+						</a>
+						.
+					</p>
 				</div>
 			</div>
 		</section>

--- a/webapp/src/components/info/landing/LandingHeroSection.stories.tsx
+++ b/webapp/src/components/info/landing/LandingHeroSection.stories.tsx
@@ -8,8 +8,6 @@ const meta = {
 	tags: ["autodocs"],
 	args: {
 		onSignIn: fn(),
-		onGoToDashboard: fn(),
-		isSignedIn: false,
 	},
 } satisfies Meta<typeof LandingHeroSection>;
 
@@ -21,13 +19,6 @@ export const Default: Story = {
 		// One DOM serves the scattered and the stacked composition; a second copy means the
 		// two layouts have drifted apart.
 		await expect(canvas.getAllByText("Export reports to CSV")).toHaveLength(1);
-	},
-};
-
-export const SignedIn: Story = {
-	args: { isSignedIn: true },
-	play: async ({ canvas }) => {
-		await expect(canvas.getByRole("button", { name: /dashboard/i })).toBeVisible();
 	},
 };
 

--- a/webapp/src/components/info/landing/LandingHeroSection.tsx
+++ b/webapp/src/components/info/landing/LandingHeroSection.tsx
@@ -21,8 +21,6 @@ import styles from "./LandingVisuals.module.css";
 
 interface LandingHeroSectionProps {
 	onSignIn: (idpHint: string) => void;
-	onGoToDashboard?: () => void;
-	isSignedIn: boolean;
 }
 
 const itemVariants = {
@@ -204,11 +202,7 @@ export function HeroScene() {
 	);
 }
 
-export function LandingHeroSection({
-	onSignIn,
-	onGoToDashboard,
-	isSignedIn,
-}: LandingHeroSectionProps) {
+export function LandingHeroSection({ onSignIn }: LandingHeroSectionProps) {
 	const reduceMotion = useReducedMotion();
 	return (
 		<section
@@ -266,9 +260,7 @@ export function LandingHeroSection({
 						className="relative z-10 mt-8 flex w-full flex-col items-center gap-3 sm:w-auto sm:flex-row"
 					>
 						<LandingSignInCta
-							isSignedIn={isSignedIn}
 							onSignIn={onSignIn}
-							onGoToDashboard={onGoToDashboard}
 							size="lg"
 							className="h-11 w-full px-5 shadow-lg shadow-primary/10 sm:w-auto"
 						/>

--- a/webapp/src/components/info/landing/LandingPage.stories.tsx
+++ b/webapp/src/components/info/landing/LandingPage.stories.tsx
@@ -11,31 +11,18 @@ const meta = {
 	},
 	args: {
 		onSignIn: fn(),
-		onGoToDashboard: fn(),
 	},
 } satisfies Meta<typeof LandingPage>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
-	args: {
-		isSignedIn: false,
-	},
-};
-
-export const SignedIn: Story = {
-	args: {
-		isSignedIn: true,
-	},
-};
+export const Default: Story = {};
 
 export const Mobile: Story = {
-	args: { isSignedIn: false },
 	parameters: { viewport: { defaultViewport: "reflow" }, chromatic: { viewports: [320] } },
 };
 
 export const DarkMode: Story = {
-	args: { isSignedIn: false },
 	globals: { theme: "dark" },
 };

--- a/webapp/src/components/info/landing/LandingPage.tsx
+++ b/webapp/src/components/info/landing/LandingPage.tsx
@@ -6,26 +6,16 @@ import { LandingProjectOriginsSection } from "./LandingProjectOriginsSection";
 
 interface LandingPageProps {
 	onSignIn: (idpHint: string) => void;
-	onGoToDashboard?: () => void;
-	isSignedIn?: boolean;
 }
 
-export function LandingPage({ onSignIn, onGoToDashboard, isSignedIn = false }: LandingPageProps) {
+export function LandingPage({ onSignIn }: LandingPageProps) {
 	return (
 		<div className="flex flex-col">
-			<LandingHeroSection
-				onSignIn={onSignIn}
-				onGoToDashboard={onGoToDashboard}
-				isSignedIn={isSignedIn}
-			/>
+			<LandingHeroSection onSignIn={onSignIn} />
 			<LandingFeaturesSection />
 			<LandingProjectOriginsSection />
 			<LandingFaqSection />
-			<LandingCtaSection
-				onSignIn={onSignIn}
-				onGoToDashboard={onGoToDashboard}
-				isSignedIn={isSignedIn}
-			/>
+			<LandingCtaSection onSignIn={onSignIn} />
 		</div>
 	);
 }

--- a/webapp/src/components/leaderboard/LeaderboardFilter.tsx
+++ b/webapp/src/components/leaderboard/LeaderboardFilter.tsx
@@ -1,4 +1,5 @@
 import { SlidersHorizontal } from "lucide-react";
+import type { LeaderboardSchedule } from "@/lib/timeframe";
 
 import type { LeaderboardVariant } from "@/components/leaderboard/LeaderboardPage";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -16,14 +17,9 @@ export interface LeaderboardFilterProps {
 	onTimeframeChange?: (afterDate: string, beforeDate?: string, timeframe?: string) => void;
 	selectedTeam?: string;
 	selectedSort?: LeaderboardSortType;
-	initialAfterDate?: string;
-	initialBeforeDate?: string;
-	leaderboardSchedule?: {
-		day: number;
-		hour: number;
-		minute: number;
-		formatted: string;
-	};
+	afterDate?: string;
+	beforeDate?: string;
+	leaderboardSchedule?: LeaderboardSchedule;
 	selectedMode: LeaderboardVariant;
 	onModeChange?: (mode: LeaderboardVariant) => void;
 	leaguesEnabled?: boolean;
@@ -36,21 +32,13 @@ export function LeaderboardFilter({
 	onTimeframeChange,
 	selectedTeam,
 	selectedSort,
-	initialAfterDate,
-	initialBeforeDate,
+	afterDate,
+	beforeDate,
 	leaderboardSchedule,
 	selectedMode,
 	onModeChange,
 	leaguesEnabled = true,
-}: LeaderboardFilterProps & {
-	initialAfterDate?: string;
-	initialBeforeDate?: string;
-	leaderboardSchedule?: {
-		day: number;
-		hour: number;
-		minute: number;
-	};
-}) {
+}: LeaderboardFilterProps) {
 	return (
 		<Card>
 			<CardHeader>
@@ -87,8 +75,8 @@ export function LeaderboardFilter({
 					)}
 					<TimeframeFilter
 						onTimeframeChange={onTimeframeChange}
-						initialAfterDate={initialAfterDate}
-						initialBeforeDate={initialBeforeDate}
+						afterDate={afterDate}
+						beforeDate={beforeDate}
 						leaderboardSchedule={leaderboardSchedule}
 					/>
 				</div>

--- a/webapp/src/components/leaderboard/LeaderboardPage.tsx
+++ b/webapp/src/components/leaderboard/LeaderboardPage.tsx
@@ -1,5 +1,6 @@
 import { Trophy } from "lucide-react";
 import type { ReactNode } from "react";
+import type { LeaderboardSchedule } from "@/lib/timeframe";
 
 import type { LeaderboardEntry, UserInfo } from "@/api/types.gen";
 import { PageHeader } from "@/components/core/PageHeader";
@@ -30,14 +31,10 @@ interface LeaderboardPageProps {
 	renderUserLink?: (username: string, children: ReactNode) => ReactNode;
 	selectedTeam?: string;
 	selectedSort?: LeaderboardSortType;
-	initialAfterDate?: string;
-	initialBeforeDate?: string;
+	afterDate?: string;
+	beforeDate?: string;
 	leaderboardEnd?: string;
-	leaderboardSchedule?: {
-		day: number;
-		hour: number;
-		minute: number;
-	};
+	leaderboardSchedule?: LeaderboardSchedule;
 	selectedMode: LeaderboardVariant;
 	onModeChange?: (mode: LeaderboardVariant) => void;
 	renderTeamLink?: (teamId: number, children: ReactNode) => ReactNode;
@@ -60,8 +57,8 @@ export function LeaderboardPage({
 	renderUserLink,
 	selectedTeam,
 	selectedSort,
-	initialAfterDate,
-	initialBeforeDate,
+	afterDate,
+	beforeDate,
 	leaderboardEnd,
 	leaderboardSchedule,
 	selectedMode,
@@ -69,13 +66,6 @@ export function LeaderboardPage({
 	renderTeamLink,
 	leaguesEnabled = true,
 }: LeaderboardPageProps) {
-	const formattedSchedule = leaderboardSchedule
-		? {
-				...leaderboardSchedule,
-				formatted: `${String(leaderboardSchedule.hour).padStart(2, "0")}:${String(leaderboardSchedule.minute).padStart(2, "0")} on day ${leaderboardSchedule.day}`,
-			}
-		: undefined;
-
 	return (
 		<PageLayout>
 			<PageHeader
@@ -96,9 +86,9 @@ export function LeaderboardPage({
 								onTimeframeChange={onTimeframeChange}
 								selectedTeam={selectedTeam}
 								selectedSort={selectedSort}
-								initialAfterDate={initialAfterDate}
-								initialBeforeDate={initialBeforeDate}
-								leaderboardSchedule={formattedSchedule}
+								afterDate={afterDate}
+								beforeDate={beforeDate}
+								leaderboardSchedule={leaderboardSchedule}
 								leaguesEnabled={leaguesEnabled}
 							/>
 						</div>

--- a/webapp/src/components/leaderboard/TimeframeFilter.stories.tsx
+++ b/webapp/src/components/leaderboard/TimeframeFilter.stories.tsx
@@ -1,60 +1,38 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import type * as React from "react";
-import { useState } from "react";
-import { fn } from "storybook/test";
+import { expect, fn, screen, waitFor } from "storybook/test";
 
 import { STORY_NOW } from "@/components/common/story-clock";
 import { DEFAULT_SCHEDULE, formatDateRangeForApi, getDateRangeForPreset } from "@/lib/timeframe";
 
+import { Stateful } from "@/stories/stateful";
+
 import { TimeframeFilter } from "./TimeframeFilter";
 
-// Calculate default dates using the shared timeframe utilities
 const defaultRange = getDateRangeForPreset(new Date(STORY_NOW), "this-week", DEFAULT_SCHEDULE);
 const { after: defaultAfter, before: defaultBefore } = formatDateRangeForApi(defaultRange);
 
-/**
- * TimeframeFilter is the timeframe selector for the leaderboard page.
- * It provides preset options (this week, last week, etc.) and custom date range selection.
- *
- * Key features:
- * - Icons for each preset type for quick visual recognition
- * - Detailed labels showing actual date ranges (e.g., "This week, since Tue Dec 3")
- * - Supports leaderboard schedule awareness for correct week boundaries
- * - Stacked layout for sidebar placement
- */
 const meta = {
 	component: TimeframeFilter,
 	tags: ["autodocs"],
+	render: (args) => (
+		<Stateful initial={{ after: args.afterDate, before: args.beforeDate }}>
+			{(dates, setDates) => (
+				<TimeframeFilter
+					{...args}
+					afterDate={dates.after}
+					beforeDate={dates.before}
+					onTimeframeChange={(after, before, timeframe) => {
+						setDates({ after, before });
+						args.onTimeframeChange?.(after, before, timeframe);
+					}}
+				/>
+			)}
+		</Stateful>
+	),
 	parameters: {
 		layout: "centered",
 	},
-	argTypes: {
-		onTimeframeChange: {
-			description:
-				"Callback fired when timeframe selection changes. Receives (afterDate, beforeDate?, timeframe?)",
-			action: "timeframe changed",
-		},
-		initialAfterDate: {
-			description: "Initial start date in ISO format",
-			control: "text",
-		},
-		initialBeforeDate: {
-			description: "Initial end date in ISO format",
-			control: "text",
-		},
-		leaderboardSchedule: {
-			description: "Schedule information for leaderboard updates",
-			control: "object",
-		},
-		openEndedPresets: {
-			description: 'When true, presets like "this week" emit only afterDate (open-ended)',
-			control: "boolean",
-		},
-		enableAllActivityOption: {
-			description: 'Enable an "All activity" option that covers full history',
-			control: "boolean",
-		},
-	},
+
 	args: {
 		onTimeframeChange: fn(),
 	},
@@ -63,97 +41,74 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-/**
- * Default view without any schedule or initial date range.
- * Shows the standard timeframe selection options.
- */
 export const Default: Story = {
-	args: {},
+	play: async ({ canvas, userEvent }) => {
+		await userEvent.click(canvas.getByRole("combobox", { name: "Timeframe" }));
+		await userEvent.click(await screen.findByRole("option", { name: "Last month" }));
+		await waitFor(() =>
+			expect(canvas.getByRole("combobox", { name: "Timeframe" })).toHaveTextContent("Last month"),
+		);
+	},
 };
 
-/**
- * Shows timeframe filter with leaderboard schedule information.
- * The schedule affects how "this week" and "last week" are calculated.
- */
 export const WithSchedule: Story = {
 	args: {
 		leaderboardSchedule: {
 			day: 1, // Monday
 			hour: 9,
 			minute: 0,
-			formatted: "Mondays at 09:00",
 		},
 	},
 };
 
-/**
- * Custom schedule starting on Friday - for teams with end-of-week reviews.
- */
 export const FridaySchedule: Story = {
 	args: {
 		leaderboardSchedule: {
 			day: 5, // Friday
 			hour: 16,
 			minute: 30,
-			formatted: "Fridays at 16:30",
 		},
 	},
 };
 
-/**
- * Tuesday schedule at 9 AM - common configuration.
- */
 export const TuesdaySchedule: Story = {
 	args: {
 		leaderboardSchedule: {
 			day: 2, // Tuesday
 			hour: 9,
 			minute: 0,
-			formatted: "Tuesdays at 09:00",
 		},
 	},
 };
 
-/**
- * With initial dates pre-selected for "This week".
- */
 export const ThisWeekSelected: Story = {
 	args: {
-		initialAfterDate: defaultAfter,
-		initialBeforeDate: defaultBefore,
+		afterDate: defaultAfter,
+		beforeDate: defaultBefore,
 		leaderboardSchedule: {
 			day: 1,
 			hour: 9,
 			minute: 0,
-			formatted: "Mondays at 09:00",
 		},
 	},
 };
 
-/**
- * With "Last week" dates pre-selected.
- */
 export const LastWeekSelected: Story = {
 	args: (() => {
 		const range = getDateRangeForPreset(new Date(STORY_NOW), "last-week", DEFAULT_SCHEDULE);
 		const { after, before } = formatDateRangeForApi(range);
 		return {
-			initialAfterDate: after,
-			initialBeforeDate: before,
+			afterDate: after,
+			beforeDate: before,
 			leaderboardSchedule: {
 				day: 1,
 				hour: 9,
 				minute: 0,
-				formatted: "Mondays at 09:00",
 			},
 		};
 	})(),
 };
 
-/**
- * With "All activity" option enabled.
- * Useful for viewing complete history.
- */
 export const WithAllActivityOption: Story = {
 	args: {
 		enableAllActivityOption: true,
@@ -161,15 +116,10 @@ export const WithAllActivityOption: Story = {
 			day: 1,
 			hour: 9,
 			minute: 0,
-			formatted: "Mondays at 09:00",
 		},
 	},
 };
 
-/**
- * With open-ended presets mode.
- * "This week" and "this month" will only emit afterDate without beforeDate.
- */
 export const OpenEndedMode: Story = {
 	args: {
 		openEndedPresets: true,
@@ -177,53 +127,6 @@ export const OpenEndedMode: Story = {
 			day: 1,
 			hour: 9,
 			minute: 0,
-			formatted: "Mondays at 09:00",
-		},
-	},
-};
-
-function InteractiveHarness(props: React.ComponentProps<typeof TimeframeFilter>) {
-	const [afterDate, setAfterDate] = useState<string | undefined>(props.initialAfterDate);
-	const [beforeDate, setBeforeDate] = useState<string | undefined>(props.initialBeforeDate);
-	const [timeframe, setTimeframe] = useState<string | undefined>();
-
-	return (
-		<div className="flex flex-col gap-4 w-64">
-			<TimeframeFilter
-				{...props}
-				initialAfterDate={afterDate}
-				initialBeforeDate={beforeDate}
-				onTimeframeChange={(after, before, tf) => {
-					setAfterDate(after);
-					setBeforeDate(before);
-					setTimeframe(tf);
-					props.onTimeframeChange?.(after, before, tf);
-				}}
-			/>
-			<div className="text-sm text-muted-foreground font-mono bg-muted p-3 rounded-md">
-				<div>
-					<strong>timeframe:</strong> {timeframe ?? "undefined"}
-				</div>
-				<div>
-					<strong>after:</strong> {afterDate ?? "undefined"}
-				</div>
-				<div>
-					<strong>before:</strong> {beforeDate ?? "undefined"}
-				</div>
-			</div>
-		</div>
-	);
-}
-
-/** Driven by local state, so picking a preset feeds the dates back in the way a page does. */
-export const Interactive: Story = {
-	render: (props) => <InteractiveHarness {...props} />,
-	args: {
-		leaderboardSchedule: {
-			day: 1,
-			hour: 9,
-			minute: 0,
-			formatted: "Mondays at 09:00",
 		},
 	},
 };

--- a/webapp/src/components/leaderboard/TimeframeFilter.test.tsx
+++ b/webapp/src/components/leaderboard/TimeframeFilter.test.tsx
@@ -1,0 +1,91 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { TimeframeFilter } from "./TimeframeFilter";
+
+vi.mock("@/components/common/use-now", () => ({
+	useNow: () => new Date(2026, 8, 16, 12).getTime(),
+}));
+
+const bookmark = { after: "2026-09-02T09:45:00+02:00", before: "2026-09-08T18:30:00+02:00" };
+
+function ControlledFilter({ openEndedPresets = false }: { openEndedPresets?: boolean }) {
+	const [range, setRange] = useState<{ after: string; before?: string }>(bookmark);
+	return (
+		<>
+			<TimeframeFilter
+				openEndedPresets={openEndedPresets}
+				afterDate={range.after}
+				beforeDate={range.before}
+				onTimeframeChange={(after, before) => setRange({ after, before })}
+			/>
+			<output aria-label="Selected interval">
+				{range.after}/{range.before}
+			</output>
+			<button type="button" onClick={() => setRange(bookmark)}>
+				Restore bookmark
+			</button>
+		</>
+	);
+}
+
+describe("TimeframeFilter", () => {
+	it("preserves precise bookmarked dates on mount and after external navigation", async () => {
+		render(<ControlledFilter />);
+		const user = userEvent.setup();
+		const interval = `${bookmark.after}/${bookmark.before}`;
+		expect(screen.getByLabelText("Selected interval").textContent).toBe(interval);
+		expect(screen.getByRole("combobox", { name: "Timeframe" }).textContent).toContain(
+			"Custom range",
+		);
+		await user.click(screen.getByRole("combobox", { name: "Timeframe" }));
+		await user.click(await screen.findByRole("option", { name: "Last week" }));
+		expect(screen.getByRole("combobox", { name: "Timeframe" }).textContent).toContain("Last week");
+		await user.click(screen.getByRole("button", { name: "Restore bookmark" }));
+		expect(screen.getByLabelText("Selected interval").textContent).toBe(interval);
+		expect(screen.getByRole("combobox", { name: "Timeframe" }).textContent).toContain(
+			"Custom range",
+		);
+	});
+
+	it("only changes the interval after the user chooses a custom day", async () => {
+		render(<ControlledFilter />);
+		const user = userEvent.setup();
+		await user.click(screen.getByRole("button", { name: "Choose custom dates" }));
+		expect(screen.getByLabelText("Selected interval").textContent).toBe(
+			`${bookmark.after}/${bookmark.before}`,
+		);
+		await user.click(screen.getByRole("button", { name: /September 12th, 2026/ }));
+		expect(screen.getByLabelText("Selected interval").textContent).toMatch(
+			/^2026-09-02T00:00:00(?:Z|[+-]\d{2}:\d{2})\/2026-09-13T00:00:00(?:Z|[+-]\d{2}:\d{2})$/,
+		);
+		screen.getByRole("dialog");
+	});
+	it.each([
+		{ preset: "This week", after: "2026-09-14T09:00:00", before: "2026-09-21T09:00:00" },
+		{ preset: "This month", after: "2026-09-01T00:00:00", before: "2026-10-01T00:00:00" },
+	])("bounds $preset to the complete leaderboard period", async ({ preset, after, before }) => {
+		render(<ControlledFilter />);
+		const user = userEvent.setup();
+		await user.click(screen.getByRole("combobox", { name: "Timeframe" }));
+		await user.click(await screen.findByRole("option", { name: preset }));
+		expect(
+			screen
+				.getByLabelText("Selected interval")
+				.textContent.split("/")
+				.map((date) => date.slice(0, 19)),
+		).toStrictEqual([after, before]);
+	});
+
+	it("keeps the upper bound open when requested", async () => {
+		render(<ControlledFilter openEndedPresets />);
+		const user = userEvent.setup();
+		await user.click(screen.getByRole("combobox", { name: "Timeframe" }));
+		await user.click(await screen.findByRole("option", { name: "This month" }));
+		expect(screen.getByLabelText("Selected interval").textContent).toMatch(
+			/^2026-09-01T00:00:00(?:Z|[+-]\d{2}:\d{2})\/$/,
+		);
+	});
+});

--- a/webapp/src/components/leaderboard/TimeframeFilter.tsx
+++ b/webapp/src/components/leaderboard/TimeframeFilter.tsx
@@ -1,17 +1,6 @@
-import {
-	addDays,
-	addWeeks,
-	endOfMonth,
-	format,
-	formatISO,
-	isSameYear,
-	parseISO,
-	startOfMonth,
-	subDays,
-} from "date-fns";
+import { addDays, addWeeks, endOfMonth, format, isSameYear, startOfMonth, subDays } from "date-fns";
 import { CalendarDays, CalendarIcon, CalendarRange, Clock } from "lucide-react";
-// oxlint-disable-next-line no-restricted-imports -- `schedule` below is a dependency of the emitting effect, so its identity decides whether that effect re-runs; see the note there.
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useState } from "react";
 import type { DateRange } from "react-day-picker";
 
 import { useNow } from "@/components/common/use-now";
@@ -26,27 +15,24 @@ import {
 	SelectTrigger,
 	SelectValue,
 } from "@/components/ui/select";
+import { asDate } from "@/lib/dates";
 import {
 	DEFAULT_SCHEDULE,
 	detectPresetFromDates,
 	formatDateRangeForApi,
 	formatDropdownLabel,
 	getDateRangeForPreset,
-	type LeaderboardSchedule,
 	type TimeframePreset,
+	type LeaderboardSchedule,
 } from "@/lib/timeframe";
 import { cn } from "@/lib/utils";
 
 export interface TimeframeFilterProps {
 	onTimeframeChange?: (afterDate: string, beforeDate?: string, timeframe?: string) => void;
-	initialAfterDate?: string;
-	initialBeforeDate?: string;
-	leaderboardSchedule?: {
-		day: number;
-		hour: number;
-		minute: number;
-		formatted?: string;
-	};
+	/** Selected ISO interval: inclusive start and exclusive end. */
+	afterDate?: string;
+	beforeDate?: string;
+	leaderboardSchedule?: LeaderboardSchedule;
 	/**
 	 * When true, presets "this week/this month" emit only afterDate (open-ended).
 	 * "Last week/last month" always send both bounds so their labels remain bounded.
@@ -58,7 +44,6 @@ export interface TimeframeFilterProps {
 	enableAllActivityOption?: boolean;
 }
 
-/** Icon component for each preset type */
 function PresetIcon({ preset, className }: { preset: TimeframePreset; className?: string }) {
 	const iconClass = cn("h-4 w-4 shrink-0", className);
 
@@ -79,47 +64,26 @@ function PresetIcon({ preset, className }: { preset: TimeframePreset; className?
 export function TimeframeFilter({
 	onTimeframeChange,
 	leaderboardSchedule,
-	initialAfterDate,
-	initialBeforeDate,
+	afterDate,
+	beforeDate,
 	openEndedPresets = false,
 	enableAllActivityOption = false,
 }: TimeframeFilterProps) {
-	// Keyed on the three scalars, not on `leaderboardSchedule`: callers pass that inline, and a fresh
-	// identity each render would re-run the emitting effect below each render.
-	const scheduleDay = leaderboardSchedule?.day ?? DEFAULT_SCHEDULE.day;
-	const scheduleHour = leaderboardSchedule?.hour ?? DEFAULT_SCHEDULE.hour;
-	const scheduleMinute = leaderboardSchedule?.minute ?? DEFAULT_SCHEDULE.minute;
-	const schedule = useMemo<LeaderboardSchedule>(
-		() => ({ day: scheduleDay, hour: scheduleHour, minute: scheduleMinute }),
-		[scheduleDay, scheduleHour, scheduleMinute],
+	const schedule = leaderboardSchedule ?? DEFAULT_SCHEDULE;
+	const [customRangeOpen, setCustomRangeOpen] = useState(false);
+	const now = new Date(useNow());
+	const selectedPreset = detectPresetFromDates(
+		now,
+		afterDate,
+		beforeDate,
+		schedule,
+		enableAllActivityOption,
 	);
-
-	const [chosenPreset, setChosenPreset] = useState<TimeframePreset>();
-	// Ticks, so a week or month boundary crossed with the page open rolls the emitted range over
-	// instead of stranding it in the period that ended.
-	const nowMs = useNow();
-	const now = new Date(nowMs);
-
-	const selectedPreset =
-		chosenPreset ??
-		detectPresetFromDates(
-			now,
-			initialAfterDate,
-			initialBeforeDate,
-			schedule,
-			enableAllActivityOption,
-		);
-
-	const [customRange, setCustomRange] = useState<DateRange | undefined>(() => {
-		if (selectedPreset === "custom" && initialAfterDate) {
-			const from = parseISO(initialAfterDate);
-			const to = initialBeforeDate ? subDays(parseISO(initialBeforeDate), 1) : undefined;
-			return { from, to };
-		}
-		return undefined;
-	});
-
-	const lastEmittedRef = useRef<{ after: string; before?: string } | null>(null);
+	const startDate = asDate(afterDate);
+	const before = asDate(beforeDate);
+	const customRange = startDate
+		? { from: startDate, to: before ? subDays(before, 1) : undefined }
+		: undefined;
 
 	const baseItems: { value: TimeframePreset; label: string }[] = [
 		{ value: "this-week", label: formatDropdownLabel("this-week") },
@@ -132,88 +96,29 @@ export function TimeframeFilter({
 		? [{ value: "all-activity", label: formatDropdownLabel("all-activity") }, ...baseItems]
 		: baseItems;
 
-	// Emit changes when preset or custom range changes
-	useEffect(() => {
-		if (!onTimeframeChange) return;
-
-		let range: { after: string; before: string | undefined };
-
-		const at = new Date(nowMs);
-
-		if (selectedPreset === "custom") {
-			if (!customRange?.from) return;
-			const dateRange = getDateRangeForPreset(at, selectedPreset, schedule, {
-				from: customRange.from,
-				to: customRange.to,
-			});
-			range = formatDateRangeForApi(dateRange);
-		} else {
-			const dateRange = getDateRangeForPreset(at, selectedPreset, schedule);
-			// For leaderboard, we may need bounded ranges even for "this week"
-			if (!openEndedPresets && dateRange.before === undefined) {
-				// Force bounded range for leaderboard display
-				if (selectedPreset === "this-week" || selectedPreset === "last-week") {
-					// For weeks, use the week end
-					range = {
-						after: formatISO(dateRange.after),
-						before: formatISO(addWeeks(dateRange.after, 1)),
-					};
-				} else if (selectedPreset === "this-month") {
-					// For this month, use next month start
-					const monthEnd = startOfMonth(addDays(endOfMonth(dateRange.after), 1));
-					range = {
-						after: formatISO(dateRange.after),
-						before: formatISO(monthEnd),
-					};
-				} else {
-					range = formatDateRangeForApi(dateRange);
-				}
-			} else {
-				range = formatDateRangeForApi(dateRange);
-			}
-		}
-
-		if (
-			lastEmittedRef.current?.after === range.after &&
-			lastEmittedRef.current.before === range.before
-		) {
+	const handlePresetChange = (preset: TimeframePreset) => {
+		if (preset === "custom") {
+			setCustomRangeOpen(true);
 			return;
 		}
-
-		lastEmittedRef.current = range;
-		onTimeframeChange(range.after, range.before, selectedPreset);
-	}, [nowMs, selectedPreset, customRange, schedule, onTimeframeChange, openEndedPresets]);
-
-	const handlePresetChange = (preset: TimeframePreset) => {
-		setChosenPreset(preset);
-
-		if (preset === "custom" && !customRange?.from) {
-			// If we have an initial after date from props (from a previous preset),
-			// use it as the from date and set to as now
-			if (initialAfterDate) {
-				const fromDate = parseISO(initialAfterDate);
-				setCustomRange({
-					from: fromDate,
-					to: now,
-				});
-			} else {
-				// Fallback to last 7 days
-				setCustomRange({
-					from: subDays(now, 7),
-					to: now,
-				});
-			}
+		setCustomRangeOpen(false);
+		const range = getDateRangeForPreset(now, preset, schedule);
+		if (!openEndedPresets && !range.before) {
+			if (preset === "this-week") range.before = addWeeks(range.after, 1);
+			if (preset === "this-month") range.before = startOfMonth(addDays(endOfMonth(range.after), 1));
 		}
+		const dates = formatDateRangeForApi(range);
+		onTimeframeChange?.(dates.after, dates.before, preset);
 	};
 
 	const handleCustomRangeChange = (range: DateRange | undefined) => {
-		if (range) {
-			setChosenPreset("custom");
-			setCustomRange(range);
-		}
+		if (!range?.from) return;
+		const dates = formatDateRangeForApi(
+			getDateRangeForPreset(now, "custom", schedule, { from: range.from, to: range.to }),
+		);
+		onTimeframeChange?.(dates.after, dates.before, "custom");
 	};
 
-	// Format custom range label for the button
 	const formatCustomRangeLabel = () => {
 		if (!customRange?.from) return "Pick dates";
 		const from = customRange.from;
@@ -274,14 +179,15 @@ export function TimeframeFilter({
 					</SelectItem>
 				</SelectContent>
 			</Select>
-			{selectedPreset === "custom" && (
+			{(selectedPreset === "custom" || customRangeOpen) && (
 				<div className="pt-2">
 					<div className="grid gap-2">
-						<Popover>
+						<Popover open={customRangeOpen} onOpenChange={setCustomRangeOpen}>
 							<PopoverTrigger
 								render={
 									<Button
 										id="date"
+										aria-label="Choose custom dates"
 										variant="outline"
 										className={cn(
 											"w-full justify-start text-left font-normal",

--- a/webapp/src/components/profile/ProfilePage.stories.tsx
+++ b/webapp/src/components/profile/ProfilePage.stories.tsx
@@ -228,3 +228,10 @@ export const ActivityUnavailable: Story = {
 		onRetryActivityMonitor: fn(),
 	},
 };
+
+export const LoadingActivity: Story = {
+	args: {
+		...Default.args,
+		isActivityLoading: true,
+	},
+};

--- a/webapp/src/components/profile/ProfilePage.stories.tsx
+++ b/webapp/src/components/profile/ProfilePage.stories.tsx
@@ -220,3 +220,11 @@ export const MobileReflow: Story = {
 	},
 	play: expectNoPageOverflow,
 };
+
+export const ActivityUnavailable: Story = {
+	args: {
+		...Default.args,
+		activityMonitorError: { status: 503 },
+		onRetryActivityMonitor: fn(),
+	},
+};

--- a/webapp/src/components/profile/ProfilePage.tsx
+++ b/webapp/src/components/profile/ProfilePage.tsx
@@ -14,6 +14,8 @@ interface ProfileProps {
 	providerType?: ProviderType;
 	profileData?: Profile;
 	activityMonitorData?: ProfileActivityMonitor;
+	activityMonitorError?: unknown;
+	onRetryActivityMonitor?: () => void;
 	activityMonitorFilters: ActivityMonitorFilters;
 	onActivityMonitorFiltersChange: (filters: ActivityMonitorFilters) => void;
 	isLoading: boolean;
@@ -36,6 +38,8 @@ export function ProfilePage({
 	providerType = "GITHUB",
 	profileData,
 	activityMonitorData,
+	activityMonitorError,
+	onRetryActivityMonitor,
 	activityMonitorFilters,
 	onActivityMonitorFiltersChange,
 	isLoading,
@@ -81,21 +85,29 @@ export function ProfilePage({
 					<Separator />
 				</>
 			)}
-			<ProfileContent
-				providerType={providerType}
-				activityMonitorData={activityMonitorData}
-				activityMonitorFilters={activityMonitorFilters}
-				onActivityMonitorFiltersChange={onActivityMonitorFiltersChange}
-				isLoading={isLoading}
-				username={username}
-				displayName={profileData?.userInfo.name}
-				currUserIsDashboardUser={currUserIsDashboardUser}
-				workspaceSlug={workspaceSlug}
-				afterDate={after}
-				beforeDate={before}
-				onTimeframeChange={onTimeframeChange}
-				schedule={schedule}
-			/>
+			{activityMonitorError ? (
+				<QueryErrorAlert
+					error={activityMonitorError}
+					title="Could not load activity"
+					onRetry={onRetryActivityMonitor}
+				/>
+			) : (
+				<ProfileContent
+					providerType={providerType}
+					activityMonitorData={activityMonitorData}
+					activityMonitorFilters={activityMonitorFilters}
+					onActivityMonitorFiltersChange={onActivityMonitorFiltersChange}
+					isLoading={isLoading}
+					username={username}
+					displayName={profileData?.userInfo.name}
+					currUserIsDashboardUser={currUserIsDashboardUser}
+					workspaceSlug={workspaceSlug}
+					afterDate={after}
+					beforeDate={before}
+					onTimeframeChange={onTimeframeChange}
+					schedule={schedule}
+				/>
+			)}
 		</div>
 	);
 }

--- a/webapp/src/components/profile/ProfilePage.tsx
+++ b/webapp/src/components/profile/ProfilePage.tsx
@@ -19,6 +19,7 @@ interface ProfileProps {
 	activityMonitorFilters: ActivityMonitorFilters;
 	onActivityMonitorFiltersChange: (filters: ActivityMonitorFilters) => void;
 	isLoading: boolean;
+	isActivityLoading?: boolean;
 	error?: unknown;
 	onRetry?: () => void;
 	username: string;
@@ -43,6 +44,7 @@ export function ProfilePage({
 	activityMonitorFilters,
 	onActivityMonitorFiltersChange,
 	isLoading,
+	isActivityLoading = isLoading,
 	error,
 	onRetry,
 	username,
@@ -97,7 +99,7 @@ export function ProfilePage({
 					activityMonitorData={activityMonitorData}
 					activityMonitorFilters={activityMonitorFilters}
 					onActivityMonitorFiltersChange={onActivityMonitorFiltersChange}
-					isLoading={isLoading}
+					isLoading={isActivityLoading}
 					username={username}
 					displayName={profileData?.userInfo.name}
 					currUserIsDashboardUser={currUserIsDashboardUser}

--- a/webapp/src/components/profile/ProfileTimeframePicker.stories.tsx
+++ b/webapp/src/components/profile/ProfileTimeframePicker.stories.tsx
@@ -1,55 +1,33 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import type * as React from "react";
-import { useState } from "react";
-import { fn } from "storybook/test";
+import { expect, fn, screen } from "storybook/test";
 
 import { STORY_NOW } from "@/components/common/story-clock";
 import { DEFAULT_SCHEDULE, formatDateRangeForApi, getDateRangeForPreset } from "@/lib/timeframe";
+import { Stateful } from "@/stories/stateful";
 
 import { ProfileTimeframePicker } from "./ProfileTimeframePicker";
 
-// Calculate default dates using the shared timeframe utilities
 const defaultRange = getDateRangeForPreset(new Date(STORY_NOW), "this-week", DEFAULT_SCHEDULE);
 const { after: defaultAfter, before: defaultBefore } = formatDateRangeForApi(defaultRange);
 
-/**
- * ProfileTimeframePicker is a compact, single-row timeframe selector designed for the profile page.
- * It provides preset options (this week, last week, this month, last month, all time)
- * and custom date range selection with a calendar popover.
- *
- * Key features:
- * - Icons for each preset type for quick visual recognition
- * - Detailed labels showing actual date ranges (e.g., "This week, since Tue Dec 3")
- * - Supports leaderboard schedule awareness for correct week boundaries
- * - Minimal footprint while providing comprehensive date selection
- */
 const meta = {
 	component: ProfileTimeframePicker,
 	parameters: { layout: "centered" },
 	tags: ["autodocs"],
-	argTypes: {
-		afterDate: {
-			description: "Start date in ISO format",
-			control: "text",
-		},
-		beforeDate: {
-			description: "End date in ISO format (undefined for open-ended ranges)",
-			control: "text",
-		},
-		onTimeframeChange: {
-			description:
-				"Callback fired when timeframe selection changes. Receives (afterDate, beforeDate?)",
-			action: "timeframe changed",
-		},
-		enableAllActivity: {
-			description: 'Show "All time" option in the dropdown',
-			control: "boolean",
-		},
-		schedule: {
-			description: "Leaderboard schedule configuration. Affects week start calculation.",
-			control: "object",
-		},
-	},
+	render: (args) => (
+		<Stateful initial={{ afterDate: args.afterDate, beforeDate: args.beforeDate }}>
+			{(dates, setDates) => (
+				<ProfileTimeframePicker
+					{...args}
+					{...dates}
+					onTimeframeChange={(afterDate, beforeDate) => {
+						setDates({ afterDate, beforeDate });
+						args.onTimeframeChange?.(afterDate, beforeDate);
+					}}
+				/>
+			)}
+		</Stateful>
+	),
 	args: {
 		afterDate: defaultAfter,
 		beforeDate: defaultBefore,
@@ -62,16 +40,15 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-/**
- * Default state with "This week" preselected.
- * Shows the detailed label with date range context.
- */
-export const Default: Story = {};
+export const Default: Story = {
+	play: async ({ canvas, args, userEvent }) => {
+		await userEvent.click(canvas.getByRole("combobox", { name: "Timeframe" }));
+		await userEvent.click(screen.getByRole("option", { name: "All time" }));
+		await expect(canvas.getByRole("combobox", { name: "Timeframe" })).toHaveTextContent("All time");
+		await expect(args.onTimeframeChange).toHaveBeenCalledOnce();
+	},
+};
 
-/**
- * All time - showing the entire activity history.
- * Useful for viewing a user's complete contribution history.
- */
 export const AllTime: Story = {
 	args: {
 		afterDate: "1970-01-01T00:00:00.000Z",
@@ -79,10 +56,6 @@ export const AllTime: Story = {
 	},
 };
 
-/**
- * Last week selection - shows a bounded date range.
- * The label displays the exact date range of the previous week.
- */
 export const LastWeek: Story = {
 	args: (() => {
 		const range = getDateRangeForPreset(new Date(STORY_NOW), "last-week", DEFAULT_SCHEDULE);
@@ -91,9 +64,6 @@ export const LastWeek: Story = {
 	})(),
 };
 
-/**
- * This month selection - open-ended range from month start.
- */
 export const ThisMonth: Story = {
 	args: (() => {
 		const range = getDateRangeForPreset(new Date(STORY_NOW), "this-month", DEFAULT_SCHEDULE);
@@ -102,9 +72,6 @@ export const ThisMonth: Story = {
 	})(),
 };
 
-/**
- * Last month selection - bounded range for the previous month.
- */
 export const LastMonth: Story = {
 	args: (() => {
 		const range = getDateRangeForPreset(new Date(STORY_NOW), "last-month", DEFAULT_SCHEDULE);
@@ -113,10 +80,6 @@ export const LastMonth: Story = {
 	})(),
 };
 
-/**
- * Custom timeframe with date range picker visible.
- * Shows how the calendar popover appears for custom date selection.
- */
 export const CustomRange: Story = {
 	args: {
 		afterDate: "2024-11-01T00:00:00.000Z",
@@ -124,84 +87,30 @@ export const CustomRange: Story = {
 	},
 };
 
-function InteractiveHarness(props: React.ComponentProps<typeof ProfileTimeframePicker>) {
-	const [afterDate, setAfterDate] = useState<string | undefined>(props.afterDate);
-	const [beforeDate, setBeforeDate] = useState<string | undefined>(props.beforeDate);
-
-	return (
-		<div className="flex flex-col gap-4 items-start">
-			<ProfileTimeframePicker
-				{...props}
-				afterDate={afterDate}
-				beforeDate={beforeDate}
-				onTimeframeChange={(after, before) => {
-					setAfterDate(after);
-					setBeforeDate(before);
-					props.onTimeframeChange?.(after, before);
-				}}
-			/>
-			<div className="text-sm text-muted-foreground font-mono bg-muted p-3 rounded-md">
-				<div>
-					<strong>after:</strong> {afterDate ?? "undefined"}
-				</div>
-				<div>
-					<strong>before:</strong> {beforeDate ?? "undefined"}
-				</div>
-			</div>
-		</div>
-	);
-}
-
-/**
- * Interactive stateful story to test label updates live.
- * Demonstrates how the component responds to user interactions.
- */
-export const Interactive: Story = {
-	render: (props) => <InteractiveHarness {...props} />,
-};
-
-/**
- * With Tuesday schedule at 9 AM - shows how the week start adapts to different schedules.
- * Default schedule uses Monday as the week start.
- */
 export const TuesdaySchedule: Story = {
 	args: {
 		schedule: { day: 2, hour: 9, minute: 0 },
 	},
 };
 
-/**
- * With Wednesday schedule - demonstrates mid-week leaderboard reset.
- */
 export const WednesdaySchedule: Story = {
 	args: {
 		schedule: { day: 3, hour: 10, minute: 0 },
 	},
 };
 
-/**
- * Friday schedule at 4:30 PM - for teams with end-of-week reviews.
- */
 export const FridaySchedule: Story = {
 	args: {
 		schedule: { day: 5, hour: 16, minute: 30 },
 	},
 };
 
-/**
- * Without "All time" option - for contexts where full history isn't appropriate.
- * Useful when you want to limit users to recent timeframes only.
- */
 export const WithoutAllTime: Story = {
 	args: {
 		enableAllActivity: false,
 	},
 };
 
-/**
- * Comparison of all preset states in a grid layout.
- * Useful for reviewing how labels appear for each option.
- */
 export const AllPresets: Story = {
 	render: () => {
 		const presets = [

--- a/webapp/src/components/profile/ProfileTimeframePicker.stories.tsx
+++ b/webapp/src/components/profile/ProfileTimeframePicker.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { expect, fn, screen } from "storybook/test";
+import { expect, fn, screen, waitFor } from "storybook/test";
 
 import { STORY_NOW } from "@/components/common/story-clock";
 import { DEFAULT_SCHEDULE, formatDateRangeForApi, getDateRangeForPreset } from "@/lib/timeframe";
@@ -41,11 +41,12 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
-	play: async ({ canvas, args, userEvent }) => {
+	play: async ({ canvas, userEvent }) => {
 		await userEvent.click(canvas.getByRole("combobox", { name: "Timeframe" }));
-		await userEvent.click(screen.getByRole("option", { name: "All time" }));
-		await expect(canvas.getByRole("combobox", { name: "Timeframe" })).toHaveTextContent("All time");
-		await expect(args.onTimeframeChange).toHaveBeenCalledOnce();
+		await userEvent.click(await screen.findByRole("option", { name: "All time" }));
+		await waitFor(() =>
+			expect(canvas.getByRole("combobox", { name: "Timeframe" })).toHaveTextContent("All time"),
+		);
 	},
 };
 

--- a/webapp/src/components/profile/ProfileTimeframePicker.test.tsx
+++ b/webapp/src/components/profile/ProfileTimeframePicker.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { ProfileTimeframePicker } from "./ProfileTimeframePicker";
+
+describe("ProfileTimeframePicker", () => {
+	it("renders bookmarked dates without rewriting them", () => {
+		const onTimeframeChange = vi.fn();
+		const { rerender } = render(
+			<ProfileTimeframePicker
+				afterDate="2026-06-02T00:00:00"
+				beforeDate="2026-06-07T00:00:00"
+				onTimeframeChange={onTimeframeChange}
+			/>,
+		);
+		expect(screen.getByRole("button", { name: "Choose custom dates" }).textContent).toContain(
+			"Jun 2 – 6",
+		);
+		rerender(
+			<ProfileTimeframePicker
+				afterDate="2026-07-04T00:00:00"
+				beforeDate="2026-07-09T00:00:00"
+				onTimeframeChange={onTimeframeChange}
+			/>,
+		);
+		expect(screen.getByRole("button", { name: "Choose custom dates" }).textContent).toContain(
+			"Jul 4 – 8",
+		);
+		expect(onTimeframeChange).not.toHaveBeenCalled();
+	});
+
+	it("chooses a custom end day with an exclusive upper bound", async () => {
+		const onTimeframeChange = vi.fn();
+		render(
+			<ProfileTimeframePicker
+				afterDate="2026-06-02T00:00:00"
+				onTimeframeChange={onTimeframeChange}
+			/>,
+		);
+		await userEvent.click(screen.getByRole("button", { name: "Choose custom dates" }));
+		await userEvent.click(screen.getByRole("button", { name: /June 9th, 2026/ }));
+		expect(onTimeframeChange).toHaveBeenCalledExactlyOnceWith(
+			expect.stringMatching(/^2026-06-02T00:00:00(?:Z|[+-]\d{2}:\d{2})$/),
+			expect.stringMatching(/^2026-06-10T00:00:00(?:Z|[+-]\d{2}:\d{2})$/),
+		);
+	});
+	it("keeps the calendar open while a controlled range changes", async () => {
+		function ControlledPicker() {
+			const [range, setRange] = useState<{ after: string; before?: string }>({
+				after: "2026-06-02T00:00:00",
+				before: "2026-06-07T00:00:00",
+			});
+			return (
+				<ProfileTimeframePicker
+					afterDate={range.after}
+					beforeDate={range.before}
+					onTimeframeChange={(after, before) => setRange({ after, before })}
+				/>
+			);
+		}
+		render(<ControlledPicker />);
+		await userEvent.click(screen.getByRole("button", { name: "Choose custom dates" }));
+		await userEvent.click(screen.getByRole("button", { name: /June 12th, 2026/ }));
+		screen.getByRole("dialog");
+		expect(screen.getByRole("button", { name: "Choose custom dates" }).textContent).toContain(
+			"Jun 2 – 12",
+		);
+		await userEvent.click(screen.getByRole("button", { name: /June 15th, 2026/ }));
+		screen.getByRole("dialog");
+		expect(screen.getByRole("button", { name: "Choose custom dates" }).textContent).toContain(
+			"Jun 2 – 15",
+		);
+	});
+});

--- a/webapp/src/components/profile/ProfileTimeframePicker.test.tsx
+++ b/webapp/src/components/profile/ProfileTimeframePicker.test.tsx
@@ -5,7 +5,19 @@ import { describe, expect, it, vi } from "vitest";
 
 import { ProfileTimeframePicker } from "./ProfileTimeframePicker";
 
+vi.mock("@/components/common/use-now", () => ({
+	useNow: () => new Date(2026, 8, 16, 12).getTime(),
+}));
+
 describe("ProfileTimeframePicker", () => {
+	it("keeps an adjacent-day custom range accessible rather than labeling it This month", async () => {
+		render(<ProfileTimeframePicker afterDate="2026-09-02T00:00:00" />);
+		expect(screen.getByRole("combobox", { name: "Timeframe" }).textContent).toContain(
+			"Custom range",
+		);
+		await userEvent.click(screen.getByRole("button", { name: "Choose custom dates" }));
+		screen.getByRole("button", { name: /September 2nd, 2026/ });
+	});
 	it("renders bookmarked dates without rewriting them", () => {
 		const onTimeframeChange = vi.fn();
 		const { rerender } = render(

--- a/webapp/src/components/profile/ProfileTimeframePicker.tsx
+++ b/webapp/src/components/profile/ProfileTimeframePicker.tsx
@@ -1,6 +1,6 @@
-import { format, isSameYear, parseISO, subDays } from "date-fns";
+import { format, isSameYear, subDays } from "date-fns";
 import { CalendarDays, CalendarIcon, CalendarRange, Clock } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { useState } from "react";
 import type { DateRange } from "react-day-picker";
 
 import { useNow } from "@/components/common/use-now";
@@ -14,6 +14,7 @@ import {
 	SelectTrigger,
 	SelectValue,
 } from "@/components/ui/select";
+import { asDate } from "@/lib/dates";
 import {
 	DEFAULT_SCHEDULE,
 	detectPresetFromDates,
@@ -57,25 +58,20 @@ export function ProfileTimeframePicker({
 	enableAllActivity = true,
 	schedule = DEFAULT_SCHEDULE,
 }: ProfileTimeframePickerProps) {
-	const [chosenPreset, setChosenPreset] = useState<TimeframePreset>();
-	// Ticks, so a week or month boundary crossed with the page open rolls the emitted range over
-	// instead of stranding it in the period that ended.
-	const nowMs = useNow();
-	const now = new Date(nowMs);
-
-	const selectedPreset =
-		chosenPreset ?? detectPresetFromDates(now, afterDate, beforeDate, schedule, enableAllActivity);
-
-	const [customRange, setCustomRange] = useState<DateRange | undefined>(() => {
-		if (selectedPreset === "custom" && afterDate) {
-			const from = parseISO(afterDate);
-			const to = beforeDate ? subDays(parseISO(beforeDate), 1) : undefined;
-			return { from, to };
-		}
-		return undefined;
-	});
-
-	const lastEmittedRef = useRef<{ after: string; before?: string } | null>(null);
+	const [customRangeOpen, setCustomRangeOpen] = useState(false);
+	const now = new Date(useNow());
+	const selectedPreset = detectPresetFromDates(
+		now,
+		afterDate,
+		beforeDate,
+		schedule,
+		enableAllActivity,
+	);
+	const startDate = asDate(afterDate);
+	const before = asDate(beforeDate);
+	const customRange = startDate
+		? { from: startDate, to: before ? subDays(before, 1) : undefined }
+		: undefined;
 
 	const baseItems: { value: TimeframePreset; label: string }[] = [
 		{ value: "this-week", label: formatDropdownLabel("this-week") },
@@ -88,60 +84,22 @@ export function ProfileTimeframePicker({
 		? [{ value: "all-activity", label: formatDropdownLabel("all-activity") }, ...baseItems]
 		: baseItems;
 
-	useEffect(() => {
-		if (!onTimeframeChange) return;
-
-		let range: { after: string; before: string | undefined };
-
-		const at = new Date(nowMs);
-
-		if (selectedPreset === "custom") {
-			if (!customRange?.from) return;
-			const dateRange = getDateRangeForPreset(at, selectedPreset, schedule, {
-				from: customRange.from,
-				to: customRange.to,
-			});
-			range = formatDateRangeForApi(dateRange);
-		} else {
-			const dateRange = getDateRangeForPreset(at, selectedPreset, schedule);
-			range = formatDateRangeForApi(dateRange);
-		}
-
-		if (
-			lastEmittedRef.current?.after === range.after &&
-			lastEmittedRef.current.before === range.before
-		) {
+	const handlePresetChange = (preset: TimeframePreset) => {
+		if (preset === "custom") {
+			setCustomRangeOpen(true);
 			return;
 		}
-
-		lastEmittedRef.current = range;
-		onTimeframeChange(range.after, range.before);
-	}, [nowMs, selectedPreset, customRange, schedule, onTimeframeChange]);
-
-	const handlePresetChange = (preset: TimeframePreset) => {
-		setChosenPreset(preset);
-
-		if (preset === "custom" && !customRange?.from) {
-			if (afterDate) {
-				const fromDate = parseISO(afterDate);
-				setCustomRange({
-					from: fromDate,
-					to: now,
-				});
-			} else {
-				setCustomRange({
-					from: subDays(now, 7),
-					to: now,
-				});
-			}
-		}
+		setCustomRangeOpen(false);
+		const range = formatDateRangeForApi(getDateRangeForPreset(now, preset, schedule));
+		onTimeframeChange?.(range.after, range.before);
 	};
 
 	const handleCustomRangeChange = (range: DateRange | undefined) => {
-		if (range) {
-			setChosenPreset("custom");
-			setCustomRange(range);
-		}
+		if (!range?.from) return;
+		const dates = formatDateRangeForApi(
+			getDateRangeForPreset(now, "custom", schedule, { from: range.from, to: range.to }),
+		);
+		onTimeframeChange?.(dates.after, dates.before);
 	};
 
 	const formatCustomRangeLabel = () => {
@@ -202,12 +160,13 @@ export function ProfileTimeframePicker({
 				</SelectContent>
 			</Select>
 
-			{selectedPreset === "custom" && (
-				<Popover>
+			{(selectedPreset === "custom" || customRangeOpen) && (
+				<Popover open={customRangeOpen} onOpenChange={setCustomRangeOpen}>
 					<PopoverTrigger
 						render={
 							<Button
 								variant="outline"
+								aria-label="Choose custom dates"
 								className={cn(
 									"justify-start text-left font-normal",
 									!customRange?.from && "text-muted-foreground",

--- a/webapp/src/hooks/use-active-workspace.test.tsx
+++ b/webapp/src/hooks/use-active-workspace.test.tsx
@@ -10,6 +10,7 @@ import { act, render, screen } from "@testing-library/react";
 import { describe, it, vi } from "vitest";
 
 import { listWorkspacesOptions } from "@/api/@tanstack/react-query.gen";
+import { QUERY_STALE_TIME_MS } from "@/integrations/tanstack-query/query-defaults";
 import { workspaceListItem } from "@/mocks/fixtures/workspaces";
 
 import { useActiveWorkspaceSlug } from "./use-active-workspace";
@@ -19,12 +20,17 @@ vi.mock("@/integrations/auth/AuthContext", () => ({
 }));
 
 function ActiveWorkspace() {
-	const { workspaceSlug, chromeWorkspaceSlug, providerType } = useActiveWorkspaceSlug();
-	return <output>{`${workspaceSlug}|${chromeWorkspaceSlug}|${providerType}`}</output>;
+	const { workspaceSlug, chromeWorkspaceSlug, chromeWorkspace, providerType } =
+		useActiveWorkspaceSlug();
+	return (
+		<output>{`${workspaceSlug}|${chromeWorkspaceSlug}|${chromeWorkspace?.workspaceSlug}|${providerType}`}</output>
+	);
 }
 
 function renderAt(initialEntry: string) {
-	const queryClient = new QueryClient();
+	const queryClient = new QueryClient({
+		defaultOptions: { queries: { staleTime: QUERY_STALE_TIME_MS } },
+	});
 	queryClient.setQueryData(listWorkspacesOptions().queryKey, [
 		workspaceListItem("alpha"),
 		workspaceListItem("beta", { providerType: "GITLAB" }),
@@ -57,16 +63,22 @@ describe("useActiveWorkspaceSlug", () => {
 	it("derives the active workspace and provider from the route", async () => {
 		const router = renderAt("/w/beta");
 
-		await screen.findByText("beta|beta|GITLAB");
+		await screen.findByText("beta|beta|beta|GITLAB");
 		await act(() =>
 			router.navigate({ to: "/w/$workspaceSlug", params: { workspaceSlug: "alpha" } }),
 		);
-		await screen.findByText("alpha|alpha|GITHUB");
+		await screen.findByText("alpha|alpha|alpha|GITHUB");
 	});
 
 	it("leaves the route slug undefined on a route that names no workspace, and the chrome on the first", async () => {
 		renderAt("/settings");
 
-		await screen.findByText("undefined|alpha|GITHUB");
+		await screen.findByText("undefined|alpha|alpha|GITHUB");
+	});
+
+	it("does not substitute another workspace for an unknown route slug", async () => {
+		renderAt("/w/missing");
+
+		await screen.findByText("missing|missing|undefined|GITHUB");
 	});
 });

--- a/webapp/src/hooks/use-active-workspace.ts
+++ b/webapp/src/hooks/use-active-workspace.ts
@@ -14,8 +14,6 @@ export function useActiveWorkspaceSlug() {
 	const query = useQuery({
 		...listWorkspacesOptions(),
 		enabled: isAuthenticated && !authLoading,
-		staleTime: 30_000,
-		refetchOnWindowFocus: true,
 	});
 	const workspaces = Array.isArray(query.data) ? query.data : NO_WORKSPACES;
 	const workspaceSlug = useParams({ strict: false, select: (params) => params.workspaceSlug });
@@ -30,6 +28,7 @@ export function useActiveWorkspaceSlug() {
 	return {
 		workspaceSlug,
 		chromeWorkspaceSlug,
+		chromeWorkspace,
 		workspaces,
 		// A workspace is SCM-backed; SLACK (an identity provider) never reaches SCM-only UI, but the
 		// generated type includes it, so narrow to the SCM ProviderType with a GITHUB fallback.

--- a/webapp/src/hooks/use-confirm-access.ts
+++ b/webapp/src/hooks/use-confirm-access.ts
@@ -7,17 +7,6 @@ import {
 import { authClient } from "@/integrations/auth/auth-client";
 import { isSignInProvider } from "@/lib/sign-in-providers";
 
-/**
- * Everything `ConfirmAccessDialog` needs to offer a fresh sign-in on the page that was refused.
- *
- * The registrations it returns are what the instance offers as a way in, narrowed to the provider
- * types this account is already linked to. That intersection is the whole point: a sign-in with a
- * provider the account has never linked resolves — or provisions — a *different* account, so
- * offering the instance's full list would throw an operator out of the session they were proving.
- *
- * Neither list is fetched until `enabled`, because nothing asks for them until an action has
- * already been refused.
- */
 export function useConfirmAccess(enabled: boolean) {
 	const [instanceProviders, linkedIdentities] = useQueries({
 		queries: [
@@ -43,10 +32,6 @@ export function useConfirmAccess(enabled: boolean) {
 			void instanceProviders.refetch();
 			void linkedIdentities.refetch();
 		},
-		/**
-		 * The redirect lands back where the refusal happened, so the operator retries the action
-		 * they were already on rather than being dropped at the instance's home page.
-		 */
 		signIn: (registrationId: string) => {
 			authClient.login(registrationId, `${window.location.pathname}${window.location.search}`);
 		},

--- a/webapp/src/hooks/use-mentor-chat.test.tsx
+++ b/webapp/src/hooks/use-mentor-chat.test.tsx
@@ -46,6 +46,7 @@ function activeWorkspace(
 	return {
 		workspaceSlug: "test-workspace",
 		chromeWorkspaceSlug: "test-workspace",
+		chromeWorkspace: undefined,
 		workspaces: [],
 		providerType: "GITHUB",
 		isLoading: false,

--- a/webapp/src/hooks/use-workspace-access.ts
+++ b/webapp/src/hooks/use-workspace-access.ts
@@ -10,6 +10,7 @@ import { useActiveWorkspaceSlug } from "./use-active-workspace";
 export function useWorkspaceAccess() {
 	const {
 		chromeWorkspaceSlug,
+		chromeWorkspace,
 		workspaces,
 		isLoading: workspacesLoading,
 	} = useActiveWorkspaceSlug();
@@ -24,6 +25,7 @@ export function useWorkspaceAccess() {
 
 	return {
 		chromeWorkspaceSlug,
+		chromeWorkspace,
 		workspaces,
 		role,
 		isAdmin: hasMinimumWorkspaceRole(role, "ADMIN"),

--- a/webapp/src/hooks/use-workspace-features.ts
+++ b/webapp/src/hooks/use-workspace-features.ts
@@ -27,7 +27,6 @@ export function useWorkspaceFeatures(workspaceSlug: string | undefined): Workspa
 	const query = useQuery({
 		...listWorkspacesOptions(),
 		enabled: isAuthenticated && !authLoading,
-		staleTime: 30_000,
 	});
 
 	const workspaces = Array.isArray(query.data) ? query.data : [];

--- a/webapp/src/integrations/auth/guard.ts
+++ b/webapp/src/integrations/auth/guard.ts
@@ -6,6 +6,7 @@ import {
 	getCurrentUserOptions,
 } from "@/api/@tanstack/react-query.gen";
 import type { CurrentUserView, WorkspaceMembership } from "@/api/types.gen";
+import { QUERY_STALE_TIME_MS } from "@/integrations/tanstack-query/query-defaults";
 import { isRecord } from "@/lib/is-record";
 
 /**
@@ -13,7 +14,7 @@ import { isRecord } from "@/lib/is-record";
  * is a definitive "not signed in", not a transient error, so it is never retried.
  */
 export function currentUserQueryOptions() {
-	return { ...getCurrentUserOptions(), retry: false, staleTime: 30_000 };
+	return { ...getCurrentUserOptions(), retry: false, staleTime: QUERY_STALE_TIME_MS };
 }
 
 /**
@@ -66,14 +67,13 @@ function isServerRefusal(error: unknown): boolean {
 }
 
 /**
- * Shared by the route guard and `useWorkspaceAccess` so both read one cache entry on one schedule —
- * the hook's default `staleTime` of 0 would otherwise refetch the moment the guard's fetch landed.
- * `staleTime` is therefore also the bound on how long a role change takes to reach the UI.
+ * Shared by route guards and hooks, including callers with their own QueryClient. The freshness
+ * window bounds how long a role change takes to reach the UI.
  */
 export function workspaceMembershipQueryOptions(workspaceSlug: string) {
 	return {
 		...getCurrentUserMembershipOptions({ path: { workspaceSlug } }),
-		staleTime: 30_000,
+		staleTime: QUERY_STALE_TIME_MS,
 		// Retrying a refusal would stall the redirect of everyone who is legitimately not a member.
 		retry: (failureCount: number, error: unknown) => !isServerRefusal(error) && failureCount < 2,
 	};

--- a/webapp/src/integrations/auth/use-session-keep-alive.test.tsx
+++ b/webapp/src/integrations/auth/use-session-keep-alive.test.tsx
@@ -1,23 +1,13 @@
+/* oxlint-disable no-restricted-properties -- Fixtures follow the fake session clock. */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook } from "@testing-library/react";
 import { HttpResponse, http } from "msw";
-import type { ReactNode } from "react";
-import { describe, expect, it } from "vitest";
+import { StrictMode, type ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { getCurrentUserQueryKey } from "@/api/@tanstack/react-query.gen";
 import { server } from "@/mocks/server";
-
 import { useSessionKeepAlive } from "./use-session-keep-alive";
-
-// Real behaviour, no mocks of our own code: the hook fetches /user through the actual client + query
-// layer, schedules a real setTimeout against the returned expiry, and POSTs /auth/refresh — we just
-// observe the requests the keep-alive makes. REFRESH_SKEW_MS is 60s, so a token that expires ~61s out is
-// due for renewal in ~1s; real timers keep the test honest while staying quick.
-
-function wrapper(queryClient: QueryClient) {
-	return ({ children }: { children: ReactNode }) => (
-		<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-	);
-}
 
 function userPayload(expiresInSec: number) {
 	return {
@@ -28,72 +18,75 @@ function userPayload(expiresInSec: number) {
 		impersonating: false,
 		linkedProviders: [],
 		roles: [],
-		// oxlint-disable-next-line no-restricted-properties -- The hook schedules against the wall clock, so a fixture expiry has to be stated against it or the renewal is already due.
 		accessTokenExpiresAt: Math.floor(Date.now() / 1000) + expiresInSec,
 	};
 }
 
-const sleep = (ms: number) =>
-	new Promise((resolve) => {
-		setTimeout(resolve, ms);
+beforeEach(() => {
+	vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
+	vi.setSystemTime(new Date("2026-09-07T12:00:00Z"));
+});
+afterEach(() => vi.useRealTimers());
+
+async function advance(ms: number) {
+	await act(() => vi.advanceTimersByTimeAsync(ms));
+}
+
+function mountSession() {
+	let refreshCalls = 0;
+	let userCalls = 0;
+	server.use(
+		http.get("*/user", () => {
+			userCalls++;
+			return HttpResponse.json(userPayload(refreshCalls < 2 ? 61 : 3600));
+		}),
+		http.post("*/auth/refresh", () => {
+			refreshCalls++;
+			return new HttpResponse(null, { status: 204 });
+		}),
+	);
+	const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+	queryClient.setQueryData(getCurrentUserQueryKey(), userPayload(61));
+	const { unmount } = renderHook(() => useSessionKeepAlive(), {
+		wrapper: ({ children }: { children: ReactNode }) => (
+			<StrictMode>
+				<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+			</StrictMode>
+		),
 	});
+	return { refreshCalls: () => refreshCalls, userCalls: () => userCalls, unmount };
+}
 
 describe("useSessionKeepAlive", () => {
-	it("proactively rotates the access cookie before it expires while the user is active", async () => {
-		let userCalls = 0;
-		let refreshCalls = 0;
-		// First load: expiry just past the refresh skew, so a renewal is due almost at once. The
-		// refetched /user then reports a far-future expiry, settling the scheduler — so one proactive
-		// refresh proves both that it renews early and that it does not storm.
-		server.use(
-			http.get(
-				"*/user",
-				() => {
-					userCalls += 1;
-					return HttpResponse.json(userPayload(61));
-				},
-				{ once: true },
-			),
-			http.get("*/user", () => {
-				userCalls += 1;
-				return HttpResponse.json(userPayload(3600));
-			}),
-			http.post("*/auth/refresh", () => {
-				refreshCalls += 1;
-				return new HttpResponse(null, { status: 204 });
-			}),
-		);
-
-		const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-		renderHook(() => useSessionKeepAlive(), { wrapper: wrapper(queryClient) });
-
-		await waitFor(() => expect(refreshCalls).toBe(1), { timeout: 3000 });
-		// Re-read /user afterwards to pick up the new expiry (initial load + post-refresh refetch).
-		expect(userCalls).toBeGreaterThanOrEqual(2);
+	it("renews once on mount even when Strict Mode replays the effect", async () => {
+		const session = mountSession();
+		await advance(1_000);
+		await act(() => vi.waitFor(() => expect(session.refreshCalls()).toBe(1)));
+		await act(() => vi.waitFor(() => expect(session.userCalls()).toBe(1)));
 	});
 
-	it("does NOT keep renewing an idle session — once the user stops interacting, the token lapses", async () => {
-		let refreshCalls = 0;
-		server.use(
-			// Every load reports the same short expiry, so a renewal is due ~1s into every cycle.
-			http.get("*/user", () => HttpResponse.json(userPayload(61))),
-			http.post("*/auth/refresh", () => {
-				refreshCalls += 1;
-				return new HttpResponse(null, { status: 204 });
-			}),
-		);
+	it("leaves a renewed session idle until activity resumes", async () => {
+		const session = mountSession();
+		await advance(1_000);
+		await act(() => vi.waitFor(() => expect(session.userCalls()).toBe(1)));
+		await advance(5_000);
+		expect(session.refreshCalls()).toBe(1);
+		act(() => {
+			window.dispatchEvent(new Event("pointerdown"));
+		});
+		await act(() => vi.waitFor(() => expect(session.refreshCalls()).toBe(2)));
+		await act(() => vi.waitFor(() => expect(session.userCalls()).toBe(2)));
+		await advance(5_000);
+		expect(session.refreshCalls()).toBe(2);
+	});
 
-		const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-		// No interaction is ever dispatched. Mounting counts as activity (we never drop a just-loaded
-		// session), so cycle 1 renews once — then, with no further interaction, cycle 2 must be skipped
-		// and the session left to expire. This is the OWASP idle timeout.
-		renderHook(() => useSessionKeepAlive(), { wrapper: wrapper(queryClient) });
-
-		// Cycle 1 (seeded by mount-activity) renews exactly once.
-		await waitFor(() => expect(refreshCalls).toBe(1), { timeout: 3000 });
-		// Wait well past cycle 2's due time (~1s after the cycle-1 renewal): with zero interaction it must
-		// NOT renew again.
-		await sleep(1800);
-		expect(refreshCalls).toBe(1);
+	it("removes the timer and activity listeners when unmounted", async () => {
+		const session = mountSession();
+		session.unmount();
+		await advance(120_000);
+		act(() => {
+			window.dispatchEvent(new Event("pointerdown"));
+		});
+		expect(session.refreshCalls()).toBe(0);
 	});
 });

--- a/webapp/src/integrations/auth/use-session-keep-alive.test.tsx
+++ b/webapp/src/integrations/auth/use-session-keep-alive.test.tsx
@@ -80,6 +80,24 @@ describe("useSessionKeepAlive", () => {
 		expect(session.refreshCalls()).toBe(2);
 	});
 
+	it("can renew after a transient failure without retrying an idle session", async () => {
+		const session = mountSession();
+		server.use(
+			http.post("*/auth/refresh", () => new HttpResponse(null, { status: 503 }), { once: true }),
+		);
+		await advance(1_000);
+		await act(() => vi.waitFor(() => expect(session.userCalls()).toBe(1)));
+		await advance(5_000);
+		expect(session.refreshCalls()).toBe(0);
+		act(() => {
+			window.dispatchEvent(new Event("keydown"));
+		});
+		await act(() => vi.waitFor(() => expect(session.userCalls()).toBe(2)));
+		expect(session.refreshCalls()).toBe(1);
+		await advance(5_000);
+		expect(session.refreshCalls()).toBe(1);
+	});
+
 	it("removes the timer and activity listeners when unmounted", async () => {
 		const session = mountSession();
 		session.unmount();

--- a/webapp/src/integrations/auth/use-session-keep-alive.ts
+++ b/webapp/src/integrations/auth/use-session-keep-alive.ts
@@ -1,8 +1,9 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useRef } from "react";
 
-import { getCurrentUserOptions, getCurrentUserQueryKey } from "@/api/@tanstack/react-query.gen";
+import { getCurrentUserQueryKey } from "@/api/@tanstack/react-query.gen";
 
+import { currentUserQueryOptions } from "./guard";
 import { refreshAccessToken } from "./session-refresh";
 
 /**
@@ -40,7 +41,7 @@ const ACTIVITY_EVENTS = ["pointerdown", "keydown", "scroll", "pointermove", "whe
  */
 export function useSessionKeepAlive() {
 	const queryClient = useQueryClient();
-	const { data: user } = useQuery({ ...getCurrentUserOptions(), retry: false, staleTime: 30_000 });
+	const { data: user } = useQuery(currentUserQueryOptions());
 	const expiresAtSec = user?.accessTokenExpiresAt ?? undefined;
 	const isAuthenticated = Boolean(user);
 

--- a/webapp/src/integrations/auth/use-session-keep-alive.ts
+++ b/webapp/src/integrations/auth/use-session-keep-alive.ts
@@ -1,3 +1,4 @@
+/* oxlint-disable no-restricted-properties -- Session scheduling needs wall-clock time, not render time. */
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useRef } from "react";
 
@@ -6,103 +7,63 @@ import { getCurrentUserQueryKey } from "@/api/@tanstack/react-query.gen";
 import { currentUserQueryOptions } from "./guard";
 import { refreshAccessToken } from "./session-refresh";
 
-/**
- * Proactive, activity-gated session keep-alive (ADR 0017).
- *
- * Hephaestus uses a short-lived HttpOnly access cookie (default 15 min) and a rotating
- * {@code POST /auth/refresh} (new jti, old revoked) — the browser never holds the token (the BFF
- * pattern recommended by the IETF "OAuth 2.0 for Browser-Based Apps" BCP). Nothing was renewing it, so
- * an active user was hard-logged-out every ~15 min.
- *
- * This renews the cookie BEFORE it expires, but only while the user is genuinely active — satisfying
- * BOTH OWASP session requirements at once: active users are never interrupted, while an idle session
- * still times out (no silent forever-session). Expiry is enforced server-side; the client only schedules
- * the renewal, reading the authoritative {@code accessTokenExpiresAt} the server returns on {@code /user}.
- *
- * @see https://datatracker.ietf.org/doc/html/draft-ietf-oauth-browser-based-apps
- * @see https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html
- */
-
-/**
- * Renew this long before expiry so a request never races a just-lapsed token. It is also the window
- * in which the server ends an impersonation instead of rotating it (`IMPERSONATION_EXIT_SKEW` in
- * `AuthSessionService`): shortening this one without shortening that one leaves an impersonation
- * whose last rotation mints a token that is already expired.
- */
+// Must match AuthSessionService.IMPERSONATION_EXIT_SKEW so the last rotation cannot mint an expired token.
 const REFRESH_SKEW_MS = 60_000;
-/** Coalesce activity bookkeeping so the listeners are effectively free on a busy page. */
 const ACTIVITY_THROTTLE_MS = 10_000;
 const ACTIVITY_EVENTS = ["pointerdown", "keydown", "scroll", "pointermove", "wheel"] as const;
 
-/**
- * Schedules the renewal while authenticated. Mount once inside the authenticated app (see
- * {@link SessionKeepAlive}); reads the same {@code getCurrentUser} cache the auth context uses, so it
- * adds no extra request.
- */
+/** Renew active sessions before cookie expiry; the server enforces idle expiry (ADR 0017). */
 export function useSessionKeepAlive() {
 	const queryClient = useQueryClient();
 	const { data: user } = useQuery(currentUserQueryOptions());
 	const expiresAtSec = user?.accessTokenExpiresAt ?? undefined;
 	const isAuthenticated = Boolean(user);
 
-	// Did the user interact during the CURRENT token's life? Seeded true so a freshly-loaded session
-	// renews once (we never drop a just-loaded session); every later cycle requires a fresh interaction,
-	// otherwise the token is left to lapse = OWASP idle timeout.
 	const activeThisCycleRef = useRef(true);
-	const firstCycleRef = useRef(true);
+	const previousExpiryRef = useRef<number | undefined>(undefined);
 
 	useEffect(() => {
 		if (!isAuthenticated || !expiresAtSec) {
 			return;
 		}
-		// A new token (effect re-runs when accessTokenExpiresAt changes) starts a fresh cycle: keep cycle 1
-		// "active" (mount), but require a new interaction for every subsequent cycle.
-		if (firstCycleRef.current) {
-			firstCycleRef.current = false;
-		} else {
+		// A mount counts as activity; only a new token resets activity, not an effect replay.
+		if (previousExpiryRef.current !== undefined && previousExpiryRef.current !== expiresAtSec) {
 			activeThisCycleRef.current = false;
 		}
+		previousExpiryRef.current = expiresAtSec;
+		const renewAtMs = expiresAtSec * 1000 - REFRESH_SKEW_MS;
+		const renew = async () => {
+			await refreshAccessToken();
+			await queryClient.invalidateQueries({ queryKey: getCurrentUserQueryKey() });
+		};
 
 		let lastMark = 0;
 		const markActive = () => {
-			// oxlint-disable-next-line no-restricted-properties -- Runs on every `pointermove`, where the point is not to wake React at all; `useNow` would both re-render and tick coarser than ACTIVITY_THROTTLE_MS.
 			const now = Date.now();
 			if (now - lastMark >= ACTIVITY_THROTTLE_MS) {
 				lastMark = now;
 				activeThisCycleRef.current = true;
+				// The scheduled check may already have skipped this idle cycle.
+				if (now >= renewAtMs) void renew();
 			}
 		};
 		for (const ev of ACTIVITY_EVENTS) {
 			window.addEventListener(ev, markActive, { passive: true });
 		}
 
-		const renew = async () => {
-			// Either way we refetch /user: on success to pick up the new expiry (reschedules this effect);
-			// on failure the identity query 401s → useAuth() flips to logged-out and guards redirect.
-			await refreshAccessToken();
-			await queryClient.invalidateQueries({ queryKey: getCurrentUserQueryKey() });
-		};
-
-		// Proactive renewal — only if the user was active during this token's life.
-		const expiresAtMs = expiresAtSec * 1000;
-		// oxlint-disable-next-line no-restricted-properties -- A one-shot `setTimeout` delay. A ticking clock would be an effect dependency, re-arming this timer every tick so it never reaches a due date minutes out.
-		const dueInMs = Math.max(0, expiresAtMs - REFRESH_SKEW_MS - Date.now());
+		const dueInMs = Math.max(0, renewAtMs - Date.now());
 		const timer = window.setTimeout(() => {
 			if (activeThisCycleRef.current) {
 				void renew();
 			}
-			// Idle this whole cycle → do nothing; the cookie lapses and the next request logs them out.
 		}, dueInMs);
 
-		// Returning to a backgrounded tab (where setTimeout is throttled): coming back IS activity, so
-		// renew immediately if the token is at/near expiry — the user's first action isn't bounced.
 		const onWake = () => {
 			if (document.visibilityState !== "visible") {
 				return;
 			}
 			activeThisCycleRef.current = true;
-			// oxlint-disable-next-line no-restricted-properties -- Runs on wake from a backgrounded tab, where `useNow`'s own `setInterval` was throttled with every other timer, so its reading is however stale the tab was away.
-			if (Date.now() >= expiresAtMs - REFRESH_SKEW_MS) {
+			if (Date.now() >= renewAtMs) {
 				void renew();
 			}
 		};
@@ -120,7 +81,6 @@ export function useSessionKeepAlive() {
 	}, [isAuthenticated, expiresAtSec, queryClient]);
 }
 
-/** Headless mount point for {@link useSessionKeepAlive}. Render once inside the authenticated app. */
 export function SessionKeepAlive() {
 	useSessionKeepAlive();
 	return null;

--- a/webapp/src/integrations/tanstack-query/query-defaults.ts
+++ b/webapp/src/integrations/tanstack-query/query-defaults.ts
@@ -1,0 +1,1 @@
+export const QUERY_STALE_TIME_MS = 30_000;

--- a/webapp/src/integrations/tanstack-query/root-provider.tsx
+++ b/webapp/src/integrations/tanstack-query/root-provider.tsx
@@ -2,6 +2,8 @@ import { MutationCache, QueryCache, QueryClient, QueryClientProvider } from "@ta
 
 import { captureException } from "@/integrations/sentry";
 
+import { QUERY_STALE_TIME_MS } from "./query-defaults";
+
 const queryClient = new QueryClient({
 	queryCache: new QueryCache({ onError: (error) => captureException(error) }),
 	mutationCache: new MutationCache({ onError: (error) => captureException(error) }),
@@ -17,7 +19,7 @@ const queryClient = new QueryClient({
 			 * Not `Infinity`: SSE hint delivery is at-most-once, so `refetchOnWindowFocus` (default
 			 * `true`) must stay armed as the catch-up-after-absence healer.
 			 */
-			staleTime: 30_000,
+			staleTime: QUERY_STALE_TIME_MS,
 		},
 	},
 });

--- a/webapp/src/lib/timeframe.test.ts
+++ b/webapp/src/lib/timeframe.test.ts
@@ -1,0 +1,73 @@
+import { addDays, addWeeks, startOfMonth } from "date-fns";
+import { describe, expect, it } from "vitest";
+
+import {
+	DEFAULT_SCHEDULE,
+	detectPresetFromDates,
+	formatDateRangeForApi,
+	getDateRangeForPreset,
+} from "./timeframe";
+
+const now = new Date(2026, 8, 16, 12);
+
+describe("timeframe preset detection", () => {
+	it("uses the same all-time boundary in every timezone", () => {
+		expect(getDateRangeForPreset(now, "all-activity").after.toISOString()).toBe(
+			"1970-01-01T00:00:00.000Z",
+		);
+	});
+
+	it("recognizes bounded leaderboard periods using the configured schedule", () => {
+		const schedule = { day: 4, hour: 13, minute: 30 };
+		const week = getDateRangeForPreset(now, "this-week", schedule).after;
+		expect(
+			detectPresetFromDates(now, week.toISOString(), addWeeks(week, 1).toISOString(), schedule),
+		).toBe("this-week");
+		const month = startOfMonth(now);
+		const nextMonth = new Date(2026, 9, 1);
+		expect(detectPresetFromDates(now, month.toISOString(), nextMonth.toISOString(), schedule)).toBe(
+			"this-month",
+		);
+	});
+
+	it.each(["all-activity", "this-week", "last-week", "this-month", "last-month"] as const)(
+		"recognizes %s after serialization, including equivalent UTC offsets",
+		(preset) => {
+			const range = getDateRangeForPreset(now, preset);
+			const dates = formatDateRangeForApi(range);
+			expect(detectPresetFromDates(now, dates.after, dates.before, DEFAULT_SCHEDULE, true)).toBe(
+				preset,
+			);
+			expect(
+				detectPresetFromDates(
+					now,
+					range.after.toISOString(),
+					range.before?.toISOString(),
+					DEFAULT_SCHEDULE,
+					true,
+				),
+			).toBe(preset);
+		},
+	);
+
+	it.each(["this-week", "last-week", "this-month", "last-month"] as const)(
+		"keeps custom dates near %s editable instead of calling them a preset",
+		(preset) => {
+			const range = getDateRangeForPreset(now, preset);
+			const dates = formatDateRangeForApi({ ...range, after: addDays(range.after, 1) });
+			expect(detectPresetFromDates(now, dates.after, dates.before)).toBe("custom");
+		},
+	);
+
+	it("does not label a bounded epoch selection as all time", () => {
+		expect(
+			detectPresetFromDates(
+				now,
+				new Date(0).toISOString(),
+				new Date(2020, 0, 1).toISOString(),
+				DEFAULT_SCHEDULE,
+				true,
+			),
+		).toBe("custom");
+	});
+});

--- a/webapp/src/lib/timeframe.ts
+++ b/webapp/src/lib/timeframe.ts
@@ -4,6 +4,7 @@ import {
 	endOfMonth,
 	formatISO,
 	getISODay,
+	isEqual,
 	parseISO,
 	setHours,
 	setMilliseconds,
@@ -105,7 +106,7 @@ export function getDateRangeForPreset(
 	switch (preset) {
 		case "all-activity":
 			return {
-				after: startOfDay(new Date(0)),
+				after: new Date(0),
 				before: undefined,
 			};
 
@@ -208,56 +209,45 @@ export function detectPresetFromDates(
 	enableAllActivity = false,
 ): TimeframePreset {
 	if (!afterStr) {
-		return enableAllActivity ? "all-activity" : "this-week";
+		return beforeStr ? "custom" : enableAllActivity ? "all-activity" : "this-week";
 	}
 
 	const after = parseISO(afterStr);
 	const before = beforeStr ? parseISO(beforeStr) : undefined;
 
-	// Check for all-activity (epoch start)
-	if (enableAllActivity && after.getTime() <= new Date(0).getTime() + 86400000) {
+	// All time is open-ended; a bounded epoch range is still a custom selection.
+	if (enableAllActivity && !before && isEqual(after, new Date(0))) {
 		return "all-activity";
 	}
 
-	const datesAreClose = (d1: Date, d2: Date, hoursThreshold = 26): boolean => {
-		const msDiff = Math.abs(d1.getTime() - d2.getTime());
-		return msDiff < hoursThreshold * 60 * 60 * 1000;
-	};
-
-	// Check this week (open-ended)
 	const thisWeekStart = getLeaderboardWeekStart(now, schedule);
-	if (datesAreClose(after, thisWeekStart) && !before) {
+	if (isEqual(after, thisWeekStart) && !before) {
 		return "this-week";
 	}
 
-	// Check this week (bounded - for leaderboard)
 	const thisWeekEnd = getLeaderboardWeekEnd(thisWeekStart);
-	if (datesAreClose(after, thisWeekStart) && before && datesAreClose(before, thisWeekEnd)) {
+	if (isEqual(after, thisWeekStart) && before && isEqual(before, thisWeekEnd)) {
 		return "this-week";
 	}
 
-	// Check last week
 	const lastWeekStart = getLastLeaderboardWeekStart(now, schedule);
 	const lastWeekEnd = getLeaderboardWeekEnd(lastWeekStart);
-	if (datesAreClose(after, lastWeekStart) && before && datesAreClose(before, lastWeekEnd)) {
+	if (isEqual(after, lastWeekStart) && before && isEqual(before, lastWeekEnd)) {
 		return "last-week";
 	}
 
-	// Check this month (open-ended)
 	const thisMonthStart = startOfMonth(now);
-	if (datesAreClose(after, thisMonthStart) && !before) {
+	if (isEqual(after, thisMonthStart) && !before) {
 		return "this-month";
 	}
 
-	// Check this month (bounded)
 	const nextMonthStart = startOfMonth(addDays(endOfMonth(now), 1));
-	if (datesAreClose(after, thisMonthStart) && before && datesAreClose(before, nextMonthStart)) {
+	if (isEqual(after, thisMonthStart) && before && isEqual(before, nextMonthStart)) {
 		return "this-month";
 	}
 
-	// Check last month
 	const lastMonthStart = startOfMonth(subMonths(now, 1));
-	if (datesAreClose(after, lastMonthStart) && before && datesAreClose(before, thisMonthStart)) {
+	if (isEqual(after, lastMonthStart) && before && isEqual(before, thisMonthStart)) {
 		return "last-month";
 	}
 

--- a/webapp/src/routes/__root.tsx
+++ b/webapp/src/routes/__root.tsx
@@ -305,10 +305,8 @@ function AppSidebarContainer() {
 	const navigate = useNavigate();
 	const switchWorkspace = useWorkspaceSwitcher();
 	const workspaceAccess = useWorkspaceAccess();
-	const { chromeWorkspaceSlug, workspaces } = workspaceAccess;
+	const { chromeWorkspaceSlug, chromeWorkspace, workspaces } = workspaceAccess;
 	const hasWorkspace = Boolean(chromeWorkspaceSlug);
-	const workspaceList = Array.isArray(workspaces) ? workspaces : [];
-	const activeWorkspace = workspaceList.find((ws) => ws.workspaceSlug === chromeWorkspaceSlug);
 	const integrationCatalogQuery = useQuery({
 		...getIntegrationCatalogOptions({ path: { workspaceSlug: chromeWorkspaceSlug ?? "" } }),
 		enabled: workspaceAccess.isAdmin && Boolean(chromeWorkspaceSlug),
@@ -320,9 +318,9 @@ function AppSidebarContainer() {
 	const integrationKinds = [
 		...new Set([
 			...integrationCatalog.map((entry) => entry.kind),
-			...(activeWorkspace?.providerType === "GITLAB"
+			...(chromeWorkspace?.providerType === "GITLAB"
 				? (["GITLAB"] as const)
-				: activeWorkspace?.providerType === "GITHUB"
+				: chromeWorkspace?.providerType === "GITHUB"
 					? (["GITHUB"] as const)
 					: []),
 		]),
@@ -349,7 +347,7 @@ function AppSidebarContainer() {
 		return null;
 	}
 
-	const handleWorkspaceChange = (ws: typeof activeWorkspace) => {
+	const handleWorkspaceChange = (ws: typeof chromeWorkspace) => {
 		if (!ws) return;
 		void switchWorkspace(ws);
 	};
@@ -366,8 +364,8 @@ function AppSidebarContainer() {
 			hasMentorAccess={hasMentorAccess}
 			integrationKinds={integrationKinds}
 			context={sidebarContext}
-			workspaces={workspaceList}
-			activeWorkspace={activeWorkspace}
+			workspaces={workspaces}
+			activeWorkspace={chromeWorkspace}
 			onWorkspaceChange={handleWorkspaceChange}
 			onAddWorkspace={handleAddWorkspace}
 			workspacesLoading={workspaceAccess.isLoading}

--- a/webapp/src/routes/_authenticated/w/$workspaceSlug/admin/integrations.tsx
+++ b/webapp/src/routes/_authenticated/w/$workspaceSlug/admin/integrations.tsx
@@ -1,9 +1,6 @@
 import { createFileRoute, Outlet } from "@tanstack/react-router";
 
 import { SyncFreshnessBanner } from "@/components/admin/integrations/SyncFreshnessBanner";
-import { Spinner } from "@/components/ui/spinner";
-import { NoWorkspace } from "@/components/workspace/NoWorkspace";
-import { useActiveWorkspaceSlug } from "@/hooks/use-active-workspace";
 import { useSyncEvents } from "@/hooks/use-sync-events";
 import { SyncLivenessProvider } from "@/hooks/use-sync-liveness";
 import { workspaceAdminHead } from "@/lib/page-title";
@@ -14,20 +11,8 @@ export const Route = createFileRoute("/_authenticated/w/$workspaceSlug/admin/int
 });
 
 function IntegrationsLayout() {
-	const { workspaceSlug, isLoading } = useActiveWorkspaceSlug();
-
+	const { workspaceSlug } = Route.useParams();
 	const livePushUnavailable = useSyncEvents(workspaceSlug);
-
-	if (!workspaceSlug && !isLoading) {
-		return <NoWorkspace />;
-	}
-	if (!workspaceSlug) {
-		return (
-			<div className="flex h-64 items-center justify-center">
-				<Spinner className="h-8 w-8" />
-			</div>
-		);
-	}
 
 	return (
 		<SyncLivenessProvider livePushUnavailable={livePushUnavailable}>

--- a/webapp/src/routes/_authenticated/w/$workspaceSlug/admin/integrations/-credential-recovery-route.test.tsx
+++ b/webapp/src/routes/_authenticated/w/$workspaceSlug/admin/integrations/-credential-recovery-route.test.tsx
@@ -3,7 +3,14 @@ import userEvent from "@testing-library/user-event";
 import { HttpResponse, http } from "msw";
 import { describe, expect, it, vi } from "vitest";
 
-import type { ConnectionSyncStatus, IntegrationCatalogEntry, Workspace } from "@/api/types.gen";
+import { getIntegrationCatalogQueryKey } from "@/api/@tanstack/react-query.gen";
+import type {
+	ConnectionSyncStatus,
+	IntegrationCatalogEntry,
+	SyncJob,
+	Workspace,
+} from "@/api/types.gen";
+import type { Wire } from "@/lib/dates";
 import { workspaceListItem } from "@/mocks/fixtures/workspaces";
 import { server } from "@/mocks/server";
 import { ROUTE_RENDER_WAIT, renderRouteAt, renderRouteAtWithRouter } from "@/test/router-harness";
@@ -124,6 +131,59 @@ describe("source-control credential recovery", () => {
 		expect(screen.queryByRole("button", { name: "Sync now" })).toBeNull();
 	});
 
+	it("isolates a pending token replacement when switching workspaces", async () => {
+		const { workspace } = mockConnection("GITHUB");
+		let releaseResponse = () => {};
+		const response = new Promise<void>((resolve) => {
+			releaseResponse = resolve;
+		});
+		server.use(
+			http.get("*/workspaces", () =>
+				HttpResponse.json([workspaceListItem("acme"), workspaceListItem("other")]),
+			),
+			http.patch("*/workspaces/acme/token", async () => {
+				await response;
+				return HttpResponse.json(workspace);
+			}),
+		);
+		const { router, queryClient } = renderRouteAtWithRouter("/w/acme/admin/integrations/scm");
+		const input = await screen.findByLabelText(
+			"New personal access token",
+			undefined,
+			ROUTE_RENDER_WAIT,
+		);
+		const user = userEvent.setup();
+		await user.type(input, "acme-private-token");
+		await user.click(screen.getByRole("button", { name: "Replace token" }));
+		await screen.findByRole("button", { name: "Saving token…" });
+		try {
+			await act(() =>
+				router.navigate({
+					to: "/w/$workspaceSlug/admin/integrations/scm",
+					params: { workspaceSlug: "other" },
+				}),
+			);
+			await waitFor(() => {
+				expect(screen.getByLabelText("New personal access token")).toHaveProperty(
+					"disabled",
+					false,
+				);
+				expect(screen.getByLabelText("New personal access token")).toHaveProperty("value", "");
+			});
+		} finally {
+			releaseResponse();
+		}
+		await waitFor(() =>
+			expect(
+				queryClient.getQueryState(
+					getIntegrationCatalogQueryKey({
+						path: { workspaceSlug: "acme" },
+					}),
+				)?.isInvalidated,
+			).toBe(true),
+		);
+	});
+
 	it("keeps GitHub App connections on the installation recovery path", async () => {
 		mockConnection("GITHUB", 123);
 		renderRouteAt("/w/acme/admin/integrations/scm");
@@ -165,4 +225,61 @@ describe("Outline connection drafts", () => {
 			expect(screen.getByLabelText("Server URL")).toHaveProperty("value", "");
 		});
 	});
+});
+
+describe("integration job history", () => {
+	it.each([
+		{ integration: "scm", kind: "GITHUB" },
+		{ integration: "slack", kind: "SLACK" },
+		{ integration: "outline", kind: "OUTLINE" },
+	] as const)(
+		"resets $integration pagination without showing the previous workspace's jobs",
+		async ({ integration, kind }) => {
+			const { entry } = mockConnection("GITHUB");
+			let releaseResponse = () => {};
+			const response = new Promise<void>((resolve) => {
+				releaseResponse = resolve;
+			});
+			const requestedPages: Array<string | null> = [];
+			const job = {
+				id: 1,
+				createdAt: "2026-09-07T12:00:00Z",
+				status: "SUCCEEDED",
+				type: "RECONCILIATION",
+				trigger: "MANUAL",
+				cancelRequested: false,
+				itemsProcessed: 123456,
+			} satisfies Wire<SyncJob>;
+			server.use(
+				http.get("*/workspaces", () =>
+					HttpResponse.json([workspaceListItem("acme"), workspaceListItem("other")]),
+				),
+				http.get("*/workspaces/:workspaceSlug/connections/catalog", () =>
+					HttpResponse.json([{ ...entry, kind }]),
+				),
+				http.get("*/workspaces/:workspaceSlug/connections", () =>
+					HttpResponse.json([{ id: 7, kind: "OUTLINE", state: "SUSPENDED" }]),
+				),
+				http.get("*/workspaces/other/connections/7/sync/jobs", async ({ request }) => {
+					requestedPages.push(new URL(request.url).searchParams.get("page"));
+					await response;
+					return HttpResponse.json({ content: [], totalPages: 0 });
+				}),
+				http.get("*/workspaces/acme/connections/7/sync/jobs", () =>
+					HttpResponse.json({ content: [job], totalPages: 2 }),
+				),
+			);
+			const { router } = renderRouteAtWithRouter(`/w/acme/admin/integrations/${integration}`);
+			await screen.findByText("123,456", undefined, ROUTE_RENDER_WAIT);
+			await userEvent.setup().click(screen.getByRole("button", { name: "Go to next page" }));
+			try {
+				await act(() => router.navigate({ to: `/w/other/admin/integrations/${integration}` }));
+				await waitFor(() => expect(requestedPages).toStrictEqual(["0"]));
+				expect(screen.queryByText("123,456")).toBeNull();
+			} finally {
+				releaseResponse();
+			}
+			await screen.findByText("No sync jobs yet");
+		},
+	);
 });

--- a/webapp/src/routes/_authenticated/w/$workspaceSlug/admin/integrations/-credential-recovery-route.test.tsx
+++ b/webapp/src/routes/_authenticated/w/$workspaceSlug/admin/integrations/-credential-recovery-route.test.tsx
@@ -1,0 +1,168 @@
+import { act, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { HttpResponse, http } from "msw";
+import { describe, expect, it, vi } from "vitest";
+
+import type { ConnectionSyncStatus, IntegrationCatalogEntry, Workspace } from "@/api/types.gen";
+import { workspaceListItem } from "@/mocks/fixtures/workspaces";
+import { server } from "@/mocks/server";
+import { ROUTE_RENDER_WAIT, renderRouteAt, renderRouteAtWithRouter } from "@/test/router-harness";
+
+vi.setConfig({ testTimeout: 30_000 });
+
+// This route test owns credential HTTP requests; the SSE transport has its own hook suite.
+vi.mock("@/hooks/use-sync-events", () => ({ useSyncEvents: () => false }));
+
+function mockConnection(kind: "GITHUB" | "GITLAB", installationId?: number) {
+	const listed = workspaceListItem("acme", { providerType: kind });
+	const workspace = {
+		...listed,
+		kind,
+		installationId,
+		gitlabWebhookRegistered: false,
+		hasPersonalAccessToken: installationId == null,
+		hasSlackToken: false,
+		isPubliclyViewable: false,
+		practiceReviewAutoTriggerEnabled: false,
+		practiceReviewManualTriggerEnabled: false,
+		updatedAt: listed.createdAt,
+	} satisfies Workspace;
+	const entry = {
+		kind,
+		displayName: kind === "GITLAB" ? "GitLab" : "GitHub",
+		connected: true,
+		connectionId: 7,
+		connectionState: "ACTIVE",
+		credentialsUnreadableSince: installationId == null ? listed.createdAt : undefined,
+	} satisfies IntegrationCatalogEntry;
+	const status = {
+		connectionId: 7,
+		connectionState: "ACTIVE",
+		kind,
+		health: "HEALTHY",
+		resourceCounts: { total: 0, errored: 0, pending: 0, stale: 0 },
+		backfillSupported: true,
+	} satisfies ConnectionSyncStatus;
+	server.use(
+		http.get("*/workspaces", () => HttpResponse.json([listed])),
+		http.get("*/workspaces/:workspaceSlug", () => HttpResponse.json(workspace)),
+		http.get("*/workspaces/:workspaceSlug/members/me", () =>
+			HttpResponse.json({ role: "ADMIN", userId: 1, userLogin: "ada", userName: "Ada" }),
+		),
+		http.get("*/workspaces/:workspaceSlug/connections/catalog", () => HttpResponse.json([entry])),
+		http.get("*/workspaces/:workspaceSlug/connections/7/sync", () => HttpResponse.json(status)),
+		http.get("*/workspaces/:workspaceSlug/connections/7/sync/resources", () =>
+			HttpResponse.json([]),
+		),
+		http.get("*/workspaces/:workspaceSlug/connections/7/sync/jobs", () =>
+			HttpResponse.json({ content: [], totalPages: 0 }),
+		),
+		http.get("*/workspaces/:workspaceSlug/repositories", () => HttpResponse.json([])),
+	);
+	return { entry, workspace };
+}
+
+describe("source-control credential recovery", () => {
+	it.each(["GITHUB", "GITLAB"] as const)(
+		"replaces an unreadable %s token and restores sync controls",
+		async (kind) => {
+			const { entry, workspace } = mockConnection(kind);
+			const requests: unknown[] = [];
+			server.use(
+				http.patch("*/workspaces/acme/token", async ({ request }) => {
+					requests.push(await request.json());
+					entry.credentialsUnreadableSince = undefined;
+					return HttpResponse.json(workspace);
+				}),
+			);
+			renderRouteAt("/w/acme/admin/integrations/scm");
+			const input = await screen.findByLabelText(
+				"New personal access token",
+				undefined,
+				ROUTE_RENDER_WAIT,
+			);
+			expect(screen.queryByRole("button", { name: "Sync now" })).toBeNull();
+
+			const user = userEvent.setup();
+			await user.type(input, "  replacement-token  ");
+			await user.click(screen.getByRole("button", { name: "Replace token" }));
+
+			await screen.findByRole("button", { name: "Sync now" }, ROUTE_RENDER_WAIT);
+			expect(requests).toStrictEqual([{ personalAccessToken: "replacement-token" }]);
+			expect(screen.queryByText("The stored token can't be read")).toBeNull();
+			await waitFor(() => expect(input).toHaveProperty("value", ""));
+		},
+	);
+
+	it("keeps the draft and the unreadable state when replacement fails", async () => {
+		mockConnection("GITLAB");
+		server.use(
+			http.patch("*/workspaces/acme/token", () =>
+				HttpResponse.json(
+					{
+						status: 409,
+						title: "Conflict",
+						detail: "This connection changed. Reload before replacing its token.",
+					},
+					{ status: 409 },
+				),
+			),
+		);
+		renderRouteAt("/w/acme/admin/integrations/scm");
+		const input = await screen.findByLabelText(
+			"New personal access token",
+			undefined,
+			ROUTE_RENDER_WAIT,
+		);
+		const user = userEvent.setup();
+		await user.type(input, "replacement-token");
+		await user.click(screen.getByRole("button", { name: "Replace token" }));
+
+		await screen.findByText("This connection changed. Reload before replacing its token.");
+		expect(input).toHaveProperty("value", "replacement-token");
+		screen.getByText("The stored token can't be read");
+		expect(screen.queryByRole("button", { name: "Sync now" })).toBeNull();
+	});
+
+	it("keeps GitHub App connections on the installation recovery path", async () => {
+		mockConnection("GITHUB", 123);
+		renderRouteAt("/w/acme/admin/integrations/scm");
+
+		const installationLink = await screen.findByRole(
+			"link",
+			{ name: "Manage installation on GitHub" },
+			ROUTE_RENDER_WAIT,
+		);
+		expect(installationLink.getAttribute("href")).toBe("https://github.com/settings/installations");
+		expect(screen.queryByLabelText("New personal access token")).toBeNull();
+	});
+});
+
+describe("Outline connection drafts", () => {
+	it("does not carry a server URL or token into another workspace", async () => {
+		mockConnection("GITHUB");
+		server.use(
+			http.get("*/workspaces", () =>
+				HttpResponse.json([workspaceListItem("acme"), workspaceListItem("other")]),
+			),
+			http.get("*/workspaces/:workspaceSlug/connections", () => HttpResponse.json([])),
+		);
+		const { router } = renderRouteAtWithRouter("/w/acme/admin/integrations/outline");
+		const input = await screen.findByLabelText("API token", undefined, ROUTE_RENDER_WAIT);
+		const user = userEvent.setup();
+		await user.type(screen.getByLabelText("Server URL"), "https://outline.acme.test");
+		await user.type(input, "private-workspace-token");
+
+		await act(() =>
+			router.navigate({
+				to: "/w/$workspaceSlug/admin/integrations/outline",
+				params: { workspaceSlug: "other" },
+			}),
+		);
+
+		await waitFor(() => {
+			expect(screen.getByLabelText("API token")).toHaveProperty("value", "");
+			expect(screen.getByLabelText("Server URL")).toHaveProperty("value", "");
+		});
+	});
+});

--- a/webapp/src/routes/_authenticated/w/$workspaceSlug/admin/integrations/index.tsx
+++ b/webapp/src/routes/_authenticated/w/$workspaceSlug/admin/integrations/index.tsx
@@ -15,7 +15,6 @@ import { QueryErrorAlert } from "@/components/common/QueryErrorAlert";
 import { PageHeader } from "@/components/core/PageHeader";
 import { PageLayout } from "@/components/core/PageLayout";
 import { Skeleton } from "@/components/ui/skeleton";
-import { useActiveWorkspaceSlug } from "@/hooks/use-active-workspace";
 import { useLivePushUnavailable } from "@/hooks/use-sync-liveness";
 import { workspaceAdminHead } from "@/lib/page-title";
 import { problemDetailOf } from "@/lib/problem-detail";
@@ -26,13 +25,9 @@ export const Route = createFileRoute("/_authenticated/w/$workspaceSlug/admin/int
 });
 
 function IntegrationsOverview() {
-	const { workspaceSlug } = useActiveWorkspaceSlug();
-	const slug = workspaceSlug ?? "";
+	const { workspaceSlug: slug } = Route.useParams();
 
-	const catalogQuery = useQuery({
-		...getIntegrationCatalogOptions({ path: { workspaceSlug: slug } }),
-		enabled: Boolean(workspaceSlug),
-	});
+	const catalogQuery = useQuery(getIntegrationCatalogOptions({ path: { workspaceSlug: slug } }));
 
 	return (
 		<PageLayout>

--- a/webapp/src/routes/_authenticated/w/$workspaceSlug/admin/integrations/outline.tsx
+++ b/webapp/src/routes/_authenticated/w/$workspaceSlug/admin/integrations/outline.tsx
@@ -17,7 +17,6 @@ import { PageLayout } from "@/components/core/PageLayout";
 import { OutlineIcon } from "@/components/icons/brand";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
-import { useActiveWorkspaceSlug } from "@/hooks/use-active-workspace";
 import { useOutlineIntegration } from "@/hooks/use-outline-integration";
 import { useLivePushUnavailable } from "@/hooks/use-sync-liveness";
 import { workspaceAdminHead } from "@/lib/page-title";
@@ -32,8 +31,7 @@ export const Route = createFileRoute("/_authenticated/w/$workspaceSlug/admin/int
 const JOBS_PAGE_SIZE = 10;
 
 function OutlineIntegrationPage() {
-	const { workspaceSlug } = useActiveWorkspaceSlug();
-	const slug = workspaceSlug ?? "";
+	const { workspaceSlug: slug } = Route.useParams();
 	const [jobsPage, setJobsPage] = useState(0);
 	const livePushUnavailable = useLivePushUnavailable();
 	const outline = useOutlineIntegration(slug);
@@ -50,7 +48,7 @@ function OutlineIntegrationPage() {
 			path: { workspaceSlug: slug, connectionId: connectionId ?? -1 },
 			query: { page: jobsPage, size: JOBS_PAGE_SIZE },
 		}),
-		enabled: Boolean(workspaceSlug) && connectionId != null,
+		enabled: connectionId != null,
 		refetchInterval: syncPollInterval(outline.hasActiveJob, livePushUnavailable),
 		placeholderData: (previousData) => previousData,
 	});
@@ -63,9 +61,9 @@ function OutlineIntegrationPage() {
 				description="Mirror Outline collections so their documents reach practice reviews as context."
 			/>
 
-			{workspaceSlug != null && outline.isLoading && <Skeleton className="h-48 w-full" />}
+			{outline.isLoading && <Skeleton className="h-48 w-full" />}
 
-			{workspaceSlug != null && outline.connectionsError && (
+			{outline.connectionsError && (
 				<QueryErrorAlert
 					error={outline.connectionsError}
 					title="We couldn't load the Outline connection"
@@ -73,7 +71,7 @@ function OutlineIntegrationPage() {
 				/>
 			)}
 
-			{workspaceSlug != null && !outline.isLoading && !outline.connectionsError && (
+			{!outline.isLoading && !outline.connectionsError && (
 				<>
 					{outline.hasConnection && outline.statusError && (
 						<QueryErrorAlert
@@ -114,7 +112,10 @@ function OutlineIntegrationPage() {
 						</Card>
 					)}
 
-					<OutlineConnectCard {...outline.connectCardProps} />
+					<OutlineConnectCard
+						key={`${slug}:${connectionId ?? "new"}`}
+						{...outline.connectCardProps}
+					/>
 
 					{outline.collectionsProps && <OutlineCollectionsSection {...outline.collectionsProps} />}
 				</>

--- a/webapp/src/routes/_authenticated/w/$workspaceSlug/admin/integrations/outline.tsx
+++ b/webapp/src/routes/_authenticated/w/$workspaceSlug/admin/integrations/outline.tsx
@@ -24,6 +24,7 @@ import { workspaceAdminHead } from "@/lib/page-title";
 export const Route = createFileRoute("/_authenticated/w/$workspaceSlug/admin/integrations/outline")(
 	{
 		head: workspaceAdminHead("Outline"),
+		remountDeps: ({ params }) => params.workspaceSlug,
 		component: OutlineIntegrationPage,
 	},
 );
@@ -112,10 +113,7 @@ function OutlineIntegrationPage() {
 						</Card>
 					)}
 
-					<OutlineConnectCard
-						key={`${slug}:${connectionId ?? "new"}`}
-						{...outline.connectCardProps}
-					/>
+					<OutlineConnectCard key={connectionId ?? "new"} {...outline.connectCardProps} />
 
 					{outline.collectionsProps && <OutlineCollectionsSection {...outline.collectionsProps} />}
 				</>

--- a/webapp/src/routes/_authenticated/w/$workspaceSlug/admin/integrations/scm.tsx
+++ b/webapp/src/routes/_authenticated/w/$workspaceSlug/admin/integrations/scm.tsx
@@ -18,6 +18,7 @@ import {
 	removeRepositoryToMonitorMutation,
 	triggerSyncJobMutation,
 	updateConnectionSyncJobMutation,
+	updateTokenMutation,
 } from "@/api/@tanstack/react-query.gen";
 import { AdminRepositoriesSettings } from "@/components/admin/integrations/AdminRepositoriesSettings";
 import { ConnectionStateNotice } from "@/components/admin/integrations/ConnectionStateNotice";
@@ -29,12 +30,12 @@ import {
 	SyncResourcesTable,
 } from "@/components/admin/integrations/SyncResourcesTable";
 import { SyncStatusHeader } from "@/components/admin/integrations/SyncStatusHeader";
+import { WorkspaceScmTokenSettings } from "@/components/admin/integrations/WorkspaceScmTokenSettings";
 import { PageHeader } from "@/components/core/PageHeader";
 import { PageLayout } from "@/components/core/PageLayout";
 import { GithubIcon, GitlabIcon } from "@/components/icons/brand";
 import { buttonVariants } from "@/components/ui/button";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
-import { useActiveWorkspaceSlug } from "@/hooks/use-active-workspace";
 import { useLivePushUnavailable } from "@/hooks/use-sync-liveness";
 import { workspaceAdminHead } from "@/lib/page-title";
 import { problemDetailOf } from "@/lib/problem-detail";
@@ -48,16 +49,12 @@ const JOBS_PAGE_SIZE = 10;
 
 function ScmIntegrationPage() {
 	const queryClient = useQueryClient();
-	const { workspaceSlug } = useActiveWorkspaceSlug();
-	const slug = workspaceSlug ?? "";
+	const { workspaceSlug: slug } = Route.useParams();
 	const [jobsPage, setJobsPage] = useState(0);
 	const livePushUnavailable = useLivePushUnavailable();
 
 	const workspaceQueryOptions = getWorkspaceOptions({ path: { workspaceSlug: slug } });
-	const workspaceQuery = useQuery({
-		...workspaceQueryOptions,
-		enabled: Boolean(workspaceSlug),
-	});
+	const workspaceQuery = useQuery(workspaceQueryOptions);
 	const workspaceData = workspaceQuery.data;
 
 	const kind = workspaceData ? (workspaceData.kind === "GITLAB" ? "GITLAB" : "GITHUB") : undefined;
@@ -65,10 +62,7 @@ function ScmIntegrationPage() {
 	const isAppInstallationWorkspace = kind === "GITHUB" && workspaceData?.installationId != null;
 
 	const catalogQueryOptions = getIntegrationCatalogOptions({ path: { workspaceSlug: slug } });
-	const catalogQuery = useQuery({
-		...catalogQueryOptions,
-		enabled: Boolean(workspaceSlug),
-	});
+	const catalogQuery = useQuery(catalogQueryOptions);
 	const entry = kind ? catalogQuery.data?.find((e) => e.kind === kind) : undefined;
 	const hasConnection = entry?.connected === true;
 	const isConnectionActive = entry?.connectionState === "ACTIVE";
@@ -79,7 +73,7 @@ function ScmIntegrationPage() {
 	});
 	const statusQuery = useQuery({
 		...statusQueryOptions,
-		enabled: Boolean(workspaceSlug) && connectionId != null,
+		enabled: connectionId != null,
 		refetchInterval: (query) =>
 			syncPollInterval(query.state.data?.activeJob != null, livePushUnavailable),
 	});
@@ -97,7 +91,7 @@ function ScmIntegrationPage() {
 		refetch: refetchResources,
 	} = useQuery({
 		...resourcesQueryOptions,
-		enabled: Boolean(workspaceSlug) && connectionId != null,
+		enabled: connectionId != null,
 		refetchInterval: syncPollInterval(hasActiveJob, livePushUnavailable),
 	});
 
@@ -113,7 +107,7 @@ function ScmIntegrationPage() {
 		refetch: refetchJobs,
 	} = useQuery({
 		...jobsQueryOptions,
-		enabled: Boolean(workspaceSlug) && connectionId != null,
+		enabled: connectionId != null,
 		refetchInterval: syncPollInterval(hasActiveJob, livePushUnavailable),
 		placeholderData: (previousData) => previousData,
 	});
@@ -128,7 +122,6 @@ function ScmIntegrationPage() {
 		refetch: refetchRepositories,
 	} = useQuery({
 		...repositoriesQueryOptions,
-		enabled: Boolean(workspaceSlug),
 	});
 
 	const invalidateSyncState = () => {
@@ -167,6 +160,19 @@ function ScmIntegrationPage() {
 		onSuccess: onRepositorySetChanged,
 		onError: (e) => {
 			toast.error("Failed to stop monitoring repository", { description: problemDetailOf(e) });
+		},
+	});
+
+	const replaceToken = useMutation({
+		...updateTokenMutation(),
+		gcTime: 0,
+		onSuccess: async () => {
+			await Promise.all([
+				queryClient.invalidateQueries({ queryKey: workspaceQueryOptions.queryKey }),
+				queryClient.invalidateQueries({ queryKey: catalogQueryOptions.queryKey }),
+			]);
+			invalidateSyncState();
+			toast.success("Personal access token replaced");
 		},
 	});
 
@@ -220,7 +226,13 @@ function ScmIntegrationPage() {
 				<ConnectionStateNotice
 					connectionState={entry.connectionState}
 					credentialsUnreadableSince={entry.credentialsUnreadableSince}
-					credentialRecovery="Replace it by storing a new personal access token for this workspace"
+					credentialRecovery={
+						isAppInstallationWorkspace
+							? "Reconnect through the GitHub App installation"
+							: isConnectionActive
+								? "Replace it using the personal access token form below"
+								: "Reconnect this source-control integration before replacing its token"
+					}
 					displayName={label}
 				/>
 			)}
@@ -274,6 +286,27 @@ function ScmIntegrationPage() {
 					});
 				}}
 			/>
+
+			{isConnectionActive && kind && !isAppInstallationWorkspace && (
+				<WorkspaceScmTokenSettings
+					key={slug}
+					providerLabel={label}
+					isSaving={replaceToken.isPending}
+					error={replaceToken.error}
+					onSave={async (personalAccessToken) => {
+						try {
+							await replaceToken.mutateAsync({
+								path: { workspaceSlug: slug },
+								body: { personalAccessToken },
+							});
+							replaceToken.reset();
+							return true;
+						} catch {
+							return false;
+						}
+					}}
+				/>
+			)}
 
 			{hasConnection && (
 				<Card>

--- a/webapp/src/routes/_authenticated/w/$workspaceSlug/admin/integrations/scm.tsx
+++ b/webapp/src/routes/_authenticated/w/$workspaceSlug/admin/integrations/scm.tsx
@@ -42,6 +42,7 @@ import { problemDetailOf } from "@/lib/problem-detail";
 
 export const Route = createFileRoute("/_authenticated/w/$workspaceSlug/admin/integrations/scm")({
 	head: workspaceAdminHead("Source control"),
+	remountDeps: ({ params }) => params.workspaceSlug,
 	component: ScmIntegrationPage,
 });
 
@@ -289,7 +290,6 @@ function ScmIntegrationPage() {
 
 			{isConnectionActive && kind && !isAppInstallationWorkspace && (
 				<WorkspaceScmTokenSettings
-					key={slug}
 					providerLabel={label}
 					isSaving={replaceToken.isPending}
 					error={replaceToken.error}

--- a/webapp/src/routes/_authenticated/w/$workspaceSlug/admin/integrations/slack.tsx
+++ b/webapp/src/routes/_authenticated/w/$workspaceSlug/admin/integrations/slack.tsx
@@ -37,7 +37,6 @@ import { PageLayout } from "@/components/core/PageLayout";
 import { SlackIcon } from "@/components/icons/brand";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
-import { useActiveWorkspaceSlug } from "@/hooks/use-active-workspace";
 import { useLivePushUnavailable } from "@/hooks/use-sync-liveness";
 import { workspaceAdminHead } from "@/lib/page-title";
 import { problemDetailOf } from "@/lib/problem-detail";
@@ -51,23 +50,16 @@ const JOBS_PAGE_SIZE = 10;
 
 function SlackIntegrationPage() {
 	const queryClient = useQueryClient();
-	const { workspaceSlug } = useActiveWorkspaceSlug();
-	const slug = workspaceSlug ?? "";
+	const { workspaceSlug: slug } = Route.useParams();
 	const [jobsPage, setJobsPage] = useState(0);
 	const livePushUnavailable = useLivePushUnavailable();
 
 	const workspaceQueryOptions = getWorkspaceOptions({ path: { workspaceSlug: slug } });
-	const workspaceQuery = useQuery({
-		...workspaceQueryOptions,
-		enabled: Boolean(workspaceSlug),
-	});
+	const workspaceQuery = useQuery(workspaceQueryOptions);
 	const workspaceData = workspaceQuery.data;
 
 	const catalogQueryOptions = getIntegrationCatalogOptions({ path: { workspaceSlug: slug } });
-	const catalogQuery = useQuery({
-		...catalogQueryOptions,
-		enabled: Boolean(workspaceSlug),
-	});
+	const catalogQuery = useQuery(catalogQueryOptions);
 	const catalog = catalogQuery.data;
 	const entry = catalog?.find((e) => e.kind === "SLACK");
 	const hasConnection = entry?.connected === true;
@@ -79,7 +71,7 @@ function SlackIntegrationPage() {
 		...getConnectionSyncStatusOptions({
 			path: { workspaceSlug: slug, connectionId: connectionId ?? -1 },
 		}),
-		enabled: Boolean(workspaceSlug) && connectionId != null,
+		enabled: connectionId != null,
 		refetchInterval: (query) =>
 			syncPollInterval(query.state.data?.activeJob != null, livePushUnavailable),
 	});
@@ -96,7 +88,7 @@ function SlackIntegrationPage() {
 		...listConnectionSyncResourcesOptions({
 			path: { workspaceSlug: slug, connectionId: connectionId ?? -1 },
 		}),
-		enabled: Boolean(workspaceSlug) && connectionId != null,
+		enabled: connectionId != null,
 		refetchInterval: syncPollInterval(hasActiveJob, livePushUnavailable),
 	});
 
@@ -112,7 +104,7 @@ function SlackIntegrationPage() {
 		refetch: refetchJobs,
 	} = useQuery({
 		...jobsQueryOptions,
-		enabled: Boolean(workspaceSlug) && connectionId != null,
+		enabled: connectionId != null,
 		refetchInterval: syncPollInterval(hasActiveJob, livePushUnavailable),
 		placeholderData: (previousData) => previousData,
 	});
@@ -125,7 +117,7 @@ function SlackIntegrationPage() {
 		refetch: refetchSlackChannels,
 	} = useQuery({
 		...slackChannelsQueryOptions,
-		enabled: Boolean(workspaceSlug && workspaceData?.hasSlackToken),
+		enabled: workspaceData?.hasSlackToken === true,
 		refetchInterval: syncPollInterval(hasActiveJob, livePushUnavailable),
 	});
 
@@ -139,7 +131,7 @@ function SlackIntegrationPage() {
 		refetch: refetchSlackChannelCandidates,
 	} = useQuery({
 		...slackChannelCandidatesQueryOptions,
-		enabled: Boolean(workspaceSlug && workspaceData?.hasSlackToken),
+		enabled: workspaceData?.hasSlackToken === true,
 	});
 
 	const invalidateSlackChannels = () => {
@@ -321,7 +313,7 @@ function SlackIntegrationPage() {
 				</Card>
 			)}
 
-			{workspaceSlug != null && !routeLoading && !routeError && (
+			{!routeLoading && !routeError && (
 				<AdminSlackNotificationSettings
 					key={`slack:${workspaceData?.slackConnectionId ?? "none"}:${workspaceData?.leaderboardNotificationChannelId ?? ""}:${workspaceData?.leaderboardNotificationEnabled ?? false}:${workspaceData?.leaderboardScheduleDay ?? ""}:${workspaceData?.leaderboardScheduleTime ?? ""}:${workspaceData?.leaderboardNotificationTeam ?? ""}`}
 					workspaceSlug={slug}
@@ -341,7 +333,7 @@ function SlackIntegrationPage() {
 				/>
 			)}
 
-			{workspaceSlug != null && !routeLoading && !routeError && (
+			{!routeLoading && !routeError && (
 				<AdminSlackChannelsSettings
 					workspaceSlug={slug}
 					hasSlackConnection={isConnectionActive}

--- a/webapp/src/routes/_authenticated/w/$workspaceSlug/admin/integrations/slack.tsx
+++ b/webapp/src/routes/_authenticated/w/$workspaceSlug/admin/integrations/slack.tsx
@@ -43,6 +43,7 @@ import { problemDetailOf } from "@/lib/problem-detail";
 
 export const Route = createFileRoute("/_authenticated/w/$workspaceSlug/admin/integrations/slack")({
 	head: workspaceAdminHead("Slack"),
+	remountDeps: ({ params }) => params.workspaceSlug,
 	component: SlackIntegrationPage,
 });
 

--- a/webapp/src/routes/_authenticated/w/$workspaceSlug/index.tsx
+++ b/webapp/src/routes/_authenticated/w/$workspaceSlug/index.tsx
@@ -321,8 +321,8 @@ function LeaderboardContainer() {
 			teamLabelsById={teamLabelsById}
 			selectedTeam={team}
 			selectedSort={sort}
-			initialAfterDate={effectiveDates.after}
-			initialBeforeDate={effectiveDates.before}
+			afterDate={effectiveDates.after}
+			beforeDate={effectiveDates.before}
 			leaderboardEnd={leaderboardEnd}
 			leaderboardSchedule={schedule}
 			onTeamChange={handleTeamChange}

--- a/webapp/src/routes/_authenticated/w/$workspaceSlug/reviews.tsx
+++ b/webapp/src/routes/_authenticated/w/$workspaceSlug/reviews.tsx
@@ -1,19 +1,14 @@
 import { createFileRoute, Navigate, Outlet } from "@tanstack/react-router";
 
+import { ReviewResultsSkeleton } from "@/components/admin/practice-reviews/ReviewResultsSkeleton";
 import { QueryErrorAlert } from "@/components/common/QueryErrorAlert";
-import { Spinner } from "@/components/ui/spinner";
+import { TRACE_PAGE_SIZE } from "@/components/practice-trace/TraceListPage";
 import { useWorkspaceFeatures } from "@/hooks/use-workspace-features";
 
 export const Route = createFileRoute("/_authenticated/w/$workspaceSlug/reviews")({
 	component: ReviewActivityLayout,
 });
 
-/**
- * Review activity exists only where practices review the work, so a workspace with practice reviews
- * off does not have this surface at all — the sidebar drops the entry and a link kept from before,
- * or from another workspace, lands on the workspace home rather than on a page that can only
- * explain itself.
- */
 function ReviewActivityLayout() {
 	const { workspaceSlug } = Route.useParams();
 	const featureState = useWorkspaceFeatures(workspaceSlug);
@@ -36,11 +31,7 @@ function ReviewActivityLayout() {
 	}
 
 	if (featureState.isLoading || practicesEnabled !== true) {
-		return (
-			<div className="flex min-h-0 flex-1 items-center justify-center">
-				<Spinner className="h-8 w-8" />
-			</div>
-		);
+		return <ReviewResultsSkeleton label="Loading review activity" rows={TRACE_PAGE_SIZE} />;
 	}
 
 	return <Outlet />;

--- a/webapp/src/routes/_authenticated/w/$workspaceSlug/reviews/$artifactKind.$artifactId.tsx
+++ b/webapp/src/routes/_authenticated/w/$workspaceSlug/reviews/$artifactKind.$artifactId.tsx
@@ -15,6 +15,7 @@ import { hasMinimumWorkspaceRole } from "@/lib/workspace-roles";
 export const Route = createFileRoute(
 	"/_authenticated/w/$workspaceSlug/reviews/$artifactKind/$artifactId",
 )({
+	remountDeps: ({ params }) => params,
 	// `artifactKind` stays the wire id (`scm.pull_request`) rather than a short slug: kinds are an
 	// open vocabulary, and a slug map would make a kind this build has never heard of unreachable.
 	loader: ({ params: { artifactId } }) => {
@@ -40,10 +41,12 @@ function ReviewActivityDetailRoute() {
 	});
 	const requestReview = useMutation({
 		...requestPracticeReviewMutation(),
-		onSuccess: (outcome) => {
+		onSuccess: (outcome, { path, body }) => {
 			if (outcome.status !== "SUBMITTED") return;
 			void queryClient.invalidateQueries({
-				queryKey: getArtifactTraceQueryKey({ path: { workspaceSlug, artifactKind, artifactId } }),
+				queryKey: getArtifactTraceQueryKey({
+					path: { ...path, artifactKind: body.artifactKind, artifactId: body.artifactId },
+				}),
 			});
 			toast.success("Review started");
 		},

--- a/webapp/src/routes/_authenticated/w/$workspaceSlug/reviews/-route.test.tsx
+++ b/webapp/src/routes/_authenticated/w/$workspaceSlug/reviews/-route.test.tsx
@@ -1,4 +1,5 @@
 import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { HttpResponse, http } from "msw";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -92,4 +93,15 @@ describe("review activity routes", () => {
 
 		await screen.findByRole("heading", { name: "Page Not Found" }, ROUTE_RENDER_WAIT);
 	});
+});
+
+it("changes the work filter without resetting scroll", async () => {
+	const { router } = renderRouteAtWithRouter("/w/acme/reviews");
+	const control = await screen.findByRole("combobox", { name: "Show" }, ROUTE_RENDER_WAIT);
+	const scroll = vi.spyOn(window, "scrollTo").mockReturnValue(undefined);
+	await userEvent.click(control);
+	await userEvent.click(await screen.findByRole("option", { name: "Issues" }));
+	await vi.waitFor(() => expect(router.state.location.search).toMatchObject({ kind: "scm.issue" }));
+	expect(scroll).not.toHaveBeenCalled();
+	scroll.mockRestore();
 });

--- a/webapp/src/routes/_authenticated/w/$workspaceSlug/reviews/-trace-detail-route.test.tsx
+++ b/webapp/src/routes/_authenticated/w/$workspaceSlug/reviews/-trace-detail-route.test.tsx
@@ -1,12 +1,13 @@
-import { screen, waitFor } from "@testing-library/react";
+import { act, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { HttpResponse, http } from "msw";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { getArtifactTraceQueryKey } from "@/api/@tanstack/react-query.gen";
 import { artifactTrace } from "@/components/practice-trace/story-mock-data";
 import { workspaceListItem } from "@/mocks/fixtures/workspaces";
 import { server } from "@/mocks/server";
-import { ROUTE_RENDER_WAIT, renderRouteAt } from "@/test/router-harness";
+import { ROUTE_RENDER_WAIT, renderRouteAt, renderRouteAtWithRouter } from "@/test/router-harness";
 
 // Mounting the real route pulls in the whole app shell and its lazy modules.
 vi.setConfig({ testTimeout: 20_000 });
@@ -136,5 +137,72 @@ describe("asking for a review by hand", () => {
 			"Only the work's author or assignees, or a workspace admin, can ask for a review of it.",
 		);
 		expect(screen.queryByText("No review was started")).toBeNull();
+	});
+});
+
+describe("review requests belong to the reviewed work", () => {
+	it("does not carry a refusal to another artifact", async () => {
+		server.use(
+			http.post(REQUEST_PATH, () =>
+				HttpResponse.json({
+					status: "REFUSED",
+					reason: "REQUEST_COOLDOWN_ACTIVE",
+					reasonDescription: COOLDOWN_SENTENCE,
+				}),
+			),
+		);
+		const { router } = renderRouteAtWithRouter("/w/acme/reviews/scm.pull_request/1423");
+		await clickAsk();
+		await screen.findByText(COOLDOWN_SENTENCE);
+		await act(() =>
+			router.navigate({
+				to: "/w/$workspaceSlug/reviews/$artifactKind/$artifactId",
+				params: { workspaceSlug: "acme", artifactKind: "scm.issue", artifactId: "1430" },
+			}),
+		);
+		await screen.findByRole("button", { name: "Review this now" }, ROUTE_RENDER_WAIT);
+		expect(screen.queryByText(COOLDOWN_SENTENCE)).toBeNull();
+	});
+
+	it("finishes an outstanding request against its original artifact after navigation", async () => {
+		let respond = (_response: Response) => {};
+		const response = new Promise<Response>((resolve) => {
+			respond = resolve;
+		});
+		server.use(http.post(REQUEST_PATH, () => response));
+		const { router, queryClient } = renderRouteAtWithRouter(
+			"/w/acme/reviews/scm.pull_request/1423",
+		);
+		await clickAsk();
+		await act(() =>
+			router.navigate({
+				to: "/w/$workspaceSlug/reviews/$artifactKind/$artifactId",
+				params: { workspaceSlug: "acme", artifactKind: "scm.issue", artifactId: "1430" },
+			}),
+		);
+		const ask = await screen.findByRole("button", { name: "Review this now" }, ROUTE_RENDER_WAIT);
+		expect(ask.hasAttribute("disabled")).toBe(false);
+		const otherReads = traceReads;
+		await act(async () =>
+			respond(
+				HttpResponse.json({ status: "SUBMITTED", jobId: "0f2b7c1e-9a3d-4c5b-8e1f-2d6a7b8c9d01" }),
+			),
+		);
+		await screen.findByText("Review started");
+		expect(
+			queryClient.getQueryState(
+				getArtifactTraceQueryKey({
+					path: { workspaceSlug: "acme", artifactKind: "scm.pull_request", artifactId: 1423 },
+				}),
+			)?.isInvalidated,
+		).toBe(true);
+		expect(
+			queryClient.getQueryState(
+				getArtifactTraceQueryKey({
+					path: { workspaceSlug: "acme", artifactKind: "scm.issue", artifactId: 1430 },
+				}),
+			)?.isInvalidated,
+		).toBe(false);
+		expect(traceReads).toBe(otherReads);
 	});
 });

--- a/webapp/src/routes/_authenticated/w/$workspaceSlug/reviews/index.tsx
+++ b/webapp/src/routes/_authenticated/w/$workspaceSlug/reviews/index.tsx
@@ -22,6 +22,7 @@ function ReviewActivityListRoute() {
 				return { ...next, page: pageParam(next.page) };
 			},
 			replace: true,
+			resetScroll: false,
 		});
 
 	const query = useQuery({

--- a/webapp/src/routes/_authenticated/w/$workspaceSlug/user/$username/-practice-group-route.test.tsx
+++ b/webapp/src/routes/_authenticated/w/$workspaceSlug/user/$username/-practice-group-route.test.tsx
@@ -278,6 +278,11 @@ it("restores the bookmarked custom timeframe on Back without scrolling on select
 	expect(screen.getByRole("button", { name: "Choose custom dates" }).textContent).toContain(
 		"Jun 2 – 6",
 	);
+	act(() => router.history.forward());
+	await vi.waitFor(() =>
+		expect(screen.getByRole("combobox", { name: "Timeframe" }).textContent).toContain("Last week"),
+	);
+	expect(screen.queryByRole("button", { name: "Choose custom dates" })).toBeNull();
 });
 
 it.each([
@@ -309,3 +314,34 @@ it.each([
 		screen.getByRole("heading", { name: "Developer ada" });
 	},
 );
+
+it("does not present the previous timeframe's activity as the newly selected range", async () => {
+	let respond = (_response: Response) => {};
+	const pendingActivity = new Promise<Response>((resolve) => {
+		respond = resolve;
+	});
+	let activityReads = 0;
+	server.use(
+		http.get("*/workspaces", () => HttpResponse.json([workspaceListItem("acme")])),
+		http.get("*/workspaces/:workspaceSlug/profile/ada", () => HttpResponse.json(profile("ada"))),
+		http.get("*/workspaces/:workspaceSlug/profile/:login/activity-monitor", () =>
+			HttpResponse.json(activityMonitor),
+		),
+	);
+	renderRouteAtWithRouter("/w/acme/user/ada?after=2026-06-02T00:00:00Z");
+	await screen.findByRole("heading", { name: "No review activity" }, ROUTE_RENDER_WAIT);
+	server.use(
+		http.get("*/workspaces/:workspaceSlug/profile/:login/activity-monitor", () => {
+			activityReads++;
+			return pendingActivity.then((response) => response.clone());
+		}),
+	);
+	await userEvent.click(screen.getByRole("combobox", { name: "Timeframe" }));
+	await userEvent.click(await screen.findByRole("option", { name: "Last week" }));
+	await vi.waitFor(() => expect(activityReads).toBe(1));
+	expect(screen.queryByRole("heading", { name: "No review activity" })).toBeNull();
+	screen.getByRole("heading", { name: "Developer ada" });
+	screen.getByRole("combobox", { name: "Timeframe" });
+	await act(async () => respond(HttpResponse.json(activityMonitor)));
+	await screen.findByRole("heading", { name: "No review activity" }, ROUTE_RENDER_WAIT);
+});

--- a/webapp/src/routes/_authenticated/w/$workspaceSlug/user/$username/-practice-group-route.test.tsx
+++ b/webapp/src/routes/_authenticated/w/$workspaceSlug/user/$username/-practice-group-route.test.tsx
@@ -1,0 +1,311 @@
+import { act, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { HttpResponse, http } from "msw";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	listPracticeGroupReviewRunsInfiniteQueryKey,
+	listWorkspacesQueryKey,
+} from "@/api/@tanstack/react-query.gen";
+import type { PracticeGroupTrend, ProfileActivityMonitor } from "@/api/types.gen";
+import { currentUser } from "@/mocks/fixtures/auth";
+import { workspaceListItem } from "@/mocks/fixtures/workspaces";
+import { server } from "@/mocks/server";
+import { ROUTE_RENDER_WAIT, renderRouteAtWithRouter } from "@/test/router-harness";
+
+vi.setConfig({ testTimeout: 40_000 });
+const path = "/w/acme/user/ada/practice-groups/review-ready-work";
+const group = {
+	id: 1,
+	slug: "review-ready-work",
+	name: "Packaging work for review",
+	visibleInPracticeDashboards: true,
+	displayOrder: 0,
+	autonomy: { effective: "AUTOMATIC", inherited: true, source: "WORKSPACE" },
+};
+const profile = (login: string) => ({
+	userInfo: {
+		id: 1,
+		login,
+		name: `Developer ${login}`,
+		htmlUrl: `https://github.com/${login}`,
+		leaguePoints: 0,
+	},
+	contributedRepositories: [],
+	xpRecord: { currentLevel: 1, currentLevelXP: 0, totalXP: 0, xpNeeded: 150 },
+});
+
+const activityMonitor = {
+	authoredPullRequests: [],
+	repositories: [],
+	reviewActivity: [],
+	totalAuthoredPullRequestCount: 0,
+	totalReviewActivityCount: 0,
+	activityStats: {
+		numberOfApprovals: 0,
+		numberOfChangeRequests: 0,
+		numberOfClosedIssues: 0,
+		numberOfClosedPullRequests: 0,
+		numberOfCodeComments: 0,
+		numberOfComments: 0,
+		numberOfMergedPullRequests: 0,
+		numberOfOpenPullRequests: 0,
+		numberOfOpenedIssues: 0,
+		numberOfOwnReplies: 0,
+		numberOfReviewedPRs: 0,
+		numberOfUnknowns: 0,
+		score: 0,
+	},
+} satisfies ProfileActivityMonitor;
+
+let practiceReads = 0;
+beforeEach(() => {
+	practiceReads = 0;
+	server.use(
+		http.get("*/user", () => HttpResponse.json({ ...currentUser, username: "ada" })),
+		http.get("*/workspaces", () =>
+			HttpResponse.json([workspaceListItem("acme", { practicesEnabled: true })]),
+		),
+		http.get("*/workspaces/:workspaceSlug", () => HttpResponse.json(workspaceListItem("acme"))),
+		http.get("*/workspaces/:workspaceSlug/members/me", () =>
+			HttpResponse.json({ role: "MEMBER", userId: 1, userLogin: "ada", userName: "Ada" }),
+		),
+		http.get("*/workspaces/:workspaceSlug/practice-groups", () => {
+			practiceReads++;
+			return HttpResponse.json([group]);
+		}),
+		http.get("*/workspaces/:workspaceSlug/practice-groups/standings", () => HttpResponse.json([])),
+		http.get("*/workspaces/:workspaceSlug/practices/standings", () => HttpResponse.json([])),
+		http.get("*/workspaces/:workspaceSlug/practices/reviewed", () =>
+			HttpResponse.json([
+				{ slug: "small-changes", name: "Keep changes focused", groupSlug: group.slug },
+			]),
+		),
+		http.get("*/workspaces/:workspaceSlug/practice-groups/:groupSlug/trend", () =>
+			HttpResponse.json({
+				group: {
+					scope: "GROUP",
+					slug: group.slug,
+					direction: "INSUFFICIENT_EVIDENCE",
+					opportunities: [],
+					support: {
+						bundleSize: 5,
+						credibilityThreshold: 0.95,
+						currentOpportunities: 0,
+						previousOpportunities: 0,
+						opportunitiesUntilComparable: 10,
+						ropeHalfWidth: 0.1,
+					},
+				},
+				practices: [],
+			} satisfies PracticeGroupTrend),
+		),
+		http.get("*/workspaces/:workspaceSlug/practice-groups/:groupSlug/review-runs", () =>
+			HttpResponse.json({ content: [], page: 0, hasNext: false }),
+		),
+		http.get(
+			"*/workspaces/:workspaceSlug/profile/:login",
+			() => new HttpResponse(null, { status: 404 }),
+		),
+		http.get("*/workspaces/:workspaceSlug/profile/:login/activity-monitor", () =>
+			HttpResponse.json(activityMonitor),
+		),
+	);
+});
+describe("practice-group routes", () => {
+	it("redirects a disabled workspace's bookmark without querying practices", async () => {
+		server.use(
+			http.get("*/workspaces", () =>
+				HttpResponse.json([workspaceListItem("acme", { practicesEnabled: false })]),
+			),
+		);
+		const { router } = renderRouteAtWithRouter(path);
+		await vi.waitFor(() => expect(router.state.location.pathname).toBe("/w/acme/user/ada"));
+		expect(practiceReads).toBe(0);
+	});
+	it("waits for features without redirecting, then loads the enabled surface", async () => {
+		let respond = (_response: Response) => {};
+		const response = new Promise<Response>((resolve) => {
+			respond = resolve;
+		});
+		server.use(http.get("*/workspaces", () => response.then((value) => value.clone())));
+		const { router, queryClient } = renderRouteAtWithRouter(path);
+		await vi.waitFor(() =>
+			expect(queryClient.getQueryState(listWorkspacesQueryKey())?.fetchStatus).toBe("fetching"),
+		);
+		expect(router.state.location.pathname).toBe(path);
+		expect(practiceReads).toBe(0);
+		await act(async () =>
+			respond(HttpResponse.json([workspaceListItem("acme", { practicesEnabled: true })])),
+		);
+		await screen.findByRole("heading", { name: group.name }, ROUTE_RENDER_WAIT);
+		expect(practiceReads).toBeGreaterThan(0);
+	});
+	it("keeps a feature failure recoverable instead of redirecting", async () => {
+		server.use(http.get("*/workspaces", () => new HttpResponse(null, { status: 500 })));
+		const { router } = renderRouteAtWithRouter(path);
+		await screen.findByText("Couldn't load workspace features", undefined, ROUTE_RENDER_WAIT);
+		expect(router.state.location.pathname).toBe(path);
+		expect(practiceReads).toBe(0);
+		server.use(
+			http.get("*/workspaces", () =>
+				HttpResponse.json([workspaceListItem("acme", { practicesEnabled: true })]),
+			),
+		);
+		await userEvent.click(screen.getByRole("button", { name: /retry/i }));
+		await screen.findByRole("heading", { name: group.name }, ROUTE_RENDER_WAIT);
+	});
+	it("filters and clears review runs without resetting scroll", async () => {
+		const { router } = renderRouteAtWithRouter(path);
+		const main = await screen.findByRole("main");
+		const filter = await within(main).findByRole(
+			"button",
+			{
+				name: "Show review runs for Keep changes focused",
+			},
+			ROUTE_RENDER_WAIT,
+		);
+		const scroll = vi.spyOn(window, "scrollTo").mockReturnValue(undefined);
+		await userEvent.click(filter);
+		await vi.waitFor(() =>
+			expect(router.state.location.search).toMatchObject({ practice: "small-changes" }),
+		);
+		await userEvent.click(
+			screen.getByRole("button", { name: "Clear review-run filter for Keep changes focused" }),
+		);
+		await vi.waitFor(() => expect(router.state.location.search).not.toHaveProperty("practice"));
+		expect(scroll).not.toHaveBeenCalled();
+		scroll.mockRestore();
+	});
+});
+
+it("does not label another developer's profile with the previous developer's data", async () => {
+	let respond = (_response: Response) => {};
+	const pendingProfile = new Promise<Response>((resolve) => {
+		respond = resolve;
+	});
+	server.use(
+		http.get("*/workspaces", () => HttpResponse.json([workspaceListItem("acme")])),
+		http.get("*/workspaces/:workspaceSlug/profile/ada", () => HttpResponse.json(profile("ada"))),
+		http.get("*/workspaces/:workspaceSlug/profile/bob", () =>
+			pendingProfile.then((value) => value.clone()),
+		),
+	);
+	const { router } = renderRouteAtWithRouter("/w/acme/user/ada");
+	await screen.findByRole("heading", { name: "Developer ada" }, ROUTE_RENDER_WAIT);
+	await act(() =>
+		router.navigate({
+			to: "/w/$workspaceSlug/user/$username",
+			params: { workspaceSlug: "acme", username: "bob" },
+		}),
+	);
+	expect(screen.queryByRole("heading", { name: "Developer ada" })).toBeNull();
+	await act(async () => respond(HttpResponse.json(profile("bob"))));
+	await screen.findByRole("heading", { name: "Developer bob" }, ROUTE_RENDER_WAIT);
+});
+
+it("refreshes every cached filter of the group after responding to feedback", async () => {
+	const observationId = "00000000-0000-0000-0000-000000000001";
+	let usefulness: "HELPFUL" | undefined;
+	server.use(
+		http.get("*/workspaces/:workspaceSlug/practice-groups/:groupSlug/review-runs", () =>
+			HttpResponse.json({
+				content: [
+					{
+						reviewId: "00000000-0000-0000-0000-000000000003",
+						reviewedAt: "2026-09-01T10:00:00Z",
+						reviewedWork: { id: 1, type: "scm.pull_request", title: "A focused change" },
+						observations: [
+							{
+								observationId,
+								feedbackId: "00000000-0000-0000-0000-000000000002",
+								practiceSlug: "small-changes",
+								practiceName: "Keep changes focused",
+								title: "Two concerns in one change",
+								presence: "PRESENT",
+								assessment: "BAD",
+								feedbackUsefulness: usefulness,
+							},
+						],
+					},
+				],
+				hasNext: false,
+				page: 0,
+			}),
+		),
+		http.get("*/workspaces/:workspaceSlug/practices/observations/:observationId", () =>
+			HttpResponse.json({ observedAt: "2026-09-01T10:00:00Z" }),
+		),
+		http.put("*/workspaces/:workspaceSlug/practices/feedback/:feedbackId/response", () => {
+			usefulness = "HELPFUL";
+			return HttpResponse.json({ usefulness: "HELPFUL" });
+		}),
+	);
+	const { queryClient } = renderRouteAtWithRouter(`${path}?observation=${observationId}`);
+	const main = await screen.findByRole("main");
+	const helpful = await within(main).findByRole("button", { name: "Helpful" }, ROUTE_RENDER_WAIT);
+	const filtered = listPracticeGroupReviewRunsInfiniteQueryKey({
+		path: { workspaceSlug: "acme", groupSlug: group.slug },
+		query: { size: 10, practiceSlug: "small-changes" },
+	});
+	queryClient.setQueryData(filtered, { pages: [{ content: [], hasNext: false }], pageParams: [0] });
+	await userEvent.click(helpful);
+	await vi.waitFor(() => expect(helpful.getAttribute("aria-pressed")).toBe("true"));
+	expect(queryClient.getQueryState(filtered)?.isInvalidated).toBe(true);
+});
+
+it("restores the bookmarked custom timeframe on Back without scrolling on selection", async () => {
+	const after = "2026-06-02T00:00:00Z";
+	const before = "2026-06-07T00:00:00Z";
+	server.use(
+		http.get("*/workspaces", () => HttpResponse.json([workspaceListItem("acme")])),
+		http.get("*/workspaces/:workspaceSlug/profile/ada", () => HttpResponse.json(profile("ada"))),
+	);
+	const { router } = renderRouteAtWithRouter(`/w/acme/user/ada?after=${after}&before=${before}`);
+	await screen.findByRole("heading", { name: "Developer ada" }, ROUTE_RENDER_WAIT);
+	const scroll = vi.spyOn(window, "scrollTo").mockReturnValue(undefined);
+	await userEvent.click(screen.getByRole("combobox", { name: "Timeframe" }));
+	await userEvent.click(await screen.findByRole("option", { name: "Last week" }));
+	await vi.waitFor(() => expect(router.state.location.search.after).not.toBe(after));
+	expect(scroll).not.toHaveBeenCalled();
+	scroll.mockRestore();
+	act(() => router.history.back());
+	await vi.waitFor(() => expect(router.state.location.search).toMatchObject({ after, before }));
+	await vi.waitFor(() =>
+		expect(screen.getByRole("combobox", { name: "Timeframe" }).textContent).toContain(
+			"Custom range",
+		),
+	);
+	expect(screen.getByRole("button", { name: "Choose custom dates" }).textContent).toContain(
+		"Jun 2 – 6",
+	);
+});
+
+it.each([
+	{
+		subject: "workspace",
+		endpoint: "*/workspaces/:workspaceSlug",
+		response: workspaceListItem("acme"),
+	},
+	{
+		subject: "activity",
+		endpoint: "*/workspaces/:workspaceSlug/profile/:login/activity-monitor",
+		response: activityMonitor,
+	},
+])(
+	"retries a failed $subject query without discarding the loaded profile",
+	async ({ endpoint, response }) => {
+		server.use(
+			http.get("*/workspaces", () => HttpResponse.json([workspaceListItem("acme")])),
+			http.get("*/workspaces/:workspaceSlug/profile/ada", () => HttpResponse.json(profile("ada"))),
+			http.get(endpoint, () => HttpResponse.json({ status: 503 }, { status: 503 })),
+		);
+		renderRouteAtWithRouter("/w/acme/user/ada");
+		await screen.findByText("Could not load activity", {}, ROUTE_RENDER_WAIT);
+		screen.getByRole("heading", { name: "Developer ada" });
+		server.use(http.get(endpoint, () => HttpResponse.json(response)));
+		await userEvent.click(screen.getByRole("button", { name: "Retry" }));
+		await vi.waitFor(() => expect(screen.queryByText("Could not load activity")).toBeNull());
+		screen.getByRole("combobox", { name: "Timeframe" });
+		screen.getByRole("heading", { name: "Developer ada" });
+	},
+);

--- a/webapp/src/routes/_authenticated/w/$workspaceSlug/user/$username/index.tsx
+++ b/webapp/src/routes/_authenticated/w/$workspaceSlug/user/$username/index.tsx
@@ -208,10 +208,11 @@ function UserProfile() {
 				limit: monitorLimit,
 			}}
 			onActivityMonitorFiltersChange={handleActivityMonitorFiltersChange}
-			isLoading={
-				profileQuery.isPending ||
+			isLoading={profileQuery.isPending || workspaceQuery.isPending}
+			isActivityLoading={
 				workspaceQuery.isPending ||
-				(activityMonitorQuery.isPending && !activityMonitorQuery.data)
+				activityMonitorQuery.isPending ||
+				activityMonitorQuery.isPlaceholderData
 			}
 			error={profileQuery.error ?? undefined}
 			onRetry={() => void profileQuery.refetch()}

--- a/webapp/src/routes/_authenticated/w/$workspaceSlug/user/$username/index.tsx
+++ b/webapp/src/routes/_authenticated/w/$workspaceSlug/user/$username/index.tsx
@@ -24,6 +24,7 @@ import {
 } from "@/lib/activity-monitor";
 import { resolveLeaderboardSchedule } from "@/lib/leaderboard-schedule";
 import { toScmProviderType } from "@/lib/provider";
+import { useSearchState } from "@/lib/search-params";
 import { formatDateRangeForApi, getDateRangeForPreset } from "@/lib/timeframe";
 
 const profileSearchSchema = z.object({
@@ -37,8 +38,6 @@ const profileSearchSchema = z.object({
 		.max(MAX_ACTIVITY_MONITOR_LIMIT)
 		.default(DEFAULT_ACTIVITY_MONITOR_LIMIT),
 });
-
-type ProfileSearchParams = z.infer<typeof profileSearchSchema>;
 
 const parseRepositoryIds = (value?: string): number[] => {
 	if (!value) return [];
@@ -58,6 +57,7 @@ const serializeRepositoryIds = (repositoryIds: number[]) => {
 
 export const Route = createFileRoute("/_authenticated/w/$workspaceSlug/user/$username/")({
 	component: UserProfile,
+	remountDeps: ({ params }) => params,
 	validateSearch: profileSearchSchema,
 	search: {
 		middlewares: [retainSearchParams(["after", "before", "monitorRepositories", "monitorLimit"])],
@@ -74,6 +74,7 @@ function UserProfile() {
 	const practicesEnabled = featureState.features?.practicesEnabled;
 	const { after, before, monitorRepositories, monitorLimit } = Route.useSearch();
 	const navigate = useNavigate({ from: Route.fullPath });
+	const setSearch = useSearchState();
 
 	const workspaceQuery = useQuery({
 		...getWorkspaceOptions({
@@ -167,23 +168,19 @@ function UserProfile() {
 	});
 
 	const handleTimeframeChange = (nextAfter: string, nextBefore?: string) => {
-		void navigate({
-			search: (prev: ProfileSearchParams) => ({
-				...prev,
-				after: nextAfter,
-				before: nextBefore,
-			}),
-		});
+		void setSearch((prev) => ({
+			...prev,
+			after: nextAfter,
+			before: nextBefore,
+		}));
 	};
 
 	const handleActivityMonitorFiltersChange = (filters: ActivityMonitorFilters) => {
-		void navigate({
-			search: (prev: ProfileSearchParams) => ({
-				...prev,
-				monitorRepositories: serializeRepositoryIds(filters.repositoryIds),
-				monitorLimit: filters.limit === DEFAULT_ACTIVITY_MONITOR_LIMIT ? undefined : filters.limit,
-			}),
-		});
+		void setSearch((prev) => ({
+			...prev,
+			monitorRepositories: serializeRepositoryIds(filters.repositoryIds),
+			monitorLimit: filters.limit === DEFAULT_ACTIVITY_MONITOR_LIMIT ? undefined : filters.limit,
+		}));
 	};
 
 	if (featureState.isError) {
@@ -201,6 +198,11 @@ function UserProfile() {
 			providerType={toScmProviderType(workspaceQuery.data?.providerType)}
 			profileData={profileQuery.data}
 			activityMonitorData={activityMonitorQuery.data}
+			activityMonitorError={workspaceQuery.error ?? activityMonitorQuery.error}
+			onRetryActivityMonitor={() => {
+				if (workspaceQuery.isError) void workspaceQuery.refetch();
+				if (activityMonitorQuery.isError) void activityMonitorQuery.refetch();
+			}}
 			activityMonitorFilters={{
 				repositoryIds: selectedRepositoryIds,
 				limit: monitorLimit,

--- a/webapp/src/routes/_authenticated/w/$workspaceSlug/user/$username/practice-groups.$groupSlug.tsx
+++ b/webapp/src/routes/_authenticated/w/$workspaceSlug/user/$username/practice-groups.$groupSlug.tsx
@@ -1,5 +1,5 @@
 import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { createFileRoute, redirect, useNavigate } from "@tanstack/react-router";
+import { createFileRoute, Navigate, redirect, useNavigate } from "@tanstack/react-router";
 import { toast } from "sonner";
 import { z } from "zod";
 import {
@@ -15,6 +15,7 @@ import {
 	replaceFeedbackResponseMutation,
 } from "@/api/@tanstack/react-query.gen";
 import type { PracticeStanding } from "@/api/types.gen";
+import { QueryErrorAlert } from "@/components/common/QueryErrorAlert";
 import {
 	PracticeGroupDetailPage,
 	type ReviewRunFeedState,
@@ -23,9 +24,11 @@ import {
 	isEmptyFeedbackResponse,
 	type ObservationDetailState,
 } from "@/components/profile/review-runs";
+import { useWorkspaceFeatures } from "@/hooks/use-workspace-features";
 import { resolveCurrentUser } from "@/integrations/auth/guard";
 import { loadedPages } from "@/integrations/tanstack-query/spring-page";
 import { problemDetailOf } from "@/lib/problem-detail";
+import { useSearchState } from "@/lib/search-params";
 
 const ACTIVITY_PAGE_SIZE = 10;
 
@@ -47,6 +50,7 @@ export const Route = createFileRoute(
 	"/_authenticated/w/$workspaceSlug/user/$username/practice-groups/$groupSlug",
 )({
 	validateSearch: practiceGroupDetailSearchSchema,
+	remountDeps: ({ params }) => params,
 	beforeLoad: async ({ context, params }) => {
 		const user = await resolveCurrentUser(context.queryClient);
 		const isOwnProfile = user?.username?.toLowerCase() === params.username.toLowerCase();
@@ -58,16 +62,44 @@ export const Route = createFileRoute(
 			});
 		}
 	},
-	component: PracticeGroupDetail,
+	component: PracticeGroupRoute,
 });
+
+function PracticeGroupRoute() {
+	const { workspaceSlug, username } = Route.useParams();
+	const featureState = useWorkspaceFeatures(workspaceSlug);
+	if (featureState.isError) {
+		return (
+			<QueryErrorAlert
+				error={featureState.error}
+				title="Couldn't load workspace features"
+				onRetry={featureState.refetch}
+			/>
+		);
+	}
+	if (featureState.features?.practicesEnabled === false) {
+		return (
+			<Navigate
+				to="/w/$workspaceSlug/user/$username"
+				params={{ workspaceSlug, username }}
+				replace
+			/>
+		);
+	}
+	if (featureState.features?.practicesEnabled !== true) {
+		return <PracticeGroupDetailPage isLoading />;
+	}
+	return <PracticeGroupDetail />;
+}
 
 function PracticeGroupDetail() {
 	const { workspaceSlug, username, groupSlug } = Route.useParams();
 	const { practice: selectedPracticeSlug, observation: openObservationId } = Route.useSearch();
 	const navigate = useNavigate({ from: Route.fullPath });
 	const queryClient = useQueryClient();
+	const setSearch = useSearchState();
 	const updateSelection = (search: { practice?: string; observation?: string }) =>
-		void navigate({ search: (previous) => ({ ...previous, ...search }) });
+		void setSearch((previous) => ({ ...previous, ...search }));
 
 	const groupsQuery = useQuery({
 		...listGroupsOptions({
@@ -101,7 +133,7 @@ function PracticeGroupDetail() {
 	});
 	const invalidateReviewRuns = () =>
 		queryClient.invalidateQueries({
-			queryKey: listPracticeGroupReviewRunsInfiniteQueryKey(reviewRunsRequest),
+			queryKey: listPracticeGroupReviewRunsInfiniteQueryKey({ path: { workspaceSlug, groupSlug } }),
 		});
 	const replaceResponseMutation = useMutation({
 		...replaceFeedbackResponseMutation(),

--- a/webapp/src/routes/consent.tsx
+++ b/webapp/src/routes/consent.tsx
@@ -42,12 +42,7 @@ function ConsentPage() {
 	const navigate = useNavigate();
 	const queryClient = useQueryClient();
 	const { logout } = useAuth();
-	const { data, isError, refetch } = useQuery({
-		...getConsentStatusOptions({}),
-		// The guard above has just resolved this; refetching immediately would only risk replacing a
-		// usable notice with an error state.
-		staleTime: 30_000,
-	});
+	const { data, isError, refetch } = useQuery(getConsentStatusOptions({}));
 	const mutation = useMutation({
 		...completeFirstLoginConsentMutation(),
 		onSuccess: (status) => {


### PR DESCRIPTION
## What changed and why

Recent release follow-ups left gaps between successful-path implementations and their failure, timeout, recovery, and navigation states. This is a coordinated post-merge hardening pass across review execution, integration recovery, profile/review navigation, account exports, and deployment verification—not just the cleanup inventory in #1909.

Fixes #1909.
Fixes #1860.
Fixes #1863.

### Review execution and trustworthy results

- Recover failed account exports after transaction rollback, including commit-time failures; count success only after commit and retain failure metrics when the database is unavailable.
- Bound retry and composition work by the time actually remaining. Stop sessions that finish initialization after cancellation, preserve admitted observations before composition, and fit the watchdog inside short sandbox timeouts.
- Keep preparation/session-initialization failures inside the recovery boundary: failed reconnaissance can fall back, failed observers can retry, and failed retry setup cannot discard completed observations.
- Require recorded coverage before a trace reports a practice assessed with nothing to report. Actual observations still take precedence.
- Reject nested traversal in output archive paths. Share issue classification across precompute scripts and prevent empty normalized titles from classifying substantive bodies as title echoes.

### Recovery and navigation

- Add the missing GitHub/GitLab personal-access-token replacement form using the existing endpoint. Clear a saved secret, retain a failed draft, refresh connection health, and keep GitHub App installation management separate.
- Reset SCM, Slack, and Outline job pagination and pending form state when workspace identity changes; never show the previous workspace’s placeholder rows.
- Reset Outline connection drafts and review/profile local state at their actual identity boundaries. Invalidate the artifact a mutation acted on, not whichever artifact is currently open.
- Gate practice-group queries on confirmed feature availability; distinguish loading, disabled, and failed states. Refresh every cached feedback filter after a response changes and preserve scroll when changing filters.
- Show recoverable workspace/activity errors without discarding the loaded developer profile. While a new filter loads, render activity skeletons rather than presenting old results under the new dates.
- Make profile and leaderboard timeframes URL-controlled rather than shadowing them with local state and mount-time effects. Preserve exact bookmarked timestamps and browser history; distinguish real custom intervals from nearby presets and use one timezone-independent All time boundary. Remove duplicate schedule types and unused display formatting.
- Renew sessions when activity resumes after an idle renewal check, while keeping idle expiry and Strict Mode effect replay correct.
- Reuse existing brand icons and guaranteed route parameters; remove unreachable landing states, duplicated defaults, test-only production seams, and obsolete commentary.

### Deployment verification

- Replace reconciler source-text assertions with subprocess regressions covering the symlinked entry point, tooling adoption before channel fetch, pending metrics after success/failure, trusted verifier selection, and Compose ordering. An unlocked image in the final stack must leave the applied release and every container untouched.
- Correct certificate migration instructions to use Docker's actual volume mountpoint and explain safe migration/rollback without overwriting newer certificates.
- Retain intentional per-worker gateway flood protection and document its actual scope rather than presenting it as a fleet-wide quota.

## How to test

- `vp run format` then `vp run check`: **all 41 quality tasks passed**.
- `MANAGEMENT_PORT=0 SERVER_PORT=0 vp run test:server:unit`: **7,215 passed**. Focused trace/timeout suites: **64 passed**.
- `vp run test:webapp`: **1,121 app tests and 168 lint-rule tests passed**. `vp run build:webapp` passed.
- `vp run test:agents`: **172 passed**, including nine actual-runner subprocess regressions for late initialization, exhausted composition, retained admitted output, and initialization failures.
- Deployment subprocess tests exercise temporary repositories, symlink startup, command ordering and persisted metrics. Removing historical fixes makes their corresponding regressions fail.
- The export/credential PostgreSQL integration tests (**3 passed**) and architecture suite (**304 passed**) were verified in the first batch; their implementation is unchanged by this expansion.
- Adversarial proof: the old implementations fail the new workspace-isolation, timeframe, placeholder-activity, and runtime-initialization regressions. Removing the deployment image guard fails the negative subprocess test. Date behavior passes in UTC, Europe/Berlin, and America/New_York.
- Manual UI checks: replace a GitHub/GitLab PAT successfully and unsuccessfully; switch Outline workspaces with a draft; navigate between reviews while a request runs; change profile dates and use Back; retry a failed activity request.

Latest-commit [CI on `2e1fb605d`](https://github.com/hephaestus-build/Hephaestus/actions/runs/34147130438) is green: **44 checks passed, 15 skipped, none pending or failing**. GitHub reports CLEAN/MERGEABLE. Draft-specific jobs remain skipped; visual sign-off is outstanding.

## Release impact

Patch changesets describe each user/operator-visible correction. No dependency, HTTP contract, schema, or released migration changes. No required operator action; the certificate migration instructions apply only to hosts moving from the former bind mount.

## Notes for reviewers

Review in the groups above; the critical contracts are transaction commit vs recovery, actual remaining runtime budget, recorded vs unknown coverage, route identity vs pending mutations, and credential state vs available recovery controls. Tests assert persisted state, real HTTP behavior, browser-router state, or subprocess outputs rather than copied implementation text.

Issues #1862 and #1915 remain out of scope and must stay open. Pruning old deployment trees requires an explicit certificate/rollback retention policy. Unavailable repositories need persistent provider-aware state and reappearance behavior; a blanket 404 workaround would hide authorization or transport failures.

## Visual evidence

Automated Storybook interaction and Chromatic checks passed on the latest revision. Review the [public Storybook preview](https://hephaestus-build-storybook-pr-1979.surge.sh/), especially [credential recovery](https://hephaestus-build-storybook-pr-1979.surge.sh/?path=/story/components-admin-integrations-workspacescmtokensettings--unreadable-git-lab-token) and the [controlled timeframe picker](https://hephaestus-build-storybook-pr-1979.surge.sh/?path=/story/components-profile-profiletimeframepicker--default).

Before/after screenshots and manual checks of the recovery/navigation states are outstanding. This PR remains a draft until visual verification is complete.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workspace administrators can replace unreadable GitHub or GitLab tokens without removing repositories or synced work.
  * Landing pages now consistently present sign-in and installation guidance.
  * Profile activity and integration failures offer clearer loading states and retry actions.
  * Review and leaderboard filters preserve bookmarked dates and scroll position more reliably.

* **Bug Fixes**
  * Export failures are recorded accurately, with success metrics published only after completion.
  * GitLab icons display correctly for custom provider names.
  * Practice reviews better preserve completed results and explain missing coverage.
  * Session renewal, workspace switching, and integration state handling are more reliable.
  * Review output paths reject unsafe traversal patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->