### PR TITLE
test(server): cover observation detail isolation

### DIFF
--- a/.changeset/observation-read-documentation.md
+++ b/.changeset/observation-read-documentation.md
@@ -1,0 +1,4 @@
+---
+---
+
+Correct internal observation-query documentation and remove redundant test commentary. No production behavior changes.

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/practices/observation/ObservationRepository.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/practices/observation/ObservationRepository.java
@@ -32,16 +32,9 @@ import org.springframework.transaction.annotation.Transactional;
 @Repository
 public interface ObservationRepository extends JpaRepository<Observation, UUID> {
     /**
-     * Excludes observations about an artifact in a repository a workspace team has hidden from contributions.
-     *
-     * <p>One text, concatenated into every native query that needs it, because five hand-kept copies is five
-     * chances for one of them to be forgotten — which is exactly what happened to the review-runs queries.
-     * Adding a surface now means adding this constant to it, and a surface that omits it omits it visibly.
-     *
-     * <p>Binds to the aliases {@code f} (the observation) and {@code p} (its practice), so every query using
-     * it must name those two the same way. Native rather than JPQL: it reaches the integration module's
-     * {@code issue} table and the workspace module's team settings, neither of which the practices module may
-     * hold an entity reference to.
+     * Excludes observations about artifacts in repositories hidden from contributions in this workspace.
+     * Requires the observation alias {@code f}. Native SQL crosses integration and workspace tables
+     * without introducing cross-module entity references.
      */
     String HIDDEN_REPOSITORY_GUARD = """
                   AND NOT EXISTS (
@@ -61,16 +54,8 @@ public interface ObservationRepository extends JpaRepository<Observation, UUID> 
     Optional<Observation> findByIdAndWorkspaceId(@Param("id") UUID id, @Param("workspaceId") Long workspaceId);
 
     /**
-     * The {@link #findByIdAndWorkspaceId} answer for a whole set of ids, in one round trip.
-     *
-     * <p>Same workspace predicate and the same entity graph as the single-id form. The graph is the point
-     * as much as the batching is: {@code ReviewClaimCurrentness} compares the evaluated
-     * {@code practiceRevision} against {@code practice.currentRevision}, so a batch that dropped it would
-     * trade one N+1 for a lazier one.
-     *
-     * <p>An id with no row in the result is an id the caller may not read — an observation that does not
-     * exist and one belonging to another workspace collapse into the same absence the single-id
-     * {@link Optional} reports empty. Callers guard an empty {@code ids}.
+     * Loads both practice revisions for batched currentness checks without per-observation lazy loads.
+     * Callers must guard an empty {@code ids} collection.
      */
     @EntityGraph(attributePaths = {"practice.currentRevision", "practiceRevision"})
     @Query("SELECT f FROM Observation f WHERE f.id IN :ids AND f.workspaceId = :workspaceId")
@@ -110,11 +95,7 @@ public interface ObservationRepository extends JpaRepository<Observation, UUID> 
         Long getProblems();
 
         Long getNotApplicable();
-        /**
-         * Runs where the practice looked and could not settle the question. Counted apart from
-         * {@link #getNotApplicable()}: both are silence on the artifact, but an operator reading a review
-         * summary needs "nothing here to judge" told apart from "we could not tell".
-         */
+
         Long getInconclusive();
     }
 
@@ -502,12 +483,7 @@ public interface ObservationRepository extends JpaRepository<Observation, UUID> 
     List<DeveloperPracticeSummaryProjection> findSummaryByDeveloperAndWorkspace(
             @Param("aboutUserId") Long aboutUserId, @Param("workspaceId") Long workspaceId);
 
-    /**
-     * Single observation by ID within a workspace, restricted to a specific about-user.
-     *
-     * <p>Ownership is enforced in the query (not in Java) to avoid lazy-load
-     * fragility and to keep the auth check atomic with the fetch.
-     */
+    /** Developer and workspace predicates restrict the selected data; they do not authorize the caller. */
     @EntityGraph(attributePaths = {"practice.currentRevision", "practiceRevision"})
     @Query("""
         SELECT f FROM Observation f
@@ -667,7 +643,6 @@ public interface ObservationRepository extends JpaRepository<Observation, UUID> 
     /**
      * The runs (agent jobs) that produced ≥1 correlation-keyed observation for a target, newest first by the
      * run's latest detection. Pass {@code PageRequest.of(0, 2)} to get the two most-recent runs to diff.
-     * Workspace-scoped via {@code Practice.workspace}.
      *
      * <p>A {@code BACKFILL} run is never one of the two. The diff is read as "did this get fixed between
      * the two times we looked", and a sweep that looked at the artifact long after the fact would answer
@@ -992,10 +967,6 @@ public interface ObservationRepository extends JpaRepository<Observation, UUID> 
     /**
      * One person's own measurements of one practice inside a window — the evidence a process-level
      * message about that practice stands on.
-     *
-     * <p>Workspace-scoped through the practice, exactly as every other read here: {@code observation}
-     * carries no workspace column of its own, so the join IS the tenancy predicate and dropping it would
-     * make a pattern about one workspace citable in another.
      *
      * <p>Deliberately NOT deduped to each artifact's latest run: whether a problem recurred across
      * separate pieces of work is the question, and a re-review of the same pull request is the same

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/practices/observation/ObservationService.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/practices/observation/ObservationService.java
@@ -26,15 +26,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
- * Service for reading practice observations scoped to the authenticated developer.
- *
- * <p>All methods resolve the current user from the security context via
- * {@link UserRepository#getCurrentUser()}. If the user is not yet synced as a
- * developer (e.g., first login before any PR activity), list/summary endpoints
- * return empty results rather than failing.
- *
- * <p>For single-observation access, developer ownership is enforced in SQL — a
- * non-owner receives 404 (not 403) to avoid leaking observation existence.
+ * Developer-scoped observation reads and workspace-scoped supporting queries.
+ * Pull-request reads intentionally include observations about other developers.
  */
 @Service
 @RequiredArgsConstructor
@@ -134,8 +127,7 @@ public class ObservationService {
             List.of(FeedbackChannel.IN_CONTEXT.name(), FeedbackChannel.IN_CHAT.name());
 
     /**
-     * Single observation detail. Ownership is enforced in the SQL query itself —
-     * an observation belonging to another developer simply won't be returned.
+     * Missing and unowned observations both raise not-found to avoid disclosing their existence.
      *
      * @return the observation if it exists and belongs to the current user
      * @throws EntityNotFoundException if no user, or observation not found/not owned

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/practices/observation/ObservationRepositoryIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/practices/observation/ObservationRepositoryIntegrationTest.java
@@ -135,6 +135,43 @@ class ObservationRepositoryIntegrationTest extends BaseIntegrationTest {
         return practiceRepository.save(practice);
     }
 
+    @Test
+    void shouldRequireBothDeveloperAndWorkspaceWhenReadingObservationDetail() {
+        UUID id = UUID.randomUUID();
+        observationRepository.insertIfAbsent(
+                id,
+                "scoped-detail",
+                agentJob.getId(),
+                workspace.getId(),
+                practice.getId(),
+                practice.getCurrentRevision().getId(),
+                "scm.pull_request",
+                42L,
+                aboutUser.getId(),
+                "Review observation",
+                "ABSENT",
+                "BAD",
+                "MAJOR",
+                null,
+                null,
+                null,
+                Instant.now(),
+                "LIVE");
+        User otherDeveloper =
+                userRepository.save(TestUserFactory.createUser(101L, "other-developer", aboutUser.getProvider()));
+        Workspace otherWorkspace = workspaceRepository.save(WorkspaceTestFixtures.activeWorkspace("other-workspace"));
+
+        assertThat(observationRepository.findByIdAndDeveloperAndWorkspace(id, aboutUser.getId(), workspace.getId()))
+                .map(Observation::getId)
+                .contains(id);
+        assertThat(observationRepository.findByIdAndDeveloperAndWorkspace(
+                        id, otherDeveloper.getId(), workspace.getId()))
+                .isEmpty();
+        assertThat(observationRepository.findByIdAndDeveloperAndWorkspace(
+                        id, aboutUser.getId(), otherWorkspace.getId()))
+                .isEmpty();
+    }
+
     @Nested
     class InsertIfAbsentTests {
 
@@ -298,7 +335,6 @@ class ObservationRepositoryIntegrationTest extends BaseIntegrationTest {
 
         @Test
         void purgeDoesNotAffectOtherWorkspace() {
-            // Create workspace B with its own practice and finding
             Workspace workspaceB = workspaceRepository.save(WorkspaceTestFixtures.activeWorkspace("ws-b"));
             Practice practiceB = new Practice();
             practiceB.setAutomatedReviewPolicy(PracticeTestEvidence.pullRequest());
@@ -316,7 +352,6 @@ class ObservationRepositoryIntegrationTest extends BaseIntegrationTest {
             agentJobB.setConfigSnapshot(OBJECT_MAPPER.valueToTree(Map.of("model", "test")));
             agentJobB = agentJobRepository.save(agentJobB);
 
-            // Finding in workspace A
             observationRepository.insertIfAbsent(
                     UUID.randomUUID(),
                     "ws-a-key",
@@ -336,7 +371,6 @@ class ObservationRepositoryIntegrationTest extends BaseIntegrationTest {
                     null,
                     Instant.now(),
                     "LIVE");
-            // Finding in workspace B
             observationRepository.insertIfAbsent(
                     UUID.randomUUID(),
                     "ws-b-key",
@@ -358,10 +392,8 @@ class ObservationRepositoryIntegrationTest extends BaseIntegrationTest {
                     "LIVE");
             assertThat(observationRepository.findAll()).hasSize(2);
 
-            // Purge workspace A only
             observationRepository.deleteAllByPracticeWorkspaceId(workspace.getId());
 
-            // Workspace B's finding must survive
             List<Observation> remaining = observationRepository.findAll();
             assertThat(remaining).hasSize(1);
             assertThat(remaining.get(0).getOccurrenceKey()).isEqualTo("ws-b-key");
@@ -371,16 +403,9 @@ class ObservationRepositoryIntegrationTest extends BaseIntegrationTest {
     @Nested
     class PracticeRemovalTests {
 
-        /**
-         * Removing a practice from the catalog is refused while anything was ever measured against it.
-         *
-         * <p>A cascading foreign key here would let pruning the catalog silently erase the recorded
-         * history of everyone measured against that practice — the substrate the whole product exists to
-         * build. Practices retire; measurements persist, and the database is what enforces it.
-         */
+        /** Deleting a practice must not cascade to its recorded observations. */
         @Test
         void refusesToRemoveAPracticeThatHasBeenMeasuredAgainst() {
-            // Create a second practice with its own finding
             Practice otherPractice = new Practice();
             otherPractice.setAutomatedReviewPolicy(PracticeTestEvidence.pullRequest());
             otherPractice.setWorkspace(workspace);
@@ -391,7 +416,6 @@ class ObservationRepositoryIntegrationTest extends BaseIntegrationTest {
             otherPractice = practiceRepository.save(otherPractice);
             otherPractice = pinCurrentRevision(otherPractice);
 
-            // Finding on the practice to be deleted
             observationRepository.insertIfAbsent(
                     UUID.randomUUID(),
                     "cascade-key-1",
@@ -411,7 +435,6 @@ class ObservationRepositoryIntegrationTest extends BaseIntegrationTest {
                     null,
                     Instant.now(),
                     "LIVE");
-            // Finding on the other practice (should survive)
             observationRepository.insertIfAbsent(
                     UUID.randomUUID(),
                     "cascade-key-2",
@@ -458,8 +481,6 @@ class ObservationRepositoryIntegrationTest extends BaseIntegrationTest {
         }
 
         private void insertForJob(String key, UUID jobId, long artifactId, String presence, Instant observedAt) {
-            // Former-GOOD practice valence: PRESENT -> GOOD (strength), ABSENT -> BAD (problem). A
-            // NOT_APPLICABLE observation has no sign at all (assessment + severity are null).
             boolean notApplicable = "NOT_APPLICABLE".equals(presence);
             String assessment = notApplicable ? null : ("PRESENT".equals(presence) ? "GOOD" : "BAD");
             String severity = notApplicable ? null : "INFO";
@@ -487,9 +508,6 @@ class ObservationRepositoryIntegrationTest extends BaseIntegrationTest {
         @Test
         @DisplayName("dashboard summary counts only the latest run per target (re-review dedup)")
         void countsOnlyLatestRunPerArtifact() {
-            // The SAME target (PR 42) reviewed twice: an earlier run said ABSENT/BAD, a later run said PRESENT/GOOD.
-            // A naive COUNT would show 2 observations (1 PRESENT, 1 ABSENT); the dashboard must show the
-            // target's CURRENT state only — 1 observation, PRESENT/GOOD.
             AgentJob laterJob = anotherJob();
             insertForJob("dedup-old", agentJob.getId(), 42L, "ABSENT", Instant.parse("2026-03-18T10:00:00Z"));
             insertForJob("dedup-new", laterJob.getId(), 42L, "PRESENT", Instant.parse("2026-03-20T10:00:00Z"));
@@ -509,8 +527,6 @@ class ObservationRepositoryIntegrationTest extends BaseIntegrationTest {
         @Test
         @DisplayName("each distinct target contributes its own latest run")
         void countsEachTargetIndependently() {
-            // Target 42 reviewed twice (latest = PRESENT/GOOD); target 43 reviewed once (ABSENT/BAD). The dedup is
-            // per-target, so the older run survives for 43 while only the newer run survives for 42.
             AgentJob laterJob = anotherJob();
             insertForJob("t42-old", agentJob.getId(), 42L, "ABSENT", Instant.parse("2026-03-18T10:00:00Z"));
             insertForJob("t42-new", laterJob.getId(), 42L, "PRESENT", Instant.parse("2026-03-20T10:00:00Z"));
@@ -529,9 +545,6 @@ class ObservationRepositoryIntegrationTest extends BaseIntegrationTest {
         @Test
         @DisplayName("NOT_APPLICABLE inflates totalObservations but never good/bad, and is omitted from findRecent")
         void notApplicableCountedInTotalButExcludedFromRecent() {
-            // A NOT_APPLICABLE observation (no assessment, no severity) for a distinct target so the latest-run
-            // dedup keeps it: it must count toward totalObservations yet contribute to neither good nor bad
-            // (so total != good + bad by design), and the mentor's drill-down list must omit it entirely.
             insertForJob("na-target", agentJob.getId(), 50L, "NOT_APPLICABLE", Instant.parse("2026-03-20T10:00:00Z"));
             insertForJob("bad-target", agentJob.getId(), 51L, "ABSENT", Instant.parse("2026-03-20T11:00:00Z"));
 
@@ -540,9 +553,9 @@ class ObservationRepositoryIntegrationTest extends BaseIntegrationTest {
 
             assertThat(summary).hasSize(1);
             DeveloperPracticeSummaryProjection row = summary.get(0);
-            assertThat(row.getTotalObservations()).isEqualTo(2L); // NA + BAD both counted
+            assertThat(row.getTotalObservations()).isEqualTo(2L);
             assertThat(row.getGoodCount()).isEqualTo(0L);
-            assertThat(row.getBadCount()).isEqualTo(1L); // only the BAD row, the NA is excluded
+            assertThat(row.getBadCount()).isEqualTo(1L);
 
             List<Observation> recent = observationRepository.findRecentByDeveloperAndWorkspace(
                     aboutUser.getId(),
@@ -551,7 +564,6 @@ class ObservationRepositoryIntegrationTest extends BaseIntegrationTest {
                     true,
                     PageRequest.of(0, 50));
 
-            // The NA row is filtered out of the drill-down list; only the actionable BAD finding remains.
             assertThat(recent).hasSize(1);
             assertThat(recent.get(0).getOccurrenceKey()).isEqualTo("bad-target");
             assertThat(recent.get(0).getPresence()).isEqualTo(Presence.ABSENT);
@@ -562,8 +574,7 @@ class ObservationRepositoryIntegrationTest extends BaseIntegrationTest {
     class ArtifactKindTests {
 
         @Test
-        @DisplayName("persisted 'PULL_REQUEST' maps to ArtifactKinds.PULL_REQUEST on read")
-        void enumRoundTrip() {
+        void shouldRoundTripPullRequestArtifactKind() {
             UUID id = UUID.randomUUID();
             observationRepository.insertIfAbsent(
                     id,
@@ -575,7 +586,7 @@ class ObservationRepositoryIntegrationTest extends BaseIntegrationTest {
                     "scm.pull_request",
                     1L,
                     aboutUser.getId(),
-                    "Enum mapping test",
+                    "Artifact kind mapping",
                     "PRESENT",
                     "GOOD",
                     "INFO",
@@ -822,10 +833,6 @@ class ObservationRepositoryIntegrationTest extends BaseIntegrationTest {
         }
     }
 
-    /**
-     * A confirmed campaign spends real money and must produce something visible. The reflective surface
-     * admits its observations; the per-practice summary, which is read as a trend, still does not.
-     */
     @Nested
     class BackfillVisibilityTests {
 
@@ -871,18 +878,11 @@ class ObservationRepositoryIntegrationTest extends BaseIntegrationTest {
                     true,
                     PageRequest.of(0, 50));
 
-            assertThat(recent)
-                    .as(
-                            "a backfilled BAD on the developer's own pull request is exactly what 'what should I work on' asks for")
-                    .extracting(Observation::getArtifactId)
-                    .containsExactly(900L);
+            assertThat(recent).extracting(Observation::getArtifactId).containsExactly(900L);
         }
 
         @Test
-        @DisplayName("a later campaign does not erase already-delivered live feedback")
-        void aCampaignDoesNotDisplaceTheLiveReading() {
-            // Same artifact, campaign strictly newer. An origin-blind latest-run correlation would make the
-            // campaign's job "the latest run" and drop the live row the developer was actually sent.
+        void shouldPreserveLiveObservationsWhenLaterBackfillExists() {
             insert("live-reading", agentJob.getId(), 901L, Instant.parse("2026-03-20T10:00:00Z"), "LIVE");
             insert("campaign-reading", campaignJob().getId(), 901L, Instant.parse("2026-03-21T10:00:00Z"), "BACKFILL");
 
@@ -894,7 +894,6 @@ class ObservationRepositoryIntegrationTest extends BaseIntegrationTest {
                     PageRequest.of(0, 50));
 
             assertThat(recent)
-                    .as("the latest run is selected within each origin class, so both readings survive")
                     .extracting(Observation::getOrigin)
                     .containsExactlyInAnyOrder(ObservationOrigin.BACKFILL, ObservationOrigin.LIVE);
         }


### PR DESCRIPTION
## What changed and why

Observation read-path comments overstated authorization guarantees and described an outdated schema. Some test descriptions also claimed feedback had been delivered even though their fixtures created only observations.

This change corrects those descriptions, removes comments that repeat the code, and preserves explanations of non-obvious query constraints. It also adds a database regression for observation-detail lookup: the matching developer and workspace return the observation, while a different persisted developer or workspace does not.

## How to test

Passed locally:
- `vp run format`
- `vp run check`
- `MANAGEMENT_PORT=0 SERVER_PORT=0 vp run test:server:unit` — 7,215 tests passed.

Run the database-backed suite with:

```bash
MANAGEMENT_PORT=0 SERVER_PORT=0 \
HEPHAESTUS_INTEGRATION_TESTS=ObservationRepositoryIntegrationTest \
vp run test:server:integration
```

Local database verification is blocked by insufficient disk space: PostgreSQL could not initialize its test container. The integration regression therefore still needs a successful CI run.

## Release impact

No production behavior, API, schema, or UI changes. No operator action is required. The [empty changeset](https://github.com/hephaestus-build/Hephaestus/blob/elfin-python/.changeset/observation-read-documentation.md) records that no release note or version bump is needed.

## Notes for reviewers

The production Java changes are comments only. The new regression tests SQL scoping, not caller authorization. Existing assertions remain intact; two test names now describe what their fixtures actually establish.

This PR does not implement developer preview or expand impersonation. It also leaves the existing handling of failed feedback delivery unchanged.
