### PR TITLE
test(webapp): add achievement administration accessibility stories

### DIFF
--- a/.changeset/achievements-accessibility-coverage.md
+++ b/.changeset/achievements-accessibility-coverage.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add network-free accessibility coverage for achievement administration. No user-facing behavior changes.

--- a/docs/contributor/accessibility-audit-plan.md
+++ b/docs/contributor/accessibility-audit-plan.md
@@ -35,8 +35,8 @@ from those pages remain in scope.
 | Workspace administration | members, practices, review operations, models, usage and integrations |
 | Instance administration | users, workspaces, audit, catalogue, providers, models and usage |
 
-The dated [audit record](./accessibility-audit-record-template.md) expands this inventory to the routes,
-states and roles present in the tested revision.
+Use the [audit record template](./accessibility-audit-record-template.md) to expand this inventory to
+the routes, states and roles present in the tested revision.
 
 ## Evaluation
 

--- a/docs/contributor/accessibility-audit-record-2026-09-08.md
+++ b/docs/contributor/accessibility-audit-record-2026-09-08.md
@@ -1,0 +1,86 @@
+---
+title: Accessibility audit record — 8 September 2026
+description: Partial source evaluation and outstanding integrated accessibility evidence.
+---
+
+# Accessibility audit record — 8 September 2026
+
+**Incomplete evaluation. WCAG 2.2 AA conformance has not been established.**
+
+## Audit
+
+| Field | Value |
+| --- | --- |
+| Dates | 8 September 2026 |
+| Revision and release | Base revision `352ba196e65aa5c924af0531165e499b49d841bb`, plus uncommitted working-tree changes; no immutable tested revision or released artifact |
+| Scope and sample rationale | Source inventory of page components; not a WCAG-EM structured or random sample |
+| Deployment and test data | No integrated deployment evaluated. Stories use synthetic workspace members. |
+| Evaluator | Coding assistant: source inspection and automated unit/static checks; no human assistive-technology evaluator |
+| WCAG-EM report | Not produced; criterion-by-criterion evaluation remains outstanding |
+| Storybook report, revision and browser | No browser test report produced during this review |
+| Finding query | [Audit issue](https://github.com/hephaestus-build/Hephaestus/issues/1601) |
+
+## Environments
+
+| Operating system | Browser | Assistive technology | Versions and relevant settings |
+| --- | --- | --- | --- |
+| Linux development environment | Not run | None | Node 24.19.0; Vite+ 0.3.0; source inspection, static checks and jsdom route tests |
+| Windows | Firefox — not tested | NVDA — not tested | Evaluator and exact versions not supplied |
+| macOS | Safari — not tested | VoiceOver — not tested | Evaluator and exact versions not supplied |
+
+## Surfaces
+
+Integrated operation was not tested. Routes, states, roles and samples remain to be selected
+against a running revision.
+
+| Surface | Route, state and role | Keyboard | NVDA | VoiceOver | Evidence or issue |
+| --- | --- | --- | --- | --- | --- |
+| Public and legal | `/`, `/about`, `/imprint`, `/privacy`, not found; anonymous | Not tested | Not tested | Not tested | No integrated evaluation |
+| Authentication | `/login`, workspace login, callback, errors; anonymous and returning user | Not tested | Not tested | Not tested | No integrated evaluation |
+| Workspace creation | Provider selection, GitHub/GitLab connection, validation and errors | Not tested | Not tested | Not tested | No integrated evaluation |
+| Workspace home | Dashboard, teams, achievements, profiles; member | Not tested | Not tested | Not tested | No integrated evaluation |
+| Developer feedback | Reviews, trace, observations, delivery and targets; member | Not tested | Not tested | Not tested | No integrated evaluation |
+| Mentor | Threads, transcript, composer, copilot; member | Not tested | Not tested | Not tested | No integrated evaluation |
+| Personal settings | Settings, integrations, destructive actions; signed-in user | Not tested | Not tested | Not tested | No integrated evaluation |
+| Workspace administration | Members, practices, review operations, AI settings, usage, integrations; owner/admin, member denied | Not tested | Not tested | Not tested | No integrated evaluation |
+| Achievement administration | `/w/$workspaceSlug/admin/achievements`; loading, empty, error, denied, populated and pending actions | Not tested | Not tested | Not tested | Component stories added; not an integrated pass |
+| Instance administration | Users, workspaces, audit, catalogue, providers, models, usage; instance admin and denied user | Not tested | Not tested | Not tested | No integrated evaluation |
+
+## Complete processes
+
+No process was evaluated in either required screen-reader/browser environment.
+
+| Process | Roles, states and environment | Success path | Error recovery | Evidence or issue |
+| --- | --- | --- | --- | --- |
+| Sign in and return from identity provider | Anonymous, expired session | Not tested | Not tested | No integrated evaluation |
+| Create workspace and connect provider | GitHub/GitLab, authorized and denied | Not tested | Not tested | No integrated evaluation |
+| Inspect developer feedback | Member; populated, empty, unavailable | Not tested | Not tested | No integrated evaluation |
+| Converse with Heph | Member; new/existing thread, streaming, interrupted | Not tested | Not tested | No integrated evaluation |
+| Change personal settings | Signed-in user; integrations and destructive actions | Not tested | Not tested | No integrated evaluation |
+| Administer workspace | Owner/admin and member denied; configuration and mutations | Not tested | Not tested | No integrated evaluation |
+| Administer instance | Instance admin and denied user; configuration and mutations | Not tested | Not tested | No integrated evaluation |
+
+## Criterion results and automated checks
+
+The source inventory found one `*Page.tsx` component without a sibling story:
+`AdminAchievementsPage`. Stories now cover its loading, empty, error and pending states, including
+a dark error state and a narrow preview with a long member name. The stories have not been run in a
+browser during this assessment. The five route regression tests use Vitest 4.1.11 and jsdom.
+
+The inspected Storybook configuration uses Chromium with reduced motion and a default viewport of
+1440 × 900; the reflow story requests 320px. It substitutes a mock for Monaco and excludes Base UI
+focus guards from axe. Full motion, the real editor and the excluded elements were not evaluated.
+
+No integrated axe run, contrast measurements, zoom, text-spacing, target-size or criterion-by-criterion
+evaluation was performed.
+
+## Defects and retests
+
+The missing page-story coverage is tracked in
+[issue #1601](https://github.com/hephaestus-build/Hephaestus/issues/1601).
+No manual accessibility evaluation or retesting was performed.
+
+## Conclusion
+
+Evaluation remains incomplete. The [audit plan](./accessibility-audit-plan.md) defines the outstanding
+evaluation and conformance requirements.

--- a/docs/contributor/accessibility-audit-record-template.md
+++ b/docs/contributor/accessibility-audit-record-template.md
@@ -29,7 +29,8 @@ information required by the accessibility statement.
 
 ## Surfaces
 
-Use `Pass`, `Fail`, or `Not applicable`. Explain `Not applicable` and link each failure to its issue.
+Use `Pass`, `Fail`, `Not tested`, or `Not applicable`. Explain untested and inapplicable entries
+and link failures to their issues.
 
 | Surface | Route, state and role | Keyboard | NVDA | VoiceOver | Evidence or issue |
 | --- | --- | --- | --- | --- | --- |
@@ -37,6 +38,25 @@ Use `Pass`, `Fail`, or `Not applicable`. Explain `Not applicable` and link each 
 
 ## Complete processes
 
-| Process | Roles and states | Success path | Error recovery | Evidence or issue |
+Record each process separately for each evaluated environment.
+
+| Process | Roles, states and environment | Success path | Error recovery | Evidence or issue |
 | --- | --- | --- | --- | --- |
 | | | | | |
+
+## Criterion results and automated checks
+
+Link the WCAG-EM criterion report and structured and random sample rationale. Record automated tool
+versions, configuration, exclusions, results and report locations separately for component and
+integrated-page checks. Include the disposition of results requiring manual review.
+
+## Defects and retests
+
+| Issue | WCAG criterion | Surface and shared callers | Evidence | Fix revision and retest result |
+| --- | --- | --- | --- | --- |
+| | | | | |
+
+## Conclusion
+
+State evaluation completeness, remaining gaps, and the evidence supporting the public statement
+for the tested revision.

--- a/docs/user/accessibility.mdx
+++ b/docs/user/accessibility.mdx
@@ -5,7 +5,7 @@ description: The accessibility status, testing approach, and support channels fo
 
 # Accessibility statement
 
-**Last reviewed: 30 August 2026**
+**Last reviewed: 8 September 2026**
 
 Hephaestus aims to be usable by people who navigate with a keyboard, magnify content, use speech
 input, or use a screen reader.
@@ -13,24 +13,20 @@ input, or use a screen reader.
 ## Conformance status
 
 Conformance of the Hephaestus web application with
-[WCAG 2.2 Level AA](https://www.w3.org/TR/WCAG22/) **has not yet been established**. Automated checks
-pass for the maintained Storybook states, but the required keyboard and assistive-technology review
-of the integrated application is incomplete. We therefore make no WCAG conformance claim yet.
+[WCAG 2.2 Level AA](https://www.w3.org/TR/WCAG22/) **has not yet been established**.
 
 This statement covers the Hephaestus single-page application, including its presentation of imported
 content. Linked external sites and identity-provider pages are outside its scope.
 
-## Current evidence
+## Evaluation and limitations
 
-The current assessment uses automated component checks in Chromium and source analysis. Integrated
-keyboard and screen-reader evaluation is incomplete, so these results do not establish WCAG
-conformance. The scope and evidence requirements are in the
-[accessibility audit plan](/contributor/accessibility-audit-plan).
+The [assessment dated 8 September 2026](/contributor/accessibility-audit-record-2026-09-08) records a
+source review and expanded automated component-test coverage, without a browser test report.
+Integrated keyboard and screen-reader evaluation remains incomplete, including NVDA and VoiceOver,
+so accessibility barriers may remain.
 
-## Known limitations
-
-The integrated keyboard, NVDA, and VoiceOver evaluations are incomplete, so accessibility barriers
-may remain.
+The [accessibility audit plan](/contributor/accessibility-audit-plan) defines the evaluation scope
+and requirements.
 
 ## Feedback and contact
 

--- a/scripts/check-presentational-components.ts
+++ b/scripts/check-presentational-components.ts
@@ -37,7 +37,6 @@ const MOCK_MODULES = ["msw", "msw-storybook-addon", "story-mock-server", "@/mock
 const ALLOWLIST = {
 	fetching: [
 		"webapp/src/components/achievements/AchievementsView.tsx",
-		"webapp/src/components/admin/AdminAchievementsPage.tsx",
 		"webapp/src/components/admin/AdminDangerZoneSettings.tsx",
 		"webapp/src/components/admin/ai/WorkspaceLlmProviderPanel.tsx",
 		"webapp/src/components/admin/audit/AuthAuditPanel.tsx",

--- a/webapp/src/components/admin/AdminAchievementsPage.stories.tsx
+++ b/webapp/src/components/admin/AdminAchievementsPage.stories.tsx
@@ -1,0 +1,114 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { expect, fn, userEvent } from "storybook/test";
+
+import { withStandardPage } from "@/stories/decorators";
+import { expectGenuinelyDisabled } from "@/test/controls";
+
+import { AdminAchievementsPage } from "./AdminAchievementsPage";
+
+const meta = {
+	component: AdminAchievementsPage,
+	parameters: { layout: "fullscreen" },
+	decorators: [withStandardPage],
+	tags: ["autodocs"],
+	args: {
+		users: [
+			{
+				id: 1,
+				login: "ada",
+				name: "Ada Lovelace",
+				hidden: false,
+				url: "https://github.com/ada",
+				teams: [],
+				user: { id: "user-1", login: "ada", name: "Ada Lovelace", email: "ada@example.com" },
+			},
+		],
+		workspaceSlug: "acme",
+		isLoading: false,
+		isReloading: false,
+		isRecalculatingAll: false,
+		recalculatingUsers: new Set<string>(),
+		onReload: fn(),
+		onRecalculateAll: fn(),
+		onRecalculate: fn(),
+		onRetry: fn(),
+	},
+} satisfies Meta<typeof AdminAchievementsPage>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Loading: Story = {
+	args: { users: [], isLoading: true },
+	play: async ({ canvas }) => {
+		await expectGenuinelyDisabled(canvas.getByRole("button", { name: "Reload Definitions" }));
+		await expectGenuinelyDisabled(canvas.getByRole("button", { name: "Recalculate All" }));
+		await expect(canvas.getByText("Loading users...")).toBeVisible();
+	},
+};
+
+export const Empty: Story = {
+	args: { users: [] },
+	play: async ({ canvas }) => {
+		await expect(canvas.getByText("No users found")).toBeVisible();
+		await expectGenuinelyDisabled(canvas.getByRole("button", { name: "Recalculate All" }));
+		await expect(canvas.getByRole("button", { name: "Reload Definitions" })).toBeEnabled();
+	},
+};
+
+export const Error: Story = {
+	globals: { theme: "dark" },
+	args: { users: [], error: { status: 503, detail: "Achievements are temporarily unavailable." } },
+	play: async ({ canvas, args }) => {
+		await expect(canvas.getByRole("alert")).toHaveTextContent("Couldn't load achievements");
+		await expect(canvas.queryByRole("table")).not.toBeInTheDocument();
+		const retry = canvas.getByRole("button", { name: /retry/i });
+		canvas.getByRole("button", { name: "Reload Definitions" }).focus();
+		await userEvent.tab();
+		await expect(retry).toHaveFocus();
+		await userEvent.keyboard("{Enter}");
+		await expect(args.onRetry).toHaveBeenCalledOnce();
+	},
+};
+
+export const PermissionDenied: Story = {
+	args: { users: [], error: { status: 403 } },
+	play: async ({ canvas }) => {
+		await expect(canvas.getByRole("alert")).toHaveTextContent("You don't have permission");
+		await expect(canvas.queryByRole("button", { name: /retry/i })).not.toBeInTheDocument();
+	},
+};
+
+export const Reloading: Story = {
+	args: { isReloading: true },
+	play: async ({ canvas }) => {
+		await expectGenuinelyDisabled(canvas.getByRole("button", { name: "Reloading..." }));
+	},
+};
+
+export const RecalculatingAll: Story = {
+	args: { isRecalculatingAll: true },
+	play: async ({ canvas }) => {
+		await expectGenuinelyDisabled(canvas.getByRole("button", { name: "Recalculating All..." }));
+	},
+};
+
+export const RecalculatingMember: Story = {
+	args: { recalculatingUsers: new Set(["ada"]) },
+};
+
+export const Reflow: Story = {
+	args: {
+		users: meta.args.users.map((member) => ({
+			...member,
+			name: "Alexandra Montgomery-Worthington",
+			user: { ...member.user, name: "Alexandra Montgomery-Worthington" },
+		})),
+	},
+	parameters: {
+		viewport: { defaultViewport: "reflow" },
+		chromatic: { viewports: [320] },
+	},
+};

--- a/webapp/src/components/admin/AdminAchievementsPage.tsx
+++ b/webapp/src/components/admin/AdminAchievementsPage.tsx
@@ -1,20 +1,11 @@
-import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { RefreshCw, Trophy } from "lucide-react";
-import { useState } from "react";
-import { toast } from "sonner";
 
-import {
-	recalculateUserAchievementsMutation,
-	reloadAchievementsMutation,
-} from "@/api/@tanstack/react-query.gen";
 import type { ExtendedUserTeams } from "@/components/admin/types";
 import { QueryErrorAlert } from "@/components/common/QueryErrorAlert";
 import { PageHeader } from "@/components/core/PageHeader";
 import { PageLayout } from "@/components/core/PageLayout";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
-import { useAuth } from "@/integrations/auth/AuthContext";
-import { queryOperationId } from "@/lib/query-operation-id";
 
 import { AdminAchievementsTable } from "./AdminAchievementsTable";
 
@@ -24,6 +15,12 @@ interface AdminAchievementsPageProps {
 	workspaceSlug: string;
 	error?: unknown;
 	onRetry?: () => void;
+	isReloading: boolean;
+	isRecalculatingAll: boolean;
+	recalculatingUsers: Set<string>;
+	onReload: () => void;
+	onRecalculateAll: () => void;
+	onRecalculate: (username: string) => void;
 }
 
 export function AdminAchievementsPage({
@@ -32,94 +29,13 @@ export function AdminAchievementsPage({
 	workspaceSlug,
 	error,
 	onRetry,
+	isReloading,
+	isRecalculatingAll,
+	recalculatingUsers,
+	onReload,
+	onRecalculateAll,
+	onRecalculate,
 }: AdminAchievementsPageProps) {
-	const queryClient = useQueryClient();
-	const { username } = useAuth();
-	const [isRecalculatingAll, setIsRecalculatingAll] = useState(false);
-	const [recalculatingUsers, setRecalculatingUsers] = useState<Set<string>>(new Set());
-
-	const recalculateMutation = useMutation(recalculateUserAchievementsMutation());
-	const reloadMutation = useMutation(reloadAchievementsMutation());
-
-	const handleReload = () => {
-		toast.promise(
-			reloadMutation.mutateAsync({
-				path: { workspaceSlug, login: username ?? "" },
-			}),
-			{
-				loading: "Reloading achievement definitions...",
-				success: () => {
-					void queryClient.invalidateQueries({
-						predicate: (query) => {
-							const id = queryOperationId(query.queryKey);
-							return id === "getUserAchievements" || id === "getAllAchievementDefinitions";
-						},
-					});
-					return "Successfully reloaded achievements from YAML";
-				},
-				error: "Failed to reload achievement definitions",
-			},
-		);
-	};
-
-	const handleRecalculateAll = async () => {
-		if (!users.length) return;
-		setIsRecalculatingAll(true);
-
-		const toastId = toast.loading(`Starting recalculation for ${users.length} users...`);
-
-		let successCount = 0;
-		let failCount = 0;
-
-		try {
-			await Promise.all(
-				users.map((u) =>
-					recalculateMutation
-						.mutateAsync({
-							path: { workspaceSlug, login: u.user.login },
-						})
-						.then(() => successCount++)
-						.catch(() => failCount++),
-				),
-			);
-
-			if (failCount === 0) {
-				toast.success(`Successfully dispatched recalculation for ${successCount} users`, {
-					id: toastId,
-				});
-			} else {
-				toast.warning(`Dispatched recalculation for ${successCount} users, ${failCount} failed`, {
-					id: toastId,
-				});
-			}
-		} catch (_error) {
-			toast.error("An error occurred during bulk recalculation.", { id: toastId });
-		} finally {
-			setIsRecalculatingAll(false);
-		}
-	};
-
-	const handleRecalculateSingle = (targetUsername: string) => {
-		setRecalculatingUsers((prev) => new Set(prev).add(targetUsername));
-		toast.promise(
-			recalculateMutation.mutateAsync({
-				path: { workspaceSlug, login: targetUsername },
-			}),
-			{
-				loading: `Recalculating achievements for ${targetUsername}...`,
-				success: `Successfully dispatched recalculation for ${targetUsername}`,
-				error: `Failed to recalculate achievements for ${targetUsername}`,
-				finally: () => {
-					setRecalculatingUsers((prev) => {
-						const newSet = new Set(prev);
-						newSet.delete(targetUsername);
-						return newSet;
-					});
-				},
-			},
-		);
-	};
-
 	return (
 		<PageLayout>
 			<PageHeader
@@ -130,11 +46,11 @@ export function AdminAchievementsPage({
 					<>
 						<Button
 							variant="outline"
-							onClick={() => handleReload()}
-							disabled={isLoading || reloadMutation.isPending}
+							onClick={onReload}
+							disabled={isLoading || isReloading}
 							className="w-full sm:w-auto"
 						>
-							{reloadMutation.isPending ? (
+							{isReloading ? (
 								<>
 									<Spinner className="mr-2 h-4 w-4" />
 									Reloading...
@@ -147,7 +63,7 @@ export function AdminAchievementsPage({
 							)}
 						</Button>
 						<Button
-							onClick={() => void handleRecalculateAll()}
+							onClick={onRecalculateAll}
 							disabled={isLoading || isRecalculatingAll || users.length === 0}
 							className="w-full sm:w-auto"
 						>
@@ -174,7 +90,7 @@ export function AdminAchievementsPage({
 					users={users}
 					isLoading={isLoading}
 					workspaceSlug={workspaceSlug}
-					onRecalculate={(targetUsername) => handleRecalculateSingle(targetUsername)}
+					onRecalculate={onRecalculate}
 					recalculatingUsers={recalculatingUsers}
 				/>
 			)}

--- a/webapp/src/routes/_authenticated/w/$workspaceSlug/admin/-achievements-route.test.tsx
+++ b/webapp/src/routes/_authenticated/w/$workspaceSlug/admin/-achievements-route.test.tsx
@@ -1,0 +1,146 @@
+import { screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { HttpResponse, http } from "msw";
+import { describe, expect, it, vi } from "vitest";
+
+import { server } from "@/mocks/server";
+import { ROUTE_RENDER_WAIT, renderRouteAt } from "@/test/router-harness";
+
+vi.setConfig({ testTimeout: 30_000 });
+
+const workspace = {
+	id: 1,
+	workspaceSlug: "acme",
+	displayName: "Acme",
+	providerType: "GITHUB",
+	status: "ACTIVE",
+	leaguesEnabled: false,
+	leaderboardEnabled: false,
+	practicesEnabled: true,
+	mentorEnabled: false,
+	achievementsEnabled: true,
+	progressionEnabled: false,
+};
+
+function mockAchievementsRoute() {
+	server.use(
+		http.get("*/workspaces/:workspaceSlug/members/me", () =>
+			HttpResponse.json({ role: "ADMIN", userId: 1, userLogin: "octocat" }),
+		),
+		http.get("*/workspaces", () => HttpResponse.json([workspace])),
+		http.get("*/workspaces/:workspaceSlug", () => HttpResponse.json(workspace)),
+		http.get("*/workspaces/:workspaceSlug/connections/catalog", () => HttpResponse.json([])),
+		http.get("*/workspaces/:workspaceSlug/users", () =>
+			HttpResponse.json([
+				{ id: 1, login: "ada", name: "Ada Lovelace", teams: [], hidden: false },
+				{ id: 2, login: "grace", name: "Grace Hopper", teams: [], hidden: false },
+			]),
+		),
+	);
+}
+
+describe("workspace achievements route", () => {
+	it.each([
+		{
+			outcome: "success",
+			statuses: { ada: 204, grace: 204 },
+			message: "Successfully dispatched recalculation for 2 users",
+		},
+		{
+			outcome: "partial failure",
+			statuses: { ada: 204, grace: 500 },
+			message: "Dispatched recalculation for 1 users, 1 failed",
+		},
+		{
+			outcome: "failure",
+			statuses: { ada: 500, grace: 500 },
+			message: "Dispatched recalculation for 0 users, 2 failed",
+		},
+	])(
+		"reports bulk $outcome and makes the action available again",
+		async ({ statuses, message }) => {
+			mockAchievementsRoute();
+			const user = userEvent.setup();
+			const requests: string[] = [];
+			server.use(
+				http.post<{ workspaceSlug: string; login: string }>(
+					"*/workspaces/:workspaceSlug/users/:login/achievements/recalculate",
+					({ params }) => {
+						requests.push(`${params.workspaceSlug}/${params.login}`);
+						const responses: Record<string, number> = statuses;
+						return new HttpResponse(null, { status: responses[params.login] });
+					},
+				),
+			);
+			renderRouteAt("/w/acme/admin/achievements");
+			const recalculate = await screen.findByRole(
+				"button",
+				{ name: "Recalculate All" },
+				ROUTE_RENDER_WAIT,
+			);
+			await waitFor(() => expect(recalculate.hasAttribute("disabled")).toBe(false));
+			await user.click(recalculate);
+			await waitFor(() => expect([...requests].sort()).toStrictEqual(["acme/ada", "acme/grace"]));
+			await screen.findByText(message);
+			await waitFor(() =>
+				expect(
+					screen.getByRole("button", { name: "Recalculate All" }).hasAttribute("disabled"),
+				).toBe(false),
+			);
+		},
+	);
+
+	it("recalculates the selected member rather than the signed-in administrator", async () => {
+		mockAchievementsRoute();
+		const user = userEvent.setup();
+		const requests: string[] = [];
+		server.use(
+			http.post<{ workspaceSlug: string; login: string }>(
+				"*/workspaces/:workspaceSlug/users/:login/achievements/recalculate",
+				({ params }) => {
+					requests.push(`${params.workspaceSlug}/${params.login}`);
+					return new HttpResponse(null, { status: 204 });
+				},
+			),
+		);
+		renderRouteAt("/w/acme/admin/achievements");
+		const row = await screen.findByRole("row", { name: /Ada Lovelace/ }, ROUTE_RENDER_WAIT);
+		const recalculate = within(row).getByRole("button", { name: "Recalculate" });
+		await user.click(recalculate);
+		await waitFor(() => expect(requests).toStrictEqual(["acme/ada"]));
+		await waitFor(() =>
+			expect(
+				within(row).getByRole("button", { name: "Recalculate" }).hasAttribute("disabled"),
+			).toBe(false),
+		);
+	});
+
+	it("reloads definitions using the signed-in administrator", async () => {
+		mockAchievementsRoute();
+		const user = userEvent.setup();
+		const requests: string[] = [];
+		server.use(
+			http.post<{ workspaceSlug: string; login: string }>(
+				"*/workspaces/:workspaceSlug/users/:login/achievements/reload",
+				({ params }) => {
+					requests.push(`${params.workspaceSlug}/${params.login}`);
+					return new HttpResponse(null, { status: 204 });
+				},
+			),
+		);
+		renderRouteAt("/w/acme/admin/achievements");
+		const reload = await screen.findByRole(
+			"button",
+			{ name: "Reload Definitions" },
+			ROUTE_RENDER_WAIT,
+		);
+		await waitFor(() => expect(reload.hasAttribute("disabled")).toBe(false));
+		await user.click(reload);
+		await waitFor(() => expect(requests).toStrictEqual(["acme/octocat"]));
+		await waitFor(() =>
+			expect(
+				screen.getByRole("button", { name: "Reload Definitions" }).hasAttribute("disabled"),
+			).toBe(false),
+		);
+	});
+});

--- a/webapp/src/routes/_authenticated/w/$workspaceSlug/admin/achievements.tsx
+++ b/webapp/src/routes/_authenticated/w/$workspaceSlug/admin/achievements.tsx
@@ -1,13 +1,21 @@
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, Navigate } from "@tanstack/react-router";
+import { useState } from "react";
+import { toast } from "sonner";
 
-import { getUsersWithTeamsOptions } from "@/api/@tanstack/react-query.gen";
+import {
+	getUsersWithTeamsOptions,
+	recalculateUserAchievementsMutation,
+	reloadAchievementsMutation,
+} from "@/api/@tanstack/react-query.gen";
 import { AdminAchievementsPage } from "@/components/admin/AdminAchievementsPage";
 import { adaptApiUserTeams } from "@/components/admin/types";
 import { NoWorkspace } from "@/components/workspace/NoWorkspace";
 import { useActiveWorkspaceSlug } from "@/hooks/use-active-workspace";
 import { useWorkspaceFeatures } from "@/hooks/use-workspace-features";
+import { useAuth } from "@/integrations/auth/AuthContext";
 import { workspaceAdminHead } from "@/lib/page-title";
+import { queryOperationId } from "@/lib/query-operation-id";
 
 export const Route = createFileRoute("/_authenticated/w/$workspaceSlug/admin/achievements")({
 	head: workspaceAdminHead("Achievements"),
@@ -41,6 +49,89 @@ function AdminAchievementsContainer() {
 	);
 	const isLoading = isWorkspaceLoading || usersLoading;
 
+	const queryClient = useQueryClient();
+	const { username } = useAuth();
+	const [isRecalculatingAll, setIsRecalculatingAll] = useState(false);
+	const [recalculatingUsers, setRecalculatingUsers] = useState<Set<string>>(new Set());
+
+	const recalculateMutation = useMutation(recalculateUserAchievementsMutation());
+	const reloadMutation = useMutation(reloadAchievementsMutation());
+
+	const handleReload = () => {
+		toast.promise(
+			reloadMutation.mutateAsync({
+				path: { workspaceSlug: workspaceSlug ?? "", login: username ?? "" },
+			}),
+			{
+				loading: "Reloading achievement definitions...",
+				success: () => {
+					void queryClient.invalidateQueries({
+						predicate: (query) => {
+							const id = queryOperationId(query.queryKey);
+							return id === "getUserAchievements" || id === "getAllAchievementDefinitions";
+						},
+					});
+					return "Successfully reloaded achievements from YAML";
+				},
+				error: "Failed to reload achievement definitions",
+			},
+		);
+	};
+
+	const handleRecalculateAll = async () => {
+		if (!users.length) return;
+		setIsRecalculatingAll(true);
+
+		const toastId = toast.loading(`Starting recalculation for ${users.length} users...`);
+
+		try {
+			const results = await Promise.allSettled(
+				users.map((u) =>
+					recalculateMutation.mutateAsync({
+						path: { workspaceSlug: workspaceSlug ?? "", login: u.user.login },
+					}),
+				),
+			);
+			const successCount = results.filter((result) => result.status === "fulfilled").length;
+			const failCount = results.length - successCount;
+
+			if (failCount === 0) {
+				toast.success(`Successfully dispatched recalculation for ${successCount} users`, {
+					id: toastId,
+				});
+			} else {
+				toast.warning(`Dispatched recalculation for ${successCount} users, ${failCount} failed`, {
+					id: toastId,
+				});
+			}
+		} catch (_error) {
+			toast.error("An error occurred during bulk recalculation.", { id: toastId });
+		} finally {
+			setIsRecalculatingAll(false);
+		}
+	};
+
+	const handleRecalculateSingle = (targetUsername: string) => {
+		setRecalculatingUsers((prev) => new Set(prev).add(targetUsername));
+		toast.promise(
+			recalculateMutation.mutateAsync({
+				path: { workspaceSlug: workspaceSlug ?? "", login: targetUsername },
+			}),
+			{
+				loading: `Recalculating achievements for ${targetUsername}...`,
+				success: `Successfully dispatched recalculation for ${targetUsername}`,
+				error: `Failed to recalculate achievements for ${targetUsername}`,
+				finally: () => {
+					setRecalculatingUsers((prev) => {
+						const newSet = new Set(prev);
+						newSet.delete(targetUsername);
+						return newSet;
+					});
+				},
+			},
+		);
+	};
+
 	if (!workspaceSlug && !isWorkspaceLoading) {
 		return <NoWorkspace />;
 	}
@@ -56,6 +147,12 @@ function AdminAchievementsContainer() {
 
 	return (
 		<AdminAchievementsPage
+			isReloading={reloadMutation.isPending}
+			isRecalculatingAll={isRecalculatingAll}
+			recalculatingUsers={recalculatingUsers}
+			onReload={handleReload}
+			onRecalculateAll={() => void handleRecalculateAll()}
+			onRecalculate={handleRecalculateSingle}
 			users={users}
 			isLoading={isLoading || featureState.isLoading || achievementsEnabled !== true}
 			workspaceSlug={workspaceSlug ?? ""}


### PR DESCRIPTION
## What changed and why

Achievement administration was the only page component without Storybook coverage, leaving its loading, empty and error states outside the automated accessibility checks.

This adds nine stories, including pending actions, a dark error state and a narrow layout with a long member name. Data operations move into the existing route so the page can render from props without story-specific network handlers. Five route tests cover bulk success and failures, member targeting and definition reloads.

The accompanying partial assessment records what remains untested and updates the public accessibility statement without claiming WCAG conformance. The evidence template now distinguishes untested results and identifies the environment for each complete-process evaluation.

Part of https://github.com/hephaestus-build/Hephaestus/issues/1601. This PR does **not** close the audit.

## How to test

Local validation passed: the complete quality gate and all five route regressions. CI reports the Storybook browser-suite result separately; integrated manual accessibility evaluation was not performed.

- Run the repository quality gate: `vp run format` followed by `vp run check`.
- Run the route regressions:
  ```sh
  vp -C webapp test --run 'src/routes/_authenticated/w/$workspaceSlug/admin/-achievements-route.test.tsx' --maxWorkers=1
  ```
- Run the new component stories with the existing axe checks:
  ```sh
  vp -C webapp test --run --config vitest.config.storybook.ts src/components/admin/AdminAchievementsPage.stories.tsx
  ```
- In Storybook, inspect the Error and Reflow stories. In Error, Tab from Reload Definitions should skip the disabled bulk action and reach Retry; Enter should trigger retry. In Reflow, inspect the long member name and page actions at 320px.

## Release impact

No intended change to application behavior, no new dependencies and no operator action required. The [empty changeset](https://github.com/hephaestus-build/Hephaestus/blob/issue-1601-chore-webapp-pre-1-0/.changeset/achievements-accessibility-coverage.md) records the internal-only change.

## Notes for reviewers

- Start with the page/route boundary and the removal from the presentational-component exception list. The existing query and mutation client remains authoritative.
- The dated record is a partial source assessment, not a completed accessibility audit. Integrated keyboard, NVDA/Firefox and VoiceOver/Safari evaluation remains outstanding.
- No accessibility checks are disabled. No visual design changes are intended; the new stories exercise the existing page.
