### PR TITLE
chore(deps): update diagram and preview tooling

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 		"jsonc-parser": "3.3.1",
 		"mdast-util-from-markdown": "2.0.3",
 		"mdast-util-mdx": "3.0.0",
-		"mermaid": "11.16.1",
+		"mermaid": "11.17.2",
 		"micromark-extension-mdxjs": "3.0.0",
 		"mprocs": "0.9.3",
 		"npm-package-arg": "13.0.2",
@@ -35,7 +35,7 @@
 		"oxlint": "catalog:",
 		"oxlint-tsgolint": "catalog:",
 		"pg": "8.20.0",
-		"surge": "0.43.1",
+		"surge": "0.44.0",
 		"typescript": "7.0.2",
 		"vite-plus": "0.3.0",
 		"yaml": "2.9.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,7 +127,7 @@ catalogs:
       version: 7.0.2001
 
 overrides:
-  mermaid: 11.16.1
+  mermaid: 11.17.2
   vitest: 4.1.11
   '@vitest/browser': 4.1.11
   '@vitest/runner': 4.1.11
@@ -210,8 +210,8 @@ importers:
         specifier: 3.0.0
         version: 3.0.0(supports-color@8.1.1)
       mermaid:
-        specifier: 11.16.1
-        version: 11.16.1
+        specifier: 11.17.2
+        version: 11.17.2
       micromark-extension-mdxjs:
         specifier: 3.0.0
         version: 3.0.0
@@ -234,8 +234,8 @@ importers:
         specifier: 8.20.0
         version: 8.20.0
       surge:
-        specifier: 0.43.1
-        version: 0.43.1
+        specifier: 0.44.0
+        version: 0.44.0
       typescript:
         specifier: 7.0.2
         version: 7.0.2
@@ -280,7 +280,7 @@ importers:
         version: 3.10.2(@docusaurus/faster@3.10.2(@docusaurus/types@3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(esbuild@0.27.7)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(esbuild@0.27.7)(html-minifier-terser@7.2.0)(postcss@8.5.26))(@rspack/core@1.7.12)(@swc/core@1.16.1)(@swc/html@1.16.1)(@types/react@19.2.18)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(esbuild@0.27.7)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@7.0.2)
       '@docusaurus/theme-mermaid':
         specifier: 3.10.2
-        version: 3.10.2(ca5d1347ed5f2b8ecf6664f6da2cc3e4)
+        version: 3.10.2(892873e189960648cfc5f213f6cb08e9)
       '@easyops-cn/docusaurus-search-local':
         specifier: 0.55.3
         version: 0.55.3(@docusaurus/faster@3.10.2(@docusaurus/types@3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(esbuild@0.27.7)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(esbuild@0.27.7)(html-minifier-terser@7.2.0)(postcss@8.5.26))(@docusaurus/theme-common@3.10.2(299501ffb747bd8ecea706b2dc86a208))(@mdx-js/react@3.1.1(@types/react@19.2.18)(react@19.2.8))(@rspack/core@1.7.12)(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(esbuild@0.27.7)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@7.0.2)
@@ -289,7 +289,7 @@ importers:
         version: 3.1.1(@types/react@19.2.18)(react@19.2.8)
       '@mermaid-js/layout-elk':
         specifier: 0.2.3
-        version: 0.2.3(mermaid@11.16.1)
+        version: 0.2.3(mermaid@11.17.2)
       clsx:
         specifier: 2.1.1
         version: 2.1.1
@@ -2956,7 +2956,7 @@ packages:
   '@mermaid-js/layout-elk@0.2.3':
     resolution: {integrity: sha512-m46RVGfvKK1PSMdAFGDz2nksI4jusEkFxvf0lb48bYWmqLQxZpjtpruiw29MbOy9rlWJtuMf9EzG9fAF8CVZbg==}
     peerDependencies:
-      mermaid: 11.16.1
+      mermaid: 11.17.2
 
   '@mermaid-js/parser@1.2.1':
     resolution: {integrity: sha512-n12NohV3mrUyUL2o93IgG/ifeW9FTyeJn3zDxkhwa8MJ9Fxg3HQMlA3RiGmD/3UnJvheztkjjQAjA2T4LmUcpw==}
@@ -7297,6 +7297,9 @@ packages:
   fast-xml-validator@1.4.2:
     resolution: {integrity: sha512-dN1Z5tBDxhJ1e8ccerKI+MWdwZ8oUWhWTSYISFeHKUOzlaZrwnwxcHKN3d7R9IOqtCtk6ynbEiZhjo/8RtDwIA==}
 
+  fastdom@1.0.12:
+    resolution: {integrity: sha512-LB+xjSTEbjHE1cWsxu+tN2Xqr1kpi+V9aADI7sVM5ZMaXyYGPHULQMzpJMYqOTULK/73pUkWVzzObFRBkPr+hg==}
+
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
@@ -8546,8 +8549,8 @@ packages:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
 
-  mermaid@11.16.1:
-    resolution: {integrity: sha512-TQsq6u22fAn3rek5VOubrhKPo1g5hwC3FXUN9hiyupTckcYiGuuKGkNQrKYwGJkXUxZdojwRG46gsSCFZMDp4g==}
+  mermaid@11.17.2:
+    resolution: {integrity: sha512-V6K3C8EBdEsPFZXSKMJe6ppQOENxuHARr9GvHX4hh47lAbhMRD9qf4oEK7LoaRQxULMa80/qt5gHO73aCleBBg==}
 
   methods@1.1.2:
     resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
@@ -10406,6 +10409,9 @@ packages:
   strict-event-emitter@0.5.1:
     resolution: {integrity: sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==}
 
+  strictdom@1.0.1:
+    resolution: {integrity: sha512-cEmp9QeXXRmjj/rVp9oyiqcvyocWab/HaoN4+bwFeZ7QzykJD6L3yD4v12K1x0tHpqRqVpJevN3gW7kyM39Bqg==}
+
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
@@ -10523,8 +10529,8 @@ packages:
     resolution: {integrity: sha512-omvx31wB1xGfoFb2GTiWDjyzk5pEjgRIUZnlwfkfJtbH2HQv3oEwWy75BPA7i/vNjoqmu45ZJR54LCNHsF+4hw==}
     engines: {node: '>=18.13'}
 
-  surge@0.43.1:
-    resolution: {integrity: sha512-79va3SVLZkMASyf//dKu0jcSrTvsur5wwSoEkJ+bhe6NFVgddSBUYD5CnMCfPo4C05cU0it9qpCThMXIxy0qVQ==}
+  surge@0.44.0:
+    resolution: {integrity: sha512-GpYcDMYIlvsmN1DsH0803WZndrsRqLCQ9Xe/T3tqmTA7aIBvDv9Rbm8RbhN2KFg+ZYj8J+/0mJLAly4rtDOjOQ==}
     engines: {node: '>=18.13'}
     hasBin: true
 
@@ -14024,19 +14030,19 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/theme-mermaid@3.10.2(ca5d1347ed5f2b8ecf6664f6da2cc3e4)':
+  '@docusaurus/theme-mermaid@3.10.2(892873e189960648cfc5f213f6cb08e9)':
     dependencies:
       '@docusaurus/core': 3.10.2(@docusaurus/faster@3.10.2(@docusaurus/types@3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(esbuild@0.27.7)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(esbuild@0.27.7)(html-minifier-terser@7.2.0)(postcss@8.5.26))(@mdx-js/react@3.1.1(@types/react@19.2.18)(react@19.2.8))(@rspack/core@1.7.12)(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(esbuild@0.27.7)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@7.0.2)
       '@docusaurus/module-type-aliases': 3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(esbuild@0.27.7)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
       '@docusaurus/theme-common': 3.10.2(299501ffb747bd8ecea706b2dc86a208)
       '@docusaurus/types': 3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(esbuild@0.27.7)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
       '@docusaurus/utils-validation': 3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(esbuild@0.27.7)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
-      mermaid: 11.16.1
+      mermaid: 11.17.2
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
       tslib: 2.8.1
     optionalDependencies:
-      '@mermaid-js/layout-elk': 0.2.3(mermaid@11.16.1)
+      '@mermaid-js/layout-elk': 0.2.3(mermaid@11.17.2)
     transitivePeerDependencies:
       - '@docusaurus/faster'
       - '@docusaurus/plugin-content-docs'
@@ -15005,11 +15011,11 @@ snapshots:
       '@types/react': 19.2.18
       react: 19.2.8
 
-  '@mermaid-js/layout-elk@0.2.3(mermaid@11.16.1)':
+  '@mermaid-js/layout-elk@0.2.3(mermaid@11.17.2)':
     dependencies:
       d3: 7.9.0
       elkjs: 0.9.3
-      mermaid: 11.16.1
+      mermaid: 11.17.2
 
   '@mermaid-js/parser@1.2.1':
     dependencies:
@@ -19068,6 +19074,10 @@ snapshots:
       path-expression-matcher: 1.6.2
       xml-naming: 0.3.0
 
+  fastdom@1.0.12:
+    dependencies:
+      strictdom: 1.0.1
+
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
@@ -20457,7 +20467,7 @@ snapshots:
 
   merge2@1.4.1: {}
 
-  mermaid@11.16.1:
+  mermaid@11.17.2:
     dependencies:
       '@braintree/sanitize-url': 7.1.2
       '@iconify/utils': 3.1.4
@@ -20473,6 +20483,7 @@ snapshots:
       dayjs: 1.11.23
       dompurify: 3.4.14
       es-toolkit: 1.51.0
+      fastdom: 1.0.12
       katex: 0.16.47
       khroma: 2.1.0
       marked: 16.4.2
@@ -22770,6 +22781,8 @@ snapshots:
 
   strict-event-emitter@0.5.1: {}
 
+  strictdom@1.0.1: {}
+
   string-width@4.2.3:
     dependencies:
       emoji-regex: 8.0.0
@@ -22888,7 +22901,7 @@ snapshots:
       surge-ignore: 0.3.0
       tar: 7.5.22
 
-  surge@0.43.1:
+  surge@0.44.0:
     dependencies:
       chartscii: 4.0.3
       cli-table3: 0.6.5

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -38,7 +38,7 @@ catalog:
   "@vitest/runner": 4.1.11
 
 overrides:
-  mermaid: 11.16.1
+  mermaid: 11.17.2
   vitest: "catalog:"
   "@vitest/browser": "catalog:"
   "@vitest/runner": "catalog:"


### PR DESCRIPTION
## What changed and why

The diagram and preview-tool updates in #2005 and #2025 need regeneration against the merged pnpm fix. Their native rebase requests have not been processed, so this maintainer-owned replacement updates the selected pair without adding commits to bot-owned branches.

- Align the root Mermaid pin and workspace override at 11.17.2.
- Update Surge to 0.44.0. Existing publish/teardown commands do not use its new visibility flags and retain their behavior.
- Regenerate with pnpm 12.3.4 and native dedupe: only the selected packages and Mermaid's expected fastdom/strictdom dependencies change, with one shared Docusaurus context.

The originals are paused and will close only after this replacement merges.

## How to test

Verified on the pinned Node 24.20.0 and pnpm 12.3.4:

- `pnpm install --frozen-lockfile`
- `vp run format` and `vp run check`
- `vp run ci:tooling`, including diagram checks and production docs rendering
- `vp exec surge --version` reports 0.44.0.
- `vp exec surge --private --public` rejects contradictory flags with exit 1 before authentication or publication.

No preview was published or removed during local verification. Required hosted CI and merge-group checks remain required.

## Release impact

Root contributor tooling only; no application release changeset or operator action. No release is being cut.

## Notes for reviewers

[Surge upstream comparison](https://github.com/sintaxi/surge/compare/v0.43.1...v0.44.0). The native lockfile diff is intentionally small; do not restore the duplicate optional-peer snapshots from the original bot branches.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development tooling to newer versions of Mermaid and Surge.
  * Aligned the Mermaid version used across the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->