### PR TITLE
fix(ci): report skipped and unavailable Chromatic coverage

### DIFF
--- a/.github/workflows/ci-quality-gates.yml
+++ b/.github/workflows/ci-quality-gates.yml
@@ -236,6 +236,7 @@ jobs:
       statuses: write
     env:
       PREVIEW_URL: hephaestus-build-storybook-pr-${{ github.event.number }}.surge.sh
+      CHROMATIC_POLICY_SKIP: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) || startsWith(github.head_ref || github.ref_name, 'dependabot/') || startsWith(github.head_ref || github.ref_name, 'renovate/') }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -265,8 +266,7 @@ jobs:
         id: chromatic
         continue-on-error: true
         if: >-
-          success() &&
-          (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+          success() && env.CHROMATIC_POLICY_SKIP != 'true'
         uses: chromaui/action@2a0b63f30233c48591844a46d451b9cf68128186 # v18.7.2
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
@@ -274,14 +274,30 @@ jobs:
           storybookBuildDir: storybook-static
           onlyChanged: true
           zip: true
-          skip: "@(dependabot/**|renovate/**)"
-          autoAcceptChanges: ${{ github.ref == 'refs/heads/main' && 'main' || '' }}
+          skip: false
+          autoAcceptChanges: false
           exitZeroOnChanges: false
+          exitOnceUploaded: false
           logLevel: info
           junitReport: true
         env:
           CHROMATIC_BRANCH: ${{ github.head_ref || github.ref_name }}
           CHROMATIC_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Report Chromatic visual coverage
+        id: visual_coverage
+        if: always()
+        continue-on-error: true
+        env:
+          CHROMATIC_OUTCOME: ${{ steps.chromatic.outcome }}
+          CHROMATIC_CODE: ${{ steps.chromatic.outputs.code }}
+          CHROMATIC_CAPTURED: ${{ steps.chromatic.outputs.actualCaptureCount }}
+          CHROMATIC_INHERITED: ${{ steps.chromatic.outputs.inheritedCaptureCount }}
+          CHROMATIC_TESTS: ${{ steps.chromatic.outputs.testCount }}
+          CHROMATIC_ERRORS: ${{ steps.chromatic.outputs.errorCount }}
+          CHROMATIC_CHANGES: ${{ steps.chromatic.outputs.changeCount }}
+          CHROMATIC_INTERACTIONS: ${{ steps.chromatic.outputs.interactionTestFailuresCount }}
+          CHROMATIC_BUILD_URL: ${{ steps.chromatic.outputs.buildUrl }}
+        run: node scripts/report-chromatic.ts
       - name: Deploy public Storybook preview
         id: storybook_preview
         if: >-
@@ -344,9 +360,9 @@ jobs:
         if: always()
         env:
           STORYBOOK_TESTS: ${{ steps.tests.outcome }}
-          CHROMATIC: ${{ steps.chromatic.outcome }}
+          CHROMATIC: ${{ steps.visual_coverage.outcome }}
         run: |
-          if [ "$STORYBOOK_TESTS" != success ] || { [ "$CHROMATIC" != success ] && [ "$CHROMATIC" != skipped ]; }; then
+          if [ "$STORYBOOK_TESTS" != success ] || [ "$CHROMATIC" != success ]; then
             echo "::error::Storybook tests or Chromatic failed; review both independently reported steps."
             exit 1
           fi

--- a/docs/contributor/ci-cd.mdx
+++ b/docs/contributor/ci-cd.mdx
@@ -638,3 +638,63 @@ Extend the pipeline at the ownership boundary that changed; do not copy an exist
 5. Pass the change-detection output from `cicd.yml` to every reusable workflow that needs it.
 
 `scripts/ci-contract.test.ts` owns the workflow invariants; extend it when the service introduces one.
+
+## Chromatic visual coverage
+
+The Stories job reports visual coverage separately from interaction tests and the
+**Preview / Storybook** publication link. Publication is not visual approval: the final job
+verdict also requires a passing coverage report.
+
+| Verdict | Meaning and action |
+| --- | --- |
+| `tested-build` | The returned build has captured snapshots and passed without errors. It may be a reused approved build, not new captures in this CI run. |
+| `inherited` | The returned build reused baseline snapshots without new captures. Valid TurboSnap coverage, but not a newly tested recovery baseline. |
+| `quota-skipped` | An account limit blocked coverage. The job fails; an account owner must resolve the limit. |
+| `failed` | Visual differences or component/interaction errors need review. Fix errors; accept only intentional, inspected differences. |
+| `unavailable` | Chromatic failed or returned insufficient coverage evidence. The job fails; inspect the build, action logs and account limits before retrying. |
+| `policy-skipped` | Fork PRs and `dependabot/` or `renovate/` branches do not run credentialed visual tests. Interaction tests still run; this is not visual approval. |
+
+`scripts/report-chromatic.ts` interprets the action's public outputs and
+[CLI exit codes](https://www.chromatic.com/docs/cli/#exit-codes). Counts describe the returned
+build, which Chromatic can reuse; they do not establish when snapshots were captured. Accepted
+builds can retain nonzero change counts. Missing outputs fail closed, and account limits are not
+always distinguishable from other failures. Review this contract when updating the action.
+
+For visual verification of a fork contribution, a maintainer can review it and run a trusted
+same-repository branch. Do not expose project secrets to forks or use `pull_request_target`
+to bypass the policy.
+
+### Recovering quota and the baseline
+
+1. An account owner checks the project's current quota/billing and the linked build's results.
+   Resolve any account limit before retrying.
+2. Coordinate one full run on the current `main` commit after confirming snapshot capacity.
+   From the repository root:
+
+   ```bash
+   vp run --filter webapp build-storybook
+   cd webapp
+   vp exec chromatic --storybook-build-dir=storybook-static --only-changed=false --force-rebuild
+   ```
+
+   Supply `CHROMATIC_PROJECT_TOKEN` through the environment, never a committed file or command
+   argument. `--force-rebuild` prevents same-commit build reuse; `--only-changed=false` requests
+   full snapshots instead of TurboSnap inheritance.
+3. Verify in Chromatic that the build captured snapshots and completed testing. Inspect every
+   difference and component/interaction error. CI never auto-accepts, including on `main`:
+   manually accept only intentional, inspected differences, then rerun the check. Never accept
+   a publish-only, limited, errored or untested build as the recovery baseline.
+4. Reproduce component failures with the affected stories. Fix defects with story or regression
+   coverage, or link a scoped defect with reproduction details. For earlier errors that no longer
+   reproduce, record the verification evidence rather than assuming a successful upload fixed them.
+5. Record the `main` commit, build URL, captured/inherited counts, quota check and error dispositions
+   in the issue tracking the recovery. Then rerun affected PRs.
+
+### Snapshot consumption and global changes
+
+[TurboSnap](https://www.chromatic.com/docs/turbosnap/) reuses unchanged baseline snapshots.
+`webapp/chromatic.config.json` owns external-file invalidation: global styles, public files, assets
+and build configuration intentionally trigger full snapshots. Budget for those runs; do not narrow
+`externals` or broaden `untraced` to reduce quota use or latency. Follow
+[Chromatic's external-file guidance](https://www.chromatic.com/docs/turbosnap/setup/#configure-external-files)
+when changing these boundaries, and preserve dependency stats from the single Storybook build.

--- a/scripts/ci-contract.test.ts
+++ b/scripts/ci-contract.test.ts
@@ -2248,3 +2248,81 @@ void test("CodeQL selects languages with native change detection", async () => {
 	assert.ok(asArray(filters["java-kotlin"], "Java paths").includes("server/**"));
 	assert.ok(asArray(filters["javascript-typescript"], "JS paths").includes("pnpm-lock.yaml"));
 });
+
+void test("Stories enforces visual evidence independently of preview publication", async () => {
+	const workflow = parseDocument(await readFile(".github/workflows/ci-quality-gates.yml", "utf8"));
+	const jobPath = ["jobs", "webapp-stories"];
+	assert.equal(
+		workflow.getIn([...jobPath, "env", "CHROMATIC_POLICY_SKIP"]),
+		`\${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) || startsWith(github.head_ref || github.ref_name, 'dependabot/') || startsWith(github.head_ref || github.ref_name, 'renovate/') }}`,
+	);
+	const chromatic = namedStep(workflow, jobPath, "Chromatic visual testing");
+	assert.equal(chromatic.get("if"), "success() && env.CHROMATIC_POLICY_SKIP != 'true'");
+	assert.equal(chromatic.getIn(["with", "autoAcceptChanges"]), false);
+	assert.equal(chromatic.getIn(["with", "exitZeroOnChanges"]), false);
+	assert.equal(chromatic.getIn(["with", "exitOnceUploaded"]), false);
+	assert.equal(chromatic.getIn(["with", "skip"]), false);
+	const report = namedStep(workflow, jobPath, "Report Chromatic visual coverage");
+	assert.equal(report.get("if"), "always()");
+	assert.equal(report.get("continue-on-error"), true);
+	assert.equal(report.get("run"), "node scripts/report-chromatic.ts");
+	assert.equal(report.getIn(["env", "CHROMATIC_OUTCOME"]), `\${{ steps.chromatic.outcome }}`);
+	for (const [name, output] of Object.entries({
+		CODE: "code",
+		CAPTURED: "actualCaptureCount",
+		INHERITED: "inheritedCaptureCount",
+		TESTS: "testCount",
+		ERRORS: "errorCount",
+		CHANGES: "changeCount",
+		INTERACTIONS: "interactionTestFailuresCount",
+		BUILD_URL: "buildUrl",
+	}))
+		assert.equal(
+			report.getIn(["env", `CHROMATIC_${name}`]),
+			`\${{ steps.chromatic.outputs.${output} }}`,
+		);
+	const gate = namedStep(workflow, jobPath, "Evaluate stories checks");
+	assert.equal(gate.get("if"), "always()");
+	assert.equal(gate.getIn(["env", "CHROMATIC"]), `\${{ steps.visual_coverage.outcome }}`);
+});
+
+void test("global styles and assets retain full-snapshot invalidation", async () => {
+	const config: unknown = JSON.parse(await readFile("webapp/chromatic.config.json", "utf8"));
+	assert.ok(
+		config &&
+			typeof config === "object" &&
+			"externals" in config &&
+			Array.isArray(config.externals),
+	);
+	for (const pattern of [
+		"webapp/public/**",
+		"webapp/src/assets/**",
+		"webapp/**/*.css",
+		"webapp/**/*.scss",
+		"webapp/**/*.sass",
+		"webapp/tailwind.config.*",
+		"webapp/vite.*",
+		"webapp/components.json",
+	])
+		assert.ok(config.externals.includes(pattern), `${pattern} must invalidate snapshots`);
+});
+
+void test(
+	"Stories final verdict rejects every incomplete or failed leg",
+	{ skip: !bashRunsRunnerSteps() },
+	async () => {
+		const workflow = parseDocument(
+			await readFile(".github/workflows/ci-quality-gates.yml", "utf8"),
+		);
+		const command = runScript(workflow, ["jobs", "webapp-stories"], "Evaluate stories checks");
+		for (const stories of ["success", "failure", "skipped"])
+			for (const coverage of ["success", "failure", "skipped", "cancelled", ""]) {
+				const result = await runStep(command, { STORYBOOK_TESTS: stories, CHROMATIC: coverage });
+				assert.equal(
+					result.failed,
+					stories !== "success" || coverage !== "success",
+					result.diagnosis,
+				);
+			}
+	},
+);

--- a/scripts/report-chromatic.test.ts
+++ b/scripts/report-chromatic.test.ts
@@ -1,0 +1,121 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+
+import { coverageSummary, visualVerdict } from "./report-chromatic.ts";
+
+const tested = {
+	CHROMATIC_OUTCOME: "success",
+	CHROMATIC_CODE: "0",
+	CHROMATIC_CAPTURED: "10",
+	CHROMATIC_INHERITED: "20",
+	CHROMATIC_TESTS: "30",
+	CHROMATIC_ERRORS: "0",
+	CHROMATIC_CHANGES: "0",
+	CHROMATIC_INTERACTIONS: "0",
+};
+
+void test("distinguishes tested-build evidence, inherited and absent coverage", () => {
+	assert.equal(visualVerdict(tested).state, "tested-build");
+	assert.match(coverageSummary(tested), /do not prove new captures in this CI run/);
+	assert.equal(visualVerdict({ ...tested, CHROMATIC_CAPTURED: "0" }).state, "inherited");
+	assert.equal(
+		visualVerdict({ ...tested, CHROMATIC_CAPTURED: "0", CHROMATIC_INHERITED: "0" }).pass,
+		false,
+	);
+});
+
+void test("classifies account limits independently from service errors", () => {
+	for (const code of ["5", "11", "12"])
+		assert.equal(visualVerdict({ ...tested, CHROMATIC_CODE: code }).state, "quota-skipped");
+	for (const code of ["3", "6", "201", "202", "220", "255", "999", ""])
+		assert.equal(visualVerdict({ ...tested, CHROMATIC_CODE: code }).state, "unavailable");
+	assert.equal(
+		visualVerdict({ ...tested, CHROMATIC_CODE: "201", CHROMATIC_ERRORS: "1" }).state,
+		"unavailable",
+	);
+	for (const code of ["1", "2"])
+		assert.equal(visualVerdict({ ...tested, CHROMATIC_CODE: code }).state, "failed");
+});
+
+void test("missing/malformed evidence and action failures never approve coverage", () => {
+	for (const key of Object.keys(tested).filter((name) => name !== "CHROMATIC_OUTCOME"))
+		for (const value of [undefined, "", "undefined", "NaN", "-1", "1.5", "1e3", "9007199254740992"])
+			assert.equal(visualVerdict({ ...tested, [key]: value }).pass, false, `${key}: ${value}`);
+	for (const outcome of ["failure", "cancelled", "skipped", ""])
+		assert.equal(visualVerdict({ ...tested, CHROMATIC_OUTCOME: outcome }).pass, false);
+	for (const key of ["CHROMATIC_ERRORS", "CHROMATIC_INTERACTIONS"])
+		assert.equal(visualVerdict({ ...tested, [key]: "1" }).pass, false);
+	assert.equal(visualVerdict({ ...tested, CHROMATIC_TESTS: "0" }).pass, false);
+});
+
+void test("policy exemption applies only to an actually skipped action", () => {
+	assert.equal(
+		visualVerdict({ CHROMATIC_OUTCOME: "skipped", CHROMATIC_POLICY_SKIP: "true" }).state,
+		"policy-skipped",
+	);
+	assert.equal(
+		visualVerdict({ CHROMATIC_OUTCOME: "failure", CHROMATIC_POLICY_SKIP: "true" }).pass,
+		false,
+	);
+});
+
+void test("summary links only to a safe Chromatic build URL", () => {
+	assert.match(
+		coverageSummary({
+			...tested,
+			CHROMATIC_BUILD_URL: "https://www.chromatic.com/build?appId=abc&number=123",
+		}),
+		/Open Chromatic build/,
+	);
+	for (const url of [
+		// eslint-disable-next-line no-script-url -- Adversarial input must never become a summary link.
+		"javascript:alert(1)",
+		"https://evil.example/build",
+		"https://www.chromatic.com.evil.example/build",
+		"https://user:secret@www.chromatic.com/build",
+		"undefined",
+	])
+		assert.doesNotMatch(
+			coverageSummary({ ...tested, CHROMATIC_BUILD_URL: url }),
+			/Open Chromatic build/,
+		);
+});
+
+void test("CLI writes its summary and fails closed even with no outputs", () => {
+	const dir = mkdtempSync(join(tmpdir(), "chromatic-report-"));
+	try {
+		for (const [index, [env, status, state]] of (
+			[
+				[tested, 0, "tested-build"],
+				[{ ...tested, CHROMATIC_CODE: "11" }, 1, "quota-skipped"],
+				[{ ...tested, CHROMATIC_OUTCOME: "failure", CHROMATIC_CODE: "201" }, 1, "unavailable"],
+				[{}, 1, "unavailable"],
+				[{ CHROMATIC_OUTCOME: "skipped", CHROMATIC_POLICY_SKIP: "true" }, 0, "policy-skipped"],
+			] as const
+		).entries()) {
+			const summary = join(dir, `${index}.md`);
+			const run = spawnSync(process.execPath, ["scripts/report-chromatic.ts"], {
+				env: { ...env, GITHUB_STEP_SUMMARY: summary },
+				encoding: "utf8",
+			});
+			assert.equal(run.status, status, run.stderr);
+			assert.match(readFileSync(summary, "utf8"), new RegExp(`coverage: ${state}`));
+			assert.equal(run.stdout.includes("::error::"), status !== 0);
+			assert.equal(run.stdout.includes("::warning::"), state === "policy-skipped");
+		}
+	} finally {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+void test("accepted/reused builds may retain a nonzero change count", () => {
+	assert.equal(visualVerdict({ ...tested, CHROMATIC_CHANGES: "2" }).state, "tested-build");
+	assert.equal(
+		visualVerdict({ ...tested, CHROMATIC_CHANGES: "2", CHROMATIC_CODE: "1" }).pass,
+		false,
+	);
+});

--- a/scripts/report-chromatic.ts
+++ b/scripts/report-chromatic.ts
@@ -1,0 +1,100 @@
+import { appendFileSync } from "node:fs";
+
+function count(value: string | undefined): number | undefined {
+	if (!value || !/^\d+$/u.test(value)) return undefined;
+	const parsed = Number(value);
+	return Number.isSafeInteger(parsed) ? parsed : undefined;
+}
+
+export function visualVerdict(env: NodeJS.ProcessEnv) {
+	const code = count(env.CHROMATIC_CODE);
+	const captured = count(env.CHROMATIC_CAPTURED);
+	const inherited = count(env.CHROMATIC_INHERITED);
+	const tests = count(env.CHROMATIC_TESTS);
+	const errors = count(env.CHROMATIC_ERRORS);
+	const changes = count(env.CHROMATIC_CHANGES);
+	const interactions = count(env.CHROMATIC_INTERACTIONS);
+	const result = (state: string, pass: boolean, message: string) => ({ state, pass, message });
+	if (env.CHROMATIC_OUTCOME === "skipped" && env.CHROMATIC_POLICY_SKIP === "true")
+		return result(
+			"policy-skipped",
+			true,
+			"Not tested: fork or dependency-bot policy. This is not visual approval.",
+		);
+	if (code === 5 || code === 11 || code === 12)
+		return result(
+			"quota-skipped",
+			false,
+			"Coverage blocked by an account limit. Account owner: resolve the limit, then follow baseline recovery.",
+		);
+	if (code === 1 || code === 2)
+		return result(
+			"failed",
+			false,
+			"Review visual differences and fix component/interaction errors before accepting a baseline.",
+		);
+	if (env.CHROMATIC_OUTCOME !== "success" || code !== 0)
+		return result(
+			"unavailable",
+			false,
+			"Chromatic did not complete successfully. Check action logs, credentials and service status before retrying.",
+		);
+	if ((errors ?? 0) > 0 || (interactions ?? 0) > 0)
+		return result(
+			"failed",
+			false,
+			"Chromatic exited successfully but reported component/interaction errors. Fix the errors before accepting a baseline.",
+		);
+	if (
+		captured === undefined ||
+		inherited === undefined ||
+		tests === undefined ||
+		tests === 0 ||
+		errors !== 0 ||
+		changes === undefined ||
+		interactions !== 0 ||
+		captured + inherited === 0
+	)
+		return result(
+			"unavailable",
+			false,
+			"No usable visual coverage evidence. Check account limits, project testing settings and action outputs.",
+		);
+	return captured > 0
+		? result(
+				"tested-build",
+				true,
+				`Returned build: ${captured} captured snapshots, ${inherited} inherited, ${changes} visual changes; passed without errors. Approved builds may be reused: these counts do not prove new captures in this CI run.`,
+			)
+		: result(
+				"inherited",
+				true,
+				`Returned build: ${inherited} inherited snapshots, no new captures. Reused coverage, not a newly tested baseline.`,
+			);
+}
+
+export function coverageSummary(env: NodeJS.ProcessEnv) {
+	const verdict = visualVerdict(env);
+	let link = "";
+	const url = URL.parse(env.CHROMATIC_BUILD_URL ?? "");
+	if (
+		url?.protocol === "https:" &&
+		url.hostname === "www.chromatic.com" &&
+		url.username === "" &&
+		url.password === "" &&
+		url.pathname === "/build"
+	)
+		link = `\n[Open Chromatic build](${url.href.replaceAll("(", "%28").replaceAll(")", "%29")})\n`;
+
+	return `## Chromatic visual coverage: ${verdict.state}\n\n${verdict.message}\n${link}\nRecovery: [contributor guide](https://github.com/hephaestus-build/Hephaestus/blob/main/docs/contributor/ci-cd.mdx#chromatic-visual-coverage).\n`;
+}
+
+if (import.meta.main) {
+	const verdict = visualVerdict(process.env);
+	const summary = coverageSummary(process.env);
+	if (process.env.GITHUB_STEP_SUMMARY) appendFileSync(process.env.GITHUB_STEP_SUMMARY, summary);
+	console.log(summary);
+	if (!verdict.pass) console.log(`::error::${verdict.message}`);
+	else if (verdict.state === "policy-skipped") console.log(`::warning::${verdict.message}`);
+	process.exitCode = verdict.pass ? 0 : 1;
+}


### PR DESCRIPTION
## What changed and why

A published Storybook does not prove that Chromatic tested its visuals. The Stories job needs to distinguish usable visual coverage from account limits, failed tests, unavailable results, and deliberate policy skips.

This change adds a coverage summary and enforces its verdict in the final Stories check. It uses Chromatic's public action outputs, reports captured and inherited evidence separately, and rejects missing or invalid evidence. Preview publication remains independent. Existing fork and dependency-bot exclusions remain explicit rather than appearing as visual approval.

CI now explicitly waits for testing and no longer automatically accepts changes on `main`. The contributor guide explains account recovery, reviewed baseline acceptance, and why global style/asset changes must retain full-snapshot coverage.

Related to [#1647](https://github.com/hephaestus-build/Hephaestus/issues/1647); preserves the snapshot-correctness boundaries in [#1590](https://github.com/hephaestus-build/Hephaestus/issues/1590). Account-owner verification and historical component-error dispositions remain outstanding in the tracking issue.

## How to test

- Run `node --test scripts/report-chromatic.test.ts scripts/ci-contract.test.ts`. The tests cover account limits, transport failures, malformed/missing outputs, inherited and reused builds, policy skips, summaries, and the final workflow gate's exit behavior.
- Run `vp run format` and `vp run check` for the complete local quality gate.
- In the Stories job, inspect the **Chromatic visual coverage** summary. A quota or unavailable result must fail the final Stories check; a preview link must not stand in for visual approval.

Local formatting, the complete quality gate, and the focused tests passed. No credentialed Chromatic build was run locally.

## Release impact

CI tooling and contributor documentation only; no shipped application code changes, changeset, or operator migration.

Maintainers must review intentional visual differences before accepting a baseline, including on `main`. Fork and dependency-bot visual-testing exclusions are unchanged; global style/asset invalidation is preserved.

## Notes for reviewers

Start with `scripts/report-chromatic.ts` and the final Stories gate in `.github/workflows/ci-quality-gates.yml`.

- `tested-build` describes the returned build, not necessarily fresh captures: Chromatic can reuse an approved build and return its historical counts. The summary states this explicitly.
- Account-limit exit codes produce an actionable diagnosis when available. Public outputs do not always distinguish account limits from other unavailable results; missing usable evidence fails closed.
- An account owner still needs to check current quota, record a newly testing `main` baseline, and resolve or separately scope the historical component errors. This PR makes no claim that those account actions have happened.

