### PR TITLE
fix(deps): update Springdoc with its generated contract

### DIFF
--- a/.changeset/springdoc-locale-cache.md
+++ b/.changeset/springdoc-locale-cache.md
@@ -1,0 +1,5 @@
+---
+"hephaestus": patch
+---
+
+Protects instances with API documentation enabled against unbounded locale-cache growth. API documentation remains disabled by default, and no operator configuration change is required.

--- a/server/application/pom.xml
+++ b/server/application/pom.xml
@@ -51,7 +51,7 @@
         <spring-modulith.version>2.1.1</spring-modulith.version>
         <liquibase.version>5.0.4</liquibase.version>
         <liquibase-hibernate7.version>5.0.4</liquibase-hibernate7.version>
-        <springdoc.version>3.1.0</springdoc.version>
+        <springdoc.version>3.1.1</springdoc.version>
         <sentry.version>8.55.0</sentry.version>
         <logstash-logback-encoder.version>9.0</logstash-logback-encoder.version>
         <slack-bolt.version>1.51.0</slack-bolt.version>

--- a/server/openapi.yaml
+++ b/server/openapi.yaml
@@ -9463,7 +9463,7 @@ components:
           format: int64
           description: "The artifact's internal id, as the trace and review listings\
             \ report it"
-          minimum: 0
+          exclusiveMinimum: 0
         artifactKind:
           type: string
           description: "The artifact kind's wire id, e.g. scm.pull_request. A raw\
@@ -10972,7 +10972,7 @@ components:
           target:
             type: integer
             format: int32
-            minimum: 0
+            exclusiveMinimum: 0
       description: Linear progress with current and target counts
       required:
       - current


### PR DESCRIPTION
## What changed and why

Springdoc 3.1.1 fixes unbounded locale-cache growth in the API documentation endpoint: https://github.com/springdoc/springdoc-openapi/security/advisories/GHSA-rhhx-6j8h-8cvw. API documentation is disabled by default here; exposure is conditional on explicitly enabling it.

Replace #2022 with the dependency update and its actual generated contract. The new spec correctly records `exclusiveMinimum: 0` for `CreateReviewRequest.artifactId` and `LinearAchievementProgress.target`, matching their existing `@Positive` annotations. No controller or runtime validation behavior changes. Both spec and client were regenerated; all six client files remain byte-identical, so there is no artificial client diff.

## How to test

- `vp run generate:api` completes using Java 21 with `HEPHAESTUS_APPLICATION_JAR` unset, packaging the reactor and reading the spec from that JAR. The temporary endpoint used was `http://127.0.0.1:35295/v3/api-docs.yaml`; the generation task stopped its process afterward.
- `vp run format` and `vp run check` pass.
- `vp run test:server:unit`: 7,215 tests pass, no failures, errors or skips.
- Required generated-artifact, integration, database, image/security and merge-group checks remain mandatory on this replacement head. The original's stale-artifact failure is not dismissed as infrastructure.

## Release impact

Patch changeset: instances with API documentation enabled receive the security fix, with no required configuration change. API documentation remains disabled by default. No database migration or release operation.

## Notes for reviewers

This is known-vulnerability remediation under the repository's existing vulnerability-update age exception. No global age setting, security configuration, check or merge protection is weakened. The two schema constraint changes are generated from existing declarations, not hand-edited.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unbounded locale-cache growth when API documentation is enabled.
  * Updated API documentation validation so artifact IDs and achievement targets must be positive integers; zero is no longer accepted.
  * Updated the API documentation component to version 3.1.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->