### PR TITLE
ci: reduce redundant analysis and enforce PR latency budgets

### DIFF
--- a/.github/workflows/ci-profile.yml
+++ b/.github/workflows/ci-profile.yml
@@ -18,6 +18,7 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: read
+      actions: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -32,15 +33,47 @@ jobs:
           cache-type: application-server-reactor
           os: ${{ runner.os }}
 
-      - name: Restore performance history
+      - name: Find performance history
         if: github.ref_name == github.event.repository.default_branch
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        id: history
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
+          script: |
+            const repository = context.repo;
+            for await (const { data } of github.paginate.iterator(github.rest.actions.listWorkflowRuns, {
+              ...repository,
+              workflow_id: 'ci-profile.yml',
+              branch: context.payload.repository.default_branch,
+              status: 'completed',
+              per_page: 100,
+            })) {
+              for (const run of data) {
+                if (run.id === context.runId || run.head_branch !== context.payload.repository.default_branch || run.head_repository?.full_name !== `${repository.owner}/${repository.repo}`) continue;
+                const artifacts = await github.paginate(github.rest.actions.listWorkflowRunArtifacts, {
+                  ...repository,
+                  run_id: run.id,
+                  per_page: 100,
+                });
+                const history = artifacts.find((artifact) => artifact.name === 'ci-profile-history' && !artifact.expired);
+                if (history) {
+                  core.setOutput('run-id', run.id);
+                  return;
+                }
+              }
+            }
+            core.info('No retained profile history; collecting a new baseline.');
+
+      - name: Restore performance history
+        if: steps.history.outputs.run-id != ''
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ci-profile-history
+          run-id: ${{ steps.history.outputs.run-id }}
+          github-token: ${{ github.token }}
           path: ci-profile-history
-          key: ci-profile-history-${{ github.run_id }}
-          restore-keys: ci-profile-history-
 
       - name: Run integration suite with JFR
+        id: profile
         run: |
           mkdir -p ci-metrics
           /usr/bin/time -v -o ci-metrics/server-integration-resource.txt \
@@ -50,6 +83,7 @@ jobs:
             2>&1 | tee ci-metrics/server-integration.log
 
       - name: Summarize integration results
+        id: summary
         if: always()
         continue-on-error: true
         run: >-
@@ -60,9 +94,27 @@ jobs:
       - name: Enforce performance budgets
         if: success() && github.ref_name == github.event.repository.default_branch
         run: |
+          # Do not compare a rerun against its own previous attempt.
+          rm -f "ci-profile-history/${{ github.run_id }}.json"
           node scripts/check-ci-performance.ts ci-metrics/server-integration-profile.json ci-profile-history
+
+      # Keep budget failures in history so sustained regressions remain detectable.
+      - name: Record completed profile
+        id: record
+        if: ${{ !cancelled() && steps.profile.outcome == 'success' && steps.summary.outcome == 'success' && github.ref_name == github.event.repository.default_branch }}
+        run: |
           mkdir -p ci-profile-history
           cp ci-metrics/server-integration-profile.json "ci-profile-history/${{ github.run_id }}.json"
+
+      - name: Save performance history
+        if: ${{ !cancelled() && steps.record.outcome == 'success' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ci-profile-history
+          path: ci-profile-history
+          if-no-files-found: error
+          retention-days: 90
+          overwrite: true
 
       - name: Extract database cleanup timings
         if: always()
@@ -86,3 +138,30 @@ jobs:
             ci-metrics/database-cleanup.jfr.txt
           if-no-files-found: warn
           retention-days: 14
+
+  pr-latency:
+    name: Pull-request latency budget
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-toolchain
+        with:
+          install: "none"
+      - name: Measure completed PR verdicts
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: node scripts/report-ci-latency.ts
+      - name: Upload latency evidence
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: pr-latency-${{ github.run_id }}-${{ github.run_attempt }}
+          path: tmp/ci-metrics/ci-latency.json
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -16,9 +16,7 @@ on:
 
 permissions: {}
 
-# Both suites compile from source instead of depending on ci-build.yml's package job: neither
-# produces anything that ships, and each runs longer than packaging, so a dependency would only
-# lengthen the critical path. Revisit if packaging ever outlasts a suite.
+# Test compilation runs independently of release packaging to avoid a serial build dependency.
 jobs:
   server-verification:
     name: "App Server: Unit and architecture"
@@ -59,13 +57,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Surefire's `test` parameter replaces `includes`, so only the second shard's exclusion —
-          # never an inclusion of its own — keeps the two selectors complementary over every class
-          # the unsharded tier scans. scripts/ci-contract.test.ts proves the partition.
-          - shard: providers
-            tests: "de/tum/cit/aet/hephaestus/integration/**"
+          # Surefire's test selector replaces includes; an exclusion-only shard covers the remainder.
+          - shard: providers-and-startup
+            tests: "de/tum/cit/aet/hephaestus/integration/**,de/tum/cit/aet/hephaestus/StartupBudgetIntegrationTest"
           - shard: application
-            tests: "!de/tum/cit/aet/hephaestus/integration/**"
+            tests: "!de/tum/cit/aet/hephaestus/integration/**,!de/tum/cit/aet/hephaestus/StartupBudgetIntegrationTest"
     permissions:
       contents: read
       checks: write
@@ -82,8 +78,6 @@ jobs:
           os: ${{ runner.os }}
       - name: Run integration tests
         env:
-          # vite.config.ts reads this at load, so no matrix value ever reaches a run: script — which
-          # the workflow linter forbids.
           HEPHAESTUS_INTEGRATION_TESTS: ${{ matrix.tests }}
         run: vp run test:server:integration
       - name: Upload test results

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,8 +1,5 @@
 name: CodeQL
 
-# Advanced setup, not GitHub's managed default setup: only advanced setup reads a committed
-# `config-file`, and `security/semgrep/**` needs `paths-ignore` (docs/contributor/ci-cd.mdx §
-# CodeQL configuration).
 on:
   push:
     branches: [main]
@@ -15,15 +12,49 @@ permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  # A superseded analysis of a branch is wasted work, but on the default branch it is the only
-  # analysis that commit will ever get: cancelling it leaves the tip unanalysed, the SAST score drops
-  # and the scorecard ratchet fails on a main nobody broke. Two merges landing within a minute of each
-  # other is enough to trigger it.
+  # Preserve analysis for every default-branch commit.
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
+  changes:
+    name: Select analysis languages
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      languages: ${{ steps.filter.outputs.changes || '["actions","java-kotlin","javascript-typescript"]' }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
+        id: filter
+        if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+        with:
+          filters: |
+            actions:
+              - '.github/**'
+            java-kotlin:
+              - 'server/**'
+              - '.java-version'
+              - '.github/codeql/**'
+              - '.github/workflows/codeql.yml'
+            javascript-typescript:
+              - '**/*.{js,cjs,mjs,jsx,ts,cts,mts,tsx,html,vue}'
+              - '**/package.json'
+              - '**/tsconfig*.json'
+              - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
+              - 'patches/**'
+              - '.github/codeql/**'
+              - '.github/workflows/codeql.yml'
+
   analyze:
     name: Analyze (${{ matrix.language }})
+    needs: changes
+    if: needs.changes.outputs.languages != '[]'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -33,7 +64,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [actions, java-kotlin, javascript-typescript]
+        language: ${{ fromJSON(needs.changes.outputs.languages) }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/docs/contributor/ci-cd.mdx
+++ b/docs/contributor/ci-cd.mdx
@@ -95,10 +95,9 @@ still reports `skipped`, not `success`. A workflow that never triggers reports n
 required context left pending blocks the queue for good — `merge_group` supports no `paths:` filter
 in any case, so the filtering lives in each job's `if`. The queue builds up to
 `max_entries_to_build: 2` groups speculatively, a repository-ruleset field rather than a file here,
-and each group costs a whole `CI/CD` run, so a job added to `cicd.yml` is paid for once per group in
-flight. Two rather than three because the plan allows 20 concurrent jobs across every run in the
-repository: a third group starved pull-request runs and its own siblings for the sake of a merge
-pace the queue rarely reaches.
+and each group starts a `CI/CD` run. GitHub's
+[runner concurrency limits](https://docs.github.com/en/actions/reference/limits#job-concurrency-limits-for-github-hosted-runners)
+apply across workflows, so queue parallelism competes with pull-request validation for capacity.
 
 A failed merge group drops its pull requests from the queue without failing any check on them, so
 CI updates a comment on the pull request named by the merge group's head ref with the run link. It
@@ -162,7 +161,10 @@ which covers the whole tree where TruffleHog covers a pull request's own commits
 Renovate groups routine updates only when they share a review and verification boundary. Production
 dependencies remain separate unless Renovate identifies a package family that must move together.
 Major updates and minor updates to pre-1.0 dependencies remain ungrouped, wait seven days, and require
-Dependency Dashboard approval. Vulnerability alerts remain ungrouped and bypass those gates.
+Dependency Dashboard approval. Native
+[branch and PR limits](https://docs.renovatebot.com/configuration-options/#branchconcurrentlimit)
+bound routine update concurrency; the hourly limit only restricts PR creation. Vulnerability alerts
+remain ungrouped and bypass those gates and limits.
 
 Lockfile maintenance runs on Mondays. `renovate.json` owns the managed ecosystems and extraction
 rules; `scripts/renovate-config.test.ts` exercises each custom manager against its source. The Node,
@@ -191,6 +193,10 @@ reproduce a run locally. A pull request from a fork gets the scan verdict but no
 because GitHub caps a fork token's `security-events` access at read.
 
 ### CodeQL configuration
+
+PR and merge-group diffs select analysis languages, not individual files: each selected language
+scans its configured source tree. Main and scheduled runs select all languages, as do changes to
+the CodeQL workflow or configuration. The language filters live in `.github/workflows/codeql.yml`.
 
 `.github/workflows/codeql.yml` runs CodeQL under advanced setup: only advanced setup reads a
 committed config file, and `.github/codeql/codeql-config.yml` excludes `security/semgrep/**`,
@@ -360,7 +366,7 @@ why the label is the authority, and which alternatives were priced and declined,
 | `semgrep.yml` | Pull request, push to main, merge group | Tests and scans the repository's own TLS rule pack |
 | `rescan-main-images.yml` | Weekly, manual | Rescans main's published images against the release vulnerability policy and keeps one tracking issue in step with the findings |
 | `rescan-release-images.yml` | Weekly, manual | Rescans the latest published release's images and reports drift on the vulnerability response issue |
-| `ci-profile.yml` | Weekly, manual | Profiles server integration tests and Spring contexts |
+| `ci-profile.yml` | Weekly, manual | Enforces PR latency budgets and profiles server integration tests and Spring contexts |
 | `ci-server-clean-reference.yml` | Weekly, manual | Records cold server phases and compares generated JARs |
 | `scorecard-ratchet.yml` | Push to main, branch-protection change, weekly, manual | Fails when a Scorecard check drops below the committed baseline; a push fails only for the checks its own commit decides |
 | `deploy-preview.yml` | `preview` label added, or a push, reopen or ready-for-review on a labelled PR | Waits for this commit's attested CI images, deploys them, and registers the native GitHub deployment |
@@ -487,17 +493,13 @@ reaches no such commit builds every image itself. `detect-changes` resolves that
 
 - `Quality` legs and `Test` suites start from source; `Build` gates start when `App Server: Package`
   uploads its artifact.
-- `App Server: Integration` runs two matrix shards: `providers` selects the `integration` package
-  and `application` excludes it. Both keep the `integration` tag filter and run in their own JVM and
-  Testcontainers database. The split is by package boundary rather than by size, so the tier's wall
-  time is the larger `application` shard's. Because
-  Surefire's `-Dtest` replaces its include patterns, only `application`'s pure exclusion keeps the
-  two selectors complementary over every class the unsharded run scans; an inclusion of its own
-  would drop whatever it failed to name. `scripts/ci-contract.test.ts` proves the partition against
-  the test sources, so a selector that drifts fails `check` rather than passing green. The selector
-  reaches Maven through `HEPHAESTUS_INTEGRATION_TESTS`, which `vite.config.ts` reads when it loads,
-  so the matrix value never appears in a `run:` script. `fail-fast: false` lets both shards report,
-  and `CI Status Gate` requires the aggregate `Test` result. Locally the tier runs whole.
+- `App Server: Integration` has two shards: `providers-and-startup` selects the `integration`
+  package and `StartupBudgetIntegrationTest`; `application` excludes both. Both retain the
+  `integration` tag filter and run in separate JVMs and Testcontainers databases. The startup test
+  owns a database separate from other Spring contexts. Surefire's `-Dtest` replaces its include
+  patterns, so the second selector is exclusion-only; `scripts/ci-contract.test.ts` checks that
+  the selectors partition the tier. Both shards report with `fail-fast: false`, and
+  `CI Status Gate` requires their aggregate result. Locally the tier runs whole.
 - Pull requests and merge groups build `linux/amd64`; pushes to `main`, and every run on the Version
   PR's branch, build both architectures. A pull request and a merge group each also build only the
   images their own diff touched and alias the rest, while the Version PR's branch builds all of
@@ -505,7 +507,8 @@ reaches no such commit builds every image itself. `detect-changes` resolves that
   every image build in the run.
 - The `Quality` matrix uses `fail-fast: false`; the image matrix in `reusable-docker-build.yml` uses
   `fail-fast: true`.
-- Pull-request runs cancel superseded runs; `release.yml` never cancels.
+- Pull-request runs cancel superseded runs; `release.yml` never cancels. PR and dispatch lanes
+  remain separate because they validate different refs: the PR merge ref and the branch head.
 - A run on `main` that leaves a per-commit record — `codeql.yml`, `semgrep.yml`, `scorecard.yml`,
   `scorecard-ratchet.yml` — is never cancelled, because it is the only run that commit will get and
   its absence is what a later score reads as a gap. Those workflows write
@@ -520,15 +523,54 @@ for workflow and job run time, queue time, failure rate, and runner usage. Each 
 also includes the current run's dependency-aware timeline and job summary, and JUnit results appear
 as `Test Results - …` check runs.
 
-The weekly `CI profile` workflow covers the server-specific data GitHub does not provide: JFR,
-resource usage, JUnit results, and Spring context-cache metrics. It signals only after three
-consecutive regressions against five earlier default-branch profiles. Branch dispatches produce
-standalone diagnostic artifacts without changing or enforcing that baseline. The exact invocation is
-that workflow's `Run integration suite with JFR` step; `SpringTestContextArchitectureTest` enforces
-the reviewed Spring context keys.
+### Pull-request latency
 
-The weekly **Server Phase Reference** workflow records cache-disabled Maven generation, compilation,
-test-compilation, and execution profiles and compares two clean generated-client JARs.
+The full-verification target is a six-minute median and a seven-minute p90, measured from workflow
+creation to completion of **CI Status Gate**. `CI profile` samples the ten most recent successful,
+first-attempt PR runs with full server and browser verification from the latest 100 completed PR
+runs created in the last 28 days. Lightweight changes and Version-PR runs cannot satisfy this
+cohort. Failed and cancelled counts describe the bounded listing, not a repository-wide failure
+rate. Fewer than ten qualifying runs fails as insufficient evidence; budget failures also retain
+the JSON report.
+
+Reproduce the observer with an authenticated GitHub CLI:
+
+```bash
+GITHUB_REPOSITORY=owner/repository vp run report:ci-latency
+```
+
+To inspect one completed run, download its metadata and every page of jobs for the same attempt.
+Replace `RUN_ID` and `ATTEMPT` in both requests:
+
+```bash
+mkdir -p tmp/ci-timings
+gh api repos/{owner}/{repo}/actions/runs/RUN_ID/attempts/ATTEMPT > tmp/ci-timings/run.json
+gh api --paginate 'repos/{owner}/{repo}/actions/runs/RUN_ID/attempts/ATTEMPT/jobs?per_page=100' |
+  jq -s '{total_count: .[0].total_count, jobs: [.[].jobs[]]}' > tmp/ci-timings/jobs.json
+vp run report:ci-timings tmp/ci-timings/run.json tmp/ci-timings/jobs.json
+```
+
+The report separates time before job creation, time before the first runner, per-job start delay,
+and execution time. Start delay includes dependency waiting, so it is not a pure runner-queue
+metric. Summed execution times overlap: they measure runner demand, not verdict latency. Retries
+retain the original run creation time and must not enter first-attempt percentiles. Unlike the
+gate's in-flight summary, this report uses its completed verdict and rejects incomplete job lists
+or mixed attempts. Keep raw API evidence under `tmp/`, not in committed performance snapshots.
+
+### Server profiles
+
+`CI profile` records JFR, resource usage, JUnit results and Spring context-cache metrics. It signals
+a sustained regression after three consecutive profiles exceed variance limits against five earlier
+default-branch profiles or absolute Spring-context limits. Only successful test runs with valid
+summaries enter history, including runs whose performance budget fails. History is restored from this repository's default-branch
+workflow artifacts, retained for 90 days; a rerun replaces its own sample. Without seven earlier
+profiles, the sustained-regression check has no verdict. Branch dispatches produce diagnostic
+artifacts without changing or enforcing the baseline.
+
+The workflow's `Run integration suite with JFR` step owns the invocation;
+`SpringTestContextArchitectureTest` enforces the reviewed Spring context keys. The weekly
+**Server Phase Reference** workflow records cache-disabled Maven generation, compilation,
+test-compilation and execution profiles and compares two clean generated-client JARs.
 
 ## Running CI locally
 

--- a/renovate.json
+++ b/renovate.json
@@ -240,8 +240,8 @@
 		"groupName": null
 	},
 	"ignorePaths": ["**/node_modules/**", "**/target/**", "**/dist/**", "**/build/**"],
-	"prConcurrentLimit": 5,
-	"branchConcurrentLimit": 10,
+	"prConcurrentLimit": 2,
+	"branchConcurrentLimit": 2,
 	"prHourlyLimit": 2,
 	"osvVulnerabilityAlerts": true,
 	"dependencyDashboardOSVVulnerabilitySummary": "unresolved"

--- a/scripts/ci-contract.test.ts
+++ b/scripts/ci-contract.test.ts
@@ -475,6 +475,16 @@ void describe("CI contract", () => {
 		assert.ok(isMap(matrix), "server-integration runs no matrix");
 		const selectors = matrixValues(matrix, "tests");
 		assert.equal(selectors.length, 2, "The tier is sharded in two");
+		const startup = "de/tum/cit/aet/hephaestus/StartupBudgetIntegrationTest";
+		assert.ok(surefireSelects(selectors[0] ?? "", startup));
+		assert.ok(!surefireSelects(selectors[1] ?? "", startup));
+		const startupSource = await readFile(
+			`server/application/src/test/java/${startup}.java`,
+			"utf8",
+		);
+		assert.match(startupSource, /@Tag\("integration"\)/);
+		assert.doesNotMatch(startupSource, /@Tag\("architecture"\)/);
+
 		for (const selector of selectors)
 			assert.doesNotMatch(
 				selector,
@@ -2191,4 +2201,40 @@ void test("every Semgrep rule ships a positive and a negative fixture", async ()
 			assert.match(fixtures, new RegExp(`ok: ${id}$`, "m"), `${id} has no compliant example`);
 		}
 	}
+});
+
+void test("CodeQL selects languages with native change detection", async () => {
+	const workflow = parseDocument(await readFile(".github/workflows/codeql.yml", "utf8"));
+	assert.equal(workflow.getIn(["jobs", "analyze", "needs"]), "changes");
+	assert.equal(
+		workflow.getIn(["jobs", "analyze", "if"]),
+		"needs.changes.outputs.languages != '[]'",
+	);
+	assert.equal(
+		workflow.getIn(["jobs", "analyze", "strategy", "matrix", "language"]),
+		`\${{ fromJSON(needs.changes.outputs.languages) }}`,
+	);
+	assert.equal(
+		workflow.getIn(["jobs", "changes", "outputs", "languages"]),
+		`\${{ steps.filter.outputs.changes || '["actions","java-kotlin","javascript-typescript"]' }}`,
+	);
+	const steps = workflow.getIn(["jobs", "changes", "steps"]);
+	assert.ok(isSeq(steps));
+	const selection = steps.items.find((item) => isMap(item) && item.get("id") === "filter");
+	assert.ok(isMap(selection));
+	assert.equal(
+		selection.get("if"),
+		"github.event_name == 'pull_request' || github.event_name == 'merge_group'",
+	);
+	const filter = step(workflow, ["jobs", "changes"], "dorny/paths-filter");
+	const filters = asRecord(parseDocument(String(filter.get("filters"))).toJSON(), "CodeQL filters");
+	assert.deepEqual(Object.keys(filters), ["actions", "java-kotlin", "javascript-typescript"]);
+	for (const [language, patterns] of Object.entries(filters)) {
+		const paths = asArray(patterns, language);
+		assert.ok(
+			paths.some((pattern) => typeof pattern === "string" && pattern.startsWith(".github/")),
+		);
+	}
+	assert.ok(asArray(filters["java-kotlin"], "Java paths").includes("server/**"));
+	assert.ok(asArray(filters["javascript-typescript"], "JS paths").includes("pnpm-lock.yaml"));
 });

--- a/scripts/ci-profile-history.test.ts
+++ b/scripts/ci-profile-history.test.ts
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import { test } from "node:test";
+
+import { isMap, isSeq, parseDocument } from "yaml";
+
+const workflow = parseDocument(await readFile(".github/workflows/ci-profile.yml", "utf8"));
+const steps = workflow.getIn(["jobs", "server-integration", "steps"]);
+assert.ok(isSeq(steps));
+const selection = steps.items.find((item) => isMap(item) && item.get("id") === "history");
+assert.ok(isMap(selection));
+const source = selection.getIn(["with", "script"]);
+assert.equal(typeof source, "string");
+
+function selectHistory(pages: unknown[][], artifacts: Record<number, unknown[]>): string {
+	const result = spawnSync(process.execPath, ["--input-type=module"], {
+		input: `
+const context = {repo: {owner: 'owner', repo: 'repo'}, runId: 10, payload: {repository: {default_branch: 'main'}}};
+const core = {setOutput: (name, value) => process.stdout.write(String(value)), info: () => {}};
+const pages = ${JSON.stringify(pages)};
+const artifacts = ${JSON.stringify(artifacts)};
+const paginate = Object.assign(async (_, {run_id}) => artifacts[run_id] ?? [], {
+  iterator: async function* (_, options) {
+    if (options.workflow_id !== 'ci-profile.yml' || options.branch !== 'main' || options.status !== 'completed') throw Error('Untrusted query');
+    for (const data of pages) yield {data};
+  },
+});
+const github = {paginate, rest: {actions: {listWorkflowRuns: {}, listWorkflowRunArtifacts: {}}}};
+await (async () => {${String(source)}})();`,
+		encoding: "utf8",
+	});
+	assert.equal(result.status, 0, result.stderr);
+	return result.stdout;
+}
+
+const run = (id: number, headBranch = "main", repository = "owner/repo") => ({
+	id,
+	head_branch: headBranch,
+	head_repository: { full_name: repository },
+});
+const history = { name: "ci-profile-history", expired: false };
+
+void test("history skips this rerun, foreign sources and incomplete profiles across pages", () => {
+	assert.equal(
+		selectHistory([[run(10), run(9, "feature"), run(8, "main", "fork/repo"), run(7)], [run(6)]], {
+			10: [history],
+			9: [history],
+			8: [history],
+			7: [],
+			6: [history],
+		}),
+		"6",
+	);
+});
+
+void test("a budget-failed run's completed profile remains usable", () => {
+	assert.equal(selectHistory([[{ ...run(9), conclusion: "failure" }]], { 9: [history] }), "9");
+});
+
+void test("expired history cannot become a baseline", () => {
+	assert.equal(selectHistory([[run(9)]], { 9: [{ ...history, expired: true }] }), "");
+});

--- a/scripts/dispatch-version-pr-ci.test.ts
+++ b/scripts/dispatch-version-pr-ci.test.ts
@@ -2,7 +2,12 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import { describe, test } from "node:test";
 
-import { needsDispatch, parseRuns, versionBranch } from "./dispatch-version-pr-ci.ts";
+import {
+	needsDispatch,
+	parseBranchHead,
+	parseRuns,
+	versionBranch,
+} from "./dispatch-version-pr-ci.ts";
 
 const SHA = "a".repeat(40);
 const OTHER = "b".repeat(40);
@@ -11,8 +16,6 @@ void describe("the Version PR's CI branch", () => {
 	void test("follows the base branch changesets is configured with", async () => {
 		assert.equal(versionBranch({ baseBranch: "main" }), "changeset-release/main");
 		assert.equal(versionBranch({ baseBranch: "release/2" }), "changeset-release/release/2");
-		// The committed configuration, so renaming the base branch cannot silently leave the Version
-		// PR unvalidated while every check still passes.
 		const config: unknown = JSON.parse(await readFile(".changeset/config.json", "utf8"));
 		assert.equal(versionBranch(config), "changeset-release/main");
 	});
@@ -26,18 +29,43 @@ void describe("the Version PR's CI branch", () => {
 void describe("dispatching CI for a Version PR head", () => {
 	void test("dispatches a head commit no run has covered", () => {
 		assert.equal(needsDispatch(SHA, []), true);
-		assert.equal(needsDispatch(SHA, [{ headSha: OTHER }]), true);
+		assert.equal(needsDispatch(SHA, [{ headSha: OTHER, conclusion: "success" }]), true);
 	});
 
 	void test("stays quiet when the head already has a run", () => {
-		// A push to main that leaves the Version PR's tree unchanged must not queue a second run of
-		// the same commit, and a re-run of this workflow must not either.
-		assert.equal(needsDispatch(SHA, [{ headSha: OTHER }, { headSha: SHA }]), false);
+		assert.equal(
+			needsDispatch(SHA, [
+				{ headSha: OTHER, conclusion: "success" },
+				{ headSha: SHA, conclusion: "success" },
+			]),
+			false,
+		);
 	});
 
 	void test("reads head commits out of the workflow runs API", () => {
-		assert.deepEqual(parseRuns({ workflow_runs: [{ head_sha: SHA, id: 1 }] }), [{ headSha: SHA }]);
+		assert.deepEqual(
+			parseRuns({ workflow_runs: [{ head_sha: SHA, id: 1, conclusion: "success" }] }),
+			[{ headSha: SHA, conclusion: "success" }],
+		);
 		assert.throws(() => parseRuns({}), /workflow_runs must be an array/);
 		assert.throws(() => parseRuns({ workflow_runs: [{ id: 1 }] }), /head_sha must be a string/);
 	});
+});
+
+void test("cancelled validation is recoverable but failed validation is not retried blindly", () => {
+	assert.equal(needsDispatch(SHA, [{ headSha: SHA, conclusion: "cancelled" }]), true);
+	for (const conclusion of [null, "success", "failure"])
+		assert.equal(needsDispatch(SHA, [{ headSha: SHA, conclusion }]), false);
+});
+
+void test("a missing Version branch is distinct from a malformed API response", () => {
+	assert.equal(parseBranchHead([], "changeset-release/main"), undefined);
+	const ref = { ref: "refs/heads/changeset-release/main", object: { sha: SHA } };
+	assert.equal(parseBranchHead([ref], "changeset-release/main"), SHA);
+	assert.equal(parseBranchHead([ref], "changeset-release/ma"), undefined);
+	assert.throws(() => parseBranchHead({ message: "API unavailable" }, "main"), /matching refs/);
+	assert.throws(
+		() => parseBranchHead([{ ...ref, object: {} }], "changeset-release/main"),
+		/branch sha/,
+	);
 });

--- a/scripts/dispatch-version-pr-ci.test.ts
+++ b/scripts/dispatch-version-pr-ci.test.ts
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict";
-import { readFile } from "node:fs/promises";
+import { spawnSync } from "node:child_process";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { describe, test } from "node:test";
+import { fileURLToPath } from "node:url";
 
 import {
 	needsDispatch,
@@ -69,3 +73,41 @@ void test("a missing Version branch is distinct from a malformed API response", 
 		/branch sha/,
 	);
 });
+
+void test(
+	"the CLI preserves reserved characters in branch lookup URLs",
+	{ skip: process.platform === "win32" },
+	async (context) => {
+		const directory = await mkdtemp(path.join(tmpdir(), "version-pr-"));
+		context.after(() => rm(directory, { recursive: true, force: true }));
+		await mkdir(path.join(directory, ".changeset"));
+		await writeFile(
+			path.join(directory, ".changeset/config.json"),
+			'{"baseBranch":"release#2026%"}',
+		);
+		await writeFile(
+			path.join(directory, "gh"),
+			`#!/bin/sh
+[ "$1" = api ] || exit 1
+[ "$2" = 'repos/owner/repo/git/matching-refs/heads/changeset-release/release%232026%25' ] || exit 2
+printf '[]'
+`,
+			{ mode: 0o755 },
+		);
+		const result = spawnSync(
+			process.execPath,
+			[fileURLToPath(new URL("./dispatch-version-pr-ci.ts", import.meta.url))],
+			{
+				cwd: directory,
+				env: {
+					...process.env,
+					GITHUB_REPOSITORY: "owner/repo",
+					PATH: `${directory}${path.delimiter}${process.env.PATH ?? ""}`,
+				},
+				encoding: "utf8",
+			},
+		);
+		assert.equal(result.status, 0, result.stderr);
+		assert.match(result.stdout, /No changeset-release\/release#2026% branch/);
+	},
+);

--- a/scripts/dispatch-version-pr-ci.ts
+++ b/scripts/dispatch-version-pr-ci.ts
@@ -50,7 +50,12 @@ export function parseBranchHead(value: unknown, branch: string): string | undefi
 async function branchHead(repository: string, branch: string): Promise<string | undefined> {
 	// Missing branches return no matching refs; transport and authentication errors still fail.
 	return parseBranchHead(
-		JSON.parse(await gh(["api", `repos/${repository}/git/matching-refs/heads/${branch}`])),
+		JSON.parse(
+			await gh([
+				"api",
+				`repos/${repository}/git/matching-refs/heads/${branch.split("/").map(encodeURIComponent).join("/")}`,
+			]),
+		),
 		branch,
 	);
 }

--- a/scripts/dispatch-version-pr-ci.ts
+++ b/scripts/dispatch-version-pr-ci.ts
@@ -1,32 +1,9 @@
-/**
- * Runs CI/CD on the Version PR's branch.
- *
- * `changesets/action` pushes the Version PR with `GITHUB_TOKEN`, and a push made with that token
- * starts no workflow run. The conclusion drawn from that was that the Version PR cannot be checked
- * at all, so it merged through a standing ruleset bypass — leaving the one commit whose merge cuts a
- * release as the one commit no gate had looked at before it landed.
- *
- * The premise is wrong in one specific way. `workflow_dispatch` and `repository_dispatch` are the
- * two documented exceptions to the no-new-run rule, so the same `GITHUB_TOKEN` can start the same
- * CI/CD workflow on the same branch. The run reports its `All CI Passed` commit status onto the
- * branch head, which is the Version PR's head commit, so the Version PR can carry required checks
- * like any other and needs no bypass. No app, no personal access token, no long-lived credential.
- *
- * The rule is one line: every Version PR head commit gets a CI/CD run. Asking whether one already
- * exists, rather than tracking what changed, makes a missed dispatch self-healing on the next push
- * to `main` and makes a repeat push that changed nothing free.
- */
+// Version-PR trigger contract: docs/contributor/ci-cd.mdx.
 import { asArray, asRecord, asString, readJsonFile } from "./lib/json.ts";
 import { output } from "./lib/process.ts";
 
-/** The CI/CD workflow the Version PR must pass, by file name, as `gh workflow run` names it. */
 export const CI_WORKFLOW = "cicd.yml";
 
-/**
- * The branch `changesets/action` maintains the Version PR on. Changesets derives it from the
- * configured base branch, so this reads the same `.changeset/config.json` rather than restating the
- * name — a base-branch rename must not silently stop validating releases.
- */
 export function versionBranch(config: unknown): string {
 	const baseBranch = asString(asRecord(config, "changeset config").baseBranch, "baseBranch");
 	if (!baseBranch) throw new Error("changeset config declares no baseBranch");
@@ -35,18 +12,26 @@ export function versionBranch(config: unknown): string {
 
 export interface WorkflowRun {
 	readonly headSha: string;
+	readonly conclusion: string | null;
 }
 
-/** Every Version PR head commit gets a run; a head that already has one is already covered. */
+// Failed validation requires an explicit rerun; cancellation does not.
 export function needsDispatch(headSha: string, runs: readonly WorkflowRun[]): boolean {
-	return !runs.some((run) => run.headSha === headSha);
+	return !runs.some((run) => run.headSha === headSha && run.conclusion !== "cancelled");
 }
 
 export function parseRuns(value: unknown): WorkflowRun[] {
 	return asArray(asRecord(value, "workflow runs").workflow_runs, "workflow_runs").map(
-		(run, index) => ({
-			headSha: asString(asRecord(run, `run ${index}`).head_sha, `run ${index} head_sha`),
-		}),
+		(run, index) => {
+			const record = asRecord(run, `run ${index}`);
+			return {
+				headSha: asString(record.head_sha, `run ${index} head_sha`),
+				conclusion:
+					record.conclusion === null
+						? null
+						: asString(record.conclusion, `run ${index} conclusion`),
+			};
+		},
 	);
 }
 
@@ -54,20 +39,20 @@ async function gh(args: string[]): Promise<string> {
 	return output("gh", args);
 }
 
+export function parseBranchHead(value: unknown, branch: string): string | undefined {
+	const refs = asArray(value, "matching refs").map((ref) => asRecord(ref, "ref"));
+	const ref = refs.find(
+		(candidate) => asString(candidate.ref, "ref name") === `refs/heads/${branch}`,
+	);
+	return ref ? asString(asRecord(ref.object, "ref object").sha, "branch sha") : undefined;
+}
+
 async function branchHead(repository: string, branch: string): Promise<string | undefined> {
-	try {
-		return asString(
-			asRecord(
-				asRecord(JSON.parse(await gh(["api", `repos/${repository}/branches/${branch}`])), "branch")
-					.commit,
-				"branch commit",
-			).sha,
-			"branch commit sha",
-		);
-	} catch {
-		// No Version PR branch: there are no pending changesets, so there is nothing to validate.
-		return undefined;
-	}
+	// Missing branches return no matching refs; transport and authentication errors still fail.
+	return parseBranchHead(
+		JSON.parse(await gh(["api", `repos/${repository}/git/matching-refs/heads/${branch}`])),
+		branch,
+	);
 }
 
 if (import.meta.main) {
@@ -83,18 +68,12 @@ if (import.meta.main) {
 				await gh([
 					"api",
 					`repos/${repository}/actions/workflows/${CI_WORKFLOW}/runs?branch=${encodeURIComponent(branch)}&per_page=100`,
-					// Only the head SHA decides whether a run already exists. The unprojected listing
-					// carries the full repository object per run and passed a megabyte at 135 runs,
-					// which is a payload that grows with the branch's history for no gain.
 					"--jq",
-					"{workflow_runs: [.workflow_runs[] | {head_sha}]}",
+					"{workflow_runs: [.workflow_runs[] | {head_sha, conclusion}]}",
 				]),
 			),
 		);
 		if (needsDispatch(headSha, runs)) {
-			// `release-preflight` turns on the evidence gate's own checks — SBOM, licence,
-			// vulnerability policy on both platforms, index membership — against the images this run
-			// builds, so the Version PR proves what the release would otherwise discover first.
 			await gh(["workflow", "run", CI_WORKFLOW, "--ref", branch, "-f", "release-preflight=true"]);
 			process.stdout.write(`Dispatched CI/CD on ${branch} at ${headSha}.\n`);
 		} else {

--- a/scripts/renovate-config.test.ts
+++ b/scripts/renovate-config.test.ts
@@ -25,8 +25,8 @@ void test("Renovate creates bounded update PRs without a manual dispatch queue",
 	assert.ok(!extensions.includes(":dependencyDashboardApproval"));
 	assert.deepEqual(config.schedule, ["before 7am every weekday"]);
 	assert.equal(config.prHourlyLimit, 2);
-	assert.equal(config.prConcurrentLimit, 5);
-	assert.equal(config.branchConcurrentLimit, 10);
+	assert.equal(config.prConcurrentLimit, 2);
+	assert.equal(config.branchConcurrentLimit, 2);
 	assert.ok(Array.isArray(config.packageRules));
 	const rules = config.packageRules.filter(isRecord);
 	for (const [updateType, currentVersion] of [

--- a/scripts/report-ci-latency.test.ts
+++ b/scripts/report-ci-latency.test.ts
@@ -1,0 +1,102 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { isFullVerification, latencyBudget, selectLatencyRuns } from "./report-ci-latency.ts";
+
+void test("sampling excludes stale/future, retried, failed and release validation", () => {
+	const now = Date.parse("2026-01-30T00:00:00Z");
+	const run = {
+		event: "pull_request",
+		status: "completed",
+		conclusion: "success",
+		run_attempt: 1,
+		head_branch: "feature",
+		created_at: "2026-01-29T00:00:00Z",
+	};
+	const excluded = [
+		{ event: "merge_group" },
+		{ conclusion: "failure" },
+		{ conclusion: "cancelled" },
+		{ run_attempt: 2 },
+		{ head_branch: "changeset-release/main" },
+		{ status: "in_progress" },
+		{ created_at: "2025-12-31T00:00:00Z" },
+		{ created_at: "2026-01-31T00:00:00Z" },
+	];
+	assert.deepEqual(
+		selectLatencyRuns(
+			{ workflow_runs: [run, ...excluded.map((fields) => ({ ...run, ...fields }))] },
+			"changeset-release/main",
+			now,
+		),
+		[run],
+	);
+});
+
+void test("lightweight PRs cannot make full verification's latency budget pass", () => {
+	const names = [
+		"Test / App Server: Unit and architecture",
+		"Quality / Webapp",
+		"Quality / Webapp: Stories",
+		"Build / Webapp: E2E",
+		"Build / App Server: Database",
+		"Build / App Server: Generated artifacts",
+		"Test / App Server: Integration (providers)",
+		"Test / App Server: Integration (application)",
+	];
+	const jobs = names.map((name) => ({ name }));
+	assert.equal(isFullVerification(jobs), true);
+	for (const name of names)
+		assert.equal(isFullVerification(jobs.filter((job) => job.name !== name)), false, name);
+	assert.equal(isFullVerification([{ name: "Quality / Tooling and Docs" }]), false);
+});
+
+void test("the target constrains both the median and tail, and insufficient data is not success", () => {
+	assert.equal(latencyBudget([]).status, "insufficient-data");
+	assert.equal(latencyBudget([1]).status, "insufficient-data");
+	assert.equal(latencyBudget(Array.from({ length: 10 }, () => 360)).status, "within-budget");
+	assert.equal(latencyBudget(Array.from({ length: 10 }, () => 361)).status, "exceeded");
+	const tail = latencyBudget([1, 2, 3, 4, 5, 6, 7, 8, 1800, 1800]);
+	assert.equal(tail.p50Seconds, 5.5);
+	assert.equal(tail.p90Seconds, 1800);
+	assert.equal(tail.status, "exceeded");
+	assert.throws(() => latencyBudget([Number.NaN]), /finite/);
+});
+
+void test(
+	"the CLI saves insufficient-sample evidence before failing",
+	{ skip: process.platform === "win32" },
+	async (context) => {
+		const directory = await mkdtemp(path.join(tmpdir(), "ci-latency-"));
+		context.after(() => rm(directory, { recursive: true, force: true }));
+		await mkdir(path.join(directory, ".changeset"));
+		await writeFile(path.join(directory, ".changeset/config.json"), '{"baseBranch":"main"}');
+		await writeFile(
+			path.join(directory, "gh"),
+			`#!/bin/sh\nprintf '%s\\n' '{"workflow_runs":[]}'\n`,
+			{ mode: 0o755 },
+		);
+		const result = spawnSync(
+			process.execPath,
+			[fileURLToPath(new URL("./report-ci-latency.ts", import.meta.url))],
+			{
+				cwd: directory,
+				env: {
+					...process.env,
+					GITHUB_REPOSITORY: "owner/repo",
+					PATH: `${directory}${path.delimiter}${process.env.PATH ?? ""}`,
+				},
+				encoding: "utf8",
+			},
+		);
+		assert.equal(result.status, 1, result.stderr);
+		const evidence = await readFile(path.join(directory, "tmp/ci-metrics/ci-latency.json"), "utf8");
+		assert.match(evidence, /"status": "insufficient-data"/);
+		assert.match(evidence, /"runs": \[\]/);
+	},
+);

--- a/scripts/report-ci-latency.ts
+++ b/scripts/report-ci-latency.ts
@@ -1,0 +1,135 @@
+import { mkdir, writeFile } from "node:fs/promises";
+
+import { versionBranch } from "./dispatch-version-pr-ci.ts";
+import { asArray, asRecord, asString, parseJson, readJsonFile } from "./lib/json.ts";
+import { output } from "./lib/process.ts";
+import { summarizeCiTimings } from "./report-ci-timings.ts";
+
+const WINDOW_DAYS = 28;
+
+export function selectLatencyRuns(value: unknown, releaseBranch: string, now: number) {
+	return asArray(asRecord(value, "runs response").workflow_runs, "workflow_runs")
+		.map((run) => asRecord(run, "run"))
+		.filter((run) => {
+			const created = Date.parse(asString(run.created_at, "created_at"));
+			if (!Number.isFinite(created)) throw new Error("Invalid run creation timestamp");
+			return (
+				run.event === "pull_request" &&
+				run.status === "completed" &&
+				run.conclusion === "success" &&
+				run.run_attempt === 1 &&
+				run.head_branch !== releaseBranch &&
+				created <= now &&
+				created >= now - WINDOW_DAYS * 24 * 60 * 60 * 1000
+			);
+		})
+		.toSorted((a, b) =>
+			asString(b.created_at, "created_at").localeCompare(asString(a.created_at, "created_at")),
+		);
+}
+
+export function isFullVerification(jobs: readonly { name: string }[]) {
+	const names = new Set(jobs.map((job) => job.name));
+	return (
+		[
+			"Test / App Server: Unit and architecture",
+			"Quality / Webapp",
+			"Quality / Webapp: Stories",
+			"Build / Webapp: E2E",
+			"Build / App Server: Database",
+			"Build / App Server: Generated artifacts",
+		].every((name) => names.has(name)) &&
+		jobs.filter((job) => job.name.startsWith("Test / App Server: Integration (")).length === 2
+	);
+}
+
+export function latencyBudget(values: number[]) {
+	if (values.some((value) => !Number.isFinite(value) || value < 0))
+		throw new Error("Verdict durations must be finite and nonnegative");
+	const sorted = values.toSorted((a, b) => a - b);
+	const middle = Math.floor(sorted.length / 2);
+	const upper = sorted[middle] ?? 0;
+	const p50 =
+		sorted.length === 0
+			? null
+			: sorted.length % 2 === 0
+				? ((sorted[middle - 1] ?? 0) + upper) / 2
+				: upper;
+	const p90 = sorted[Math.ceil(sorted.length * 0.9) - 1] ?? null;
+	return {
+		count: values.length,
+		p50Seconds: p50,
+		p90Seconds: p90,
+		p50LimitSeconds: 360,
+		p90LimitSeconds: 420,
+		status:
+			values.length < 10
+				? "insufficient-data"
+				: p50 !== null && p90 !== null && p50 <= 360 && p90 <= 420
+					? "within-budget"
+					: "exceeded",
+	};
+}
+
+if (import.meta.main) {
+	const repository = process.env.GITHUB_REPOSITORY;
+	if (!repository || !/^[\w.-]+\/[\w.-]+$/.test(repository))
+		throw new Error("GITHUB_REPOSITORY must be owner/repository");
+	const releaseBranch = versionBranch(await readJsonFile(".changeset/config.json"));
+	const now = Date.now();
+	const since = new Date(now - WINDOW_DAYS * 24 * 60 * 60 * 1000).toISOString();
+	const listing = asRecord(
+		parseJson(
+			await output("gh", [
+				"api",
+				`repos/${repository}/actions/workflows/cicd.yml/runs?event=pull_request&status=completed&created=${encodeURIComponent(`>=${since}`)}&per_page=100`,
+			]),
+		),
+		"runs response",
+	);
+	const listedRuns = asArray(listing.workflow_runs, "workflow_runs").map((run) =>
+		asRecord(run, "run"),
+	);
+	const summaries = [];
+	let fullCount = 0;
+	for (const run of selectLatencyRuns(listing, releaseBranch, now)) {
+		const id = run.id;
+		if (typeof id !== "number" || !Number.isSafeInteger(id) || id < 1)
+			throw new Error("Invalid run ID");
+		const pages = asArray(
+			parseJson(
+				await output("gh", [
+					"api",
+					"--paginate",
+					"--slurp",
+					`repos/${repository}/actions/runs/${id}/attempts/1/jobs?per_page=100`,
+				]),
+			),
+			"job pages",
+		).map((page) => asRecord(page, "job page"));
+		const jobs = pages.flatMap((page) => asArray(page.jobs, "jobs"));
+		const summary = summarizeCiTimings(run, { total_count: pages[0]?.total_count, jobs });
+		const cohort = isFullVerification(summary.jobs) ? "full-verification" : "partial-verification";
+		summaries.push({ ...summary, cohort });
+		if (cohort === "full-verification" && ++fullCount === 10) break;
+	}
+	const budget = latencyBudget(
+		summaries.filter((run) => run.cohort === "full-verification").map((run) => run.verdictSeconds),
+	);
+	// Counts describe the bounded listing, not a repository-wide reliability rate.
+	const report = {
+		observedAt: new Date(now).toISOString(),
+		windowDays: WINDOW_DAYS,
+		listingLimit: 100,
+		listed: listedRuns.length,
+		failed: listedRuns.filter((run) => run.conclusion === "failure").length,
+		cancelled: listedRuns.filter((run) => run.conclusion === "cancelled").length,
+		budget,
+		runs: summaries,
+	};
+	await mkdir("tmp/ci-metrics", { recursive: true });
+	await writeFile("tmp/ci-metrics/ci-latency.json", `${JSON.stringify(report, null, 2)}\n`);
+	process.stdout.write(`${JSON.stringify(budget, null, 2)}\n`);
+	if (budget.status !== "within-budget")
+		throw new Error(`PR latency budget: ${budget.status}; see tmp/ci-metrics/ci-latency.json`);
+}

--- a/scripts/report-ci-timings.test.ts
+++ b/scripts/report-ci-timings.test.ts
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { summarizeCiTimings } from "./report-ci-timings.ts";
+
+const at = (seconds: number) => new Date(seconds * 1000).toISOString();
+const run = {
+	id: 1,
+	run_attempt: 1,
+	status: "completed",
+	created_at: at(0),
+	updated_at: at(999),
+	html_url: "https://github.com/example/project/actions/runs/1",
+	event: "pull_request",
+};
+const job = (name: string, created: number, start: number, end: number) => ({
+	name,
+	run_id: 1,
+	run_attempt: 1,
+	status: "completed",
+	conclusion: "success",
+	created_at: at(created),
+	started_at: at(start),
+	completed_at: at(end),
+	html_url: `${run.html_url}/job/1`,
+});
+const jobs = {
+	total_count: 3,
+	jobs: [job("Build", 10, 30, 90), job("Tests", 10, 20, 100), job("CI Status Gate", 100, 110, 115)],
+};
+
+void test("separates admission, job queue and execution without treating parallel work as wall time", () => {
+	const result = summarizeCiTimings(run, jobs);
+	assert.equal(result.verdictSeconds, 115); // updated_at is not the verdict.
+	assert.equal(result.beforeJobsCreatedSeconds, 10);
+	assert.equal(result.firstRunnerSeconds, 20);
+	assert.equal(result.jobStartDelaySeconds, 40);
+	assert.equal(result.runnerSeconds, 145);
+	assert.equal(result.jobs[0]?.name, "Tests");
+});
+
+void test("excludes skipped placeholders, including GitHub's reversed placeholder timestamps", () => {
+	const skipped = { ...job("Skipped", 0, 1, 0), conclusion: "skipped" };
+	assert.deepEqual(
+		summarizeCiTimings(run, { total_count: 4, jobs: [...jobs.jobs, skipped] }),
+		summarizeCiTimings(run, jobs),
+	);
+});
+
+void test("reports failures and retries explicitly rather than hiding them in successful first attempts", () => {
+	const failed = jobs.jobs.map((entry) => ({ ...entry, conclusion: "failure", run_attempt: 2 }));
+	const result = summarizeCiTimings({ ...run, run_attempt: 2 }, { total_count: 3, jobs: failed });
+	assert.equal(result.attempt, 2);
+	assert.equal(result.conclusion, "failure");
+});
+
+void test("rejects incomplete, mixed-attempt and malformed API responses", () => {
+	assert.throws(() => summarizeCiTimings({ ...run, status: "in_progress" }, jobs), /not completed/);
+	assert.throws(() => summarizeCiTimings(run, { ...jobs, total_count: 4 }), /Incomplete/);
+	assert.throws(() => summarizeCiTimings({ ...run, run_attempt: 2 }, jobs), /this run and attempt/);
+	assert.throws(() => summarizeCiTimings({ ...run, created_at: "bad" }, jobs), /Invalid timestamp/);
+	assert.throws(() => summarizeCiTimings(run, { total_count: 0, jobs: [] }), /No executed/);
+	assert.throws(
+		() =>
+			summarizeCiTimings(run, {
+				...jobs,
+				jobs: jobs.jobs.map((entry) =>
+					entry.name === "CI Status Gate" ? { ...entry, conclusion: "skipped" } : entry,
+				),
+			}),
+		/Gate is missing/,
+	);
+	assert.throws(() => summarizeCiTimings({ ...run, created_at: at(15) }, jobs), /out of order/);
+	assert.throws(
+		() => summarizeCiTimings(run, { total_count: 1, jobs: [jobs.jobs[0]] }),
+		/Gate is missing/,
+	);
+	assert.throws(
+		() =>
+			summarizeCiTimings(run, { ...jobs, jobs: [job("Build", 30, 20, 40), ...jobs.jobs.slice(1)] }),
+		/out of order/,
+	);
+});

--- a/scripts/report-ci-timings.ts
+++ b/scripts/report-ci-timings.ts
@@ -1,0 +1,70 @@
+import { asArray, asRecord, asString, readJsonFile } from "./lib/json.ts";
+
+function timestamp(value: unknown, label: string): number {
+	const parsed = Date.parse(asString(value, label));
+	if (!Number.isFinite(parsed)) throw new Error(`Invalid timestamp: ${label}`);
+	return parsed;
+}
+
+export function summarizeCiTimings(runValue: unknown, jobsValue: unknown) {
+	const run = asRecord(runValue, "run");
+	if (run.status !== "completed") throw new Error("Run is not completed");
+	for (const key of ["id", "run_attempt"]) {
+		if (!Number.isSafeInteger(run[key]) || typeof run[key] !== "number" || run[key] < 1)
+			throw new Error(`Invalid run ${key}`);
+	}
+	const response = asRecord(jobsValue, "jobs response");
+	const jobs = asArray(response.jobs, "jobs").map((value) => asRecord(value, "job"));
+	if (jobs.length !== response.total_count)
+		throw new Error("Incomplete jobs response; fetch every page");
+	for (const job of jobs) {
+		if (job.run_id !== run.id || job.run_attempt !== run.run_attempt)
+			throw new Error("Jobs must belong to this run and attempt");
+	}
+	const executed = jobs.filter((job) => job.conclusion !== "skipped");
+	if (executed.length === 0) throw new Error("No executed jobs");
+	const gate = jobs.find((job) => job.name === "CI Status Gate");
+	if (!gate || gate.status !== "completed" || gate.conclusion === "skipped")
+		throw new Error("Completed CI Status Gate is missing");
+	const created = timestamp(run.created_at, "run.created_at");
+	const gateEnd = timestamp(gate.completed_at, "gate.completed_at");
+	const timings = executed.map((job) => {
+		const queued = timestamp(job.created_at, "job.created_at");
+		const started = timestamp(job.started_at, "job.started_at");
+		const completed = timestamp(job.completed_at, "job.completed_at");
+		if (completed < started || started < queued || queued < created)
+			throw new Error("Job timestamps are out of order");
+		return {
+			name: asString(job.name, "job.name"),
+			url: asString(job.html_url, "job.html_url"),
+			creationToStartSeconds: (started - queued) / 1000,
+			executionSeconds: (completed - started) / 1000,
+			started,
+			queued,
+		};
+	});
+	return {
+		url: asString(run.html_url, "run.html_url"),
+		event: asString(run.event, "run.event"),
+		attempt: run.run_attempt,
+		conclusion: asString(gate.conclusion, "gate.conclusion"),
+		// Retries retain created_at: never mix them into first-attempt latency percentiles.
+		verdictSeconds: (gateEnd - created) / 1000,
+		beforeJobsCreatedSeconds: (Math.min(...timings.map((job) => job.queued)) - created) / 1000,
+		firstRunnerSeconds: (Math.min(...timings.map((job) => job.started)) - created) / 1000,
+		// Creation-to-start can include dependency waiting; it is not a pure runner-queue metric.
+		// Neither sum is an additive portion of verdict time: jobs overlap.
+		jobStartDelaySeconds: timings.reduce((sum, job) => sum + job.creationToStartSeconds, 0),
+		runnerSeconds: timings.reduce((sum, job) => sum + job.executionSeconds, 0),
+		jobs: timings
+			.toSorted((a, b) => b.executionSeconds - a.executionSeconds)
+			.map(({ started: _started, queued: _queued, ...job }) => job),
+	};
+}
+
+if (import.meta.main) {
+	const [runFile, jobsFile] = process.argv.slice(2);
+	if (!runFile || !jobsFile) throw new Error("Usage: report:ci-timings <run.json> <jobs.json>");
+	const [run, jobs] = await Promise.all([readJsonFile(runFile), readJsonFile(jobsFile)]);
+	process.stdout.write(`${JSON.stringify(summarizeCiTimings(run, jobs), null, 2)}\n`);
+}

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/StartupBudgetIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/StartupBudgetIntegrationTest.java
@@ -20,12 +20,15 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 
-/** Guards the application-controlled portion of Spring's startup path against slow bean initialization. */
 @SpringBootTest(useMainMethod = UseMainMethod.ALWAYS)
 @ActiveProfiles("test")
 @Import({TestSecurityConfig.class, TestAsyncConfiguration.class})
-@Tag("architecture")
+@Tag("integration")
 class StartupBudgetIntegrationTest {
+
+    // Isolate schema creation/drop from other contexts sharing the PostgreSQL container.
+    private static final PostgreSQLTestContainer.TestDatabase DATABASE =
+            PostgreSQLTestContainer.createDatabase("startup_budget");
 
     private static final String BEAN_INSTANTIATE = "spring.beans.instantiate";
 
@@ -36,10 +39,9 @@ class StartupBudgetIntegrationTest {
 
     @DynamicPropertySource
     static void datasource(DynamicPropertyRegistry registry) {
-        var postgres = PostgreSQLTestContainer.getInstance();
-        registry.add("spring.datasource.url", postgres::getJdbcUrl);
-        registry.add("spring.datasource.username", postgres::getUsername);
-        registry.add("spring.datasource.password", postgres::getPassword);
+        registry.add("spring.datasource.url", DATABASE::jdbcUrl);
+        registry.add("spring.datasource.username", DATABASE::username);
+        registry.add("spring.datasource.password", DATABASE::password);
     }
 
     @Autowired
@@ -57,9 +59,7 @@ class StartupBudgetIntegrationTest {
                 .toList();
 
         assertThat(beans.stream().map(StartupBudgetIntegrationTest::beanNameOf))
-                .as(
-                        "%s is exempt below, so it has to be a bean that is really built — a renamed one would widen the exemption to nothing in silence",
-                        JPA_WARM_UP_BEAN)
+                .as("startup events must contain the exempt bean %s", JPA_WARM_UP_BEAN)
                 .contains(JPA_WARM_UP_BEAN);
 
         var slowest = beans.stream()
@@ -69,8 +69,7 @@ class StartupBudgetIntegrationTest {
 
         assertThat(slowest.getDuration())
                 .as(
-                        "slowest bean instantiation %s (%s) exceeded the %s budget — that bean is doing egregious "
-                                + "synchronous work on the startup path; check its constructor/@PostConstruct.",
+                        "slowest bean instantiation %s (%s); budget %s",
                         slowest.getDuration(), beanNameOf(slowest), PER_BEAN_CEILING)
                 .isLessThan(PER_BEAN_CEILING);
     }

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/scm/github/project/GitHubProjectItemSyncServiceTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/scm/github/project/GitHubProjectItemSyncServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -14,6 +15,7 @@ import static org.mockito.Mockito.when;
 import de.tum.cit.aet.hephaestus.integration.core.framework.SyncSchedulerProperties;
 import de.tum.cit.aet.hephaestus.integration.scm.domain.common.ProcessingContext;
 import de.tum.cit.aet.hephaestus.integration.scm.domain.repository.Repository;
+import de.tum.cit.aet.hephaestus.integration.scm.github.common.ExponentialBackoff;
 import de.tum.cit.aet.hephaestus.integration.scm.github.common.GitHubExceptionClassifier;
 import de.tum.cit.aet.hephaestus.integration.scm.github.common.GitHubExceptionClassifier.Category;
 import de.tum.cit.aet.hephaestus.integration.scm.github.common.GitHubExceptionClassifier.ClassificationResult;
@@ -637,7 +639,7 @@ class GitHubProjectItemSyncServiceTest extends BaseUnitTest {
         }
 
         @Test
-        void shouldHandleExceptionDuringPaginationAndBreak() {
+        void shouldStopAfterThreeRetriesWithoutPersistingItems() {
             Repository repository = new Repository();
             when(graphQlClientProvider.forScope(SCOPE_ID)).thenReturn(graphQlClient);
             when(syncProperties.graphqlTimeout()).thenReturn(Duration.ofSeconds(10));
@@ -649,10 +651,18 @@ class GitHubProjectItemSyncServiceTest extends BaseUnitTest {
             when(exceptionClassifier.classifyWithDetails(any()))
                     .thenReturn(ClassificationResult.of(GitHubExceptionClassifier.Category.RETRYABLE, "Network error"));
 
-            int result = service.syncRemainingProjectItems(
-                    SCOPE_ID, "I_nodeId", false, repository, "cursor", PARENT_ISSUE_ID);
+            try (var backoff = mockStatic(ExponentialBackoff.class)) {
+                int result = service.syncRemainingProjectItems(
+                        SCOPE_ID, "I_nodeId", false, repository, "cursor", PARENT_ISSUE_ID);
 
-            assertThat(result).isZero();
+                assertThat(result).isZero();
+                verify(requestSpec, times(4)).execute();
+                verify(transactionTemplate, never()).execute(any());
+                backoff.verify(() -> ExponentialBackoff.sleep(1));
+                backoff.verify(() -> ExponentialBackoff.sleep(2));
+                backoff.verify(() -> ExponentialBackoff.sleep(3));
+                backoff.verifyNoMoreInteractions();
+            }
         }
 
         @Test

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -382,6 +382,8 @@ export default defineConfig({
 			"schema:gitlab": run("node scripts/update-gitlab-schema.ts"),
 			"schema:outline": run("node scripts/update-outline-spec.ts"),
 			"schema:nats": run("node scripts/nats-extract-examples.ts"),
+			"report:ci-latency": run("node scripts/report-ci-latency.ts"),
+			"report:ci-timings": run("node scripts/report-ci-timings.ts"),
 			"report:test-results": run("node scripts/summarize-test-results.ts"),
 			"release:version": run("changeset version && node scripts/sync-release-version.ts"),
 


### PR DESCRIPTION
## What changed and why

Full PR verification has a slow tail: a recent sample of ten successful first-attempt runs had a median of 8m 50.5s and a p90 of 27m 57s. This PR reduces avoidable work and makes that latency visible without dropping test, coverage, or security checks.

- Select CodeQL languages from PR and merge-group changes while preserving each language's configured analysis scope. Main and scheduled scans still analyze all languages.
- Move the Spring startup-budget test into the provider integration shard, with its own database, and test retry exhaustion without sleeping through backoff delays.
- Bound routine Renovate concurrency with its native limits; vulnerability updates retain their bypass.
- Add a scheduled full-verification latency observer with a six-minute median and seven-minute p90 budget. Lightweight PRs cannot satisfy the sample, and insufficient data fails with retained evidence.
- Store integration performance history in workflow artifacts, including completed profiles that exceed the budget. Recover cancelled Version-PR validation without hiding API errors or automatically retrying failed validation. Branch lookup URLs preserve reserved characters in legal branch names.

Related: #1590, #1591, #1908. These remain open: this PR does not establish that the six-minute target is met or resolve every CI-structure concern.

## How to test

- `vp run format` and `vp run check` passed on the final tree.
- `node --test scripts/ci-contract.test.ts scripts/ci-profile-history.test.ts scripts/report-ci-*.test.ts scripts/dispatch-version-pr-ci.test.ts scripts/renovate-config.test.ts` passed: 84 tests, no failures or skips.
- During implementation, the server unit/architecture suite passed 7,518 tests and the provider/startup integration shard passed 537 tests, with no failures or skips. The subsequent Java edits only changed comments and assertion diagnostics.
- Actionlint passed the changed workflows with ShellCheck disabled.
- The documented attempt-specific GitHub API commands were exercised against [a completed CI run](https://github.com/hephaestus-build/Hephaestus/actions/runs/34150896227), reproducing its 1,756-second verdict.
- With an authenticated GitHub CLI, run `GITHUB_REPOSITORY=hephaestus-build/Hephaestus vp run report:ci-latency`. Inspect `tmp/ci-metrics/ci-latency.json`; the existing sample exceeds the budget and correctly exits unsuccessfully.

## Release impact

No shipped application code, API, database schema, or UI changes. No changeset or operator action is required: the server changes are test-only, and the remaining changes affect CI, repository tooling, and contributor documentation.

## Notes for reviewers

Start with `.github/workflows/ci-tests.yml` and `codeql.yml` for execution changes, then `scripts/report-ci-latency.ts` for the measurement contract. The observer selects ten successful first-attempt full-verification PRs from at most 100 completed PR runs in the last 28 days; failed and cancelled counts describe that bounded listing, not overall reliability.

This is not evidence of a six-minute speedup. Existing runs show both substantial pre-execution delays and execution time above target. Post-merge measurements under normal load are needed before accepting the latency goal. The artifact-backed integration history starts a new baseline; its cross-run restoration needs verification in consecutive default-branch profile runs.

PR merge-ref and workflow-dispatch branch-head validation remain separate. The build-once artifact flow and test coverage requirements are unchanged.
