### PR TITLE
ci: make profiling reliable without instrumenting PR tests

### DIFF
--- a/.changeset/reliable-ci-profiling.md
+++ b/.changeset/reliable-ci-profiling.md
@@ -1,0 +1,4 @@
+---
+---
+
+CI-only: repair test-JVM profiling and retain diagnostic reports. No shipped application behavior or operator action changes.

--- a/.github/workflows/ci-profile.yml
+++ b/.github/workflows/ci-profile.yml
@@ -34,7 +34,7 @@ jobs:
           os: ${{ runner.os }}
 
       - name: Find performance history
-        if: github.ref_name == github.event.repository.default_branch
+        if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
         id: history
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
@@ -54,7 +54,7 @@ jobs:
                   run_id: run.id,
                   per_page: 100,
                 });
-                const history = artifacts.find((artifact) => artifact.name === 'ci-profile-history' && !artifact.expired);
+                const history = artifacts.find((artifact) => artifact.name === 'ci-profile-history-jfr' && !artifact.expired);
                 if (history) {
                   core.setOutput('run-id', run.id);
                   return;
@@ -67,32 +67,43 @@ jobs:
         if: steps.history.outputs.run-id != ''
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: ci-profile-history
+          name: ci-profile-history-jfr
           run-id: ${{ steps.history.outputs.run-id }}
           github-token: ${{ github.token }}
           path: ci-profile-history
 
       - name: Run integration suite with JFR
         id: profile
+        shell: bash
         run: |
-          mkdir -p ci-metrics
+          mkdir -p ci-metrics/maven
           /usr/bin/time -v -o ci-metrics/server-integration-resource.txt \
             vp run test:server:integration \
-            -DargLine=-XX:StartFlightRecording=filename=target/integration-profile.jfr,settings=profile,dumponexit=true \
+            '-Dhephaestus.test.jvmArgs=-XX:StartFlightRecording=filename=target/integration-profile.jfr,settings=profile,dumponexit=true -Xlog:jfr+startup=off' \
             -Dlogging.level.org.springframework.test.context.cache=DEBUG \
+            -Dprofile=server-integration -DprofileFormat=JSON \
+            -Dmaven-profiler-report-directory=../ci-metrics/maven \
             2>&1 | tee ci-metrics/server-integration.log
+
+      - name: Validate profile artifacts
+        id: recording
+        if: ${{ !cancelled() && steps.profile.outcome == 'success' }}
+        run: |
+          jq -e '.projects | length > 0' ci-metrics/maven/*.json > /dev/null
+          jfr summary server/application/target/integration-profile.jfr > ci-metrics/jfr-summary.txt
+          jfr print --events hephaestus.test.DatabaseCleanup \
+            server/application/target/integration-profile.jfr > ci-metrics/database-cleanup.jfr.txt
 
       - name: Summarize integration results
         id: summary
         if: always()
-        continue-on-error: true
         run: >-
           vp run report:test-results "Server Integration Profile"
           server/application/target/surefire-reports ci-metrics/server-integration-profile.json
           ci-metrics/server-integration.log ci-metrics/server-integration-resource.txt
 
       - name: Enforce performance budgets
-        if: success() && github.ref_name == github.event.repository.default_branch
+        if: success() && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
         run: |
           # Do not compare a rerun against its own previous attempt.
           rm -f "ci-profile-history/${{ github.run_id }}.json"
@@ -101,7 +112,7 @@ jobs:
       # Keep budget failures in history so sustained regressions remain detectable.
       - name: Record completed profile
         id: record
-        if: ${{ !cancelled() && steps.profile.outcome == 'success' && steps.summary.outcome == 'success' && github.ref_name == github.event.repository.default_branch }}
+        if: ${{ !cancelled() && steps.profile.outcome == 'success' && steps.recording.outcome == 'success' && steps.summary.outcome == 'success' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
         run: |
           mkdir -p ci-profile-history
           cp ci-metrics/server-integration-profile.json "ci-profile-history/${{ github.run_id }}.json"
@@ -110,25 +121,17 @@ jobs:
         if: ${{ !cancelled() && steps.record.outcome == 'success' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: ci-profile-history
+          name: ci-profile-history-jfr
           path: ci-profile-history
           if-no-files-found: error
           retention-days: 90
           overwrite: true
 
-      - name: Extract database cleanup timings
-        if: always()
-        continue-on-error: true
-        run: >-
-          jfr print --events hephaestus.test.DatabaseCleanup
-          server/application/target/integration-profile.jfr
-          > ci-metrics/database-cleanup.jfr.txt
-
       - name: Upload profile
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: server-integration-profile-${{ github.run_id }}
+          name: server-integration-profile-${{ github.run_id }}-${{ github.run_attempt }}
           path: |
             server/application/target/integration-profile.jfr
             server/application/target/surefire-reports
@@ -136,10 +139,13 @@ jobs:
             ci-metrics/server-integration.log
             ci-metrics/server-integration-resource.txt
             ci-metrics/database-cleanup.jfr.txt
+            ci-metrics/jfr-summary.txt
+            ci-metrics/maven
           if-no-files-found: warn
           retention-days: 14
 
   pr-latency:
+    if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
     name: Pull-request latency budget
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -47,6 +47,14 @@ jobs:
           path: "server/application/target/surefire-reports/TEST-*.xml"
           reporter: java-junit
           fail-on-error: false
+      - name: Retain raw test reports
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: server-verification-reports-${{ github.run_attempt }}
+          path: server/application/target/surefire-reports
+          retention-days: 14
+          if-no-files-found: warn
 
   server-integration:
     name: "App Server: Integration (${{ matrix.shard }})"
@@ -88,3 +96,11 @@ jobs:
           path: "server/application/target/surefire-reports/TEST-*.xml"
           reporter: java-junit
           fail-on-error: false
+      - name: Retain raw test reports
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: server-integration-${{ matrix.shard }}-reports-${{ github.run_attempt }}
+          path: server/application/target/surefire-reports
+          retention-days: 14
+          if-no-files-found: warn

--- a/docs/contributor/ci-cd.mdx
+++ b/docs/contributor/ci-cd.mdx
@@ -526,7 +526,7 @@ as `Test Results - …` check runs.
 ### Pull-request latency
 
 The full-verification target is a six-minute median and a seven-minute p90, measured from workflow
-creation to completion of **CI Status Gate**. `CI profile` samples the ten most recent successful,
+creation to completion of **CI Status Gate**. On the default branch, `CI profile` samples the ten most recent successful,
 first-attempt PR runs with full server and browser verification from the latest 100 completed PR
 runs created in the last 28 days. Lightweight changes and Version-PR runs cannot satisfy this
 cohort. Failed and cancelled counts describe the bounded listing, not a repository-wide failure
@@ -559,15 +559,28 @@ or mixed attempts. Keep raw API evidence under `tmp/`, not in committed performa
 
 ### Server profiles
 
-`CI profile` records JFR, resource usage, JUnit results and Spring context-cache metrics. It signals
+Normal PR test jobs retain Surefire reports for 14 days, separately for each suite, shard and
+attempt. Use those reports and GitHub's step timings before rerunning tests with instrumentation.
+Deep profiling stays in the manual/weekly workflow, not on the PR critical path.
+
+`CI profile` records JFR, Maven phase timings, resource usage, JUnit results and Spring context-cache
+metrics. It signals
 a sustained regression after three consecutive profiles exceed variance limits against five earlier
-default-branch profiles or absolute Spring-context limits. Only successful test runs with valid
-summaries enter history, including runs whose performance budget fails. History is restored from this repository's default-branch
-workflow artifacts, retained for 90 days; a rerun replaces its own sample. Without seven earlier
+default-branch profiles or absolute Spring-context limits. Only successful test runs with a readable
+JFR recording and valid summaries enter history, including runs whose performance budget fails.
+History is restored from this repository's default-branch JFR history artifacts, retained for
+90 days; a rerun replaces its own sample. Uninstrumented runs are not baseline candidates. Without seven earlier
 profiles, the sustained-regression check has no verdict. Branch dispatches produce diagnostic
 artifacts without changing or enforcing the baseline.
 
-The workflow's `Run integration suite with JFR` step owns the invocation;
+The workflow's `Run integration suite with JFR` step owns the invocation. Additional test-JVM flags
+use `-Dhephaestus.test.jvmArgs=...`; Surefire and Failsafe compose these with JaCoCo's late-bound
+arguments and the configured memory limits. Missing recordings, Maven reports, resource metrics
+or Spring-context measurements fail the profile rather than becoming zero-valued baselines.
+For local shard profiling, use the same `HEPHAESTUS_INTEGRATION_TESTS` selector as the CI matrix
+and the Java version pinned in `.java-version`. Compare the same suite, runtime and cache state;
+the weekly whole-tier baseline is not comparable to one shard.
+
 `SpringTestContextArchitectureTest` enforces the reviewed Spring context keys. The weekly
 **Server Phase Reference** workflow records cache-disabled Maven generation, compilation,
 test-compilation and execution profiles and compares two clean generated-client JARs.

--- a/scripts/check-ci-performance.test.ts
+++ b/scripts/check-ci-performance.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
-import { regressions } from "./check-ci-performance.ts";
+import { parseSummary, regressions } from "./check-ci-performance.ts";
 import type { TestSummary } from "./summarize-test-results.ts";
 
 const summary = (startup: number, wall = 200): TestSummary => ({
@@ -41,4 +41,45 @@ await test("signals only three consecutive misses against five prior profiles", 
 		"context startup exceeded 120s in three consecutive profiles",
 		"wall time exceeded variance limit 240.0 three times",
 	]);
+});
+
+await test("rejects incomplete, failed, and nonfinite profiles before comparison", () => {
+	for (const invalid of [
+		{ ...summary(100), files: 0 },
+		{ ...summary(100), tests: 0 },
+		{ ...summary(100), skipped: 1 },
+		{ ...summary(100), failures: 1 },
+		{ ...summary(100), errors: 1 },
+		{ ...summary(100), testTimeSeconds: -1 },
+		{ ...summary(100), testTimeSeconds: Infinity },
+		{ ...summary(100), tests: 1.5 },
+		summary(100, 0),
+	]) {
+		assert.throws(() => regressions(invalid, []));
+		assert.throws(() => regressions(summary(100), [invalid]));
+	}
+});
+
+await test("validates numeric fields in persisted profiles", () => {
+	assert.deepEqual(parseSummary(JSON.stringify(summary(100))), summary(100));
+	assert.throws(
+		() =>
+			parseSummary(
+				JSON.stringify(summary(100)).replace('"wallTimeSeconds":200', '"wallTimeSeconds":1e999'),
+			),
+		/Invalid CI metrics field/,
+	);
+	assert.throws(
+		() => parseSummary(JSON.stringify({ ...summary(100), testTimeSeconds: -1 })),
+		/Invalid CI metrics field/,
+	);
+});
+
+await test("missing Spring logs cannot appear as a faster profile", () => {
+	for (const key of ["contextStarts", "contextCacheMisses"] as const) {
+		const current = summary(100);
+		assert.ok(current.performance);
+		current.performance[key] = 0;
+		assert.throws(() => regressions(current, []), /no Spring context measurements/);
+	}
 });

--- a/scripts/check-ci-performance.ts
+++ b/scripts/check-ci-performance.ts
@@ -2,7 +2,8 @@ import { appendFile, readdir, readFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 
-import type { TestSummary } from "./summarize-test-results.ts";
+import { isRecord } from "./lib/json.ts";
+import { type TestSummary, validateProfile } from "./summarize-test-results.ts";
 
 type Metric = {
 	name: string;
@@ -86,8 +87,9 @@ function historyMarkdown(summaries: TestSummary[]): string {
 }
 
 export function regressions(current: TestSummary, history: TestSummary[]): string[] {
+	validateProfile(current);
+	for (const previous of history) validateProfile(previous);
 	const failures: string[] = [];
-	if (current.performance === undefined) return ["performance metrics are missing"];
 	const usable = history.filter((summary) => summary.performance !== undefined).slice(-7);
 	if (usable.length < 7) return failures;
 	const baselineRuns = usable.slice(0, 5);
@@ -107,13 +109,12 @@ export function regressions(current: TestSummary, history: TestSummary[]): strin
 	return failures;
 }
 
-function parseSummary(json: string): TestSummary {
+export function parseSummary(json: string): TestSummary {
 	const value: unknown = JSON.parse(json);
-	const isRecord = (candidate: unknown): candidate is Record<string, unknown> =>
-		typeof candidate === "object" && candidate !== null && !Array.isArray(candidate);
 	const number = (record: Record<string, unknown>, key: string): number => {
 		const candidate = record[key];
-		if (typeof candidate !== "number") throw new Error(`Invalid CI metrics field: ${key}`);
+		if (typeof candidate !== "number" || !Number.isFinite(candidate) || candidate < 0)
+			throw new Error(`Invalid CI metrics field: ${key}`);
 		return candidate;
 	};
 	if (
@@ -124,7 +125,7 @@ function parseSummary(json: string): TestSummary {
 	) {
 		throw new Error("Invalid CI metrics summary");
 	}
-	return {
+	const summary: TestSummary = {
 		schemaVersion: 2,
 		name: value.name,
 		files: number(value, "files"),
@@ -143,6 +144,8 @@ function parseSummary(json: string): TestSummary {
 			contextCacheMisses: number(value.performance, "contextCacheMisses"),
 		},
 	};
+	validateProfile(summary);
+	return summary;
 }
 
 async function main(): Promise<void> {

--- a/scripts/ci-profile-history.test.ts
+++ b/scripts/ci-profile-history.test.ts
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { readFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { test } from "node:test";
 
 import { isMap, isSeq, parseDocument } from "yaml";
@@ -39,7 +41,7 @@ const run = (id: number, headBranch = "main", repository = "owner/repo") => ({
 	head_branch: headBranch,
 	head_repository: { full_name: repository },
 });
-const history = { name: "ci-profile-history", expired: false };
+const history = { name: "ci-profile-history-jfr", expired: false };
 
 void test("history skips this rerun, foreign sources and incomplete profiles across pages", () => {
 	assert.equal(
@@ -61,3 +63,41 @@ void test("a budget-failed run's completed profile remains usable", () => {
 void test("expired history cannot become a baseline", () => {
 	assert.equal(selectHistory([[run(9)]], { 9: [{ ...history, expired: true }] }), "");
 });
+
+void test("uninstrumented history cannot become the JFR baseline", () => {
+	assert.equal(
+		selectHistory([[run(9)]], { 9: [{ name: "ci-profile-history", expired: false }] }),
+		"",
+	);
+});
+
+void test(
+	"the profiling pipeline preserves Maven failures through tee",
+	{ skip: process.platform !== "linux" },
+	async (context) => {
+		const profile = steps.items.find((item) => isMap(item) && item.get("id") === "profile");
+		assert.ok(isMap(profile));
+		assert.equal(profile.get("shell"), "bash");
+		const command = profile.get("run");
+		assert.equal(typeof command, "string");
+		const directory = await mkdtemp(path.join(tmpdir(), "profile-pipeline-"));
+		context.after(() => rm(directory, { recursive: true, force: true }));
+		await writeFile(path.join(directory, "vp"), "#!/bin/sh\necho 'Maven failed' >&2\nexit 17\n", {
+			mode: 0o755,
+		});
+		const result = spawnSync(
+			"bash",
+			["--noprofile", "--norc", "-eo", "pipefail", "-c", String(command)],
+			{
+				cwd: directory,
+				env: { ...process.env, PATH: `${directory}${path.delimiter}${process.env.PATH ?? ""}` },
+				encoding: "utf8",
+			},
+		);
+		assert.equal(result.status, 17, result.stderr);
+		assert.match(
+			await readFile(path.join(directory, "ci-metrics/server-integration.log"), "utf8"),
+			/Maven failed/,
+		);
+	},
+);

--- a/scripts/summarize-test-results.test.ts
+++ b/scripts/summarize-test-results.test.ts
@@ -1,5 +1,10 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { test } from "node:test";
+import { fileURLToPath } from "node:url";
 
 import { markdown, parseJUnit, parsePerformance, summarize } from "./summarize-test-results.ts";
 
@@ -37,6 +42,40 @@ await test("parses outcomes and XML entities from JUnit test cases", () => {
 			skipped: true,
 		},
 	]);
+});
+
+await test("rejects invalid individual timings before they can disappear in a sum", () => {
+	for (const time of [
+		'time="-10"',
+		'time="NaN"',
+		'time="Infinity"',
+		'time="1e999"',
+		'time=""',
+		"",
+	]) {
+		assert.throws(
+			() =>
+				summarize("Server", [
+					`<testsuite><testcase name="invalid" ${time}/><testcase name="valid" time="20"/></testsuite>`,
+				]),
+			/Invalid JUnit testcase time/,
+		);
+	}
+});
+
+await test("allows missing timing only for skipped tests", () => {
+	assert.equal(
+		parseJUnit('<testsuite><testcase name="disabled"><skipped/></testcase></testsuite>')[0]
+			?.timeSeconds,
+		0,
+	);
+	assert.throws(
+		() =>
+			parseJUnit(
+				'<testsuite><testcase name="disabled" time="NaN"><skipped/></testcase></testsuite>',
+			),
+		/Invalid JUnit testcase time/,
+	);
 });
 
 await test("summarizes reports and ranks the slowest tests", () => {
@@ -94,4 +133,51 @@ Maximum resident set size (kbytes): 524288`,
 		contextStartupSeconds: 10,
 		contextCacheMisses: 2,
 	});
+});
+
+await test("does not turn missing resource measurements into zeroes", () => {
+	const resources = [
+		"User time (seconds): 12.5",
+		"System time (seconds): 2.5",
+		"Elapsed (wall clock) time (h:mm:ss or m:ss): 1:03.50",
+		"Maximum resident set size (kbytes): 524288",
+	];
+	for (let missing = 0; missing < resources.length; missing++) {
+		assert.throws(
+			() => parsePerformance("", resources.filter((_, index) => index !== missing).join("\n")),
+			/Missing or invalid/,
+		);
+	}
+	assert.throws(
+		() => parsePerformance("", resources.join("\n").replace("12.5", "-12.5")),
+		/Missing or invalid/,
+	);
+});
+
+await test("profile CLI preserves diagnostics and fails when no tests were reported", async (context) => {
+	const directory = await mkdtemp(join(tmpdir(), "profile-summary-"));
+	context.after(() => rm(directory, { recursive: true, force: true }));
+	const reports = join(directory, "reports");
+	await mkdir(reports);
+	const log = join(directory, "run.log");
+	const resources = join(directory, "resources.txt");
+	const output = join(directory, "summary.json");
+	await writeFile(log, "");
+	await writeFile(
+		resources,
+		"User time (seconds): 1\nSystem time (seconds): 1\nElapsed (wall clock) time (h:mm:ss or m:ss): 0:02\nMaximum resident set size (kbytes): 100",
+	);
+	const script = fileURLToPath(new URL("./summarize-test-results.ts", import.meta.url));
+	const result = spawnSync(process.execPath, [script, "profile", reports, output, log, resources], {
+		encoding: "utf8",
+		env: { ...process.env, GITHUB_STEP_SUMMARY: join(directory, "step-summary.md") },
+	});
+	assert.equal(result.status, 1);
+	assert.match(result.stderr, /Profile contains no executed tests/);
+	assert.match(await readFile(output, "utf8"), /"tests": 0/);
+	const ordinary = spawnSync(process.execPath, [script, "report", reports, output], {
+		encoding: "utf8",
+		env: { ...process.env, GITHUB_STEP_SUMMARY: join(directory, "step-summary.md") },
+	});
+	assert.equal(ordinary.status, 0);
 });

--- a/scripts/summarize-test-results.ts
+++ b/scripts/summarize-test-results.ts
@@ -61,15 +61,20 @@ function testCases(node: unknown): JUnitNode[] {
 }
 
 export function parseJUnit(xml: string): TestCase[] {
-	return testCases(xmlParser.parse(xml)).map((testCase) => ({
-		className: typeof testCase.classname === "string" ? testCase.classname : "unknown class",
-		name: typeof testCase.name === "string" ? testCase.name : "unnamed test",
-		timeSeconds:
-			typeof testCase.time === "number" && Number.isFinite(testCase.time) ? testCase.time : 0,
-		failed: "failure" in testCase,
-		errored: "error" in testCase,
-		skipped: "skipped" in testCase,
-	}));
+	return testCases(xmlParser.parse(xml)).map((testCase) => {
+		const skipped = "skipped" in testCase;
+		const time = testCase.time === undefined && skipped ? 0 : testCase.time;
+		if (typeof time !== "number" || !Number.isFinite(time) || time < 0)
+			throw new Error(`Invalid JUnit testcase time: ${String(testCase.time)}`);
+		return {
+			className: typeof testCase.classname === "string" ? testCase.classname : "unknown class",
+			name: typeof testCase.name === "string" ? testCase.name : "unnamed test",
+			timeSeconds: time,
+			failed: "failure" in testCase,
+			errored: "error" in testCase,
+			skipped,
+		};
+	});
 }
 
 export function summarize(name: string, documents: string[]): TestSummary {
@@ -108,21 +113,46 @@ export function parsePerformance(
 	const elapsed = resourceUsage.match(
 		/Elapsed \(wall clock\) time .*: (?:(\d+):)?(\d+):(\d+(?:\.\d+)?)/,
 	);
+	if (elapsed === null) throw new Error("Missing or invalid elapsed resource time");
 	const value = (label: string): number => {
 		const match = resourceUsage.match(new RegExp(`${label}: (\\d+(?:\\.\\d+)?)`));
-		return match === null ? 0 : Number(match[1]);
+		if (match === null) throw new Error(`Missing or invalid resource metric: ${label}`);
+		const result = Number(match[1]);
+		if (!Number.isFinite(result)) throw new Error(`Invalid resource metric: ${label}`);
+		return result;
 	};
 	return {
-		wallTimeSeconds:
-			elapsed === null
-				? 0
-				: Number(elapsed[1] ?? 0) * 3600 + Number(elapsed[2]) * 60 + Number(elapsed[3]),
+		wallTimeSeconds: Number(elapsed[1] ?? 0) * 3600 + Number(elapsed[2]) * 60 + Number(elapsed[3]),
 		cpuTimeSeconds: value("User time \\(seconds\\)") + value("System time \\(seconds\\)"),
 		maxRssKilobytes: value("Maximum resident set size \\(kbytes\\)"),
 		contextStarts: starts.length,
 		contextStartupSeconds: starts.reduce((total, seconds) => total + seconds, 0),
 		contextCacheMisses: [...cacheMisses.values()].reduce((total, misses) => total + misses, 0),
 	};
+}
+
+export function validateProfile(summary: TestSummary): void {
+	const counts = [summary.files, summary.tests, summary.failures, summary.errors, summary.skipped];
+	if (counts.some((value) => !Number.isSafeInteger(value) || value < 0))
+		throw new Error("Invalid profile test counts");
+	if (summary.files === 0 || summary.tests <= summary.skipped)
+		throw new Error("Profile contains no executed tests");
+	if (summary.failures !== 0 || summary.errors !== 0)
+		throw new Error("Failed tests cannot enter performance history");
+	const performance = summary.performance;
+	if (performance === undefined) throw new Error("Performance metrics are missing");
+	if (
+		[summary.testTimeSeconds, ...Object.values(performance)].some(
+			(value) => !Number.isFinite(value) || value < 0,
+		)
+	)
+		throw new Error("Profile metrics must be finite and nonnegative");
+	if (performance.wallTimeSeconds === 0 || performance.maxRssKilobytes === 0)
+		throw new Error("Profile wall time and resident memory must be positive");
+	if (performance.contextStarts === 0 || performance.contextCacheMisses === 0)
+		throw new Error("Profile contains no Spring context measurements");
+	if (![performance.contextStarts, performance.contextCacheMisses].every(Number.isSafeInteger))
+		throw new Error("Invalid profile context counts");
 }
 
 export function markdown(summary: TestSummary): string {
@@ -167,6 +197,8 @@ async function main(): Promise<void> {
 	const files = await xmlFiles(resolve(input));
 	const documents = await Promise.all(files.map((file) => readFile(file, "utf8")));
 	const summary = summarize(name, documents);
+	if ((logPath === undefined) !== (resourcePath === undefined))
+		throw new Error("Profiling requires both log and resource usage files");
 	if (logPath !== undefined && resourcePath !== undefined) {
 		summary.performance = parsePerformance(
 			await readFile(logPath, "utf8"),
@@ -180,6 +212,7 @@ async function main(): Promise<void> {
 		await appendFile(process.env.GITHUB_STEP_SUMMARY, rendered);
 	}
 	process.stdout.write(rendered);
+	if (summary.performance !== undefined) validateProfile(summary);
 	if (files.length === 0) {
 		process.stderr.write(`No JUnit XML reports found below ${input}\n`);
 	}

--- a/server/application/pom.xml
+++ b/server/application/pom.xml
@@ -33,6 +33,7 @@
         <!-- Surefire expands @{argLine}. JaCoCo's prepare-agent sets it in the lifecycle; the empty
              default lets a bare surefire:test goal run without that phase. -->
         <argLine />
+        <hephaestus.test.jvmArgs />
         <surefire.excludedGroups>live</surefire.excludedGroups>
         <surefire.includedGroups>unit</surefire.includedGroups>
         <failsafe.excludedGroups>live</failsafe.excludedGroups>
@@ -586,7 +587,7 @@
                          Modulith's full class graph (1000+ classes) in the same fork as the
                          regular unit tests. 2GB OOMs on CI under that load. The dedicated
                          `architecture-tests` profile uses the same 4GB ceiling. -->
-                    <argLine>@{argLine} -Xmx${hephaestus.surefire.maxHeap} -Dspring.profiles.active=test -Dfile.encoding=UTF-8
+                    <argLine>@{argLine} ${hephaestus.test.jvmArgs} -Xmx${hephaestus.surefire.maxHeap} -Dspring.profiles.active=test -Dfile.encoding=UTF-8
                         -XX:+EnableDynamicAgentLoading -XX:+ExitOnOutOfMemoryError
                     </argLine>
                     <printSummary>true</printSummary>
@@ -613,7 +614,7 @@
 <!-- EnableDynamicAgentLoading mirrors surefire: without it Byte Buddy cannot
                          self-attach on JDK 21+ and every Mockito-using integration test fails to
                          initialize. -->
-                    <argLine>@{argLine} -Xmx4096m -Dspring.profiles.active=test -Dfile.encoding=UTF-8
+                    <argLine>@{argLine} ${hephaestus.test.jvmArgs} -Xmx4096m -Dspring.profiles.active=test -Dfile.encoding=UTF-8
                         -XX:+EnableDynamicAgentLoading
                     </argLine>
                     <groups>${failsafe.includedGroups}</groups>


### PR DESCRIPTION
## What changed and why

The existing profiling workflow could finish green without producing a Java Flight Recorder recording. That left us with incomplete evidence for slow integration tests. This follow-up to #1982 repairs collection and makes invalid measurements fail visibly, without adding deep profiling to ordinary PR test jobs.

- Pass diagnostic JVM flags separately from JaCoCo's late-bound arguments, retaining the existing memory limits. Suppress JFR's startup banner so it cannot interfere with Surefire's stdout protocol.
- Capture JFR and Maven phase timings in the same diagnostic run. Require readable artifacts, preserve Maven failures through `tee`, and make profile artifact names unique per attempt.
- Reject missing measurements, empty or failed test profiles, and invalid individual test durations before they can become performance baselines. Keep JFR history separate from older uninstrumented runs.
- Retain ordinary PRs' already-generated Surefire reports for 14 days, separately by suite, shard and attempt. No extra test execution or JFR is added to those jobs.
- Run the repository-wide historical latency budget only on the default branch. Feature-branch dispatches remain diagnostics; they do not pass or fail based on unrelated PR history. Scheduled/default-branch enforcement is unchanged.

Related: #1590. This PR improves the evidence needed to optimize CI; it does not establish that the six-minute target has been achieved.

## How to test

- `vp run format` and `vp run check` passed locally.
- [Hosted profiling passed](https://github.com/hephaestus-build/Hephaestus/actions/runs/34161603970): 1,532 integration tests, zero failures or skips. Downloaded and verified the JFR recording, Maven phase report and metrics artifact.
- `node --test scripts/ci-profile-history.test.ts scripts/summarize-test-results.test.ts scripts/check-ci-performance.test.ts scripts/ci-contract.test.ts` exercises collection, failure propagation, history selection and malformed measurements.
- Two local Java 21 runs of the application integration shard each passed 995 tests with no failures or skips: 180.53s without profiling and 180.77s with JFR, Maven profiling and Spring context-cache logging. This single sequential comparison showed no material slowdown; it is not a statistical overhead estimate or a GitHub-runner benchmark.
- A focused 26-test run verified JFR and JaCoCo together. The recording was readable and the final configuration produced no Surefire protocol warning.
- Manually dispatch **CI profile** on this branch. Check that its artifact contains the JFR recording, Maven JSON, JFR summary, resource measurements, JUnit reports and summary. Rerunning must produce an attempt-specific artifact rather than collide with the first attempt.
- On [the PR CI run](https://github.com/hephaestus-build/Hephaestus/actions/runs/34162588273), both integration shards published their raw reports; the upload steps took 1s and 2s. This measures upload-step duration, not the total impact on runner contention.

## Release impact

No shipped application behavior, API or schema change, and no operator action. The [empty changeset](https://github.com/hephaestus-build/Hephaestus/blob/ci/reliable-profiling/.changeset/reliable-ci-profiling.md) records that the Maven configuration change is test/CI-only.

## Notes for reviewers

Start with `.github/workflows/ci-profile.yml` and `server/application/pom.xml`, then the summary validation and its counterexamples. Diagnostic evidence stays out of the repository; contributor documentation owns the collection and reproduction instructions.

The implementation uses [Surefire's documented argument composition](https://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#argLine), the [existing Maven profiler](https://github.com/jcgay/maven-profiler), [GitHub's explicit Bash/pipefail behavior](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idstepsshell), and [immutable, uniquely named workflow artifacts](https://github.com/actions/upload-artifact#not-uploading-to-the-same-artifact).

JFR history starts a fresh baseline; cross-run restoration still needs consecutive default-branch profile runs. The full-tier weekly baseline must not be compared directly with one integration shard. The Liquibase squash in #1283 is deliberately separate: Liquibase is disabled in the measured application shard, and a production migration baseline requires its own equivalence and rollout work.
