### PR TITLE
fix(release): refresh current migration guide links

### DIFF
--- a/.changeset/current-migration-guide-links.md
+++ b/.changeset/current-migration-guide-links.md
@@ -1,0 +1,5 @@
+---
+"hephaestus": patch
+---
+
+The migration guide's current release lookup, compatibility policy, documentation and help links now point directly to the current repository and documentation site. Historical release image locations and signing identities remain unchanged.

--- a/.migration/README.md
+++ b/.migration/README.md
@@ -5,3 +5,6 @@ complete migration-guide entry, begins with a `#### 🔴 …` heading, and has t
 changeset whose summary contains `**Operators:**`. Never edit `MIGRATION.md`'s `### Next release`
 section. `vp run release:version` sorts fragments by filename, inserts them under a new version
 heading below the unchanged `### Next release` anchor, and then removes them.
+
+For changes to current instructions outside version history, see
+[Current migration-guide instructions](https://docs.hephaestus.build/contributor/release-management#current-migration-guide-instructions).

--- a/docs/contributor/release-management.mdx
+++ b/docs/contributor/release-management.mdx
@@ -197,6 +197,15 @@ verifies the lock signer and release identity before Compose consumes any digest
 release assets provide the per-platform SBOM, vulnerability, license, and index-membership evidence;
 `SHA256SUMS` covers that evidence set.
 
+## Current migration-guide instructions
+
+Edit `scripts/templates/migration-guide.md` for current operator instructions, not `MIGRATION.md`.
+`vp run release:version` renders the template in the Version PR; keep its single
+`<!-- VERSION_HISTORY -->` marker. Released entries retain their original text, image namespaces
+and signing identities. Add new version-specific actions through [migration fragments](#writing-changesets).
+
+Run `vp run gate:changesets` to verify generation and history preservation.
+
 ## Writing changesets
 
 A changeset summary becomes the `CHANGELOG.md` entry **verbatim** — write it in the operator/user's voice:

--- a/scripts/lib/migration-guide.ts
+++ b/scripts/lib/migration-guide.ts
@@ -1,0 +1,53 @@
+import { readFileSync } from "node:fs";
+
+import { fromMarkdown } from "mdast-util-from-markdown";
+
+const template = readFileSync(new URL("../templates/migration-guide.md", import.meta.url), "utf8");
+const marker = "<!-- VERSION_HISTORY -->\n\n";
+
+// Keep source offsets: serializing the Markdown tree would rewrite released history.
+export function migrationGuideSections(migration: string) {
+	const headings = fromMarkdown(migration).children.filter(
+		(node) => node.type === "heading" && node.depth <= 3,
+	);
+	return headings.map((node, index) => {
+		const start = node.position?.start.offset;
+		const contentStart = node.position?.end.offset;
+		if (start === undefined || contentStart === undefined) {
+			throw new Error("migration-guide: heading has no source position");
+		}
+		const end = headings[index + 1]?.position?.start.offset ?? migration.length;
+		return {
+			heading: migration.slice(start, contentStart),
+			start,
+			end,
+			content: migration.slice(contentStart, end).trim(),
+		};
+	});
+}
+
+export function renderMigrationGuide(migration: string): string {
+	const sections = migrationGuideSections(migration);
+	const starts = sections.filter((section) => section.heading === "### Next release");
+	const ends = sections.filter(
+		(section) => section.heading === "## Automatic vs Manual Migrations",
+	);
+	const from = starts[0]?.start;
+	const to = ends[0]?.start;
+	if (
+		starts.length !== 1 ||
+		ends.length !== 1 ||
+		from === undefined ||
+		to === undefined ||
+		from >= to
+	) {
+		throw new Error(
+			"migration-guide: expected exactly one ### Next release before ## Automatic vs Manual Migrations",
+		);
+	}
+	const parts = template.split(marker);
+	if (parts.length !== 2) {
+		throw new Error("migration-guide: template must contain exactly one version history marker");
+	}
+	return `${parts[0]}${migration.slice(from, to)}${parts[1]}`;
+}

--- a/scripts/sync-release-version.test.ts
+++ b/scripts/sync-release-version.test.ts
@@ -1,15 +1,92 @@
 import assert from "node:assert/strict";
 import { execFile } from "node:child_process";
-import { mkdir, mkdtemp, readFile, readdir, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 import { promisify } from "node:util";
 
-const run = promisify(execFile);
+import { migrationGuideSections, renderMigrationGuide } from "./lib/migration-guide.ts";
 
-void test("synchronizes every release-owned version reference", async () => {
+const run = promisify(execFile);
+const template = await readFile(new URL("./templates/migration-guide.md", import.meta.url), "utf8");
+const guide = (history: string) => template.replace("<!-- VERSION_HISTORY -->\n\n", () => history);
+
+void test("refreshes current instructions without changing a byte of real release history", async () => {
+	const original = await readFile(new URL("../MIGRATION.md", import.meta.url), "utf8");
+	const rendered = renderMigrationGuide(original);
+	const before = migrationGuideSections(original);
+	const after = migrationGuideSections(rendered);
+	const originalStart = before.find((section) => section.heading === "### Next release");
+	const originalEnd = before.find(
+		(section) => section.heading === "## Automatic vs Manual Migrations",
+	);
+	const start = after.find((section) => section.heading === "### Next release");
+	const end = after.find((section) => section.heading === "## Automatic vs Manual Migrations");
+	assert.ok(originalStart && originalEnd && start && end);
+	assert.equal(
+		rendered.slice(start.start, end.start),
+		original.slice(originalStart.start, originalEnd.start),
+	);
+	const current = rendered.slice(0, start.start) + rendered.slice(end.start);
+	assert.doesNotMatch(
+		current,
+		/(?:github\.com\/(?:repos\/)?ls1intum\/[Hh]ephaestus|ls1intum\.github\.io\/Hephaestus)/,
+	);
+	assert.ok(!current.includes("<!-- VERSION_HISTORY -->"));
+	for (const url of [
+		"https://api.github.com/repos/hephaestus-build/Hephaestus/releases/latest",
+		...["releases", "issues", "discussions"].map(
+			(path) => `https://github.com/hephaestus-build/Hephaestus/${path}`,
+		),
+		...["compatibility-policy", "production-setup", "backup-restore"].map(
+			(path) => `https://docs.hephaestus.build/admin/${path}`,
+		),
+	])
+		assert.ok(current.includes(url), `missing current reference: ${url}`);
+	assert.equal(renderMigrationGuide(rendered), rendered);
+});
+
+void test("refreshes an empty history without inventing a release, including on regeneration", async (t) => {
+	const history = "### Next release\n\n";
+	const original = `Old instructions\n\n${history}## Automatic vs Manual Migrations\nOld help\n`;
+	const cwd = await mkdtemp(join(tmpdir(), "migration-guide-"));
+	t.after(async () => {
+		await rm(cwd, { recursive: true, force: true });
+	});
+	await mkdir(join(cwd, "docs/admin"), { recursive: true });
+	await writeFile(join(cwd, "package.json"), '{"version":"99.0.0"}');
+	await writeFile(join(cwd, "README.md"), "VERSION=0.0.0 # the release you are installing\n");
+	await writeFile(
+		join(cwd, "docs/admin/install.mdx"),
+		"VERSION=0.0.0 # the release you are installing\n",
+	);
+	await writeFile(join(cwd, "MIGRATION.md"), original);
+	await run(process.execPath, [join(import.meta.dirname, "sync-release-version.ts")], { cwd });
+	assert.equal(await readFile(join(cwd, "MIGRATION.md"), "utf8"), guide(history));
+	await run(process.execPath, [join(import.meta.dirname, "sync-release-version.ts")], { cwd });
+	assert.equal(await readFile(join(cwd, "MIGRATION.md"), "utf8"), guide(history));
+});
+
+void test("preserves heading-shaped code and historical identities literally", () => {
+	const history =
+		"### Next release\n\n### v0.74.0\n\n```md\n### Next release\n## Automatic vs Manual Migrations\n```\n\nghcr.io/ls1intum/hephaestus/agent-pi:0.74.0\nhttps://github.com/ls1intum/Hephaestus/.github/workflows/release.yml@refs/heads/main\n";
+	assert.equal(renderMigrationGuide(guide(history)), guide(history));
+});
+
+void test("rejects missing, duplicate, or reversed history boundaries instead of dropping content", () => {
+	const start = "### Next release\n";
+	const end = "## Automatic vs Manual Migrations\n";
+	for (const input of ["", start, end, end + start, start + start + end, start + end + end]) {
+		assert.throws(() => renderMigrationGuide(input), /expected exactly one/);
+	}
+});
+
+void test("synchronizes every release-owned version reference", async (t) => {
 	const cwd = await mkdtemp(join(tmpdir(), "sync-release-version-"));
+	t.after(async () => {
+		await rm(cwd, { recursive: true, force: true });
+	});
 	await mkdir(join(cwd, "docs/admin"), { recursive: true });
 	await mkdir(join(cwd, ".migration"));
 	await writeFile(join(cwd, "package.json"), '{"version":"0.75.0"}');
@@ -21,17 +98,20 @@ void test("synchronizes every release-owned version reference", async () => {
 		join(cwd, "README.md"),
 		"```bash\n  VERSION=0.74.0 # the release you are installing\n```\n",
 	);
-	// v0.76.0 and v0.75.0 are mislabeled hand-written sections for unreleased work (the released
-	// history starts at v0.74.0) — the exact shape that broke the Version PR on main.
 	await writeFile(
 		join(cwd, "MIGRATION.md"),
-		"### Next release\n\n#### 🔴 Existing action\n\nDo it.\n\n### v0.76.0\n\n#### 🔴 Mislabeled newer action\n\nFold me.\n\n### v0.75.0\n\n#### 🔴 Mislabeled same-version action\n\nFold me too.\n\n### v0.74.0\n\nOld.\n",
+		guide(
+			"### Next release\n\n#### 🔴 Existing action\n\nDo it.\n\n### v0.76.0\n\n#### 🔴 Newer unreleased action\n\nFold me.\n\n### v0.75.0\n\n#### 🔴 Same-version unreleased action\n\nFold me too.\n\n### v0.74.0\n\nOld.\n",
+		),
 	);
 	await writeFile(
 		join(cwd, ".migration/z-last.md"),
 		"#### 🔴 Z action\n\nDo Z: keep `$$VAR`, `$&`, and `$'` literal.\n",
 	);
-	await writeFile(join(cwd, ".migration/a-first.md"), "#### 🔴 A action\n\nDo A.\n");
+	await writeFile(
+		join(cwd, ".migration/a-first.md"),
+		"#### 🔴 A action\n\nDo A.\n\n```md\n### Next release\n## Automatic vs Manual Migrations\n### v0.75.0\n```\n",
+	);
 	await writeFile(join(cwd, ".migration/README.md"), "instructions\n");
 
 	await run(process.execPath, [join(import.meta.dirname, "sync-release-version.ts")], { cwd });
@@ -44,17 +124,16 @@ void test("synchronizes every release-owned version reference", async () => {
 		await readFile(join(cwd, "README.md"), "utf8"),
 		"```bash\n  VERSION=0.75.0 # the release you are installing\n```\n",
 	);
-	const stamped =
-		"### Next release\n\n### v0.75.0\n\n#### 🔴 Existing action\n\nDo it.\n\n#### 🔴 Mislabeled newer action\n\nFold me.\n\n#### 🔴 Mislabeled same-version action\n\nFold me too.\n\n#### 🔴 A action\n\nDo A.\n\n#### 🔴 Z action\n\nDo Z: keep `$$VAR`, `$&`, and `$'` literal.\n\n### v0.74.0\n\nOld.\n";
+	const stamped = guide(
+		"### Next release\n\n### v0.75.0\n\n#### 🔴 Existing action\n\nDo it.\n\n#### 🔴 Newer unreleased action\n\nFold me.\n\n#### 🔴 Same-version unreleased action\n\nFold me too.\n\n#### 🔴 A action\n\nDo A.\n\n```md\n### Next release\n## Automatic vs Manual Migrations\n### v0.75.0\n```\n\n#### 🔴 Z action\n\nDo Z: keep `$$VAR`, `$&`, and `$'` literal.\n\n### v0.74.0\n\nOld.\n",
+	);
 	assert.equal(await readFile(join(cwd, "MIGRATION.md"), "utf8"), stamped);
 	assert.deepEqual(await readdir(join(cwd, ".migration")), ["README.md"]);
 
-	// Regeneration re-reads the script's own prior output and must be byte-idempotent.
 	await run(process.execPath, [join(import.meta.dirname, "sync-release-version.ts")], { cwd });
 	assert.equal(await readFile(join(cwd, "MIGRATION.md"), "utf8"), stamped);
 	assert.deepEqual(await readdir(join(cwd, ".migration")), ["README.md"]);
 
-	// A fragment landing between regenerations merges into the same unreleased section.
 	await writeFile(join(cwd, ".migration/late.md"), "#### 🔴 Late action\n");
 	await run(process.execPath, [join(import.meta.dirname, "sync-release-version.ts")], { cwd });
 	assert.equal(
@@ -66,7 +145,10 @@ void test("synchronizes every release-owned version reference", async () => {
 	// A same-version heading below released history is a real conflict, not prior output.
 	await writeFile(
 		join(cwd, "MIGRATION.md"),
-		`${await readFile(join(cwd, "MIGRATION.md"), "utf8")}\n### v0.75.0\n\nGhost.\n`,
+		(await readFile(join(cwd, "MIGRATION.md"), "utf8")).replace(
+			"Old.\n",
+			"Old.\n\n### v0.75.0\n\nGhost.\n",
+		),
 	);
 	await assert.rejects(
 		run(process.execPath, [join(import.meta.dirname, "sync-release-version.ts")], { cwd }),

--- a/scripts/sync-release-version.ts
+++ b/scripts/sync-release-version.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync, readdirSync, rmSync, writeFileSync } from "no
 import { join } from "node:path";
 
 import { asRecord, asString, parseJson } from "./lib/json.ts";
+import { migrationGuideSections, renderMigrationGuide } from "./lib/migration-guide.ts";
 
 const version = asString(
 	asRecord(parseJson(readFileSync("package.json", "utf8")), "package.json").version,
@@ -30,14 +31,13 @@ for (const { file, re, line } of edits) {
 }
 
 const migrationFile = "MIGRATION.md";
-const migration = readFileSync(migrationFile, "utf8");
-const pendingSections = [
-	...migration.matchAll(/^### Next release\n([\s\S]*?)(?=^### |(?![\s\S]))/gm),
-];
-if (pendingSections.length !== 1) {
+const migration = renderMigrationGuide(readFileSync(migrationFile, "utf8"));
+const sections = migrationGuideSections(migration);
+const pendingSection = sections.find((section) => section.heading === "### Next release");
+if (!pendingSection) {
 	throw new Error("sync-release-version: MIGRATION.md must contain exactly one ### Next release");
 }
-const pending = pendingSections[0]?.[1]?.trim() ?? "";
+const pending = pendingSection.content;
 const fragmentDirectory = ".migration";
 const fragmentFiles = existsSync(fragmentDirectory)
 	? readdirSync(fragmentDirectory)
@@ -45,11 +45,6 @@ const fragmentFiles = existsSync(fragmentDirectory)
 			.toSorted()
 	: [];
 
-// A version can only gain a history section by being released, and `changeset version` computes
-// the lowest unreleased version — so any section for this version or a later one is unreleased
-// content that ships now. Sections directly below the pending anchor whose headings say otherwise
-// (hand-written before fragments existed, or this script's own output when a regeneration re-reads
-// it) are absorbed into the section being stamped instead of failing the release.
 const semverAtLeast = (candidate: string, reference: string): boolean => {
 	const left = candidate.split(".").map(Number);
 	const right = reference.split(".").map(Number);
@@ -58,20 +53,25 @@ const semverAtLeast = (candidate: string, reference: string): boolean => {
 	}
 	return true;
 };
-const regionStart = pendingSections[0]?.index ?? 0;
-let regionLength = pendingSections[0]?.[0]?.length ?? 0;
+const regionStart = pendingSection.start;
+let regionEnd = pendingSection.end;
 const unreleased: string[] = [];
-for (;;) {
-	const tail = migration.slice(regionStart + regionLength);
-	const next = /^### v(\d+\.\d+\.\d+)\n([\s\S]*?)(?=^### |(?![\s\S]))/m.exec(tail);
-	if (!next || next.index !== 0 || !semverAtLeast(next[1] ?? "", version)) break;
-	unreleased.push(next[2]?.trim() ?? "");
-	regionLength += next[0].length;
+// Changesets selects the next release version; sections at or above it have not shipped.
+for (const section of sections.slice(sections.indexOf(pendingSection) + 1)) {
+	const next = /^### v(\d+\.\d+\.\d+)$/.exec(section.heading);
+	if (!next || !semverAtLeast(next[1] ?? "", version)) break;
+	unreleased.push(section.content);
+	regionEnd = section.end;
 }
 
 if (pending !== "" || unreleased.length > 0 || fragmentFiles.length > 0) {
-	const remainder = migration.slice(0, regionStart) + migration.slice(regionStart + regionLength);
-	if (remainder.split("\n").includes(`### v${version}`)) {
+	if (
+		sections.some(
+			(section) =>
+				section.heading === `### v${version}` &&
+				(section.start < regionStart || section.start >= regionEnd),
+		)
+	) {
 		throw new Error(`sync-release-version: MIGRATION.md already contains ### v${version}`);
 	}
 	const fragments = fragmentFiles.map((file) =>
@@ -80,12 +80,13 @@ if (pending !== "" || unreleased.length > 0 || fragmentFiles.length > 0) {
 	const section = ["### Next release", `### v${version}`, pending, ...unreleased, ...fragments]
 		.filter(Boolean)
 		.join("\n\n");
-	// Splicing by offset keeps `$&`/`$$` in migration notes literal.
 	writeFileSync(
 		migrationFile,
-		`${migration.slice(0, regionStart)}${section}\n\n${migration.slice(regionStart + regionLength)}`,
+		`${migration.slice(0, regionStart)}${section}\n\n${migration.slice(regionEnd)}`,
 	);
 	for (const file of fragmentFiles) rmSync(join(fragmentDirectory, file));
+} else {
+	writeFileSync(migrationFile, migration);
 }
 
 console.log(`Synced release version references to ${version}`);

--- a/scripts/templates/migration-guide.md
+++ b/scripts/templates/migration-guide.md
@@ -1,0 +1,154 @@
+# Migration Guide
+
+This document helps you upgrade between versions of Hephaestus. For what a version number promises
+(public contract, upgrade guarantee, support statement), see the
+[Compatibility Policy](https://docs.hephaestus.build/admin/compatibility-policy).
+
+> ⚠️ **Pre-1.0 Notice**: We are in active development. Minor versions (0.x.0) may contain breaking changes. Always test in staging before production.
+
+## Quick Reference
+
+| Symbol | Meaning |
+|--------|---------|
+| 🔴 | **Breaking**: Action required before upgrade |
+| 🟡 | **Deprecated**: Works now; removed in a later release — the release notes say which |
+| 🟢 | **New**: No action needed |
+
+## Check Your Version
+
+Run these from the directory you deploy from — for a self-hosted install that is
+`/opt/hephaestus/docker/self-host`, the same directory as your `.env`. Running them from the
+repository root points at a different Compose project and reports nothing.
+
+```bash
+# Deployed version (the image tag your containers run; APP_VERSION is derived from it)
+docker compose images application-server
+
+# Latest release
+curl -fsSL https://api.github.com/repos/hephaestus-build/Hephaestus/releases/latest \
+  | grep -m1 '"tag_name"'
+```
+
+Signed in, you can also read the running version straight off the app: production shows it in the
+header, linked to its release notes.
+
+---
+
+## Pre-1.0 Development (Current)
+
+During pre-1.0, we follow [Semantic Versioning 0.x conventions](https://semver.org/#spec-item-4):
+
+> Major version zero (0.y.z) is for initial development. Anything MAY change at any time.
+
+### What This Means
+
+| Version Bump | May Contain |
+|--------------|-------------|
+| `0.x.0` → `0.y.0` | Breaking changes |
+| `0.x.y` → `0.x.z` | Bug fixes, minor features |
+
+### Upgrade Checklist
+
+Before upgrading to any new `0.x.0` version:
+
+1. ✅ Read the [release notes](https://github.com/hephaestus-build/Hephaestus/releases)
+2. ✅ Check this migration guide for breaking changes
+3. ✅ Verify in staging first (auto-deployed on every release)
+4. ✅ Approve production deployment after staging verification
+
+---
+
+## Version History
+
+Entries exist only for releases that need operator action. Everything else is in the
+[release notes](https://github.com/hephaestus-build/Hephaestus/releases).
+
+<!-- VERSION_HISTORY -->
+
+## Automatic vs Manual Migrations
+
+### Automatic (No Action Needed)
+
+| Component | Tool | Notes |
+|-----------|------|-------|
+| Database schema | Liquibase | Changesets apply automatically, in order, on server startup |
+
+### Manual (Action Required)
+
+| Component | How | Notes |
+|-----------|-----|-------|
+| Environment variables | Check release notes | New config may be required |
+| Docker compose | Check `docker/` files | Image versions may change |
+
+---
+
+## Stability Roadmap
+
+### v1.0.0 (Future)
+
+At v1.0.0 the [Compatibility Policy](https://docs.hephaestus.build/admin/compatibility-policy)
+takes effect — the public contract, the "any 1.x → any later 1.y" upgrade guarantee,
+deprecation-ahead-of-removal, and latest-release-only support. Until then, expect rapid iteration and
+occasional breaking changes in minor releases.
+
+---
+
+## Common Migration Scenarios
+
+### You build against our REST API
+
+The API surface is published as `server/openapi.yaml` in each release; regenerate your client from it
+and review the release notes for endpoint changes.
+
+### New Required Environment Variable
+
+1. Check the release notes and the [Production Setup](https://docs.hephaestus.build/admin/production-setup) guide for new variables
+2. Add them to your deployment's environment (see the `docker/compose.app.yaml` env block)
+3. Restart services
+
+### Database Schema Changed
+
+Liquibase applies changelogs automatically, in order, on server startup. A failure is not silent: the
+application context fails to start, so the container exits and your orchestrator restarts it — a
+crash-loop whose first useful line is in the *first* startup attempt's log, not the latest. Capture
+that before doing anything else:
+
+```bash
+docker compose logs application-server | grep -i -m5 liquibase
+```
+
+Liquibase runs each changeset in its own transaction, so a failure leaves earlier changesets applied
+and the failing one rolled back. The database is therefore consistent but *partially migrated*, and
+the old application version may no longer match it — do not assume rolling back the image is safe.
+
+| Symptom in the log | What it means | What to do |
+| --- | --- | --- |
+| `Could not acquire change log lock` | A previous run was killed (OOM, `docker kill`, node eviction) mid-migration and left its row in `DATABASECHANGELOGLOCK`. | Confirm no server is actually running, then clear it: `UPDATE databasechangeloglock SET locked = FALSE, lockgranted = NULL, lockedby = NULL WHERE id = 1;` and restart. Never clear it while another replica may still be migrating. |
+| `Validation Failed: … checksums do not match` | A changelog file that already ran was edited. Released changelogs are immutable for exactly this reason. | Restore the file to its released content and fix forward with a *new* changelog. Do not `clearCheckSums` on production to make the error go away — it tells Liquibase to trust a file whose applied effect you no longer know. |
+| A constraint or `NOT NULL` addition fails | Existing rows violate the new rule. CI replays migrations against an empty database, so a data-incompatible migration passes CI and fails only on real data. | Do not hand-edit the schema. Report it with the failing changeset id; the fix ships as a new changelog that cleans the data first. |
+| `permission denied` / `must be owner of` | The database user lacks DDL rights on an existing object. | Grant ownership or `ALTER` on the named object and restart. |
+
+**Fix forward, do not roll back.** Changelogs carry `<rollback>` blocks, but they are never exercised
+in CI and are not a supported recovery path. The supported recoveries, in order of preference:
+
+1. **Wait for a patch release** that fixes the changeset forward. A partially migrated database keeps
+   serving on the previous image only if no applied changeset broke it — check the log for which
+   changesets succeeded before deciding.
+2. **Restore from backup** if the instance must come back now and forward-fixing will take longer than
+   the outage budget. Follow
+   [Backup & restore](https://docs.hephaestus.build/admin/backup-restore); restore the
+   database dump *and* the `.env` holding `HEPHAESTUS_SECURITY_ENCRYPTION_KEY`, or every encrypted
+   credential in the restored database is unreadable. Then pin `IMAGE_TAG` to the version the dump
+   was taken under so it is not immediately re-migrated by the release that failed.
+
+Take a database dump before every upgrade that ships a migration. The release notes flag which ones
+do.
+
+---
+
+## Getting Help
+
+1. 📖 [GitHub Discussions](https://github.com/hephaestus-build/Hephaestus/discussions) - Ask the community
+2. 🐛 [Issues](https://github.com/hephaestus-build/Hephaestus/issues) - Report problems
+3. 📝 [CHANGELOG.md](./CHANGELOG.md) - Detailed change history
+4. 🔄 [Release Notes](https://github.com/hephaestus-build/Hephaestus/releases) - Per-version details


### PR DESCRIPTION
## What changed and why

The migration guide still sends operators to the former repository and documentation site. Ordinary pull requests cannot edit `MIGRATION.md`, so this change updates its current instructions through the existing release-generation path instead of bypassing that protection.

- Move the current instructions into an editable template and render it during release versioning.
- Preserve released entries verbatim, including their original image locations and signing identities.
- Use the existing Markdown parser to distinguish real headings from fenced examples and keep footer content out of release entries.

Related to #1599; follows #1851. The generated guide correction lands in the subsequent Version PR, so this PR does not close the issue prematurely.

## How to test

- `vp run format` and `vp run check` — repository formatting and local quality gates.
- `vp run test:tooling` — release tooling and repository regression tests.
- `vp run gate:changesets` — current links, byte-preserved history, empty-history generation, fenced headings, fragment ordering, regeneration, and malformed boundaries.

Rendering the current guide changes only 10 link lines. In the generated Version PR, verify that historical entries remain unchanged and that the current links use `hephaestus-build/Hephaestus` and `docs.hephaestus.build`.

## Release impact

[Patch changeset](https://github.com/hephaestus-build/Hephaestus/blob/issue-1599-update-current-migration-guide-links/.changeset/current-migration-guide-links.md). No operator action is required. No application, upgrade, restore, image-signing, or deployment behavior changes.

## Notes for reviewers

Start with `scripts/templates/migration-guide.md` and `scripts/lib/migration-guide.ts`, then the integration in `scripts/sync-release-version.ts`. Markdown is parsed for source positions, not reserialized, so historical text stays intact.

`MIGRATION.md` and its feature-PR protection remain unchanged. The contributor guide documents the supported edit path; migration fragments remain the path for new version-specific operator actions.
