### PR TITLE
fix(deps): track independently published Bouncy Castle versions

### DIFF
--- a/.changeset/maintained-container-tls.md
+++ b/.changeset/maintained-container-tls.md
@@ -1,0 +1,5 @@
+---
+"hephaestus": patch
+---
+
+Updates the cryptography libraries used for secure Docker connections to maintained releases without requiring operator configuration changes.

--- a/server/application/pom.xml
+++ b/server/application/pom.xml
@@ -63,12 +63,12 @@
         <nullaway.version>0.14.1</nullaway.version>
         <shedlock.version>7.9.0</shedlock.version>
         <bucket4j.version>8.19.0</bucket4j.version>
-        <!-- Transitive only, via docker-java-core: bcpkix -> bcutil -> bcprov. Not managed by the
-             Spring Boot BOM, so the version it resolves to is docker-java's, and 1.82 carries
-             CVE-2025-14813 (critical) and CVE-2026-5598, both fixed in 1.84. Managed here so the
-             image scan stays clean and Renovate keeps it current; drop it once docker-java ships a
-             fixed floor of its own. -->
-        <bouncycastle.version>1.84</bouncycastle.version>
+        <!-- Override docker-java-core's transitive cryptography dependencies to keep its TLS
+             certificate handling on maintained releases. Artifacts publish patch releases
+             independently, so Renovate must track each version separately. -->
+        <bcprov.version>1.85.2</bcprov.version>
+        <bcutil.version>1.85</bcutil.version>
+        <bcpkix.version>1.85</bcpkix.version>
         <maven.build.cache.skipCache>true</maven.build.cache.skipCache>
         <maven.build.cache.skipSave>true</maven.build.cache.skipSave>
     </properties>
@@ -410,24 +410,20 @@
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
-            <!-- All three move together: Bouncy Castle only supports a matched provider, util and
-                 PKIX set. docker-java's TLS path (CertificateUtils, LocalDirectorySSLConfig) is the
-                 only consumer, and it links against PEMParser, JcaPEMKeyConverter,
-                 JcaX509CertificateConverter and BouncyCastleProvider, all unchanged in 1.84. -->
             <dependency>
                 <groupId>org.bouncycastle</groupId>
                 <artifactId>bcprov-jdk18on</artifactId>
-                <version>${bouncycastle.version}</version>
+                <version>${bcprov.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.bouncycastle</groupId>
                 <artifactId>bcutil-jdk18on</artifactId>
-                <version>${bouncycastle.version}</version>
+                <version>${bcutil.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.bouncycastle</groupId>
                 <artifactId>bcpkix-jdk18on</artifactId>
-                <version>${bouncycastle.version}</version>
+                <version>${bcpkix.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
## What changed and why

The shared Bouncy Castle version in #1996 selects 1.85.2 for artifacts that were never published at that version. Maven cannot resolve PKIX/util, so the application cannot build.

Track the three independently released artifacts separately: provider 1.85.2, util 1.85 and PKIX 1.85, matching the [official published set](https://www.bouncycastle.org/download/bouncy-castle-java/). Remove the obsolete comment claiming all version strings must match; retain the reason for managing docker-java's transitive TLS dependencies. Renovate can update each artifact naturally.

Supersedes #1996 using a maintainer-owned PR to preserve the repository's commit-author policy.

## How to test

- Maven dependency tree resolves exactly the intended three jdk18on artifacts.
- `vp run test:server:unit`: 7,215 tests pass, no failures/errors/skips.
- Real docker-java 3.7.1 certificate/private-key parsing, CA/signature verification, key/trust-store creation and SSLContext construction pass for RSA PKCS8, RSA PKCS1 and EC fixtures on Java 21.
- The TLS smoke passes both provider orderings and the actual application runtime classpath. The existing NATS LTS provider still wins on the current runtime classpath; the isolated upgraded provider also passes. No live TLS handshake is claimed.
- `vp run format` and `vp run check`; normal integration/image scanning and merge-group validation remain required.

## Release impact

Includes a patch changeset for maintained Docker-connection cryptography dependencies. No operator configuration or schema change, no release workflow dispatch.
