### PR TITLE
fix(ci): keep transitive compatibility overrides on supported majors

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -72,6 +72,27 @@
 			"dependencyDashboardApproval": true
 		},
 		{
+			"description": "Compatibility override for older transitive consumers: retain patched releases within the supported major, rather than forcing a breaking API",
+			"matchManagers": ["npm"],
+			"matchDepTypes": ["pnpm-workspace.overrides"],
+			"matchDepNames": ["js-yaml@>=4.0.0"],
+			"allowedVersions": "4.x"
+		},
+		{
+			"description": "Compatibility override for older transitive consumers: retain patched releases within the supported major, rather than forcing a breaking API",
+			"matchManagers": ["npm"],
+			"matchDepTypes": ["pnpm-workspace.overrides"],
+			"matchDepNames": ["markdown-it@<=14.1.1"],
+			"allowedVersions": "14.x"
+		},
+		{
+			"description": "Compatibility override for older transitive consumers: retain patched releases within the supported major, rather than forcing a breaking API",
+			"matchManagers": ["npm"],
+			"matchDepTypes": ["pnpm-workspace.overrides"],
+			"matchDepNames": ["uuid@<11.1.1"],
+			"allowedVersions": "11.x"
+		},
+		{
 			"matchManagers": ["npm"],
 			"matchFileNames": ["webapp/package.json"],
 			"matchPackageNames": ["ai", "@ai-sdk/react"],

--- a/scripts/renovate-config.test.ts
+++ b/scripts/renovate-config.test.ts
@@ -59,6 +59,29 @@ void test("dependency pull requests explain the human-review requirement", () =>
 	);
 });
 
+void test("compatibility overrides receive same-major fixes without restricting direct dependencies", () => {
+	assert.ok(Array.isArray(config.packageRules));
+	const rules = config.packageRules.filter(isRecord);
+	for (const [selector, versions] of [
+		["js-yaml@>=4.0.0", "4.x"],
+		["markdown-it@<=14.1.1", "14.x"],
+		["uuid@<11.1.1", "11.x"],
+	]) {
+		const rule = rules.find(
+			(candidate) =>
+				Array.isArray(candidate.matchDepNames) && candidate.matchDepNames.includes(selector),
+		);
+		assert.ok(rule);
+		// The npm extractor retains the whole override selector as depName, not packageName.
+		assert.deepEqual(rule.matchDepNames, [selector]);
+		assert.deepEqual(rule.matchManagers, ["npm"]);
+		assert.deepEqual(rule.matchDepTypes, ["pnpm-workspace.overrides"]);
+		assert.equal(rule.allowedVersions, versions);
+		assert.equal(rule.enabled, undefined);
+		assert.equal(rule.matchUpdateTypes, undefined);
+	}
+});
+
 void test("every pin of one toolchain version moves in a single pull request", () => {
 	assert.ok(Array.isArray(config.packageRules));
 	const rules = config.packageRules.filter(isRecord);


### PR DESCRIPTION
## What changed and why

Renovate proposed major upgrades to compatibility overrides for older transitive consumers. Those are not direct dependency migrations: UUID 12+, for example, removes CommonJS support needed by older callers.

Constrain only the exact workspace override selectors to their supported major (js-yaml 4, markdown-it 14, UUID 11). Same-major fixes remain enabled; direct dependencies such as webapp UUID 14 are unaffected. Matching follows Renovate's native npm extractor, which retains the full override selector as `depName`.

## How to test

- `node --test scripts/renovate-config.test.ts`: 9 tests pass.
- `vp run format` and `vp run check`: all 41 tasks pass; pre-push verification also passes.
- On the next dashboard refresh, the three forced-major suggestions should disappear while compatible fixes remain eligible.

## Release impact

Dependency automation only; no runtime dependency changes, application release, or changeset required. The intentional API-generator preview pin and coordinated PostgreSQL migration remain separate decisions.
