### PR TITLE
fix(ci): update actions and fail closed on unreadable secret scan ranges

### DIFF
--- a/.github/actions/setup-toolchain/action.yml
+++ b/.github/actions/setup-toolchain/action.yml
@@ -97,7 +97,7 @@ runs:
         cache: ${{ inputs.install == 'frozen' && 'pnpm' || '' }}
         cache-dependency-path: pnpm-lock.yaml
     - if: inputs.install == 'frozen'
-      uses: voidzero-dev/setup-vp@1b32467adbe183473499fd9d5d372c3ed9641754 # v1.18.0
+      uses: voidzero-dev/setup-vp@49c3e4e92c52e7f8392712a9267bbe71c5ab30e5 # v1.19.0
       with:
         node-manager: false
         cache: false

--- a/.github/workflows/cd-docs.yml
+++ b/.github/workflows/cd-docs.yml
@@ -167,4 +167,4 @@ jobs:
         with:
           path: docs-build
       - id: deployment
-        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
+        uses: actions/deploy-pages@368f82528645a54fb793d4d04e342629a3f51346 # v5.0.1

--- a/.github/workflows/ci-quality-gates.yml
+++ b/.github/workflows/ci-quality-gates.yml
@@ -215,7 +215,7 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: package.json
-      - uses: voidzero-dev/setup-vp@1b32467adbe183473499fd9d5d372c3ed9641754 # v1.18.0
+      - uses: voidzero-dev/setup-vp@49c3e4e92c52e7f8392712a9267bbe71c5ab30e5 # v1.19.0
         with:
           node-manager: false
           cache: false
@@ -267,7 +267,7 @@ jobs:
         if: >-
           success() &&
           (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
-        uses: chromaui/action@4cc98810d00b34b8f9e89d454d64a8ac3d088340 # v18.7.1
+        uses: chromaui/action@2a0b63f30233c48591844a46d451b9cf68128186 # v18.7.2
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           workingDir: webapp

--- a/.github/workflows/ci-security-scan.yml
+++ b/.github/workflows/ci-security-scan.yml
@@ -131,12 +131,12 @@ jobs:
       - name: Secret detection
         id: secrets
         continue-on-error: true
-        uses: trufflesecurity/trufflehog@20652fbbdefffcdaa493a5bf57ab2ac6b1db715b # v3.97.1
+        uses: trufflesecurity/trufflehog@363923b901c911a9164f50b6c423f47c15372b1c # v3.97.4
         with:
           path: ./
-          base: ${{ github.event_name == 'pull_request' && github.base_ref || '' }}
-          head: ${{ github.event_name == 'pull_request' && 'HEAD' || '' }}
-          extra_args: --debug --only-verified
+          base: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before || '' }}
+          head: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.sha }}
+          extra_args: --debug --only-verified --fail-on-scan-errors
 
       # RFC 9116 requires a valid Expires date. Fail before it lapses so an
       # active branch is forced to renew it — a stale file signals abandonment.

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -346,7 +346,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: reviewdog/action-actionlint@dbe5299849118fd6f099ba563d263d770955a64a # v1.73.2
+      - uses: reviewdog/action-actionlint@d290e336d5a743810aef4404f757dc862276d2ae # v1.73.4
         env:
           SHELLCHECK_OPTS: --severity=warning
         with:
@@ -371,7 +371,7 @@ jobs:
         with:
           persist-credentials: false
       - id: zizmor
-        uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2
+        uses: zizmorcore/zizmor-action@70fb788f84895a7701f5643d103d587e460b5c99 # v0.6.3
         with:
           min-confidence: medium
           # renovate: datasource=github-releases depName=zizmorcore/zizmor

--- a/scripts/ci-contract.test.ts
+++ b/scripts/ci-contract.test.ts
@@ -1626,6 +1626,16 @@ void describe("CI contract", () => {
 		);
 
 		const scanPath = ["jobs", "security-scan"];
+		const secretScan = stepInputs(namedStep(workflow, scanPath, "Secret detection"));
+		assert.equal(
+			secretScan.get("base"),
+			`\${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before || '' }}`,
+		);
+		assert.equal(
+			secretScan.get("head"),
+			`\${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.sha }}`,
+		);
+		assert.ok(String(secretScan.get("extra_args")).split(" ").includes("--fail-on-scan-errors"));
 		const report = stepInputs(namedStep(workflow, scanPath, "Trivy dependency scan"));
 		assert.equal(report.get("format"), "sarif");
 		assert.ok(


### PR DESCRIPTION
## Problem

The Actions update exposed a false-green secret scan: a detached pull-request checkout could not resolve the branch name `main`, scanned zero bytes, and still succeeded. Pinning the action alone does not make an unreadable scan range fail.

## Changes

- Update the six Actions dependencies from #1969 to their verified upstream tag commits.
- Pass immutable event-specific base/head SHAs for pull requests, merge groups, and pushes; manual runs retain full-history scanning.
- Use TruffleHog's native `--fail-on-scan-errors` and extend the existing workflow contract test, without adding a custom range resolver.

Supersedes #1969. This maintainer-owned replacement preserves the repository's requirement that commit authors match the pull-request author rather than adding maintainer commits to Renovate's pull request.

## Verification

- `vp run format` and `vp run check`: all 41 quality tasks pass; the pre-push gate passes again.
- Offline TruffleHog 3.97.4 against a temporary Git fixture: a valid SHA range scans 2 chunks / 944 bytes and exits 0; an unreadable base exits 1 with the new flag but exits 0 without it; a legitimate empty range remains successful.
- All six action commit pins match their upstream release tags. No runtime application change or release operation.

The effective scanner image still defaults to `latest`; #1986 tracks immutable scanner pinning together with automated updates, separately from this fail-closed correction.
