### PR TITLE
chore(deps): update the pinned Dockerfile frontend

### DIFF
--- a/.changeset/dockerfile-frontend.md
+++ b/.changeset/dockerfile-frontend.md
@@ -1,0 +1,4 @@
+---
+---
+
+Updates the Dockerfile parser used to build images; application behavior and operator configuration are unchanged.

--- a/docker/agents/pi/Dockerfile
+++ b/docker/agents/pi/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.26@sha256:ecfaec9ed6d810b56388c508f4121597bfbba70d41a6dfeee4d8cad5f295fc32
+# syntax=docker/dockerfile:1.27@sha256:bde3983e9c939224420ddaf6b784cc30e09b035a4dea01f581230c50809f372e
 # renovate: datasource=node-version depName=node
 ARG NODE_VERSION=24.20.0
 FROM ghcr.io/pnpm/pnpm:12.3.4@sha256:b81d53184f670fe19d1a33f9d5041907d314b31d596838e8133cbd83d45be043 AS dependencies

--- a/webapp/Dockerfile
+++ b/webapp/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.26@sha256:ecfaec9ed6d810b56388c508f4121597bfbba70d41a6dfeee4d8cad5f295fc32
+# syntax=docker/dockerfile:1.27@sha256:bde3983e9c939224420ddaf6b784cc30e09b035a4dea01f581230c50809f372e
 FROM ghcr.io/pnpm/pnpm:12.3.4@sha256:b81d53184f670fe19d1a33f9d5041907d314b31d596838e8133cbd83d45be043 AS build
 WORKDIR /repo
 # renovate: datasource=node-version depName=node


### PR DESCRIPTION
## What changed and why

#2013 conflicts with the merged Node/pnpm changes. This replacement changes only the Dockerfile frontend syntax pin in the two current Dockerfiles, retaining every runtime and package-manager pin.

It uses the original reviewed 1.27 digest, not a newer candidate: `sha256:bde3983e9c939224420ddaf6b784cc30e09b035a4dea01f581230c50809f372e`. Docker Hub reports publication on September 2 at 16:23 UTC; the three-day observation period has elapsed. Both the 1.27 and 1.27.0 tags resolve to this digest. No age policy is bypassed.

The original bot PR is paused and will close only after this replacement merges.

## How to test

Verified locally:

- Frozen installation on Node 24.20.0 / pnpm 12.3.4, then `vp run format` and `vp run check`.
- `docker buildx build --check --file webapp/Dockerfile .`
- `docker buildx build --check --file docker/agents/pi/Dockerfile .`

Both frontend checks complete without warnings. These checks validate Dockerfile parsing/policy, not completed images; normal required CI must build the actual images and verify their evidence before landing.

## Release impact

Empty changeset `.changeset/dockerfile-frontend.md`: build parser only, no application behavior or operator configuration change. No release is being cut.

## Notes for reviewers

[Docker Hub tag metadata](https://hub.docker.com/v2/repositories/docker/dockerfile/tags/1.27) · [Official release](https://github.com/moby/buildkit/releases/tag/dockerfile%2F1.27.0)

Renovate's generic refusal comment does not establish why its native rebase was rejected; authenticated Mend logs are unavailable. The immutable candidate's actual publication age is independently verified above.
