### PR TITLE
fix(docs): refuse to replace an ACME store that is already there

### DIFF
--- a/.changeset/acme-store-and-integration-remount.md
+++ b/.changeset/acme-store-and-integration-remount.md
@@ -1,0 +1,7 @@
+---
+"hephaestus": patch
+---
+
+Stops a sync started in one workspace from appearing to run in another. Switching workspace kept the integration overview's cards mounted, so a sync the new workspace had never asked for could still show as pending on the matching integration.
+
+The certificate migration in the pull-based deployment guide no longer risks the certificates a host is already serving: the copy refuses when the volume already holds an ACME store, instead of overwriting it and warning about it afterwards.

--- a/docs/admin/pull-based-deployment.mdx
+++ b/docs/admin/pull-based-deployment.mdx
@@ -110,18 +110,27 @@ so the ACME store cannot change during the copy. Back up that `acme.json` first;
 it is under `docker/letsencrypt/`. Copy it into the volume before starting the new proxy, or Traefik
 issues the certificates again.
 
+A volume that already holds an `acme.json` holds the store Traefik is using: copying an older backup
+over it discards the certificates currently being served. The command below refuses in that case
+rather than leaving the operator to notice, so a store that is already there has to be looked at
+deliberately before anything replaces it.
+
 On the Docker Engine host, use the volume's actual mountpoint rather than assuming Docker's data root:
 
 ```bash
 sudo docker volume create proxy_letsencrypt
 volume_path=$(sudo docker volume inspect --format '{{ .Mountpoint }}' proxy_letsencrypt)
-sudo install -m 600 /path/to/previous/acme.json "$volume_path/acme.json"
+if sudo test -s "$volume_path/acme.json"; then
+  echo "acme.json is already in proxy_letsencrypt — inspect it before replacing it" >&2
+else
+  sudo install -m 600 /path/to/previous/acme.json "$volume_path/acme.json"
+fi
 ```
 
-Do not overwrite a populated volume with an older copy. Keep the backup until the new proxy serves
-the existing certificates successfully, then re-enable reconciliation. A rollback to a release whose
-proxy still uses the bind mount needs the current ACME store copied back while Traefik is stopped;
-retaining the old release tree alone does not keep that copy current.
+Keep the backup until the new proxy serves the existing certificates successfully, then re-enable
+reconciliation. A rollback to a release whose proxy still uses the bind mount needs the current ACME
+store copied back while Traefik is stopped; retaining the old release tree alone does not keep that
+copy current.
 
 The pull-based stacks use the bundled database with its fixed credentials, so there is no
 database password to carry. On the Compose installer, `docker/self-host/setup.sh` refuses to

--- a/webapp/src/routes/_authenticated/w/$workspaceSlug/admin/integrations/index.tsx
+++ b/webapp/src/routes/_authenticated/w/$workspaceSlug/admin/integrations/index.tsx
@@ -21,6 +21,9 @@ import { problemDetailOf } from "@/lib/problem-detail";
 
 export const Route = createFileRoute("/_authenticated/w/$workspaceSlug/admin/integrations/")({
 	head: workspaceAdminHead("Integrations"),
+	// The cards are keyed by integration kind, which is the same key in every workspace, so a switch
+	// would otherwise leave a sync this workspace never asked for pending on the matching card.
+	remountDeps: ({ params }) => params.workspaceSlug,
 	component: IntegrationsOverview,
 });
 


### PR DESCRIPTION
Two review findings on #1979 that landed a minute after it merged. Both were verified against the code before changing anything.

## The certificate migration could destroy live certificates

The procedure copied `acme.json` into `proxy_letsencrypt` and put the warning against doing so **underneath** the command:

```bash
sudo install -m 600 /path/to/previous/acme.json "$volume_path/acme.json"   # overwrites unconditionally
```
> Do not overwrite a populated volume with an older copy.

An operator restoring an older backup destroyed the certificates currently being served before reaching the sentence explaining why not to. The command now refuses when a store is present, and the warning comes first — safe by construction rather than by reading order.

This is my text originally, from the volume change in #1968.

## The integration overview kept a pending sync across workspaces

`IntegrationOverviewCardContainer` is keyed by `entry.kind`, which is the same key in every workspace, while its `triggerSync` mutation is scoped to `workspaceSlug`. With no `remountDeps` on the route and no router default, switching workspace could leave a sync the new workspace never asked for pending on the matching card.

`remountDeps: ({ params }) => params.workspaceSlug` — the same line #1979 already applies to five sibling routes, so this one was simply missed.

## Verification

`typecheck:webapp` and `check:webapp` clean. The docs change is prose and a shell snippet; `gate:docs-lint` reports nothing against this file.