### PR TITLE
fix(ci): keep pnpm coherent and verify docs rendering

### DIFF
--- a/.changeset/pnpm-coherent-toolchain.md
+++ b/.changeset/pnpm-coherent-toolchain.md
@@ -1,0 +1,4 @@
+---
+---
+
+Updates build tooling consistently across local development and container builds; no intentional user-facing behavior change.

--- a/docker/agents/pi/Dockerfile
+++ b/docker/agents/pi/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.26@sha256:ecfaec9ed6d810b56388c508f4121597bfbba70d41a6dfeee4d8cad5f295fc32
 # renovate: datasource=node-version depName=node
 ARG NODE_VERSION=24.19.0
-FROM ghcr.io/pnpm/pnpm:12.0.0@sha256:bce5ae25ef95edd79e696d7fa8489b80561ef660100fd35bd0286d0f90db3dcc AS dependencies
+FROM ghcr.io/pnpm/pnpm:12.3.4@sha256:b81d53184f670fe19d1a33f9d5041907d314b31d596838e8133cbd83d45be043 AS dependencies
 ARG NODE_VERSION
 WORKDIR /opt/pi-sdk
 RUN pnpm runtime set node ${NODE_VERSION} -g

--- a/docker/agents/pi/package.json
+++ b/docker/agents/pi/package.json
@@ -6,6 +6,6 @@
     "@earendil-works/pi-coding-agent": "0.84.4"
   },
   "engines": {
-    "pnpm": "12.0.0"
+    "pnpm": "12.3.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
 	"devEngines": {
 		"packageManager": {
 			"name": "pnpm",
-			"version": "12.0.0",
+			"version": "12.3.4",
 			"onFail": "error"
 		},
 		"runtime": {
@@ -55,5 +55,5 @@
 	"engines": {
 		"node": "24.19.0"
 	},
-	"packageManager": "pnpm@12.0.0"
+	"packageManager": "pnpm@12.3.4"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,96 +7,96 @@ importers:
     configDependencies: {}
     packageManagerDependencies:
       pnpm:
-        specifier: 12.0.0
-        version: 12.0.0
+        specifier: 12.3.4
+        version: 12.3.4
 
 packages:
 
-  '@pnpm/exe.darwin-arm64@12.0.0':
-    resolution: {integrity: sha512-sqeoPfVMIfQhbwzDrKraXY2ynyuWClFqzvfImzAS/yczEru1m5SGvQ9kgFPDvQzJZ9AetedgJeDZC6qYvH8/tQ==}
+  '@pnpm/exe.darwin-arm64@12.3.4':
+    resolution: {integrity: sha512-PAyUol8T1+/+ViOiXAt51ECA+QnfXCqz6foL4bW+LsoX0NcVd5XVEM2mRQu+LV4oc7uRz9zf9U0P+XFfuQeDAw==}
     cpu: [arm64]
     os: [darwin]
 
-  '@pnpm/exe.darwin-x64@12.0.0':
-    resolution: {integrity: sha512-Quc3J6c9cGTy+LDgz1cLVgCNOU9IERuyAlDoEj0DCilKqvo50Jx1GV8k74iwn4J9fFSKkm8JrwNvtTDj3uWnUA==}
+  '@pnpm/exe.darwin-x64@12.3.4':
+    resolution: {integrity: sha512-fxP9JCk0Cdye+ePuj+GJJLMUMTqHGWRdb1dtv4How876uQ2ehxvenpgiYAir/ceO9PsYUZkFTtyZdx+rRu5QOA==}
     cpu: [x64]
     os: [darwin]
 
-  '@pnpm/exe.linux-arm64-musl@12.0.0':
-    resolution: {integrity: sha512-EVWd3OTmgsMFhXx69b5JxIzoabG9Ma7m4OeTaf0ZKBzMnfYi8u21NDQo92ToMrdYL5dYDDCHsyYIjXzk+d0HhA==}
+  '@pnpm/exe.linux-arm64-musl@12.3.4':
+    resolution: {integrity: sha512-FBOt0/7ye6O6q4AllVV5QMviB6qE6fqkeczV/+MDWQsmo+QJrlfsh6X7CpH/tClVpBZEyIbjpUoT8bNhCYBxEg==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@pnpm/exe.linux-arm64@12.0.0':
-    resolution: {integrity: sha512-cXHHW8M4rAPsYNkKZO9WVcpLLK55i9EaIsZPfIqUuY2eopd5LqnFyBge54HCh1GC0yCX8ySn0hYIi+4OyAEoDg==}
+  '@pnpm/exe.linux-arm64@12.3.4':
+    resolution: {integrity: sha512-t71AVA7LRqiKTyZ5xMYaZc2n5DfdpMbfokZuiIOXHBOM03ECnF0t4iYwaBDqJgVjlKYUOwaF/bRQajGNA4cJ4w==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@pnpm/exe.linux-x64-musl@12.0.0':
-    resolution: {integrity: sha512-UcXwMdFjly0mpddkGigHKTxe27IMv2fUK4IWW/MHmJ3yMguxXmkwNlEI4aE+G1HO2TLo20uNEUWD4ymLe/DaCQ==}
+  '@pnpm/exe.linux-x64-musl@12.3.4':
+    resolution: {integrity: sha512-RPmk7Jb/aYaFvL2iyDN/AtMY+hUEsue732WmXpcuQ9tBpMnGyA5py7Z3+e+qmQaJ0zY/4ni9jJiyPBQHujmv6w==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@pnpm/exe.linux-x64@12.0.0':
-    resolution: {integrity: sha512-6Rsl+zEWMOmus7v7/9J3OE8EMvHyNAfxYmDfmhQG4J0985OuT3G3Ho9NSGHjkBn4aU4bgklWifRhe1HX8dUSyw==}
+  '@pnpm/exe.linux-x64@12.3.4':
+    resolution: {integrity: sha512-2ZqOlSPkfwX1h5cR+FPiWf8+F+2hZT/3TvhUK5sigHqwaQCIiq8R7CGxhndKs63JtcLi2a1Qpo+wX/EoyfjyJQ==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@pnpm/exe.win32-arm64@12.0.0':
-    resolution: {integrity: sha512-O5F76A4oVFrpDGdFxEszRIThOSBfjHdH5c006gR+7UTCfiXrukr1XfqPungUI1DXcSR5gb9jBsPQqQZOAoOOxw==}
+  '@pnpm/exe.win32-arm64@12.3.4':
+    resolution: {integrity: sha512-ANyrHqyqco6SXBysUTRF74itDyyraea7IbFsKFdNXTjcFnfycTDx37EwuhdpPYFNSIh2JhUG4fByclsRfiHX7w==}
     cpu: [arm64]
     os: [win32]
 
-  '@pnpm/exe.win32-x64@12.0.0':
-    resolution: {integrity: sha512-5dKFajIEWJ1ai+KHXFJvskY6vchbunmLwSUV2ywbLymcmJjfY5XJVpgzPCyIoVCMVG0zHorr66+hM8h8b3aRfQ==}
+  '@pnpm/exe.win32-x64@12.3.4':
+    resolution: {integrity: sha512-WH/KqBPY/hq2Tb7SgQltEZytimcjgKRaCRL/aM9CI0c67iKc5TVmHUhIiL3Ux9FB4bWn36i6XewUcScQI+zG8w==}
     cpu: [x64]
     os: [win32]
 
-  pnpm@12.0.0:
-    resolution: {integrity: sha512-ni49w5EZlYaNyUuBdcIXwn6VQI+gO0oidJd48rNPdzt3zdOznt6BcbIvzVO+ajU0Lp+smUimjvWN9kiM6Jp+Zw==}
+  pnpm@12.3.4:
+    resolution: {integrity: sha512-lhqkH7B32joEpEHZ+OFevAyW2o73ELLrZ7+e58sGEOq9SPH9hfUc/+c4RnhfoPh8VqOocqHYk/hEZ0G1zORUVw==}
     engines: {node: '>=18.*'}
     hasBin: true
 
 snapshots:
 
-  '@pnpm/exe.darwin-arm64@12.0.0':
+  '@pnpm/exe.darwin-arm64@12.3.4':
     optional: true
 
-  '@pnpm/exe.darwin-x64@12.0.0':
+  '@pnpm/exe.darwin-x64@12.3.4':
     optional: true
 
-  '@pnpm/exe.linux-arm64-musl@12.0.0':
+  '@pnpm/exe.linux-arm64-musl@12.3.4':
     optional: true
 
-  '@pnpm/exe.linux-arm64@12.0.0':
+  '@pnpm/exe.linux-arm64@12.3.4':
     optional: true
 
-  '@pnpm/exe.linux-x64-musl@12.0.0':
+  '@pnpm/exe.linux-x64-musl@12.3.4':
     optional: true
 
-  '@pnpm/exe.linux-x64@12.0.0':
+  '@pnpm/exe.linux-x64@12.3.4':
     optional: true
 
-  '@pnpm/exe.win32-arm64@12.0.0':
+  '@pnpm/exe.win32-arm64@12.3.4':
     optional: true
 
-  '@pnpm/exe.win32-x64@12.0.0':
+  '@pnpm/exe.win32-x64@12.3.4':
     optional: true
 
-  pnpm@12.0.0:
+  pnpm@12.3.4:
     optionalDependencies:
-      '@pnpm/exe.darwin-arm64': 12.0.0
-      '@pnpm/exe.darwin-x64': 12.0.0
-      '@pnpm/exe.linux-arm64': 12.0.0
-      '@pnpm/exe.linux-arm64-musl': 12.0.0
-      '@pnpm/exe.linux-x64': 12.0.0
-      '@pnpm/exe.linux-x64-musl': 12.0.0
-      '@pnpm/exe.win32-arm64': 12.0.0
-      '@pnpm/exe.win32-x64': 12.0.0
+      '@pnpm/exe.darwin-arm64': 12.3.4
+      '@pnpm/exe.darwin-x64': 12.3.4
+      '@pnpm/exe.linux-arm64': 12.3.4
+      '@pnpm/exe.linux-arm64-musl': 12.3.4
+      '@pnpm/exe.linux-x64': 12.3.4
+      '@pnpm/exe.linux-x64-musl': 12.3.4
+      '@pnpm/exe.win32-arm64': 12.3.4
+      '@pnpm/exe.win32-x64': 12.3.4
 
 ---
 lockfileVersion: '9.0'

--- a/renovate.json
+++ b/renovate.json
@@ -26,6 +26,7 @@
 		"schedule": ["before 7am on monday"]
 	},
 	"rangeStrategy": "replace",
+	"postUpdateOptions": ["pnpmDedupe"],
 	"packageRules": [
 		{
 			"matchManagers": ["maven"],

--- a/scripts/ci-contract.test.ts
+++ b/scripts/ci-contract.test.ts
@@ -394,6 +394,19 @@ void describe("CI contract", () => {
 		);
 	});
 
+	void test("required tooling CI renders docs after its checks", async () => {
+		const tasks = await loadTasks();
+		const tooling = asRecord(tasks["ci:tooling"], "ci:tooling");
+		assert.deepEqual(commandsOf(tooling), ["vp run verification:docs-build"]);
+		const dependencies = asArray(tooling.dependsOn, "ci:tooling.dependsOn").map((dependency) =>
+			asString(dependency, "ci:tooling dependency"),
+		);
+		const checks = taskClosure(tasks, dependencies);
+		assert.ok(checks.has("gate:docs-lint"));
+		assert.ok(!checks.has("docs:build"), "docs must render after, not alongside, the checks");
+		assert.ok(taskClosure(tasks, ["ci:tooling"]).has("docs:build"));
+	});
+
 	void test("every local gate runs in a workflow, and every CI gate is a local gate", async () => {
 		const tasks = await loadTasks();
 		const local = taskClosure(tasks, ["quality"]);

--- a/scripts/renovate-config.test.ts
+++ b/scripts/renovate-config.test.ts
@@ -12,6 +12,10 @@ assert.ok(Array.isArray(config.extends));
 assert.ok(config.extends.every((entry) => typeof entry === "string"));
 const extensions = config.extends;
 
+void test("dependency updates normalize optional peer snapshots with the pinned pnpm", () => {
+	assert.deepEqual(config.postUpdateOptions, ["pnpmDedupe"]);
+});
+
 /**
  * Datasources whose versions are release tags, which upstreams prefix with `v` while the pins here
  * are bare. Unless a manager strips the prefix, the version Renovate resolves for a pin is the tag

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -339,17 +339,22 @@ export default defineConfig({
 
 			// What each CI job runs.
 			"ci:server": group(serverGates.concat("gate:contracts", "gate:env")),
-			"ci:tooling": group([
-				// Excluded here because another job or workflow runs them; the Windows leg re-runs what it can.
-				...policyGates.filter(
-					(gate) =>
-						!["gate:contracts", "gate:env", "gate:changesets", "gate:preview-stack"].includes(gate),
-				),
-				...agentGates,
-				...docsGates,
-				...loadGates,
-				"gate:load-syntax",
-			]),
+			// Render docs after the checks: lint cannot detect broken theme contexts during static rendering.
+			"ci:tooling": run("vp run verification:docs-build", {
+				dependsOn: [
+					// Excluded here because another job or workflow runs them; the Windows leg re-runs what it can.
+					...policyGates.filter(
+						(gate) =>
+							!["gate:contracts", "gate:env", "gate:changesets", "gate:preview-stack"].includes(
+								gate,
+							),
+					),
+					...agentGates,
+					...docsGates,
+					...loadGates,
+					"gate:load-syntax",
+				],
+			}),
 			"ci:webapp:static": group([...webappGates, "gate:docs-tokens", "verification:webapp-tests"]),
 			// The build regenerates the route tree, so it never runs beside a gate that reads it. A
 			// second name after `vp run` is an argument, not a second task, so the two are separate.

--- a/webapp/Dockerfile
+++ b/webapp/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.26@sha256:ecfaec9ed6d810b56388c508f4121597bfbba70d41a6dfeee4d8cad5f295fc32
-FROM ghcr.io/pnpm/pnpm:12.0.0@sha256:bce5ae25ef95edd79e696d7fa8489b80561ef660100fd35bd0286d0f90db3dcc AS build
+FROM ghcr.io/pnpm/pnpm:12.3.4@sha256:b81d53184f670fe19d1a33f9d5041907d314b31d596838e8133cbd83d45be043 AS build
 WORKDIR /repo
 # renovate: datasource=node-version depName=node
 ARG NODE_VERSION=24.19.0


### PR DESCRIPTION
## What changed and why

pnpm 12.0.0 can resolve Docusaurus optional peers into two copies of the same runtime context, causing Mermaid pages to fail static rendering. Upgrade pnpm to 12.3.4, which includes the native resolver fix (https://github.com/pnpm/pnpm/pull/14466), and keep both container image pins and the isolated review-runtime package manager aligned. This replaces #2008, whose update omitted the container pins.

Enable Renovate’s supported `pnpmDedupe` post-update option so bot-generated lockfiles normalize optional peer snapshots using the pinned resolver. A plain install with the new binary retains the broken graph; dedupe repairs it without custom scripts.

Run the existing production docs build through required tooling CI after its checks. The separate docs preview workflow does not cover every lockfile change or merge group, so lint alone previously allowed this failure through.

## How to test

- `pnpm install --frozen-lockfile --ignore-scripts` and the isolated `docker/agents/pi` install pass.
- `vp run format` and `vp run check` pass.
- `vp run ci:tooling` passes, including production rendering of the docs.
- On an isolated copy of the affected Zod update, pnpm 12.3.4 `dedupe --lockfile-only --ignore-scripts` reduces Docusaurus theme contexts from two to one without adding or removing any concrete package version; a second run is byte-identical.

## Release impact

Build tooling and CI only. The empty changeset records no intentional user-facing behavior change; no operator action or release is requested.

## Notes for reviewers

This branch does not rewrite unrelated application dependencies. Affected dependency branches still need native lockfile normalization and a successful docs build before merging. The CI contract test preserves docs lint coverage and ensures rendering follows the existing checks.
