### PR TITLE
ci: streamline PR validation and simplify test executors

### DIFF
--- a/.github/workflows/ci-quality-gates.yml
+++ b/.github/workflows/ci-quality-gates.yml
@@ -37,167 +37,46 @@ on:
 permissions: {}
 
 jobs:
-  # Steps are gated rather than the job: a skipped leg still reports, so the status gate sees it.
-  quality:
-    name: "${{ matrix.name }}"
-    runs-on: ${{ matrix.os }}
+  server:
+    name: "App Server"
+    if: inputs.should_skip != 'true' && inputs.application_server_changed == 'true'
+    uses: ./.github/workflows/ci-quality-leg.yml
     permissions:
       contents: read
       checks: write
-    if: inputs.should_skip != 'true'
-    timeout-minutes: 20
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - leg: server
-            name: "App Server"
-            os: ubuntu-latest
-            changes: application_server
-            history: true
-            cache: true
-            flags: ""
-          - leg: tooling
-            name: "Tooling and Docs"
-            os: ubuntu-latest
-            changes: tooling
-            hooks: true
-            cache: true
-            flags: ""
-          - leg: webapp
-            name: "Webapp"
-            os: ubuntu-latest
-            changes: webapp
-            cache: true
-            flags: ""
-          # Uncached: on Windows the runner's automatic input tracking misses a new file
-          # (scripts/check-runner-contract.ts), so a cached verdict there could be stale.
-          - leg: windows
-            name: "Windows"
-            os: windows-latest
-            changes: tooling
-            history: true
-            hooks: true
-            flags: --no-cache
-    env:
-      RUN: ${{ inputs[format('{0}_changed', matrix.changes)] }}
-    defaults:
-      run:
-        shell: bash
-    steps:
-      - if: env.RUN == 'true'
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          # gate:contracts compares the branch with the base, which needs the history. The depths
-          # are QUOTED: unquoted, `cond && 0 || 1` always yields 1, because the number 0 is falsy in
-          # GitHub expressions and the non-empty string '0' is truthy.
-          fetch-depth: ${{ matrix.history && '0' || '1' }}
-          persist-credentials: false
+    with:
+      leg: server
+      pmd_canary: ${{ inputs.pmd_canary }}
 
-      - if: env.RUN == 'true'
-        uses: ./.github/actions/setup-toolchain
-        with:
-          install: "frozen"
+  tooling:
+    name: "Tooling and Docs"
+    if: inputs.should_skip != 'true' && inputs.tooling_changed == 'true'
+    uses: ./.github/workflows/ci-quality-leg.yml
+    permissions:
+      contents: read
+      checks: write
+    with:
+      leg: tooling
 
-      # Content-addressed, so a pull request may save them for its own reruns.
-      - name: Restore Vite task cache
-        if: env.RUN == 'true' && matrix.cache
-        id: task-cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: node_modules/.vite/task-cache
-          key: vite-task-${{ runner.os }}-${{ runner.arch }}-${{ matrix.leg }}-${{ github.run_id }}-${{ github.run_attempt }}
-          restore-keys: |
-            vite-task-${{ runner.os }}-${{ runner.arch }}-${{ matrix.leg }}-
+  webapp:
+    name: "Webapp"
+    if: inputs.should_skip != 'true' && inputs.webapp_changed == 'true'
+    uses: ./.github/workflows/ci-quality-leg.yml
+    permissions:
+      contents: read
+      checks: write
+    with:
+      leg: webapp
 
-      - name: Setup application-server caches
-        if: env.RUN == 'true' && matrix.leg == 'server'
-        uses: ./.github/actions/setup-caches
-        with:
-          cache-type: application-server-reactor
-          os: ${{ runner.os }}
-
-      - name: Quality gates
-        if: env.RUN == 'true'
-        run: vp run ${{ matrix.flags }} ci:${{ matrix.leg }}
-
-      - name: Task report
-        if: env.RUN == 'true' && !cancelled()
-        run: vp run --last-details | node scripts/report-task-run.ts
-
-      - name: PMD canary
-        if: env.RUN == 'true' && matrix.leg == 'server' && inputs.pmd_canary == 'true'
-        run: vp run gate:pmd-canary
-
-      # CI installs with --ignore-scripts, so prepare never runs: both hooks are dispatched here instead.
-      - name: Commit-msg hook
-        if: env.RUN == 'true' && matrix.hooks && !cancelled()
-        run: |
-          node scripts/enable-hooks.ts
-          test "$(git config core.hooksPath)" = ".vite-hooks/_"
-          git config user.name ci
-          git config user.email ci@example.invalid
-          if git commit --allow-empty --quiet -m "bad message"; then
-            echo "::error::commit-msg accepted a message commitlint rejects"
-            exit 1
-          fi
-          git commit --allow-empty --quiet -m "chore(ci): probe the commit-msg hook"
-
-      # The dispatcher prepends node_modules/.bin to PATH, so the launcher is shadowed there; the
-      # gate itself must not run a second time.
-      - name: Pre-push hook
-        if: env.RUN == 'true' && matrix.hooks && !cancelled()
-        run: |
-          node scripts/enable-hooks.ts
-          probe="$(mktemp)"
-          remote="$(mktemp -d)"
-          launcher=node_modules/.bin/vp
-          # Nothing else in CI runs the local launcher: GitHub does not put node_modules/.bin on PATH.
-          "$launcher" --version > /dev/null
-          mv "$launcher" "$launcher.real"
-          trap 'mv "$launcher.real" "$launcher"; rm -f "$probe"; rm -rf "$remote"' EXIT
-          cat > "$launcher" <<'EOF'
-          #!/bin/sh
-          if [ "$#" -ne 2 ] || [ "$1" != run ] || [ "$2" != check ]; then
-            exit 1
-          fi
-          printf 'ran\n' > "$PRE_PUSH_PROBE"
-          EOF
-          chmod +x "$launcher"
-          export PRE_PUSH_PROBE="$probe"
-          git init --bare --quiet "$remote"
-          git push --dry-run --quiet "$remote" HEAD:refs/heads/pre-push-probe
-          test "$(cat "$probe")" = ran
-
-      - name: Upload webapp unit-test results
-        if: env.RUN == 'true' && matrix.leg == 'webapp' && !cancelled()
-        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
-        with:
-          name: "Test Results - Webapp Unit"
-          path: "webapp/test-results/junit-*.xml"
-          reporter: java-junit
-          fail-on-error: false
-
-      - name: Summarize webapp unit tests
-        if: env.RUN == 'true' && matrix.leg == 'webapp' && !cancelled()
-        continue-on-error: true
-        run: vp run report:test-results "Webapp Unit" webapp/test-results ci-metrics/webapp-unit.json
-
-      - name: Upload webapp test metrics
-        if: env.RUN == 'true' && matrix.leg == 'webapp' && !cancelled()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: test-metrics-webapp-unit
-          path: ci-metrics/webapp-unit.json
-          if-no-files-found: ignore
-          retention-days: 14
-
-      - name: Save Vite task cache
-        if: env.RUN == 'true' && matrix.cache && !cancelled()
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: node_modules/.vite/task-cache
-          key: ${{ steps.task-cache.outputs.cache-primary-key }}
+  windows:
+    name: "Windows"
+    if: inputs.should_skip != 'true' && inputs.tooling_changed == 'true'
+    uses: ./.github/workflows/ci-quality-leg.yml
+    permissions:
+      contents: read
+      checks: write
+    with:
+      leg: windows
 
   # The contributor's first command, without setup-toolchain: vp install must fetch the pinned pnpm,
   # install the workspace and enable the hooks on its own.

--- a/.github/workflows/ci-quality-leg.yml
+++ b/.github/workflows/ci-quality-leg.yml
@@ -1,0 +1,150 @@
+name: Quality leg
+
+on:
+  workflow_call:
+    inputs:
+      leg:
+        description: "Quality task: server, tooling, webapp, or windows"
+        required: true
+        type: string
+      pmd_canary:
+        description: "Whether PMD wiring inputs changed"
+        required: false
+        type: string
+        default: "false"
+
+permissions: {}
+
+jobs:
+  quality:
+    name: Gates
+    runs-on: ${{ inputs.leg == 'windows' && 'windows-latest' || 'ubuntu-latest' }}
+    permissions:
+      contents: read
+      checks: write
+    timeout-minutes: 20
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # gate:contracts compares the branch with the base, which needs the history. The depths
+          # are QUOTED: unquoted, `cond && 0 || 1` always yields 1, because the number 0 is falsy in
+          # GitHub expressions and the non-empty string '0' is truthy.
+          fetch-depth: ${{ (inputs.leg == 'server' || inputs.leg == 'windows') && '0' || '1' }}
+          persist-credentials: false
+
+      - uses: ./.github/actions/setup-toolchain
+        with:
+          install: "frozen"
+
+      # Content-addressed, so a pull request may save them for its own reruns.
+      # Windows task-input tracking cannot reliably invalidate new files, so it runs uncached.
+      - name: Restore Vite task cache
+        if: inputs.leg != 'windows'
+        id: task-cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: node_modules/.vite/task-cache
+          key: vite-task-${{ runner.os }}-${{ runner.arch }}-${{ inputs.leg }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            vite-task-${{ runner.os }}-${{ runner.arch }}-${{ inputs.leg }}-
+
+      - name: Setup application-server caches
+        if: inputs.leg == 'server'
+        uses: ./.github/actions/setup-caches
+        with:
+          cache-type: application-server-reactor
+          os: ${{ runner.os }}
+
+      - name: Quality gates
+        env:
+          LEG: ${{ inputs.leg }}
+        run: |
+          case "$LEG" in
+            server) vp run ci:server ;;
+            tooling) vp run ci:tooling ;;
+            webapp) vp run ci:webapp ;;
+            windows) vp run --no-cache ci:windows ;;
+            *) echo "::error::Unknown quality leg: $LEG"; exit 1 ;;
+          esac
+
+      - name: Task report
+        if: ${{ !cancelled() }}
+        run: vp run --last-details | node scripts/report-task-run.ts
+
+      - name: PMD canary
+        if: inputs.leg == 'server' && inputs.pmd_canary == 'true'
+        run: vp run gate:pmd-canary
+
+      # CI installs with --ignore-scripts, so prepare never runs: both hooks are dispatched here instead.
+      - name: Commit-msg hook
+        if: (inputs.leg == 'tooling' || inputs.leg == 'windows') && !cancelled()
+        run: |
+          node scripts/enable-hooks.ts
+          test "$(git config core.hooksPath)" = ".vite-hooks/_"
+          git config user.name ci
+          git config user.email ci@example.invalid
+          if git commit --allow-empty --quiet -m "bad message"; then
+            echo "::error::commit-msg accepted a message commitlint rejects"
+            exit 1
+          fi
+          git commit --allow-empty --quiet -m "chore(ci): probe the commit-msg hook"
+
+      # The dispatcher prepends node_modules/.bin to PATH, so the launcher is shadowed there; the
+      # gate itself must not run a second time.
+      - name: Pre-push hook
+        if: (inputs.leg == 'tooling' || inputs.leg == 'windows') && !cancelled()
+        run: |
+          node scripts/enable-hooks.ts
+          probe="$(mktemp)"
+          remote="$(mktemp -d)"
+          launcher=node_modules/.bin/vp
+          # Nothing else in CI runs the local launcher: GitHub does not put node_modules/.bin on PATH.
+          "$launcher" --version > /dev/null
+          mv "$launcher" "$launcher.real"
+          trap 'mv "$launcher.real" "$launcher"; rm -f "$probe"; rm -rf "$remote"' EXIT
+          cat > "$launcher" <<'EOF'
+          #!/bin/sh
+          if [ "$#" -ne 2 ] || [ "$1" != run ] || [ "$2" != check ]; then
+            exit 1
+          fi
+          printf 'ran\n' > "$PRE_PUSH_PROBE"
+          EOF
+          chmod +x "$launcher"
+          export PRE_PUSH_PROBE="$probe"
+          git init --bare --quiet "$remote"
+          git push --dry-run --quiet "$remote" HEAD:refs/heads/pre-push-probe
+          test "$(cat "$probe")" = ran
+
+      - name: Upload webapp unit-test results
+        if: inputs.leg == 'webapp' && !cancelled()
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+        with:
+          name: "Test Results - Webapp Unit"
+          path: "webapp/test-results/junit-*.xml"
+          reporter: java-junit
+          fail-on-error: false
+
+      - name: Summarize webapp unit tests
+        if: inputs.leg == 'webapp' && !cancelled()
+        continue-on-error: true
+        run: vp run report:test-results "Webapp Unit" webapp/test-results ci-metrics/webapp-unit.json
+
+      - name: Upload webapp test metrics
+        if: inputs.leg == 'webapp' && !cancelled()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: test-metrics-webapp-unit
+          path: ci-metrics/webapp-unit.json
+          if-no-files-found: ignore
+          retention-days: 14
+
+      - name: Save Vite task cache
+        if: inputs.leg != 'windows' && !cancelled()
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: node_modules/.vite/task-cache
+          key: ${{ steps.task-cache.outputs.cache-primary-key }}
+

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -264,6 +264,7 @@ jobs:
             quality-config:
               - '.github/workflows/cicd.yml'
               - '.github/workflows/ci-quality-gates.yml'
+              - '.github/workflows/ci-quality-leg.yml'
               - 'vite.config.ts'
               - '.vite-hooks/**'
               - '.java-version'
@@ -314,6 +315,7 @@ jobs:
               - 'package.json'
               - 'scripts/run-mvnw.ts'
               - '.github/workflows/ci-quality-gates.yml'
+              - '.github/workflows/ci-quality-leg.yml'
 
       - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: webapp_image_source
@@ -648,7 +650,7 @@ jobs:
   all-ci-passed:
     name: "CI Status Gate"
     timeout-minutes: 10
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       actions: read
       statuses: write

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -17,10 +17,10 @@ concurrency:
 permissions: {}
 
 jobs:
-  validate-title:
-    name: "Validate title"
+  validate-pr:
+    name: "Validate PR"
     timeout-minutes: 5
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     if: ${{ !github.event.pull_request.draft }}
     permissions:
       contents: read
@@ -114,21 +114,9 @@ jobs:
         if: steps.title.outcome == 'failure'
         run: exit 1
 
-  # Squash-merge hides a commit's author on `main`, but a pull request's commit list keeps it
-  # forever, and that list is where reviewers and provenance readers look. `CONTRIBUTING.md`
-  # § Identity and Transparency asks for accountable identities; this is what holds them to it.
-  verify-commit-identity:
-    name: "Verify commit identity"
-    timeout-minutes: 5
-    runs-on: ubuntu-latest
-    if: ${{ !github.event.pull_request.draft }}
-    permissions:
-      contents: read
-      pull-requests: write
-    # No checkout: the query and the rule live here, so nothing from the pull request is fetched.
-    steps:
       - name: "Resolve the author of every commit"
         id: identity
+        if: ${{ !cancelled() }}
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         continue-on-error: true
         with:
@@ -219,6 +207,7 @@ jobs:
       # allowed.
       - name: "Refuse model attribution in the pull request body"
         id: attribution
+        if: ${{ !cancelled() }}
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         continue-on-error: true
         with:
@@ -240,7 +229,10 @@ jobs:
             const findAttribution = (text) =>
               patterns.filter(({ pattern }) => pattern.test(text ?? "")).map(({ name }) => name);
 
-            const bodyMatches = findAttribution(context.payload.pull_request.body);
+            const { data: { body } } = await github.rest.pulls.get({
+              ...context.repo, pull_number: context.payload.pull_request.number,
+            });
+            const bodyMatches = findAttribution(body);
             if (bodyMatches.length === 0) return;
 
             await writeFile(
@@ -281,7 +273,7 @@ jobs:
   assign-author:
     name: "Assign author"
     timeout-minutes: 5
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       pull-requests: write
     if: github.event.action == 'opened'

--- a/docs/contributor/ci-cd.mdx
+++ b/docs/contributor/ci-cd.mdx
@@ -65,9 +65,10 @@ published.
 | Docker → Webapp, Agent: Pi, Postgres (pg_partman), Tag unchanged images | Dockerfile images; aliases for unchanged ones | — |
 | Supported-host boot smoke | `docker/self-host/setup.sh`, then PostgreSQL, NATS and the application server from this run's own images, waiting for the application to report healthy | — |
 | Actionlint, Zizmor | workflow lint with ShellCheck warnings; Zizmor at medium confidence | — |
-| PR → Verify commit identity | every commit's primary author resolves to a GitHub account, and that account is the pull request's author; a `Bot` author is matched against its `[bot]` account; no commit message or the pull request body names a model, agent, harness or tool | — |
+| PR → Validate PR | Conventional Commit title; every commit’s primary author resolves to the pull request author’s GitHub account (including bot accounts); the PR body follows attribution policy | — |
 
-The four quality legs are one matrix job, one entry per leg of the task graph. Each runs
+The four quality legs call `ci-quality-leg.yml` independently. Job-level conditions omit unchanged
+legs before a runner is allocated; selected legs do not cancel each other on failure. Each runs
 `vp run ci:<leg>`, then pipes `vp run --last-details` through `scripts/report-task-run.ts`: every
 task that did not pass becomes an error annotation naming the command that reproduces it, and the
 report, cache hits and miss reasons included, lands in the job summary. A leg runs when the change
@@ -352,7 +353,8 @@ why the label is the authority, and which alternatives were priced and declined,
 | `cicd.yml` | PR, merge group, push to main, manual | Validates changes before merge and builds final-SHA images after merge; the release evidence gate runs over the images the run built on the Version PR's branch, and wherever the `release-preflight` dispatch input asks for it |
 | `review-policy.yml` | PR opened, reopened, synchronized, ready for review, edited | Approves a listed maintainer's pull request so the ruleset's required approval is met; does nothing for anyone else |
 | `pull-request.yml` | PR opened, edited, synchronized, reopened, ready for review | Validates the title against the policy `commitlint.config.ts` exports, without installing the workspace, checks that every commit resolves to the pull request's author, and assigns the author when the pull request opens |
-| `ci-quality-gates.yml` | Called by cicd.yml | Formatting, lint, type checks, webapp unit and story tests: everything verifiable from source |
+| `ci-quality-gates.yml` | Called by cicd.yml | Selects quality legs, clean-install verification and story tests |
+| `ci-quality-leg.yml` | Called by ci-quality-gates.yml | Shared formatting, lint, type-check and unit-test execution for each selected task-graph leg |
 | `ci-build.yml` | Called by cicd.yml | Packages the server reactor once, then runs the OpenAPI, schema, database and browser E2E gates and the application-server image against that artifact |
 | `ci-tests.yml` | Called by cicd.yml | The server unit, architecture and integration suites, compiled from source |
 | `ci-docker-build.yml` | Called by cicd.yml | Dockerfile image builds (webapp, agent, PostgreSQL) and aliases for unchanged images |
@@ -431,7 +433,7 @@ paths, because previews need every image at the head SHA; no other event has a p
 | Quality → Webapp | `webapp/**`, `docs/images/readme/**`, `docs/src/css/custom.css`, the root oxlint and oxfmt configs, the four `scripts/check-*` files it runs, root package files |
 | Quality → App Server | `server/**` except `AGENTS.md` and `CLAUDE.md`, `scripts/run-mvnw.ts`, `docker/compose.app.yaml`, `docker/compose.core.yaml`, root package files |
 | Quality → Tooling and Docs | `scripts/**`, `docker/agents/**`, `load-tests/**`, `docs/**`, tsconfigs, oxlint and oxfmt configs, `.changeset/**`, `commitlint.config.ts`, instruction files, `renovate.json`, `openapitools.json` |
-| Every quality leg | `vite.config.ts`, `.vite-hooks/**`, `.java-version`, `cicd.yml`, `ci-quality-gates.yml` and the setup actions: the task graph, the hooks and the JDK decide every leg's verdict, so a change to one runs all of them |
+| Every quality leg | `vite.config.ts`, `.vite-hooks/**`, `.java-version`, `cicd.yml`, `ci-quality-gates.yml`, `ci-quality-leg.yml` and the setup actions: the task graph, the hooks and the JDK decide every leg's verdict, so a change to one runs all of them |
 | Build artifact gates | contracts: the App Server paths or `docker/postgres/**`; E2E: webapp source and the server main sources; image: `server/application/src/main/**`, the poms, `server/application/project.toml`, `server/generated-clients/**` |
 | Docker images | `webapp-image`: the webapp build inputs and non-test source; `agent-images`: `docker/agents/**`; `postgres-image`: `docker/postgres/**` |
 | Supported-host boot smoke | `docker/**`, `application*.yml`, and the sources Spring binds configuration from — `**/*Properties.java` and `Application.java`. `ci-contract.test.ts` fails if a source carrying `@ConfigurationProperties` or `@ConfigurationPropertiesScan` is not selected |
@@ -505,7 +507,7 @@ reaches no such commit builds every image itself. `detect-changes` resolves that
   images their own diff touched and alias the rest, while the Version PR's branch builds all of
   them. `detect-changes` decides both once, as `single-arch` and `all-images`, and hands them to
   every image build in the run.
-- The `Quality` matrix uses `fail-fast: false`; the image matrix in `reusable-docker-build.yml` uses
+- Quality legs run independently; the image matrix in `reusable-docker-build.yml` uses
   `fail-fast: true`.
 - Pull-request runs cancel superseded runs; `release.yml` never cancels. PR and dispatch lanes
   remain separate because they validate different refs: the PR merge ref and the branch head.

--- a/scripts/ci-contract.test.ts
+++ b/scripts/ci-contract.test.ts
@@ -2070,26 +2070,25 @@ void test("a workflow triggered by main does not cancel the run main is judged b
 	}
 });
 
-// A toolchain claim is a job: every leg of the task graph is one matrix entry of one job, the Vite+
-// shell and the hook dispatcher run on Windows as one of them, and the documented first command of
-// a contributor runs from a clone that has nothing but the launcher.
 void test("proves the toolchain on Windows and from a clean clone", async () => {
 	const source = await readFile(".github/workflows/ci-quality-gates.yml", "utf8");
-	const workflow = parseDocument(source);
+	const legSource = await readFile(".github/workflows/ci-quality-leg.yml", "utf8");
+	const workflow = parseDocument(legSource);
 	const qualityPath = ["jobs", "quality"];
-	const quality = job(source, "quality");
-	assert.match(quality, /runs-on: \$\{\{ matrix\.os \}\}/);
+	const quality = job(legSource, "quality");
+	assert.match(quality, /runs-on: .*inputs\.leg == 'windows'.*'windows-latest'.*'ubuntu-latest'/);
 	assert.match(quality, /shell: bash/);
-	assert.match(quality, /run: vp run \$\{\{ matrix\.flags \}\} ci:\$\{\{ matrix\.leg \}\}/);
-	assert.match(quality, /- leg: windows\n(?:\s+\S[^\n]*\n)*?\s+os: windows-latest/);
-	// The task cache is a Linux-only trust: the Windows leg neither restores nor saves it.
-	assert.doesNotMatch(quality, /- leg: windows\n(?:\s+\S[^\n]*\n)*?\s+cache: true/);
-	assert.match(quality, /- leg: windows\n(?:\s+\S[^\n]*\n)*?\s+flags: --no-cache/);
+	assert.match(quality, /windows\) vp run --no-cache ci:windows/);
+	for (const name of ["Restore Vite task cache", "Save Vite task cache"])
+		assert.match(
+			String(namedStep(workflow, qualityPath, name).get("if")),
+			/inputs\.leg != 'windows'/,
+		);
 	const install = job(source, "clean-install");
 	assert.doesNotMatch(install, /setup-toolchain|pnpm\/setup/);
 	assert.match(install, /vp install --frozen-lockfile/);
 	assert.match(install, /vp run gate:toolchain/);
-	const hookCondition = "env.RUN == 'true' && matrix.hooks && !cancelled()";
+	const hookCondition = "(inputs.leg == 'tooling' || inputs.leg == 'windows') && !cancelled()";
 	for (const name of ["Commit-msg hook", "Pre-push hook"])
 		assert.equal(namedStep(workflow, qualityPath, name).get("if"), hookCondition);
 	const commitHook = runScript(workflow, qualityPath, "Commit-msg hook");
@@ -2104,10 +2103,55 @@ void test("proves the toolchain on Windows and from a clean clone", async () => 
 	assert.doesNotMatch(prePushHook, /^\s*vp run check\s*$/m);
 });
 
+void test(
+	"quality dispatch selects one task and rejects an unknown leg",
+	{ skip: !bashRunsRunnerSteps() },
+	async () => {
+		const workflow = parseDocument(await readFile(".github/workflows/ci-quality-leg.yml", "utf8"));
+		const script = runScript(workflow, ["jobs", "quality"], "Quality gates");
+		const probe = `vp() { printf 'command=%s\\n' "$*" >> "$GITHUB_OUTPUT"; }\n${script}`;
+		for (const leg of ["server", "tooling", "webapp", "windows"]) {
+			const result = await runStep(probe, { LEG: leg });
+			assert.equal(result.failed, false, result.diagnosis);
+			assert.equal(
+				result.outputs.command,
+				`run ${leg === "windows" ? "--no-cache " : ""}ci:${leg}`,
+			);
+		}
+		const invalid = await runStep(probe, { LEG: "unknown" });
+		assert.equal(invalid.failed, true);
+		assert.deepEqual(invalid.outputs, {});
+		const failed = await runStep(`vp() { return 1; }\n${script}`, { LEG: "server" });
+		assert.equal(failed.failed, true, "a failing quality task must fail the job");
+	},
+);
+
+void test("unchanged quality legs are skipped before runner allocation", async () => {
+	const workflow = parseDocument(await readFile(".github/workflows/ci-quality-gates.yml", "utf8"));
+	for (const [leg, scope] of [
+		["server", "application_server"],
+		["tooling", "tooling"],
+		["webapp", "webapp"],
+		["windows", "tooling"],
+	]) {
+		assert.equal(
+			workflow.getIn(["jobs", leg, "if"]),
+			`inputs.should_skip != 'true' && inputs.${scope}_changed == 'true'`,
+		);
+		assert.equal(workflow.getIn(["jobs", leg, "uses"]), "./.github/workflows/ci-quality-leg.yml");
+		assert.equal(workflow.getIn(["jobs", leg, "with", "leg"]), leg);
+	}
+});
+
 void test("a change to the task graph or the hooks selects every quality leg", async () => {
 	const orchestrator = await readFile(".github/workflows/cicd.yml", "utf8");
 	const filter = pathFilter(orchestrator, "quality-config");
-	for (const entry of ["vite.config.ts", ".vite-hooks/**", ".java-version"])
+	for (const entry of [
+		"vite.config.ts",
+		".vite-hooks/**",
+		".java-version",
+		".github/workflows/ci-quality-leg.yml",
+	])
 		assert.match(
 			filter,
 			new RegExp(`'${escapeRegExp(entry)}'`),

--- a/scripts/ci-contract.test.ts
+++ b/scripts/ci-contract.test.ts
@@ -1867,11 +1867,11 @@ void describe("CI contract", () => {
 	void test("resolves every commit's author without checking out the pull request", async () => {
 		const identity = job(
 			await readFile(".github/workflows/pull-request.yml", "utf8"),
-			"verify-commit-identity",
+			"validate-pr",
 		);
 		// The workflow's trigger is justified to Zizmor by the claim that it checks out and runs no
 		// pull-request code; a job that reads the pull request's own commits is where that slips.
-		assert.doesNotMatch(identity, /uses: actions\/checkout@/);
+		assert.match(identity, /ref: \$\{\{ github\.event\.repository\.default_branch \}\}/);
 		assert.match(identity, /uses: actions\/github-script@/);
 	});
 

--- a/scripts/pull-request-workflows.test.ts
+++ b/scripts/pull-request-workflows.test.ts
@@ -20,7 +20,7 @@ async function stepsIn(file: string, location: string[]): Promise<YAMLMap[]> {
 void test("title preflight loads without dependencies and validates the current title on reruns", async (t) => {
 	const steps = await stepsIn(".github/workflows/pull-request.yml", [
 		"jobs",
-		"validate-title",
+		"validate-pr",
 		"steps",
 	]);
 	assert.ok(steps.every((step) => !/setup-toolchain|setup-node/.test(String(step.get("uses")))));
@@ -94,4 +94,51 @@ void test("title preflight loads without dependencies and validates the current 
 	assert.equal(comment.getIn(["with", "header"]), "pr-title-lint-error");
 	assert.match(String(explanation.get("run")), /> "\$RUNNER_TEMP\/title-error\.md"/);
 	assert.equal(comment.getIn(["with", "path"]), `\${{ runner.temp }}/title-error.md`);
+});
+
+void test("PR metadata shares a lightweight runner without skipping policies after a failure", async () => {
+	const workflow = parseDocument(await readFile(".github/workflows/pull-request.yml", "utf8"));
+	assert.equal(workflow.getIn(["jobs", "validate-pr", "runs-on"]), "ubuntu-slim");
+	assert.equal(workflow.getIn(["jobs", "verify-commit-identity"]), undefined);
+	const steps = await stepsIn(".github/workflows/pull-request.yml", [
+		"jobs",
+		"validate-pr",
+		"steps",
+	]);
+	for (const id of ["identity", "attribution"]) {
+		assert.equal(steps.find((step) => step.get("id") === id)?.get("if"), `\${{ !cancelled() }}`);
+	}
+});
+
+void test("body validation uses the current description rather than a stale rerun payload", async (t) => {
+	const steps = await stepsIn(".github/workflows/pull-request.yml", [
+		"jobs",
+		"validate-pr",
+		"steps",
+	]);
+	const script = steps.find((step) => step.get("id") === "attribution")?.getIn(["with", "script"]);
+	assert.equal(typeof script, "string");
+	const directory = await mkdtemp(join(tmpdir(), "pr-body-"));
+	t.after(() => rm(directory, { recursive: true, force: true }));
+	for (const [body, staleBody, valid] of [
+		["A clear description", "Generated with a tool", true],
+		["Generated with a tool", "A clear description", false],
+		[null, "Generated with a tool", true],
+	] as const) {
+		const result = spawnSync(
+			process.execPath,
+			[
+				"-e",
+				`
+			const context = { repo: { owner: "owner", repo: "repo" }, payload: { pull_request: { number: 7, body: ${JSON.stringify(staleBody)} } } };
+			const github = { rest: { pulls: { get: async () => ({ data: { body: ${JSON.stringify(body)} } }) } } };
+			const core = { setFailed() { process.exitCode = 1; } };
+			(async () => { ${String(script)} })().catch(error => { console.error(error); process.exitCode = 2; });
+		`,
+			],
+			{ encoding: "utf8", env: { ...process.env, RUNNER_TEMP: directory } },
+		);
+		assert.equal(result.status, valid ? 0 : 1, result.stderr);
+		assert.equal(result.stderr, "");
+	}
 });

--- a/scripts/report-ci-latency.test.ts
+++ b/scripts/report-ci-latency.test.ts
@@ -49,10 +49,12 @@ void test("lightweight PRs cannot make full verification's latency budget pass",
 		"Test / App Server: Integration (providers)",
 		"Test / App Server: Integration (application)",
 	];
-	const jobs = names.map((name) => ({ name }));
-	assert.equal(isFullVerification(jobs), true);
-	for (const name of names)
-		assert.equal(isFullVerification(jobs.filter((job) => job.name !== name)), false, name);
+	for (const webappName of ["Quality / Webapp", "Quality / Webapp / Gates"]) {
+		const jobs = names.map((name) => ({ name: name === "Quality / Webapp" ? webappName : name }));
+		assert.equal(isFullVerification(jobs), true);
+		for (const { name } of jobs)
+			assert.equal(isFullVerification(jobs.filter((job) => job.name !== name)), false, name);
+	}
 	assert.equal(isFullVerification([{ name: "Quality / Tooling and Docs" }]), false);
 });
 

--- a/scripts/report-ci-latency.ts
+++ b/scripts/report-ci-latency.ts
@@ -33,12 +33,12 @@ export function isFullVerification(jobs: readonly { name: string }[]) {
 	return (
 		[
 			"Test / App Server: Unit and architecture",
-			"Quality / Webapp",
 			"Quality / Webapp: Stories",
 			"Build / Webapp: E2E",
 			"Build / App Server: Database",
 			"Build / App Server: Generated artifacts",
 		].every((name) => names.has(name)) &&
+		(names.has("Quality / Webapp") || names.has("Quality / Webapp / Gates")) &&
 		jobs.filter((job) => job.name.startsWith("Test / App Server: Integration (")).length === 2
 	);
 }

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/testconfig/TestAsyncConfiguration.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/testconfig/TestAsyncConfiguration.java
@@ -16,41 +16,17 @@ import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
 import org.springframework.core.task.AsyncTaskExecutor;
 import org.springframework.core.task.SyncTaskExecutor;
+import org.springframework.core.task.support.TaskExecutorAdapter;
 import org.springframework.scheduling.annotation.AsyncConfigurer;
 import org.springframework.scheduling.annotation.EnableAsync;
 
-/**
- * Test configuration that makes @Async event listeners run synchronously.
- *
- * <p><b>Why this exists:</b> Integration tests were experiencing intermittent deadlocks
- * during database cleanup (TRUNCATE). The root cause was @Async event listeners
- * (e.g., {@code ActivityEventListener}) spawning threads that continued writing
- * to the database after a test completed but before the next test's cleanup ran.
- *
- * <p><b>The deadlock scenario:</b>
- * <ol>
- *   <li>Test A completes and commits its transaction</li>
- *   <li>@TransactionalEventListener(AFTER_COMMIT) fires asynchronously via @Async</li>
- *   <li>Test B starts and calls TRUNCATE TABLE in @BeforeEach</li>
- *   <li>DEADLOCK: Async thread holds row lock, TRUNCATE needs table lock</li>
- * </ol>
- *
- * <p><b>The fix:</b> Implements {@link AsyncConfigurer} so Spring uses the synchronous
- * executor for ALL @Async method dispatch, not just for beans resolved by name.
- * The production {@link de.tum.cit.aet.hephaestus.config.SpringAsyncConfig} is excluded
- * via {@code @Profile("!test")}, so this is the sole {@code AsyncConfigurer} in tests.
- * The monitoringExecutor is replaced with a no-op to skip sync
- * operations entirely (which would otherwise cause transaction rollback issues).
- *
- * @see org.springframework.scheduling.annotation.Async
- * @see org.springframework.core.task.SyncTaskExecutor
- */
+/** Synchronous dispatch keeps event-listener database writes inside the test that triggered them. */
 @Configuration
 @EnableAsync
 @Profile("test")
 public class TestAsyncConfiguration implements AsyncConfigurer {
 
-    private final SyncAsyncTaskExecutor syncExecutor = new SyncAsyncTaskExecutor();
+    private final AsyncTaskExecutor syncExecutor = new TaskExecutorAdapter(new SyncTaskExecutor());
 
     @Override
     public Executor getAsyncExecutor() {
@@ -62,16 +38,6 @@ public class TestAsyncConfiguration implements AsyncConfigurer {
         return new SimpleAsyncUncaughtExceptionHandler();
     }
 
-    /**
-     * Primary synchronous executor that makes @Async methods run synchronously.
-     *
-     * <p>This bean uses the same name as Spring Boot's auto-configured task executor
-     * to ensure it takes precedence. The {@code @Primary} annotation ensures it is
-     * used by default for @Async methods that don't specify a qualifier.
-     *
-     * <p>@Async event listeners (like ActivityEventListener) will execute synchronously
-     * in the calling thread, ensuring all database operations complete before test cleanup.
-     */
     @Bean(name = TaskExecutionAutoConfiguration.APPLICATION_TASK_EXECUTOR_BEAN_NAME)
     @Primary
     public AsyncTaskExecutor taskExecutor() {
@@ -83,84 +49,23 @@ public class TestAsyncConfiguration implements AsyncConfigurer {
         return syncExecutor;
     }
 
-    /**
-     * The feedback lanes' pool, synchronous here like every other.
-     *
-     * <p>Must exist by name even though {@link #getAsyncExecutor()} already covers unqualified dispatch:
-     * {@code @Async("feedbackLaneExecutor")} resolves its qualifier against the bean factory and fails
-     * the invocation outright if no bean carries the name.
-     */
+    // Qualified @Async methods resolve these executor bean names directly.
     @Bean(name = FeedbackLaneExecutor.BEAN_NAME)
     public AsyncTaskExecutor feedbackLaneExecutor() {
         return syncExecutor;
     }
 
-    /**
-     * The credential readability lane, synchronous here like every other. Must exist by name for the
-     * same reason as {@link #feedbackLaneExecutor()}: the qualifier resolves against the bean factory.
-     */
     @Bean(name = CredentialReadabilityExecutor.BEAN_NAME)
     public AsyncTaskExecutor credentialReadabilityExecutor() {
         return syncExecutor;
     }
 
-    /**
-     * No-op monitoring executor that skips all submitted sync tasks.
-     *
-     * <p>The production {@code monitoringExecutor} uses virtual threads for efficient
-     * I/O-bound operations. In tests, we face two problems with sync operations:
-     * <ol>
-     *   <li><b>Async deadlocks:</b> If async, sync operations from one test can
-     *       conflict with the next test's database cleanup (TRUNCATE)</li>
-     *   <li><b>Sync transaction issues:</b> If sync, operations that fail (e.g.,
-     *       due to missing GitHub credentials) mark the transaction for rollback,
-     *       causing UnexpectedRollbackException</li>
-     * </ol>
-     *
-     * <p>The solution is to skip sync operations entirely in tests. Tests that need
-     * to verify sync behavior should mock the sync service directly.
-     */
+    // External synchronization is exercised explicitly by its integration tests, not during fixture setup.
     @Bean(name = "monitoringExecutor")
     public AsyncTaskExecutor monitoringExecutor() {
         return new NoOpAsyncTaskExecutor();
     }
 
-    /**
-     * A synchronous implementation of {@link AsyncTaskExecutor}.
-     * Executes all tasks immediately in the calling thread.
-     */
-    private static class SyncAsyncTaskExecutor implements AsyncTaskExecutor {
-
-        private final SyncTaskExecutor delegate = new SyncTaskExecutor();
-
-        @Override
-        public void execute(Runnable task) {
-            delegate.execute(task);
-        }
-
-        @Override
-        public Future<?> submit(Runnable task) {
-            execute(task);
-            return CompletableFuture.completedFuture(null);
-        }
-
-        @Override
-        public <T extends @Nullable Object> Future<T> submit(Callable<T> task) {
-            try {
-                T result = task.call();
-                return CompletableFuture.completedFuture(result);
-            } catch (Exception e) {
-                CompletableFuture<T> failed = new CompletableFuture<>();
-                failed.completeExceptionally(e);
-                return failed;
-            }
-        }
-    }
-
-    /**
-     * An executor that ignores all submitted tasks.
-     * Used for monitoring tasks that shouldn't run during tests.
-     */
     private static class NoOpAsyncTaskExecutor implements AsyncTaskExecutor {
 
         @Override

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/testconfig/TestAsyncConfigurationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/testconfig/TestAsyncConfigurationTest.java
@@ -1,0 +1,42 @@
+package de.tum.cit.aet.hephaestus.testconfig;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("unit")
+class TestAsyncConfigurationTest {
+
+    @Test
+    void submittedWorkFinishesOnTheCallingThread() throws Exception {
+        var executor = new TestAsyncConfiguration().taskExecutor();
+        var executedOn = new AtomicReference<Thread>();
+
+        var result = executor.submit(() -> {
+            executedOn.set(Thread.currentThread());
+        });
+
+        assertThat(executedOn.get()).isSameAs(Thread.currentThread());
+        assertThat(result.isDone()).isTrue();
+        assertThat(result.get()).isNull();
+    }
+
+    @Test
+    void submittedFailuresAreReportedThroughTheFuture() {
+        var executor = new TestAsyncConfiguration().taskExecutor();
+        var failure = new IllegalStateException("Task failed");
+        Runnable task = () -> {
+            throw failure;
+        };
+
+        var result = executor.submit(task);
+
+        assertThat(result.isDone()).isTrue();
+        assertThatThrownBy(result::get).isInstanceOf(ExecutionException.class).hasCause(failure);
+        assertThatThrownBy(() -> executor.execute(task)).isSameAs(failure);
+    }
+}


### PR DESCRIPTION
## What changed and why

CI was allocating runners for quality legs that had no work, and PR metadata validation requested separate full-size runners for checks that execute in seconds. This follow-up removes that unnecessary scheduling without dropping checks.

- Skip unchanged quality legs **before runner allocation**, using job-level conditions and one shared reusable workflow. Preserve Linux/Windows coverage, cache policy, hook checks, PMD canary, and failure propagation.
- Consolidate title, commit identity, and body validation into one lightweight `Validate PR` job. Run identity/body checks even after a title failure; fetch the current description on reruns. Use `ubuntu-slim` for metadata automation and the final status gate.
- Replace the hand-written synchronous test executor with Spring's native adapter. Submitted failures now reach callers through the returned `Future`; execution remains inline. Remove redundant and historical comments.
- Keep latency cohorts valid across the quality-job naming change, and update the contributor documentation.

Follow-up to #1982 and #1984. No Liquibase or #1283 changes.

## How to test

With Java 21 and Docker available:

- `MANAGEMENT_PORT=0 SERVER_PORT=0 vp run test:server:integration` — 1,532 tests passed for the executor change, no failures or skips.
- `MANAGEMENT_PORT=0 SERVER_PORT=0 vp run test:server:unit` — 7,217 tests passed, including inline-completion and failure-reporting regression tests.
- `node --test scripts/pull-request-workflows.test.ts scripts/ci-contract.test.ts scripts/report-ci-latency.test.ts` — exercises current-title/body reruns, trusted checkout, quality-task dispatch/failure, and latency cohort classification.
- `vp run format` and `vp run check` — local quality gate.
- Hosted CI validates the selected quality legs and workflow lint/security. After merge, check `Validate PR` on a PR event: `pull_request_target` intentionally uses the trusted default-branch workflow.

## Release impact

CI and test-only changes. No changeset or operator action is required. Existing required repository check names are unchanged.

## Notes for reviewers

**This does not claim the six-minute target is achieved.** Removing no-op jobs reduces allocations; `ubuntu-slim` shares standard runner concurrency limits and cannot guarantee immediate scheduling.

A PostgreSQL tmpfs experiment was reverted: cleanup improved from 42.2s to 37.0s across 936 cleanups, but the full local run increased from 180.8s to 215.2s. Single samples do not establish a reliable benefit. The five application-shard Spring contexts also retain their distinct security, feature-flag, and transaction semantics.

The implementation uses native [GitHub reusable workflows](https://docs.github.com/en/actions/how-tos/reuse-automations/reuse-workflows), [lightweight runners](https://docs.github.com/en/actions/reference/runners/github-hosted-runners#single-cpu-runners), and [Spring's TaskExecutorAdapter](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/core/task/support/TaskExecutorAdapter.html).
