### PR TITLE
refactor(server): clarify feedback recovery and replacement guarantees

### DIFF
--- a/.changeset/precise-feedback-contracts.md
+++ b/.changeset/precise-feedback-contracts.md
@@ -1,0 +1,5 @@
+---
+---
+
+Clarifies feedback preparation and replacement guarantees and removes redundant internal commentary.
+The pattern corroboration threshold now has one owner; existing feedback limits are unchanged.

--- a/docs/admin/practice-review-operations.mdx
+++ b/docs/admin/practice-review-operations.mdx
@@ -144,6 +144,9 @@ behaviors matter independently of their exact defaults:
 
 - **Background task cadences are fixed in code.** Their thresholds may be configurable even when their
   polling schedules are not.
+- **Feedback preparation recovery has a bounded window.** The sweeper selects recent completed pull
+  request and issue reviews with missing preparation marks. Older unfinished preparation is not
+  automatically recovered. A successful empty result is complete; recovery does not rerun the model.
 - **Retryable occurrences eventually lapse.** A workspace left misconfigured can accumulate retries and
   then go quiet when their deadline passes.
 - **Nothing is ever deleted from the occurrence ledger**, in any state, including retired rows. It is the

--- a/docs/contributor/practice-review-glossary.mdx
+++ b/docs/contributor/practice-review-glossary.mdx
@@ -328,8 +328,8 @@ workspace-readable page at `/w/{workspaceSlug}/user/{username}`, not `IN_APP`; a
 A **thread** is a chain of feedback about one thing to one person on one channel, identified by a hash
 (`FeedbackThreadKey`) rather than by prose. The longitudinal channels key on the *practice*, because a
 habit claim is about the practice and not about one merge request; the in-context channel keys on the
-artifact. `thread_key` is deliberately not unique: a thread is a chain of rows over time, and the
-invariant that matters — at most one live `PREPARED` per thread — is held by a compare-and-swap.
+artifact. `thread_key` groups related feedback; it does not enforce a unique `PREPARED` item.
+Supersession atomically retires a selected `PREPARED` item, but new feedback can coexist on the thread.
 
 Supersession only ever claims `PREPARED` feedback. Say **superseded** for feedback that was prepared but
 replaced before anybody read it, and **continued** for newer feedback written beside feedback that was

--- a/docs/contributor/practice-review-pipeline.mdx
+++ b/docs/contributor/practice-review-pipeline.mdx
@@ -355,7 +355,7 @@ that never ran. In-context feedback may fall back to the observation's `evidence
 practice's `whyItMatters`, but invents no next step. Longitudinal channels have no content fallback.
 Per-channel preparation marks distinguish a successful empty result from unfinished preparation.
 The sweeper retries preparation from existing review outputs, not model composition; its
-[recovery window is bounded](../admin/practice-review-operations.mdx#limits-you-should-know-about).
+[recovery window is bounded](/admin/practice-review-operations#limits-you-should-know-about).
 
 ## Delivery and human approval
 

--- a/docs/contributor/practice-review-pipeline.mdx
+++ b/docs/contributor/practice-review-pipeline.mdx
@@ -352,8 +352,10 @@ the named thread may be superseded at all.
 
 A composition failure does not invalidate admitted observations. An empty result is distinct from a turn
 that never ran. In-context feedback may fall back to the observation's `evidenceRationale` and the
-practice's `whyItMatters`, but invents no next step. Longitudinal lanes have no content fallback; per-lane
-preparation marks let a sweeper retry only turns that did not run.
+practice's `whyItMatters`, but invents no next step. Longitudinal channels have no content fallback.
+Per-channel preparation marks distinguish a successful empty result from unfinished preparation.
+The sweeper retries preparation from existing review outputs, not model composition; its
+[recovery window is bounded](../admin/practice-review-operations.mdx#limits-you-should-know-about).
 
 ## Delivery and human approval
 

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/handler/FeedbackLanePreparationSweeper.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/handler/FeedbackLanePreparationSweeper.java
@@ -19,30 +19,10 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 /**
- * Runs the two feedback-preparation lanes for finished jobs whose lanes never ran.
+ * Retries unfinished feedback preparation for completed reviews within the recovery window.
  *
- * <p><b>What it is for.</b> Both lanes hang off one {@code @Async @TransactionalEventListener}
- * (AFTER_COMMIT) event. That event is published once and never again; the pool it is submitted to is
- * bounded and rejects with {@code AbortPolicy} when full; and a rejection surfaces inside a transaction
- * synchronisation callback where no lane code runs, so nothing logs it as a loss. A single busy sync was
- * enough to throw thousands of rejections, and the only visible consequence was that some developers
- * silently got no feedback. Preparing late is fine — the practice pages and the mentor's queue are both
- * read days later — so the fix is to make "lost" into "late".
- *
- * <p><b>How it knows.</b> Not by looking for missing {@code feedback} rows: both lanes legitimately
- * prepare nothing very often, so absence of rows cannot distinguish "decided nothing" from "never ran"
- * and a sweep built on it would re-route every recent job on every pass, forever. Each lane instead
- * records its own completion on the job ({@code agent_job.in_chat_prepared_at} /
- * {@code in_app_prepared_at}) on every non-exceptional path, and this sweep is exactly the set of
- * finished jobs missing one of those marks.
- *
- * <p><b>Idempotence</b> is the preparers', not this class's: both write at deterministic
- * {@code (agent_job_id, position)} pairs and skip what {@code existsByAgentJobIdAndPosition} already
- * finds, so a recovered job re-derives the same units and writes none of them twice.
- *
- * <p>Shaped on {@link de.tum.cit.aet.hephaestus.agent.handler.conversation.ConversationFeedbackTtlSweeper}
- * — {@code @Scheduled} plus {@code @SchedulerLock} so one pod sweeps, server role only, per-job failures
- * isolated and counted rather than aborting the pass.
+ * <p>Completion marks distinguish a successful empty result from preparation that never completed.
+ * The preparers own idempotency; this sweep does not rerun model composition or provider delivery.
  */
 @ConditionalOnServerRole
 @Component
@@ -51,23 +31,12 @@ public class FeedbackLanePreparationSweeper {
 
     private static final Logger log = LoggerFactory.getLogger(FeedbackLanePreparationSweeper.class);
 
-    /**
-     * How far back a pass looks. A lane left unprepared for longer than this is never recovered, which is
-     * the deliberate trade: the alternative is a query with no lower bound that re-reads all of history
-     * every hour to find the handful of rows an outage left behind. Comfortably longer than any pool
-     * saturation the system has produced, and shorter than the practice pages' own reading rhythm.
-     */
+    /** Jobs older than this are excluded even if preparation remains incomplete. */
     static final Duration LOOKBACK = Duration.ofHours(24);
 
-    /**
-     * How recent a job may be and still be left alone. The listener owns the fast path; without this the
-     * sweep would race a submission still sitting in the queue, and both would run the preparers at once
-     * on the same job. They would not corrupt anything — the position guard holds — but one of them would
-     * lose a unique-constraint race and log a failure that is not one.
-     */
+    /** Gives asynchronous listeners time to finish before recovery can select the same job. */
     static final Duration SETTLE = Duration.ofMinutes(10);
 
-    /** Bounds one pass, so a backlog is worked off over several passes instead of in one long lock hold. */
     static final int MAX_JOBS_PER_PASS = 500;
 
     private final AgentJobRepository agentJobRepository;
@@ -92,13 +61,7 @@ public class FeedbackLanePreparationSweeper {
         sweepNow(Instant.now());
     }
 
-    /**
-     * Recover every unprepared lane in the window ending {@code SETTLE} before {@code now}. Exposed so
-     * tests can place the window around a fixture instead of waiting for the clock.
-     *
-     * @param now the reference instant; the window is {@code [now - LOOKBACK, now - SETTLE)}
-     * @return what the pass found and what it managed to do about it
-     */
+    /** Selects unfinished preparation in {@code [now - LOOKBACK, now - SETTLE)}. */
     public SweepOutcome sweepNow(Instant now) {
         List<UnpreparedFeedbackLanes> pending = agentJobRepository.findUnpreparedFeedbackLanes(
                 now.minus(LOOKBACK), now.minus(SETTLE), PageRequest.of(0, MAX_JOBS_PER_PASS));
@@ -132,9 +95,6 @@ public class FeedbackLanePreparationSweeper {
                 failed++;
             }
         }
-        // Always logged when the pass found anything: a run of this sweeper observation work at all means the
-        // listeners are dropping events, which is a fact about the async pool worth seeing in the log even
-        // on the passes where every recovery succeeded.
         log.info(
                 "feedback.lane.sweep: {} job(s) had an unprepared lane; recovered {}, prepared {} unit(s), {} still failing",
                 pending.size(),
@@ -156,8 +116,6 @@ public class FeedbackLanePreparationSweeper {
                     .increment();
             return new LaneResult(true, units);
         } catch (RuntimeException e) {
-            // The mark stays null, so the next pass tries again — until the job falls out of the lookback
-            // window, at which point this counter is the only remaining evidence it was ever owed feedback.
             log.warn(
                     "feedback.lane.sweep: {} lane still failing for jobId={}: {}",
                     lane.tag,

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/handler/FeedbackSupersession.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/handler/FeedbackSupersession.java
@@ -10,35 +10,17 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 /**
- * Retires the message a newer one replaces, on the two lanes where "queued" and "read" are different
- * states.
+ * Replaces PREPARED in-app and conversation feedback without retiring DELIVERED feedback.
  *
- * <p><b>The rule this exists to hold: nothing that has been received may be un-said.</b> A in-app card
- * or a mentor unit becomes DELIVERED at the moment the developer actually reads it, so replacing one that
- * has already flipped would rewrite something a person has in their head. The in-context lane is not this
- * act and does not come through here — there the comment is edited in place on the merge request, so
- * retiring the delivered row is what makes the ledger agree with what is now visible, and
- * {@link FeedbackLedgerRecorder} keeps doing it.
- *
- * <p><b>The caller must write the replacement in the same transaction as the claim.</b> This is one half
- * of a swap: on its own it takes a message out of somebody's queue and puts nothing back. The two must
- * commit or roll back together, or a lost write leaves the recipient with strictly less than they had.
+ * <p>The caller must insert the replacement in the same transaction as the supersession claim.
+ * In-context reconciliation is handled separately by {@link FeedbackLedgerRecorder}.
  */
 @Component
 public class FeedbackSupersession {
 
     private static final Logger log = LoggerFactory.getLogger(FeedbackSupersession.class);
 
-    /**
-     * How many times a claim will re-aim at a thread that moved under it.
-     *
-     * <p>A run that loses the claim has learnt something: the run that beat it has queued a card of its
-     * own, and <em>that</em> is the live statement of the habit now. Aiming at it on the next pass is what
-     * keeps one habit to one live card; walking away instead would leave two, which is the pile
-     * supersession exists to prevent. Each pass either wins or discovers a target it did not know about,
-     * so the ceiling is a backstop rather than a policy — more runs than this converging on one person's
-     * one habit at one instant is a stuck producer, not a race.
-     */
+    // Retry a moved thread head, but bound contention with other producers.
     private static final int MAX_ATTEMPTS = 3;
 
     private final FeedbackRepository feedbackRepository;
@@ -47,51 +29,29 @@ public class FeedbackSupersession {
         this.feedbackRepository = feedbackRepository;
     }
 
-    /**
-     * What became of an attempt to replace the message queued on a thread, and what the replacement should
-     * therefore record.
-     *
-     * @param replacesId the row the new unit points back at, or {@code null} when it follows nothing
-     */
+    /** @param replacesId prior feedback to link, or {@code null} for a standalone piece of feedback */
     public record Outcome(Disposition disposition, @Nullable UUID replacesId) {
-        /** Nothing was claimed and nothing is followed — the unit stands on its own. */
         public static Outcome standalone() {
             return new Outcome(Disposition.NEW, null);
         }
 
-        /** Whether this call took a queued message out of the recipient's queue. */
         public boolean retiredSomething() {
             return disposition == Disposition.SUPERSEDED;
         }
     }
 
-    /** The three things a supersession attempt can turn out to be. */
     public enum Disposition {
-        /** The queued message was retired; the new unit takes its place. */
+        /** Prior feedback was retired; the replacement takes its place. */
         SUPERSEDED,
-        /**
-         * The recipient read the queued message before this run got to it. It keeps its DELIVERED state
-         * and the new unit is written anyway, pointing back at it: the thread continues rather than being
-         * rewritten.
-         */
+        /** Prior feedback remains DELIVERED; the replacement links to it as a continuation. */
         CONTINUED,
-        /** There was nothing live to follow — no thread, or another run already moved it on. */
+        /** No replacement link was acquired. */
         NEW,
     }
 
     /**
-     * Claim the message queued on one thread so a newer one can replace it.
-     *
-     * <p>Never throws on a target it could not claim, because failing to claim one is not an error. The
-     * queued message may have been read a second before this ran, another run may have replaced it first,
-     * or it may never have existed — all three are ordinary, and all three end with the new unit still
-     * being written. The reason it can be written regardless is that the compare-and-set is not what stops
-     * a developer being told the same thing twice; the composer reading what has already been said, and
-     * the lane's resurface cooldown, are. Dropping the unit here would answer a delivery race with silence
-     * about something that was measured.
-     *
-     * @param channel the lane the thread lives on; a key from another lane must not match
-     * @param threadKey the continuity key of the thread being replaced
+     * Attempts to retire the latest row on a recipient's channel-specific thread if it is PREPARED.
+     * A failed claim does not prevent the caller from preparing new feedback.
      */
     public Outcome supersede(long workspaceId, long recipientUserId, FeedbackChannel channel, String threadKey) {
         UUID lastRefused = null;
@@ -103,16 +63,12 @@ public class FeedbackSupersession {
             }
             UUID targetId = target.get();
             if (targetId.equals(lastRefused)) {
-                // The head of the thread did not move, so it is settled in a state nothing can claim —
-                // suppressed, or failed. Another pass would ask the same question and get the same answer.
+                // Do not retry an unchanged, unclaimable head.
                 break;
             }
             if (feedbackRepository.markSuperseded(workspaceId, targetId) == 1) {
                 return new Outcome(Disposition.SUPERSEDED, targetId);
             }
-            // Read between the moment the composer was shown the queue and now. The row keeps DELIVERED
-            // and the replacement still records what it follows, so the thread reads as one conversation
-            // over time rather than two unrelated messages that happen to share a key.
             if (feedbackRepository.isDelivered(workspaceId, targetId)) {
                 log.info(
                         "Supersession target was read first; continuing the thread instead: channel={}, target={}",
@@ -122,9 +78,7 @@ public class FeedbackSupersession {
             }
             lastRefused = targetId;
         }
-        // Nothing left to claim. Pointing back at a row another run has already claimed would put two
-        // rows on one link and fork a chain that is meant to be a line, so this unit follows nothing; the
-        // shared thread key is what still ties it to the thread.
+        // Keep the shared thread key without claiming a replacement link we did not acquire.
         log.info("Supersession found nothing live to claim: channel={}, threadKey={}", channel, threadKey);
         return Outcome.standalone();
     }

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/handler/composition/ComposedFeedbackUnit.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/handler/composition/ComposedFeedbackUnit.java
@@ -48,39 +48,23 @@ public record ComposedFeedbackUnit(
 
     public enum Action {
         NEW,
-        /** Replace a message that is queued and has not been read; {@link #supersedesThreadKey} says which. */
+        /** Request replacement of prepared feedback identified by {@link #supersedesThreadKey}. */
         SUPERSEDE,
-        /** Say nothing, and record why — so silence can be explained rather than look like a failure. */
         WITHHOLD,
     }
 
-    /**
-     * Why nothing is being said. Deliberately not
-     * {@link de.tum.cit.aet.hephaestus.practices.feedback.FeedbackSuppressionReason}: that enum is a
-     * database CHECK constraint and every value in it is a reason <em>the server</em> held something
-     * back, while these are the composer's reasons. Mapping one onto the other means widening the
-     * constraint, which is a schema change and belongs with the unit that makes it.
-     */
+    /** Composer withholding decisions, distinct from server-enforced delivery suppression. */
     public enum WithholdReason {
-        /** Nothing moved at this locus since it was last measured. */
         NO_MATERIAL_CHANGE,
-        /** This person has already been told this. */
         ALREADY_SAID,
-        /** True, but not worth a message. */
         BELOW_BAR,
     }
 
     /**
-     * Structured notes for the mentor, which writes the actual turn against the live conversation.
+     * Mentor context, not developer-facing prose. Authorized observation evidence is staged separately.
      *
-     * @param situation what the run saw: factual, specific, artifacts named, in the composer's own terms.
-     *     Not addressed to the developer as "you", because a note written at them is a note that will be
-     *     read out
-     * @param capability the useful understanding or behaviour the conversation should support. It is a
-     *     goal, not a prescribed question or a rule that the mentor must withhold a clear conclusion
-     * @param evidenceSummary the concise basis for the note. The original authorized observation evidence
-     *     is staged separately, so this summary cannot become the mentor's only source of truth
-     * @param inConversationSignal an observable sign the conversation helped, not an instruction to relay
+     * @param capability understanding or behaviour to support, not a prescribed question
+     * @param inConversationSignal observable sign that the conversation helped
      */
     public record ConversationBrief(
             String situation,
@@ -132,7 +116,6 @@ public record ComposedFeedbackUnit(
         }
     }
 
-    /** Whether the unit says enough to be feedback at all: something to read, and something to do. */
     public boolean isComplete() {
         if (action == Action.WITHHOLD) {
             return withholdReason != null;

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/handler/composition/FeedbackCompositionInputs.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/handler/composition/FeedbackCompositionInputs.java
@@ -10,29 +10,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
- * Stages the request that turns the feedback-composition stage on for one run: which channels it may
- * write for, how many messages each may carry, and the bar a pattern claim has to clear.
- *
- * <p>Absence is the off switch. The runner skips the stage when the file is not there, so deciding
- * <em>not</em> to compose costs nothing and needs no flag: a handler that says nothing gets a review and
- * no composition, which is what every review did before this existed.
- *
- * <p><b>The channel set is carried, not inferred.</b> One composition turn writes for every enabled lane,
- * and which lanes are enabled is a property of the occasion rather than of the composer: an event review
- * has an artifact to anchor to and enables all three, while a scheduled workspace sweep has no diff and
- * no line to point at and must disable {@link FeedbackChannel#IN_CONTEXT} — posting a pattern claim on
- * whatever merge request happens to be open is a public message about a private habit. Reading the set
- * from here rather than from what the runner can see is what lets the same stage serve both.
- *
- * <p><b>Which runs compose.</b> Only a run whose measurements are of somebody's current work. A
- * {@link ObservationOrigin#BACKFILL} sweep measures a year of finished work in an afternoon; composing
- * from it would spend tokens on messages the routers refuse anyway, and if that refusal is ever lifted it
- * should be lifted deliberately rather than by a campaign nobody connected to these surfaces.
- *
- * <p><b>Which artifact kinds compose.</b> Pull requests and issues, and deliberately not
- * {@code docs.document}. A document review's only declared lane is IN_APP, so turning composition on
- * for it would ship the Outline subsystem's first feedback of any kind in the same change that ships the
- * lane — two untested things at once, on a surface whose whole point is that its text is private.
+ * Stages composition bounds. Without the request file, the runner skips composition.
+ * Callers select channels and placements supported by the reviewed work.
  */
 public final class FeedbackCompositionInputs {
 
@@ -41,46 +20,21 @@ public final class FeedbackCompositionInputs {
         ARTIFACT,
     }
 
-    /**
-     * Messages one run may compose per lane, before each lane's own per-recipient cap. Told to the stage
-     * as well as enforced downstream, so it is not asked to write text that would be capped away the
-     * moment it lands.
-     *
-     * <p>Each number restates a cap that a lane owns, rather than importing it. Composition is upstream
-     * of every lane — it stages their input and parses their output — so a dependency the other way
-     * would make the two packages mutually recursive, and one of them would stop being readable on its
-     * own. {@code FeedbackCompositionCapsTest} asserts each number against the cap it restates, which is
-     * what stops them drifting apart. Two of the three are not importable at all: the in-context cap is
-     * package-private to the delivery package.
-     */
+    /** Per-run composition limits; delivery may impose additional per-recipient limits. */
     private static final Map<FeedbackChannel, Integer> MAX_UNITS =
             Map.of(FeedbackChannel.IN_CONTEXT, 3, FeedbackChannel.IN_APP, 2, FeedbackChannel.IN_CHAT, 3);
 
-    /**
-     * Distinct pieces of work a problem must appear on before a message may call it a pattern. Restated
-     * from the in-app router for the reason above; pinned by the same test.
-     */
-    private static final int MIN_DISTINCT_ARTIFACTS = 2;
+    /** Minimum distinct pieces of reviewed work required for a pattern claim. */
+    public static final int MIN_DISTINCT_ARTIFACTS = 2;
 
-    /** Every lane an event review can reach. A sweep passes a narrower set. */
     public static final Set<FeedbackChannel> EVENT_REVIEW_CHANNELS = EnumSet.allOf(FeedbackChannel.class);
 
     private FeedbackCompositionInputs() {}
 
-    /**
-     * Add the composition request to a job's staged inputs, if this run should compose at all.
-     *
-     * @param origin which population this run's measurements belong to
-     */
     public static void stage(Map<String, byte[]> files, ObservationOrigin origin) {
         stage(files, origin, EVENT_REVIEW_CHANNELS, EnumSet.allOf(InContextPlacementKind.class));
     }
 
-    /**
-     * Add the composition request for a run that may only reach some of the lanes.
-     *
-     * @param channels the lanes this occasion may write for; an empty set is the same as not composing
-     */
     public static void stage(Map<String, byte[]> files, ObservationOrigin origin, Set<FeedbackChannel> channels) {
         stage(files, origin, channels, EnumSet.allOf(InContextPlacementKind.class));
     }
@@ -114,12 +68,6 @@ public final class FeedbackCompositionInputs {
         files.put(SandboxLayout.FEEDBACK_COMPOSITION_PATH, request.getBytes(StandardCharsets.UTF_8));
     }
 
-    /**
-     * Every lane is named, enabled or not. A disabled lane present with {@code "enabled": false} tells the
-     * composer the surface exists and is closed for this run; a lane simply missing would read as a lane
-     * the system does not have, and the per-channel contract is only legible in contrast — "the note on
-     * the work is written elsewhere this time" is unstatable if the note is not mentioned.
-     */
     private static String channelBounds(Set<FeedbackChannel> enabled) {
         return EnumSet.allOf(FeedbackChannel.class).stream()
                 .map(channel -> "    \"%s\": { \"enabled\": %s, \"maxUnits\": %d }"

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/handler/inapp/InAppCompositionListener.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/handler/inapp/InAppCompositionListener.java
@@ -40,29 +40,16 @@ import org.springframework.transaction.event.TransactionalEventListener;
 import tools.jackson.databind.JsonNode;
 
 /**
- * Turns a finished review's composed process-level messages into IN_APP feedback units.
+ * Prepares composed IN_APP feedback and resolves its eligible supporting observations.
  *
- * <p>A failure here is logged and the feedback the developer already received is unaffected.
- *
- * <p>Late rather than lost. The event is delivered once and a submission to a saturated executor is
- * rejected outright, so this listener is not a guarantee of anything on its own — it is the fast path.
- * {@link #prepare} records that the lane ran, and {@code FeedbackLanePreparationSweeper} runs it for
- * every finished job that carries no such record.
- *
- * <p>Writes none of the words. The composer names a practice; the server — not the model — resolves
- * which of that person's measurements stand behind it, because evidence a model asserts about itself is
- * not evidence.
+ * <p>The asynchronous listener is the fast path. {@code FeedbackLanePreparationSweeper} retries
+ * unmarked jobs within its recovery window, including jobs whose listener submission was rejected.
  */
 @Component
 public class InAppCompositionListener {
 
     private static final Logger log = LoggerFactory.getLogger(InAppCompositionListener.class);
 
-    /**
-     * Ceiling on how many of a person's measurements of one practice are read to weigh a pattern. The
-     * router only needs to count distinct artifacts and check provenance, so the whole window is never
-     * required and an unbounded read would grow with how much work somebody did.
-     */
     private static final int MAX_EVIDENCE_PER_PRACTICE = 50;
 
     private final AgentJobRepository agentJobRepository;
@@ -108,17 +95,10 @@ public class InAppCompositionListener {
     }
 
     /**
-     * Route this job's composed messages to their recipients, then record that the lane ran.
+     * Records completion even when nothing is prepared. Exceptions propagate so recovery can retry
+     * jobs whose completion mark was not committed.
      *
-     * <p>Throws rather than logging, because its second caller is the recovery sweeper: a failure that
-     * leaves the mark unwritten is what makes the sweeper try again, and a caught one would look
-     * identical to success and retire the job from the sweep for good.
-     *
-     * <p>The mark is written on every non-exceptional path, including a job that composed nothing —
-     * which is the common case, since composition is a stage a review may skip. "Nothing to prepare" is
-     * an answer, and a lane that has answered must stop being swept.
-     *
-     * @return units newly prepared by this call (0 on a re-run, and 0 when nothing was composed)
+     * @return newly prepared units
      */
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public int prepare(UUID agentJobId, Long workspaceId) {
@@ -145,13 +125,8 @@ public class InAppCompositionListener {
         if (messages.isEmpty()) {
             return 0;
         }
-        // One recipient in practice — a review job files its observations against one person — but
-        // read rather than assumed, so a kind that ever files against several does not silently
-        // deliver all of their patterns to whoever happened to be first.
         List<Long> recipients = observationRepository.findSubjectUserIdsByAgentJobId(agentJobId, workspaceId);
-        // Every recipient's units share this job's id, and (agent_job_id, position) is unique, so each
-        // recipient gets its own slice of the band. The query orders by user id, so a re-run assigns
-        // the same slices and the idempotency guard still recognises what it already wrote.
+        // Stable recipient ordering preserves unique (agent_job_id, position) slots across retries.
         int positionBase = FeedbackLedgerRecorder.IN_APP_UNIT_ORDINAL_BASE;
         int prepared = 0;
         for (Long recipient : recipients) {
@@ -164,16 +139,6 @@ public class InAppCompositionListener {
         return prepared;
     }
 
-    /**
-     * This lane's share of one composition turn. The stage writes for every open surface in a single
-     * turn, so the units arrive together and each lane takes its own: a unit addressed to the merge
-     * request or to the mentor is not this producer's to route, and silently treating one as an in-app
-     * card would put a note about one line on a surface that exists to talk about habits.
-     *
-     * <p>A {@code WITHHOLD} unit is dropped here without a row, because on this lane the reason is
-     * always a property of the evidence — there was no pattern, nobody was owed anything — and a refusal
-     * that is a property of the evidence is not a withholding to explain.
-     */
     private List<ComposedInAppMessage> inAppMessages(@Nullable JsonNode jobOutput) {
         return resultParser.parse(jobOutput, FeedbackChannel.IN_APP).stream()
                 .filter(unit -> unit.action() != ComposedFeedbackUnit.Action.WITHHOLD)
@@ -183,8 +148,6 @@ public class InAppCompositionListener {
                         Objects.requireNonNull(unit.title()),
                         Objects.requireNonNull(unit.body()),
                         Objects.requireNonNull(unit.nextStep()),
-                        // Carried, not acted on here: whether the card it names is still unread is a fact
-                        // about the moment of writing, so the decision belongs where the write happens.
                         unit.supersedesThreadKey()))
                 .toList();
     }
@@ -218,22 +181,14 @@ public class InAppCompositionListener {
                         message.practiceSlug(),
                         agentJobId);
             }
-            // Only the problems are bound, not the whole window the router read: the card renders these
-            // rows as "the pieces of work this habit was observed on", so a piece of work where the
-            // practice went WELL must never appear among them.
+            // The card presents bound observations as examples of the problem, not the full review window.
             routed.add(new InAppFeedbackPreparer.RoutedMessage(
                     message, decision, InAppFeedbackRouter.problemsIn(evidence)));
         }
         return preparer.prepare(agentJobId, workspaceId, recipientUserId, List.copyOf(routed), positionBase);
     }
 
-    /**
-     * The recipient's own measurements of one practice, narrowed to what may be shown at all.
-     *
-     * <p>The visibility gate runs here and again at read: a claim measured under review rules the
-     * practice has since replaced, or one whose evidence source lost its authorization, must stop being
-     * cited. Composition freezes text; it must not freeze permission.
-     */
+    /** Filters evidence before preparation; read paths must recheck eligibility. */
     private List<Observation> visibleEvidence(
             Long workspaceId, Long recipientUserId, String practiceSlug, Instant since) {
         List<Observation> candidates = observationRepository.findRecentForSubjectAndPractice(
@@ -246,11 +201,7 @@ public class InAppCompositionListener {
         return candidates.stream().filter(o -> visible.contains(o.getId())).toList();
     }
 
-    /**
-     * The practice's effective autonomy, resolved through the practice → group → workspace chain from a
-     * projection rather than by walking associations — the same reason {@code FeedbackChannelRouter}
-     * projects it: the routing rule must not depend on whether the caller holds a session.
-     */
+    // Project autonomy to avoid depending on initialized entity associations.
     private @Nullable PracticeAutonomy effectiveTier(
             List<Observation> evidence, Long workspaceId, PracticeAutonomy workspaceDefault) {
         List<UUID> ids = evidence.stream()
@@ -268,12 +219,7 @@ public class InAppCompositionListener {
                 .orElse(null);
     }
 
-    /**
-     * Whose conduct the practice behind this evidence judges, read off its occasion. Asked with no
-     * signal, so every occasion the practice declares is considered: the question here is whether this
-     * practice can be about somebody other than the person we are about to show it to, not which run
-     * produced it.
-     */
+    // No occasion signal: consider all bindings when resolving whose conduct the practice reviews.
     private ActorRole subjectRole(List<Observation> evidence) {
         return evidence.stream()
                 .map(Observation::getPractice)

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/handler/inapp/InAppFeedbackPreparer.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/handler/inapp/InAppFeedbackPreparer.java
@@ -45,16 +45,7 @@ public class InAppFeedbackPreparer {
 
     private static final Logger log = LoggerFactory.getLogger(InAppFeedbackPreparer.class);
 
-    /**
-     * Cap on in-app units per recipient per cycle. Two, not the chat lane's three: a
-     * process-level message asks the developer to change a habit, and being handed three habits at once
-     * is how none of them get changed.
-     *
-     * <p>The composer is told the same number
-     * ({@link de.tum.cit.aet.hephaestus.agent.handler.composition.FeedbackCompositionInputs}) and its tool refuses
-     * a call past it, so in a normal run nothing arrives here to cap. The bound is kept as the last one
-     * standing: a runaway turn must not be able to fill a recipient's page.
-     */
+    /** Maximum prepared IN_APP feedback units per recipient in one preparation cycle. */
     public static final int TOP_N_PER_RECIPIENT = 2;
 
     private final FeedbackRepository feedbackRepository;

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/handler/inapp/InAppFeedbackRouter.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/handler/inapp/InAppFeedbackRouter.java
@@ -1,5 +1,6 @@
 package de.tum.cit.aet.hephaestus.agent.handler.inapp;
 
+import de.tum.cit.aet.hephaestus.agent.handler.composition.FeedbackCompositionInputs;
 import de.tum.cit.aet.hephaestus.integration.core.spi.ActorRole;
 import de.tum.cit.aet.hephaestus.practices.feedback.FeedbackChannel;
 import de.tum.cit.aet.hephaestus.practices.model.Assessment;
@@ -15,14 +16,6 @@ import java.util.Set;
 import org.jspecify.annotations.Nullable;
 
 public final class InAppFeedbackRouter {
-
-    /**
-     * Distinct artifacts a problem must appear on before it is a pattern. One occurrence is a task-level
-     * note and belongs on the work itself; claiming a habit from it would be the surface asserting more
-     * than the evidence carries. Mirrors {@code ObservationService.CORROBORATION_TARGETS}, which already
-     * holds the same line on the reflective read model.
-     */
-    public static final int CORROBORATION_ARTIFACTS = 2;
 
     /**
      * How long the same practice stays quiet on this surface after it was last shown. A habit does not
@@ -68,7 +61,7 @@ public final class InAppFeedbackRouter {
         if (problems.stream().allMatch(o -> o.getOrigin() == ObservationOrigin.BACKFILL)) {
             return InAppRoutingDecision.BACKFILL_HELD;
         }
-        if (distinctArtifacts(problems) < CORROBORATION_ARTIFACTS) {
+        if (distinctArtifacts(problems) < FeedbackCompositionInputs.MIN_DISTINCT_ARTIFACTS) {
             return InAppRoutingDecision.UNCORROBORATED;
         }
         if (lastSurfaced != null && lastSurfaced.isAfter(now.minus(Duration.ofDays(RESURFACE_COOLDOWN_DAYS)))) {

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/handler/inapp/InAppRoutingDecision.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/handler/inapp/InAppRoutingDecision.java
@@ -15,11 +15,7 @@ public enum InAppRoutingDecision {
      */
     NO_EVIDENCE,
 
-    /**
-     * Fewer than {@link InAppFeedbackRouter#CORROBORATION_ARTIFACTS} distinct artifacts carry the
-     * problem. One occurrence is a task-level note and belongs on the work, not on a surface whose whole
-     * claim is "this recurs".
-     */
+    /** Evidence does not meet the composition contract's minimum distinct-work threshold. */
     UNCORROBORATED,
 
     /** The practice's autonomy (OFF or HUMAN_APPROVAL) does not admit the in-app lane. */

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobRepository.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobRepository.java
@@ -323,18 +323,8 @@ public interface AgentJobRepository extends JpaRepository<AgentJob, UUID> {
     Optional<AgentJobLlmUsage> findLlmUsageById(@Param("id") UUID id);
 
     /**
-     * Finished jobs at least one feedback lane has no record of having run — the work
-     * {@code FeedbackLanePreparationSweeper} recovers after a rejected async submission dropped the
-     * event.
-     *
-     * <p>Bounded on both sides of the window on purpose. The upper bound leaves the listener its own
-     * chance first, so the sweeper is a backstop rather than a competitor; the lower bound stops the
-     * sweep from walking all of history, which also means a lane left unprepared for longer than the
-     * window is never recovered — it is a recovery path, not a reconciliation of the whole ledger.
-     *
-     * <p>Both marks are set even when a lane prepares nothing, so a job the sweeper handles is
-     * off this list on the next pass whatever the lanes decided. That is what keeps an hourly sweep
-     * from re-routing every recent job forever.
+     * Completed pull-request and issue reviews with unfinished preparation in {@code [from, until)}.
+     * A successful empty result has a completion mark and is excluded.
      */
     @WorkspaceAgnostic("Cross-tenant recovery sweep over jobs whose feedback lanes have no completion mark")
     @Query("SELECT new de.tum.cit.aet.hephaestus.agent.job.UnpreparedFeedbackLanes("
@@ -349,14 +339,9 @@ public interface AgentJobRepository extends JpaRepository<AgentJob, UUID> {
             @Param("from") Instant from, @Param("until") Instant until, Pageable pageable);
 
     /**
-     * Records that the conversational lane ran for this job. Written by the lane itself and by the
-     * sweeper that recovered it, so they cannot disagree about which one it was: the mark says the lane
-     * ran, not who drove it.
+     * Records successful preparation, including an empty result, without overwriting its first completion time.
      *
-     * <p>{@code IS NULL}-fenced so a sweeper racing a slow listener leaves the first completion's
-     * instant standing rather than backdating or advancing it.
-     *
-     * @return 1 when this call is the one that recorded the lane, 0 when it was already recorded
+     * @return 1 if recorded, 0 if already recorded or the job no longer exists
      */
     @WorkspaceAgnostic("ID-based lane completion mark; job ID from the lane's own event or the recovery sweep")
     @Modifying(flushAutomatically = true, clearAutomatically = true)

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/practices/feedback/FeedbackRepository.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/practices/feedback/FeedbackRepository.java
@@ -171,25 +171,10 @@ public interface FeedbackRepository extends JpaRepository<Feedback, UUID> {
             nativeQuery = true)
     int updateState(@Param("id") UUID id, @Param("state") String state);
 
-    // --- supersession ---
-    //
-    // A thread is a CHAIN of rows over time, so `thread_key` is deliberately not unique. The uniqueness
-    // that matters is "at most one live PREPARED unit per thread", and it is held by the compare-and-set
-    // below rather than by a constraint — a constraint would have to refuse the second write, and the
-    // right answer to a second write is to retire the first.
-
     /**
-     * The newest unit on one continuity thread, whatever became of it — the row a supersession is aimed
-     * at.
-     *
-     * <p><b>Newest, not newest-still-queued.</b> Deliberately unfiltered by delivery state, because the
-     * caller has to be able to tell the three zero-row outcomes apart: the thread was read, the thread was
-     * already retired by a run racing this one, or the thread does not exist. A query that pre-filtered to
-     * {@code PREPARED} would answer all three with the same empty optional.
-     *
-     * <p>Recipient-scoped as well as workspace-scoped even though the key digests both: a key is a hash,
-     * and a predicate is what makes "one person's queue is never another's" a property of the SQL rather
-     * than of the digest holding.
+     * Finds the newest row regardless of delivery state so callers can distinguish a delivered row
+     * from one already superseded. Thread keys group related feedback, not unique PREPARED items.
+     * Recipient and workspace predicates enforce isolation independently of the key's hash.
      */
     @Query(value = """
         SELECT f.id FROM feedback f
@@ -207,19 +192,10 @@ public interface FeedbackRepository extends JpaRepository<Feedback, UUID> {
             @Param("threadKey") String threadKey);
 
     /**
-     * Retires a queued unit so a newer one can take its place (compare-and-set).
+     * Atomically retires a selected PREPARED row without overwriting a concurrent delivery.
+     * Native because {@link Feedback} is {@code @Immutable}.
      *
-     * <p><b>The {@code PREPARED} predicate is the whole rule, and it lives here rather than in a prior
-     * read on purpose.</b> A read-then-write cannot express "only if nobody has read it yet": the
-     * recipient's own page flips the row to DELIVERED in an unrelated transaction, and between a check and
-     * an update there is room for exactly that. Two runs racing therefore both aim at the same row and
-     * exactly one is told it won; the loser sees rowcount 0 and treats it as an ordinary outcome. It also
-     * follows that a DELIVERED unit can never be retired by this path — nothing that has been received may
-     * be un-said.
-     *
-     * <p>Native because {@link Feedback} is {@code @Immutable} — the ORM cannot update it.
-     *
-     * @return {@code 1} when this caller retired the unit, {@code 0} when it was no longer queued
+     * @return 1 if retired, 0 if absent or no longer PREPARED
      */
     @Modifying(flushAutomatically = true)
     @Transactional

--- a/server/application/src/main/resources/agent/pi-runner-composition.ts
+++ b/server/application/src/main/resources/agent/pi-runner-composition.ts
@@ -1,14 +1,10 @@
-// Coherence rules the composed-feedback envelope must satisfy for the server to deliver what it
-// carries. Kept apart from pi-runner.ts so they can be exercised without starting a review.
-
-/** The lanes feedback can land on. Widening this fails to compile until every lane is bounded. */
 export const CHANNELS = ["IN_CONTEXT", "IN_APP", "IN_CHAT"] as const;
 export type Channel = (typeof CHANNELS)[number];
 
 export const ACTIONS = ["NEW", "SUPERSEDE", "WITHHOLD"] as const;
 export type FeedbackAction = (typeof ACTIONS)[number];
 
-/** A unit carries more than this; the tool schema in pi-runner.ts is the definition of the rest. */
+/** Partial view for coherence checks; pi-runner.ts owns the complete tool schema. */
 export interface ComposedFeedbackUnit {
 	action?: FeedbackAction;
 	channel?: Channel;
@@ -31,11 +27,7 @@ export interface ComposedFeedbackEnvelope {
 	lead?: string | null;
 }
 
-/**
- * What the composer is told about the practices the review never settled. It is not a finding and it
- * is not a clean bill: the developer's page records them as unevaluated, and anything written about
- * them would be a verdict the review cannot support.
- */
+/** Unevaluated practices support neither positive nor negative claims. */
 export function notReachedNote(notReached: readonly string[]): string {
 	if (notReached.length === 0) return "";
 	const subject =

--- a/server/application/src/main/resources/agent/pi-runner.ts
+++ b/server/application/src/main/resources/agent/pi-runner.ts
@@ -1638,12 +1638,7 @@ function scheduleDeadline(timeoutMs: number, onTimeout: () => void) {
 	return { elapsed, timer, state };
 }
 
-/**
- * Ends a session for good. A steer still queued when a session is disposed is not dropped: the SDK
- * keeps it on the agent and starts a fresh run to deliver it, so a nudge that arrived just as a
- * deadline did would spend the budget that deadline just took away. Clearing the queue first is what
- * the SDK's own interactive mode does before it aborts.
- */
+/** Clear queued steering before disposal so aborting cannot start a queued continuation. */
 function stopSession(session: AgentSession) {
 	session.clearQueue();
 	session.dispose();

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/handler/FeedbackLanePreparationSweeperTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/handler/FeedbackLanePreparationSweeperTest.java
@@ -25,13 +25,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.springframework.data.domain.Pageable;
 
-/**
- * The recovery path for feedback that a saturated async pool dropped.
- *
- * <p>Every test here fails if the sweeper stops doing something the live incident needed: leaving the
- * listener its own window, running only the lane that is actually missing, surviving one lane's failure,
- * and leaving a failed lane unmarked so the next pass retries it.
- */
 class FeedbackLanePreparationSweeperTest extends BaseUnitTest {
 
     private static final Instant NOW = Instant.parse("2026-08-16T12:00:00Z");

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/handler/composition/FeedbackCompositionCapsTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/handler/composition/FeedbackCompositionCapsTest.java
@@ -2,8 +2,6 @@ package de.tum.cit.aet.hephaestus.agent.handler.composition;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import de.tum.cit.aet.hephaestus.agent.handler.inapp.InAppFeedbackPreparer;
-import de.tum.cit.aet.hephaestus.agent.handler.inapp.InAppFeedbackRouter;
 import de.tum.cit.aet.hephaestus.agent.runtime.SandboxLayout;
 import de.tum.cit.aet.hephaestus.practices.feedback.FeedbackChannel;
 import de.tum.cit.aet.hephaestus.practices.model.ObservationOrigin;
@@ -16,15 +14,6 @@ import org.junit.jupiter.api.Test;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.json.JsonMapper;
 
-/**
- * The bounds the composer is told, against the bounds that are actually enforced.
- *
- * <p>The staging side cannot import the lanes it stages for — composition is upstream of all three, and
- * a dependency back would make the packages mutually recursive — so each number it hands the model is a
- * restatement. A restatement is only safe if something fails when the two diverge, and that is this
- * file. A composer told it may write three cards for a surface that admits two spends a turn writing
- * text that is thrown away, and the developer never learns why the third thing was not said.
- */
 class FeedbackCompositionCapsTest extends BaseUnitTest {
 
     private final JsonMapper objectMapper = JsonMapper.builder().build();
@@ -39,16 +28,16 @@ class FeedbackCompositionCapsTest extends BaseUnitTest {
     }
 
     @Test
-    void theInAppCapTheComposerIsToldIsTheCapThePreparerEnforces() {
+    void stagesTwoInAppUnitsPerRun() {
         assertThat(request.get("channels")
                         .get(FeedbackChannel.IN_APP.name())
                         .get("maxUnits")
                         .asInt())
-                .isEqualTo(InAppFeedbackPreparer.TOP_N_PER_RECIPIENT);
+                .isEqualTo(2);
     }
 
     @Test
-    void thePatternBarTheComposerIsToldIsTheBarTheRouterEnforces() {
-        assertThat(request.get("minDistinctArtifacts").asInt()).isEqualTo(InAppFeedbackRouter.CORROBORATION_ARTIFACTS);
+    void requiresTwoDistinctArtifactsForPatternClaims() {
+        assertThat(request.get("minDistinctArtifacts").asInt()).isEqualTo(2);
     }
 }

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/handler/composition/FeedbackCompositionInputsTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/handler/composition/FeedbackCompositionInputsTest.java
@@ -15,7 +15,6 @@ import org.junit.jupiter.api.Test;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.json.JsonMapper;
 
-/** The one file that decides whether a run composes at all, and which surfaces it may reach. */
 class FeedbackCompositionInputsTest extends BaseUnitTest {
 
     private final JsonMapper objectMapper = JsonMapper.builder().build();
@@ -33,11 +32,6 @@ class FeedbackCompositionInputsTest extends BaseUnitTest {
         }
     }
 
-    /**
-     * A sweep has no diff and no line to point at, so the public lane is closed — but it is closed by
-     * being named and disabled, not by being left out. The per-surface rules are only legible in
-     * contrast, and a lane that is simply missing reads as a lane the system does not have.
-     */
     @Test
     void aLaneThisOccasionCannotReachIsNamedAndDisabledRatherThanOmitted() {
         JsonNode channels = stage(ObservationOrigin.LIVE, EnumSet.of(FeedbackChannel.IN_APP, FeedbackChannel.IN_CHAT))
@@ -52,10 +46,6 @@ class FeedbackCompositionInputsTest extends BaseUnitTest {
                 .isTrue();
     }
 
-    /**
-     * Absence is the off switch, so a run that should not compose leaves no file at all rather than one
-     * saying so — the runner never opens a second session, and the decision costs nothing.
-     */
     @Test
     void aBackfillSweepStagesNothingAtAll() {
         Map<String, byte[]> files = new LinkedHashMap<>();


### PR DESCRIPTION
## What changed and why

Feedback composition and delivery comments described guarantees the implementation does not provide: preparation recovery does not rerun the model, and supersession does not enforce a single queued item per thread. Those claims could lead maintainers and operators to rely on behavior that does not exist.

This change corrects the owning documentation, removes redundant and historical commentary, and gives the pattern-corroboration threshold one authoritative value. Composition limits remain separate from per-recipient delivery limits because they constrain different populations. Feedback behavior and current limits are unchanged.

## How to test

- Run `vp run docs:build` to validate the generated documentation, including cross-section links.
- Run `vp run check` for the repository quality gates, including agent tests, type checks, and documentation checks.
- From `server/`, run:
  ```sh
  MANAGEMENT_PORT=0 SERVER_PORT=0 ./mvnw -f application/pom.xml \
    -Dtest=FeedbackLanePreparationSweeperTest,FeedbackCompositionCapsTest,FeedbackCompositionInputsTest,InAppFeedbackRouterTest,InAppFeedbackPreparerTest test
  ```
  These tests cover preparation recovery, staged composition bounds, and in-app admission and preparation.
- Review the recovery description in the contributor pipeline guide and operator limits, and the supersession description in the glossary, against the corresponding repository queries and preparers.

Local validation passed: `vp run docs:build`, `vp run format`, `vp run check`, and `MANAGEMENT_PORT=0 SERVER_PORT=0 vp run test:server:unit` (7,215 tests; no failures or skips). The focused tests above also passed (39 tests).

## Release impact

[Empty changeset](https://github.com/hephaestus-build/Hephaestus/blob/happy-seal/.changeset/precise-feedback-contracts.md): no user-facing behavior change or operator action. No API, database, configuration, or UI changes.

## Notes for reviewers

- Start with `FeedbackCompositionInputs` and `InAppFeedbackRouter`: the shared corroboration threshold is the only production logic refactor. Its value is unchanged.
- Recovery remains bounded to recent completed reviews and retries preparation from existing outputs. This PR documents that limit; it does not extend recovery.
- Supersession protects a selected `PREPARED` row from being retired after delivery. It does not prevent multiple new items on the same thread. Enforcing uniqueness would require a separate change to producer semantics and database concurrency handling.

