### PR TITLE
ci: reduce backend waits and redundant release work

### DIFF
--- a/.changeset/mentor-disconnect-before-start.md
+++ b/.changeset/mentor-disconnect-before-start.md
@@ -1,0 +1,5 @@
+---
+"hephaestus": patch
+---
+
+Release a mentor conversation promptly when its browser connection closes before the response starts, so a new message does not wait for an inactive turn to time out.

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -227,7 +227,7 @@ jobs:
           base-sha: ${{ inputs.postgres_base_sha }}
           image-changed: ${{ inputs.postgres_image_changed }}
           tag: hephaestus-postgres:ci
-      - name: Run database contract tests and the major-upgrade drill
+      - name: Run database contract tests
         run: |
           docker run -d --name postgres-db \
             -e POSTGRES_DB=hephaestus -e POSTGRES_PASSWORD=root -e POSTGRES_USER=root \
@@ -241,7 +241,8 @@ jobs:
           (cd server && ./mvnw -f application/pom.xml --batch-mode -Dmaven.build.cache.enabled=false \
             -Dsurefire.includedGroups=database surefire:test)
 
-          vp run test:postgres-upgrade
+      - name: Run the PostgreSQL major-upgrade drill
+        run: node scripts/postgres-major-upgrade-test.ts --target-image hephaestus-postgres:ci
       - name: Upload test results
         if: always()
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0

--- a/.github/workflows/ci-profile.yml
+++ b/.github/workflows/ci-profile.yml
@@ -4,6 +4,12 @@ on:
   schedule:
     - cron: "17 3 * * 1"
   workflow_dispatch:
+    inputs:
+      suite:
+        description: "Server tier to profile"
+        type: choice
+        default: all
+        options: [all, integration, verification]
 
 concurrency:
   group: ci-profile-${{ github.ref }}
@@ -14,6 +20,7 @@ permissions: {}
 jobs:
   server-integration:
     name: "Server integration profile"
+    if: github.event_name != 'workflow_dispatch' || inputs.suite != 'verification'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -142,6 +149,63 @@ jobs:
             ci-metrics/jfr-summary.txt
             ci-metrics/maven
           if-no-files-found: warn
+          retention-days: 14
+
+  server-verification:
+    name: "Server unit and architecture profile"
+    needs: server-integration
+    if: ${{ !cancelled() && (github.event_name != 'workflow_dispatch' || inputs.suite != 'integration') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-toolchain
+        with:
+          install: "frozen"
+      - uses: ./.github/actions/setup-caches
+        with:
+          cache-type: application-server-reactor
+          os: ${{ runner.os }}
+
+      - name: Run unit and architecture verification with JFR
+        id: profile
+        shell: bash
+        run: |
+          mkdir -p ci-metrics/maven
+          /usr/bin/time -v -o ci-metrics/server-verification-resource.txt \
+            vp run test:server:verification \
+            '-Dhephaestus.test.jvmArgs=-XX:StartFlightRecording=filename=target/verification-profile.jfr,settings=profile,dumponexit=true -Xlog:jfr+startup=off' \
+            -Dprofile=server-verification -DprofileFormat=JSON \
+            -Dmaven-profiler-report-directory=../ci-metrics/maven \
+            2>&1 | tee ci-metrics/server-verification.log
+
+      - name: Validate profile artifacts
+        if: ${{ !cancelled() && steps.profile.outcome == 'success' }}
+        run: |
+          jq -e '.projects | length > 0' ci-metrics/maven/*.json > /dev/null
+          jfr summary server/application/target/verification-profile.jfr > ci-metrics/jfr-summary.txt
+
+      - name: Summarize verification results
+        if: ${{ !cancelled() }}
+        run: >-
+          vp run report:test-results "Server Unit and Architecture Profile"
+          server/application/target/surefire-reports ci-metrics/server-verification-profile.json
+          ci-metrics/server-verification.log ci-metrics/server-verification-resource.txt verification
+
+      - name: Upload profile
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: server-verification-profile-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            server/application/target/verification-profile.jfr
+            server/application/target/surefire-reports
+            ci-metrics
+          if-no-files-found: error
           retention-days: 14
 
   pr-latency:

--- a/.github/workflows/version-pr.yml
+++ b/.github/workflows/version-pr.yml
@@ -1,26 +1,23 @@
 name: Version PR
 
-# Maintains the changesets Version PR; release.yml handles merged version bumps.
-#
-# The changesets action pushes with GITHUB_TOKEN, and a push made with that token starts no workflow
-# run — so the Version PR used to carry no checks at all and merged through a ruleset bypass.
-# workflow_dispatch is one of the two documented exceptions to that rule, so the same token starts
-# CI/CD on the Version PR's own branch instead; scripts/dispatch-version-pr-ci.ts has the reasoning.
-#
-# Contributor guide: docs/contributor/release-management.mdx
-
+# Versioning contract: docs/contributor/release-management.mdx.
 on:
-  push:
+  workflow_run: # zizmor: ignore[dangerous-triggers] Only successful same-repository main pushes can mutate the Version PR.
+    workflows: ["CI/CD"]
+    types: [completed]
     branches: [main]
-
-concurrency:
-  group: version-pr
-  cancel-in-progress: false
 
 permissions: {}
 
 jobs:
   version-pr:
+    if: >-
+      ${{ github.event.workflow_run.conclusion == 'success'
+        && github.event.workflow_run.event == 'push'
+        && github.event.workflow_run.head_repository.full_name == github.repository }}
+    concurrency:
+      group: version-pr
+      cancel-in-progress: false
     timeout-minutes: 15
     runs-on: ubuntu-latest
     permissions:
@@ -30,12 +27,26 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ github.event.repository.default_branch }}
           fetch-depth: 0
-      - uses: ./.github/actions/setup-toolchain
+      - name: Select the validated default-branch tip
+        id: current
+        shell: bash
+        env:
+          VALIDATED_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          if [ "$(git rev-parse HEAD)" = "$VALIDATED_SHA" ]; then
+            echo "validated=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Default branch has advanced; its successful CI run will maintain the Version PR."
+          fi
+      - if: steps.current.outputs.validated == 'true'
+        uses: ./.github/actions/setup-toolchain
         with:
           install: "frozen"
 
       - name: Maintain Version PR
+        if: steps.current.outputs.validated == 'true'
         uses: changesets/action@8488615a623b1b9c987934bb89eae8af6a946ac1 # v2.1.1
         with:
           version-script: vp run release:version
@@ -43,9 +54,8 @@ jobs:
           commit-message: "chore(release): version packages"
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      # Every Version PR head commit gets a CI/CD run, so the commit whose merge cuts a release is
-      # validated before it lands rather than after.
       - name: Run CI on the Version PR
+        if: steps.current.outputs.validated == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: node scripts/dispatch-version-pr-ci.ts

--- a/docs/contributor/ci-cd.mdx
+++ b/docs/contributor/ci-cd.mdx
@@ -121,8 +121,9 @@ a stacked layer is approved while it still targets the layer below, because reta
 lower layer merges must not depend on receiving a subsequent event. The `edited` trigger also
 re-evaluates explicit base changes.
 
-The Version PR carries checks like any other pull request. Its updates are pushed with
-`GITHUB_TOKEN`, which starts no workflow run, so `version-pr.yml` dispatches CI/CD on the Version
+The Version PR is maintained after CI/CD succeeds for the current tip of `main`; failed or
+overtaken main runs do not update it. It carries checks like any other pull request. Its updates are
+pushed with `GITHUB_TOKEN`, which starts no workflow run, so `version-pr.yml` dispatches CI/CD on the Version
 PR's branch instead — `workflow_dispatch` being one of the two events that token may start. The
 dispatched run reports `CI Status Gate` onto the branch head, which is the pull request's head
 commit, so the commit whose merge cuts a release is validated before it lands. `Verify changesets`
@@ -375,7 +376,7 @@ why the label is the authority, and which alternatives were priced and declined,
 | `cleanup-preview.yml` | Label removed, PR closed or drafted | Removes and verifies resources, then retains a cleanup tombstone |
 | `reconcile-previews.yml` | Nightly, manual | Re-sends teardown for any preview environment whose pull request is closed, drafted or unlabelled |
 | `cd-docs.yml`, `cd-docs-teardown.yml` | `docs/**` on push and pull requests; PR closed | Publishes the docs site and its pull-request previews |
-| `version-pr.yml` | Push to main | Maintains the accumulating Version PR (changesets) and dispatches CI/CD on its branch, release evidence preflight included |
+| `version-pr.yml` | Successful CI/CD completion for the current main tip | Maintains the accumulating Version PR (changesets) and dispatches CI/CD on its branch, release evidence preflight included |
 | `release.yml` | Successful CI/CD push on `main` | Publishes the release and promotes the moving series and latest image tags |
 | `release-upgrade.yml` | Called by `release.yml`, weekly | Boots the previous stable release with seeded data, then the candidate against the same database |
 | `promote.yml` | Manual dispatch, or automatically for staging | Signs the channel a host follows; hosts pull and apply it themselves |
@@ -563,10 +564,13 @@ or mixed attempts. Keep raw API evidence under `tmp/`, not in committed performa
 
 Normal PR test jobs retain Surefire reports for 14 days, separately for each suite, shard and
 attempt. Use those reports and GitHub's step timings before rerunning tests with instrumentation.
-Deep profiling stays in the manual/weekly workflow, not on the PR critical path.
+Deep profiling stays in the manual/weekly workflow, not on the PR critical path. Select
+`integration`, `verification` (unit and architecture, including coverage), or `all` when dispatching
+`CI profile`. Weekly runs profile both tiers sequentially so diagnostics do not occupy two heavy
+runners at once. Each tier retains its JFR recording, Maven phase report, resource usage and JUnit
+results for 14 days. Verification profiles are diagnostic artifacts, not integration-history samples.
 
-`CI profile` records JFR, Maven phase timings, resource usage, JUnit results and Spring context-cache
-metrics. It signals
+The integration profile additionally records Spring context-cache metrics. It signals
 a sustained regression after three consecutive profiles exceed variance limits against five earlier
 default-branch profiles or absolute Spring-context limits. Only successful test runs with a readable
 JFR recording and valid summaries enter history, including runs whose performance budget fails.
@@ -577,8 +581,9 @@ artifacts without changing or enforcing the baseline.
 
 The workflow's `Run integration suite with JFR` step owns the invocation. Additional test-JVM flags
 use `-Dhephaestus.test.jvmArgs=...`; Surefire and Failsafe compose these with JaCoCo's late-bound
-arguments and the configured memory limits. Missing recordings, Maven reports, resource metrics
-or Spring-context measurements fail the profile rather than becoming zero-valued baselines.
+arguments and the configured memory limits. Missing recordings, Maven reports or resource metrics
+fail the profile rather than becoming zero-valued baselines. Integration profiles also require
+Spring-context measurements; unit/architecture profiles do not require a Spring application to boot.
 For local shard profiling, use the same `HEPHAESTUS_INTEGRATION_TESTS` selector as the CI matrix
 and the Java version pinned in `.java-version`. Compare the same suite, runtime and cache state;
 the weekly whole-tier baseline is not comparable to one shard.

--- a/docs/contributor/release-management.mdx
+++ b/docs/contributor/release-management.mdx
@@ -45,15 +45,18 @@ sequenceDiagram
 
 1. **Every PR that changes shipped code carries a changeset.** `Verify changesets` fails the PR
    otherwise; [Writing changesets](#writing-changesets) has the rules.
-2. **The Version PR accumulates, and is checked.** On every push to `main`, `version-pr.yml`
-   maintains a PR titled `chore(release): version packages` that previews the version bump, the
+2. **The Version PR accumulates, and is checked.** After CI/CD succeeds for a push that is still the
+   tip of `main`, `version-pr.yml` maintains a PR titled `chore(release): version packages` that previews the version bump, the
    `CHANGELOG.md` section, and the `MIGRATION.md` section assembled from `.migration/` fragments at
    the `### Next release` anchor. Its updates are pushed with `GITHUB_TOKEN`, and a push made with
    that token starts no workflow run — so the same workflow dispatches CI/CD onto the Version PR's
    branch, `workflow_dispatch` being one of the two events that token may start. Every Version PR
    head commit gets one such run; `scripts/dispatch-version-pr-ci.ts` decides by asking whether the
-   head already has one, so a missed dispatch heals on the next push and an unchanged head costs
-   nothing. Every CI/CD run on that branch also carries the **release evidence preflight** below,
+   head already has one, so a missed dispatch heals on the next successful current-main CI completion
+   and an unchanged head costs nothing. Failed main runs do not update the Version PR; a successful
+   rerun or later successful tip resumes maintenance. Overtaken completions are skipped before
+   versioning, so release validation does not start alongside the same commit’s main validation.
+   Every CI/CD run on that branch also carries the **release evidence preflight** below,
    whichever event started it, and `CI Status Gate` fails there unless the preflight succeeded in the
    same run. More than one run can report that gate for a Version PR head — a dispatch and an
    approved `pull_request` run both did for v0.75.1 — and the ruleset is satisfied by either, so a

--- a/scripts/ci-profile-history.test.ts
+++ b/scripts/ci-profile-history.test.ts
@@ -101,3 +101,21 @@ void test(
 		);
 	},
 );
+
+void test("verification profiling retains coverage and runs separately from integration history", () => {
+	const verification = workflow.getIn(["jobs", "server-verification"]);
+	assert.ok(isMap(verification));
+	assert.equal(verification.get("needs"), "server-integration");
+	const items = verification.get("steps");
+	assert.ok(isSeq(items));
+	const profile = items.items.find((item) => isMap(item) && item.get("id") === "profile");
+	assert.ok(isMap(profile));
+	assert.equal(profile.get("shell"), "bash");
+	assert.match(String(profile.get("run")), /vp run test:server:verification/);
+	assert.doesNotMatch(String(profile.get("run")), /skipCoverage|skipTests/);
+	assert.match(String(profile.get("run")), /-Dhephaestus\.test\.jvmArgs=.*StartFlightRecording/);
+	assert.equal(
+		items.items.some((item) => isMap(item) && item.get("id") === "history"),
+		false,
+	);
+});

--- a/scripts/postgres-major-upgrade-test.ts
+++ b/scripts/postgres-major-upgrade-test.ts
@@ -5,6 +5,12 @@
 // up healthy and empty.
 import { spawnSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
+import { parseArgs } from "node:util";
+
+const { values } = parseArgs({ options: { "target-image": { type: "string" } } });
+const targetImage = values["target-image"];
+if (targetImage !== undefined && targetImage.trim() === "")
+	throw new Error("--target-image must name an existing local PostgreSQL image");
 
 const id = `postgres-upgrade-${randomUUID().slice(0, 8)}`;
 const source = `${id}-17`;
@@ -91,6 +97,7 @@ function fingerprint(container: string): string {
 }
 
 try {
+	if (targetImage !== undefined) docker("image", "inspect", targetImage);
 	run("docker", [
 		"build",
 		"--build-arg",
@@ -101,24 +108,13 @@ try {
 		`${id}:17`,
 		"docker/postgres",
 	]);
-	run("docker", ["build", "-t", `${id}:18`, "docker/postgres"]);
+	if (targetImage === undefined) run("docker", ["build", "-t", `${id}:18`, "docker/postgres"]);
 	docker("volume", "create", volume);
 
 	const sourcePort = start(source, volume, "/var/lib/postgresql/data", `${id}:17`);
 	if (sql(source, "SHOW server_version_num").slice(0, 2) !== "17")
 		throw new Error("source is not PostgreSQL 17");
 
-	// liquibase:update is a single-module invocation, so the reactor sibling the application
-	// depends on must be installed to the local repository first — a warm CI cache is not a given.
-	run("node", [
-		"scripts/run-mvnw.ts",
-		"-pl",
-		"generated-clients",
-		"-am",
-		"install",
-		"-DskipTests",
-		"--quiet",
-	]);
 	run("node", [
 		"scripts/run-mvnw.ts",
 		"-f",
@@ -168,7 +164,7 @@ try {
 			"POSTGRES_USER=root",
 			"-e",
 			"POSTGRES_PASSWORD=root",
-			`${id}:18`,
+			targetImage ?? `${id}:18`,
 		],
 		{ encoding: "utf8", timeout: 120_000, maxBuffer: 64 * 1024 * 1024 },
 	);
@@ -184,7 +180,7 @@ try {
 	docker("volume", "rm", volume);
 	docker("volume", "create", volume);
 
-	start(target, volume, "/var/lib/postgresql", `${id}:18`);
+	start(target, volume, "/var/lib/postgresql", targetImage ?? `${id}:18`);
 	docker("exec", target, "dropdb", "-U", "root", "hephaestus");
 	docker("exec", target, "createdb", "-U", "root", "hephaestus");
 	const restore = spawnSync(
@@ -233,5 +229,6 @@ try {
 } finally {
 	for (const container of [source, target]) spawnSync("docker", ["rm", "-f", container]);
 	spawnSync("docker", ["volume", "rm", "-f", volume]);
-	for (const image of [`${id}:17`, `${id}:18`]) spawnSync("docker", ["rmi", "-f", image]);
+	for (const image of targetImage === undefined ? [`${id}:17`, `${id}:18`] : [`${id}:17`])
+		spawnSync("docker", ["rmi", "-f", image]);
 }

--- a/scripts/postgres-major-upgrade.test.ts
+++ b/scripts/postgres-major-upgrade.test.ts
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { test } from "node:test";
+
+import { asArray, asRecord, asStringArray } from "./lib/json.ts";
+import { loadTasks } from "./lib/task-graph.ts";
+
+function preparation(args: string[], imageExists = true): (readonly string[])[] {
+	const script = new URL("./postgres-major-upgrade-test.ts", import.meta.url).href;
+	const result = spawnSync(process.execPath, ["--input-type=module"], {
+		input: `
+import childProcess from "node:child_process";
+import { syncBuiltinESMExports } from "node:module";
+const commands = [];
+childProcess.spawnSync = (command, args) => {
+  commands.push([command, ...args]);
+  let stdout = "";
+  let status = 0;
+  if (command === "node") return { status: 1, stdout: "", stderr: "stop before migrations" };
+  if (args[0] === "image" && args[1] === "inspect" && !${imageExists}) status = 1;
+  if (args[0] === "port") stdout = "127.0.0.1:54321";
+  if (args.includes("SHOW server_version_num")) stdout = "170000";
+  return { status, stdout, stderr: status ? "missing image" : "" };
+};
+syncBuiltinESMExports();
+process.argv = ["node", ${JSON.stringify(script)}, ...${JSON.stringify(args)}];
+try {
+  await import(${JSON.stringify(script)});
+  throw Error("expected fixture failure");
+} catch (error) {
+  if (!String(error).includes(${JSON.stringify(imageExists ? "stop before migrations" : "missing image")})) throw error;
+}
+process.stdout.write(JSON.stringify(commands));
+`,
+		encoding: "utf8",
+	});
+	assert.equal(result.status, 0, result.stderr);
+	const value: unknown = JSON.parse(result.stdout);
+	return asArray(value, "commands").map((command) => asStringArray(command, "command"));
+}
+
+await test("local task prepares Maven artifacts and the drill builds both PostgreSQL images", async () => {
+	const tasks = await loadTasks();
+	const task = asRecord(tasks["test:postgres-upgrade"], "upgrade task");
+	assert.ok(asStringArray(task.dependsOn, "dependencies").includes("prepare:server:generated"));
+	const commands = preparation([]);
+	assert.equal(commands.filter((command) => command[1] === "build").length, 2);
+	const maven = commands.filter((command) => command[0] === "node");
+	assert.equal(maven.length, 1);
+	assert.ok(maven[0]?.includes("liquibase:update"));
+	assert.equal(commands.filter((command) => command[1] === "rmi").length, 2);
+});
+
+await test("restored CI artifacts and PostgreSQL image are reused, not rebuilt or deleted", () => {
+	const commands = preparation(["--target-image", "hephaestus-postgres:ci"]);
+	assert.deepEqual(commands[0], ["docker", "image", "inspect", "hephaestus-postgres:ci"]);
+	assert.equal(commands.filter((command) => command[1] === "build").length, 1);
+	assert.equal(commands.filter((command) => command.includes("install")).length, 0);
+	assert.equal(commands.filter((command) => command[1] === "rmi").length, 1);
+	assert.equal(
+		commands.some((command) => command[1] === "rmi" && command.includes("hephaestus-postgres:ci")),
+		false,
+	);
+});
+
+await test("a missing explicitly supplied image fails instead of silently building a replacement", () => {
+	const commands = preparation(["--target-image", "missing:ci"], false);
+	assert.equal(
+		commands.some((command) => command[1] === "build"),
+		false,
+	);
+	assert.equal(
+		commands.some((command) => command[0] === "node"),
+		false,
+	);
+});

--- a/scripts/summarize-test-results.test.ts
+++ b/scripts/summarize-test-results.test.ts
@@ -181,3 +181,39 @@ await test("profile CLI preserves diagnostics and fails when no tests were repor
 	});
 	assert.equal(ordinary.status, 0);
 });
+
+await test("verification profiles allow no Spring contexts but still require successful executed tests", async (context) => {
+	const directory = await mkdtemp(join(tmpdir(), "verification-profile-"));
+	context.after(() => rm(directory, { recursive: true, force: true }));
+	const reports = join(directory, "reports");
+	await mkdir(reports);
+	const log = join(directory, "run.log");
+	const resources = join(directory, "resources.txt");
+	await writeFile(log, "");
+	await writeFile(
+		resources,
+		"User time (seconds): 1\nSystem time (seconds): 1\nElapsed (wall clock) time (h:mm:ss or m:ss): 0:02\nMaximum resident set size (kbytes): 100",
+	);
+	const script = fileURLToPath(new URL("./summarize-test-results.ts", import.meta.url));
+	for (const [kind, body, valid] of [
+		["verification", "", true],
+		["integration", "", false],
+		["verification", "<skipped/>", false],
+		["verification", "<failure/>", false],
+		["unknown", "", false],
+	] as const) {
+		await writeFile(
+			join(reports, "TEST-example.xml"),
+			`<testsuite><testcase classname="Example" name="test" time="1">${body}</testcase></testsuite>`,
+		);
+		const result = spawnSync(
+			process.execPath,
+			[script, "profile", reports, join(directory, "summary.json"), log, resources, kind],
+			{
+				encoding: "utf8",
+				env: { ...process.env, GITHUB_STEP_SUMMARY: join(directory, "step-summary.md") },
+			},
+		);
+		assert.equal(result.status, valid ? 0 : 1, `${kind} ${body}: ${result.stderr}`);
+	}
+});

--- a/scripts/summarize-test-results.ts
+++ b/scripts/summarize-test-results.ts
@@ -131,7 +131,10 @@ export function parsePerformance(
 	};
 }
 
-export function validateProfile(summary: TestSummary): void {
+export function validateProfile(
+	summary: TestSummary,
+	kind: "integration" | "verification" = "integration",
+): void {
 	const counts = [summary.files, summary.tests, summary.failures, summary.errors, summary.skipped];
 	if (counts.some((value) => !Number.isSafeInteger(value) || value < 0))
 		throw new Error("Invalid profile test counts");
@@ -149,7 +152,10 @@ export function validateProfile(summary: TestSummary): void {
 		throw new Error("Profile metrics must be finite and nonnegative");
 	if (performance.wallTimeSeconds === 0 || performance.maxRssKilobytes === 0)
 		throw new Error("Profile wall time and resident memory must be positive");
-	if (performance.contextStarts === 0 || performance.contextCacheMisses === 0)
+	if (
+		kind === "integration" &&
+		(performance.contextStarts === 0 || performance.contextCacheMisses === 0)
+	)
 		throw new Error("Profile contains no Spring context measurements");
 	if (![performance.contextStarts, performance.contextCacheMisses].every(Number.isSafeInteger))
 		throw new Error("Invalid profile context counts");
@@ -190,7 +196,9 @@ async function xmlFiles(path: string): Promise<string[]> {
 }
 
 async function main(): Promise<void> {
-	const [name, input, output, logPath, resourcePath] = process.argv.slice(2);
+	const [name, input, output, logPath, resourcePath, kind = "integration"] = process.argv.slice(2);
+	if (kind !== "integration" && kind !== "verification")
+		throw new Error(`Unknown profile kind: ${kind}`);
 	if (name === undefined || input === undefined || output === undefined) {
 		throw new Error("Usage: summarize-test-results <name> <report-directory> <output-json>");
 	}
@@ -212,7 +220,7 @@ async function main(): Promise<void> {
 		await appendFile(process.env.GITHUB_STEP_SUMMARY, rendered);
 	}
 	process.stdout.write(rendered);
-	if (summary.performance !== undefined) validateProfile(summary);
+	if (summary.performance !== undefined) validateProfile(summary, kind);
 	if (files.length === 0) {
 		process.stderr.write(`No JUnit XML reports found below ${input}\n`);
 	}

--- a/scripts/version-pr-workflow.test.ts
+++ b/scripts/version-pr-workflow.test.ts
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import { isMap, isSeq, parseDocument } from "yaml";
+
+import { environmentForGitFixture } from "./lib/git-environment.ts";
+
+const workflow = parseDocument(await readFile(".github/workflows/version-pr.yml", "utf8"));
+const job = workflow.getIn(["jobs", "version-pr"]);
+assert.ok(isMap(job));
+const steps = job.get("steps");
+assert.ok(isSeq(steps));
+const selection = steps.items.find((step) => isMap(step) && step.get("id") === "current");
+assert.ok(isMap(selection));
+
+void test("Version PR maintenance follows trusted successful main CI without cancelling mutations", () => {
+	const trigger = workflow.getIn(["on", "workflow_run"]);
+	assert.ok(isMap(trigger));
+	assert.deepEqual(trigger.toJSON(), {
+		workflows: ["CI/CD"],
+		types: ["completed"],
+		branches: ["main"],
+	});
+	assert.equal(workflow.getIn(["on", "push"]), undefined);
+	assert.equal(job.getIn(["concurrency", "cancel-in-progress"]), false);
+	const guard = job.get("if");
+	assert.equal(typeof guard, "string");
+	assert.match(String(guard), /github\.event\.workflow_run\.conclusion == 'success'/);
+	assert.match(String(guard), /&& github\.event\.workflow_run\.event == 'push'/);
+	assert.match(
+		String(guard),
+		/&& github\.event\.workflow_run\.head_repository\.full_name == github\.repository/,
+	);
+	const checkout = steps.items[0];
+	assert.ok(isMap(checkout));
+	assert.equal(checkout.getIn(["with", "ref"]), `\${{ github.event.repository.default_branch }}`);
+	assert.equal(
+		selection.getIn(["env", "VALIDATED_SHA"]),
+		`\${{ github.event.workflow_run.head_sha }}`,
+	);
+	const work = steps.items.slice(2);
+	assert.equal(work.length, 3);
+	for (const step of work) {
+		assert.ok(isMap(step));
+		assert.equal(step.get("if"), "steps.current.outputs.validated == 'true'");
+	}
+});
+
+void test(
+	"overtaken completions do no work, but a successful latest-tip rerun can proceed",
+	{
+		skip: process.platform === "win32",
+	},
+	async (context) => {
+		const directory = await mkdtemp(path.join(tmpdir(), "version-pr-tip-"));
+		context.after(() => rm(directory, { recursive: true, force: true }));
+		function git(...args: string[]): string {
+			const result = spawnSync("git", args, {
+				cwd: directory,
+				encoding: "utf8",
+				env: environmentForGitFixture(),
+			});
+			assert.equal(result.status, 0, result.stderr);
+			return result.stdout.trim();
+		}
+		git("init", "-q");
+		git(
+			"-c",
+			"user.name=Test",
+			"-c",
+			"user.email=test@example.com",
+			"commit",
+			"-qm",
+			"first",
+			"--allow-empty",
+		);
+		const first = git("rev-parse", "HEAD");
+		const command = selection.get("run");
+		assert.equal(typeof command, "string");
+		assert.equal(selection.get("shell"), "bash");
+		let attempt = 0;
+		async function selected(sha: string): Promise<boolean> {
+			const output = path.join(directory, `output-${attempt++}`);
+			const result = spawnSync(
+				"bash",
+				["--noprofile", "--norc", "-eo", "pipefail", "-c", String(command)],
+				{
+					cwd: directory,
+					encoding: "utf8",
+					env: environmentForGitFixture({ VALIDATED_SHA: sha, GITHUB_OUTPUT: output }),
+				},
+			);
+			assert.equal(result.status, 0, result.stderr);
+			return (
+				await readFile(output, "utf8").catch((error: unknown) => {
+					if (error instanceof Error && "code" in error && error.code === "ENOENT") return "";
+					throw error;
+				})
+			).includes("validated=true");
+		}
+		assert.equal(await selected(first), true);
+		git(
+			"-c",
+			"user.name=Test",
+			"-c",
+			"user.email=test@example.com",
+			"commit",
+			"-qm",
+			"second",
+			"--allow-empty",
+		);
+		assert.equal(await selected(first), false);
+		assert.equal(await selected(git("rev-parse", "HEAD")), true);
+	},
+);

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/mentor/chat/MentorChatService.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/mentor/chat/MentorChatService.java
@@ -360,17 +360,18 @@ public class MentorChatService implements MentorTurnRunner, MentorChatStarter {
             channel.completeWithError("Mentor turn timed out before completion.");
             outcome = MentorChatMetrics.Outcome.TIMEOUT;
         } catch (ClientDisconnectedException disconnect) {
-            // Not a turn failure: the runner subscription keeps draining and still finalises the row
-            // when the terminal chunk arrives, so do not poison the sandbox or interrupt the row.
-            log.info(
-                    "Mentor client disconnected mid-turn; runner draining to natural finish: {}",
-                    disconnect.getMessage());
-            try {
-                turnComplete.get(20, TimeUnit.SECONDS);
-            } catch (Exception drainEx) {
-                log.debug("Drain after client disconnect timed out / errored: {}", drainEx.toString());
-                if (!turnComplete.isDone()) {
-                    persistence.interrupt(cookie, state, disconnect);
+            if (clientHolder.get() == null) {
+                // No runner subscription exists to complete the persisted turn.
+                persistence.interrupt(cookie, state, disconnect);
+            } else {
+                log.info("Mentor client disconnected; runner draining: {}", disconnect.getMessage());
+                try {
+                    turnComplete.get(20, TimeUnit.SECONDS);
+                } catch (Exception drainEx) {
+                    log.debug("Drain after client disconnect timed out / errored: {}", drainEx.toString());
+                    if (!turnComplete.isDone()) {
+                        persistence.interrupt(cookie, state, disconnect);
+                    }
                 }
             }
             outcome = MentorChatMetrics.Outcome.CLIENT_DISCONNECT;
@@ -426,11 +427,6 @@ public class MentorChatService implements MentorTurnRunner, MentorChatStarter {
             throws InterruptedException, java.util.concurrent.ExecutionException, TimeoutException {
         AttachedSandbox sandbox = attachSandbox(spec);
 
-        // If the client disconnected during the (potentially seconds-long) cold-start
-        // attach, short-circuit BEFORE wiring up the runner subscription + 20s hello
-        // deadline. Without this, a dead client would hold an entire turn for the full
-        // hello timeout. The outer ClientDisconnectedException catch closes the channel
-        // and runs the finally — sandbox/client get cleaned up there.
         if (channel.isClientGone()) {
             throw new ClientDisconnectedException("Client disconnected during sandbox attach");
         }
@@ -444,23 +440,35 @@ public class MentorChatService implements MentorTurnRunner, MentorChatStarter {
                 // Per-thread event filter: the sandbox is shared by (userId, workspaceId), so
                 // a second tab in the same workspace would otherwise see this tab's events.
                 request.threadId());
-        // Publish to the disconnect hook BEFORE start(): if start() throws (rare — frame
-        // queue full, listener exception on the very first emit) the hook still finds the
-        // client and aborts cleanly. The hook's abort is idempotent on Pi's side.
+        // Publish before subscribing so a concurrent disconnect can abort the runner.
         clientHolder.set(client);
-        client.start();
-        // SSE lifecycle may have flipped the channel between bindLifecycle and clientHolder.set.
-        // Re-fire the abort AND short-circuit: without the throw, execution falls through into the
-        // 20s hello + 195s prompt deadline while still holding the per-thread lock — the exact cost
-        // the pre-attach guard at isClientGone() above was added to avoid.
-        if (channel.isClientGone()) {
-            abortRunnerOnDisconnect(client, request.threadId());
-            throw new ClientDisconnectedException("Client disconnected after runner start");
-        }
+        boolean handedOff = false;
+        try {
+            client.start();
+            if (channel.isClientGone()) {
+                abortRunnerOnDisconnect(client, request.threadId());
+                throw new ClientDisconnectedException("Client disconnected after runner start");
+            }
 
-        JsonNode hello = client.hello().get(20, TimeUnit.SECONDS);
-        verifyProtocol(hello);
-        return new RunnerHandle(sandbox, client);
+            JsonNode hello = client.hello().get(20, TimeUnit.SECONDS);
+            verifyProtocol(hello);
+            handedOff = true;
+            return new RunnerHandle(sandbox, client);
+        } catch (Exception failure) {
+            if (isPoisoning(failure)) {
+                try {
+                    sandbox.close(Duration.ofSeconds(5));
+                } catch (RuntimeException cleanupFailure) {
+                    failure.addSuppressed(cleanupFailure);
+                }
+            }
+            throw failure;
+        } finally {
+            if (!handedOff) {
+                clientHolder.compareAndSet(client, null);
+                client.close();
+            }
+        }
     }
 
     private static void closeFailedRestoreRunner(MentorRunnerClient client, AttachedSandbox sandbox) {

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/mentor/chat/MentorChatServiceTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/mentor/chat/MentorChatServiceTest.java
@@ -77,6 +77,9 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoSettings;
@@ -679,9 +682,11 @@ class MentorChatServiceTest extends BaseUnitTest {
         assertOutcomeRecorded(MentorChatMetrics.Outcome.SUCCESS);
     }
 
-    @Test
-    void runTurn_clientDisconnectOnSyncSend_recordsClientDisconnect() throws Exception {
-        emitter.disconnectAfterCalls = 1; // call #2 (DataMentorStatus) throws
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1})
+    @Timeout(5)
+    void runTurn_clientDisconnectOnSyncSend_interruptsWithoutWaitingForARunner(int successfulSends) throws Exception {
+        emitter.disconnectAfterCalls = successfulSends;
 
         runTurnSync();
 
@@ -690,8 +695,59 @@ class MentorChatServiceTest extends BaseUnitTest {
         } catch (InteractiveSandboxException e) {
             throw new AssertionError(e);
         }
+        verify(persistence).interrupt(any(), any(), any());
+        verify(persistence, never())
+                .finalise(any(), any(), any(UIMessageChunk.Finish.class), any(MentorChannel.DeliveryOutcome.class));
         assertThat(turnLock.activeKeys()).isZero();
         assertOutcomeRecorded(MentorChatMetrics.Outcome.CLIENT_DISCONNECT);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    @Timeout(5)
+    void runTurn_clientDisconnectDuringStartup_releasesSubscriptionWithoutDraining(boolean afterSubscribe)
+            throws Exception {
+        if (afterSubscribe) {
+            sandbox.onSubscribe = emitter::disconnect;
+        } else {
+            when(interactiveSandboxService.attach(any())).thenAnswer(invocation -> {
+                emitter.disconnect();
+                return sandbox;
+            });
+        }
+
+        runTurnSync();
+
+        assertThat(sandbox.listeners).isEmpty();
+        assertThat(sandbox.closed).isFalse();
+        assertThat(sandbox.methodsSent()).doesNotContain("hello", "open_thread", "prompt");
+        verify(persistence).interrupt(any(), any(), any());
+        verify(persistence, never())
+                .finalise(any(), any(), any(UIMessageChunk.Finish.class), any(MentorChannel.DeliveryOutcome.class));
+        assertThat(turnLock.activeKeys()).isZero();
+        assertOutcomeRecorded(MentorChatMetrics.Outcome.CLIENT_DISCONNECT);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void runTurn_failedHello_releasesSubscriptionAndEvictsOnlyPoisonedSandbox(boolean poisoned) {
+        sandbox.onSend = frame -> {
+            if ("hello".equals(frame.path("method").asString())) {
+                long id = frame.path("id").asLong();
+                sandbox.push(
+                        poisoned
+                                ? jsonRpcError(id, MentorRunnerException.CODE_PI_ERROR, "runner failed")
+                                : jsonRpcResult(id, mapper.createObjectNode().put("protocolVersion", -1)));
+            }
+        };
+
+        runTurnSync();
+
+        assertThat(sandbox.listeners).isEmpty();
+        assertThat(sandbox.closed.get()).isEqualTo(poisoned);
+        verify(persistence).interrupt(any(), any(), any());
+        assertThat(turnLock.activeKeys()).isZero();
+        assertOutcomeRecorded(poisoned ? MentorChatMetrics.Outcome.POISONED : MentorChatMetrics.Outcome.ERROR);
     }
 
     // 3. Runner poisoned (-32002): sandbox evicted, lock released, row interrupted
@@ -1074,6 +1130,17 @@ class MentorChatServiceTest extends BaseUnitTest {
         volatile int disconnectAfterCalls = -1;
 
         private int sendCount = 0;
+        private Runnable completionCallback = () -> {};
+
+        @Override
+        public void onCompletion(Runnable callback) {
+            completionCallback = callback;
+        }
+
+        void disconnect() {
+            clientGone = true;
+            completionCallback.run();
+        }
 
         RecordingEmitter() {
             super(60_000L);
@@ -1132,6 +1199,8 @@ class MentorChatServiceTest extends BaseUnitTest {
         /** Called on every send — installed by the test driver to script responses. */
         volatile Consumer<JsonNode> onSend = f -> {};
 
+        Runnable onSubscribe = () -> {};
+
         @Override
         public SandboxIdentity identity() {
             return new SandboxIdentity(sessionId, Long.toString(USER_ID), Long.toString(WORKSPACE_ID));
@@ -1147,6 +1216,7 @@ class MentorChatServiceTest extends BaseUnitTest {
         @Override
         public Disposable subscribe(Consumer<JsonNode> listener) {
             listeners.add(listener);
+            onSubscribe.run();
             return () -> listeners.remove(listener);
         }
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -274,7 +274,9 @@ export default defineConfig({
 				`${mvnw} -pl application -am package -Dspring-boot.repackage.skip=true -Dsurefire.includedGroups=integration${integrationShard} -Dparallel=none --batch-mode`,
 			),
 			"test:server:mutation": run("node scripts/run-security-mutations.ts"),
-			"test:postgres-upgrade": run("node scripts/postgres-major-upgrade-test.ts"),
+			"test:postgres-upgrade": run("node scripts/postgres-major-upgrade-test.ts", {
+				dependsOn: ["prepare:server:generated"],
+			}),
 
 			// Webapp
 			// `vp check` is format plus lint; the format half is `gate:webapp-format`, so one failure


### PR DESCRIPTION
## What changed and why

Backend verification included an unnecessary 20-second wait, database verification repeated work its build job had already done, and release validation competed with the main build that produced its inputs. This follow-up reduces that work without dropping checks.

- **Fix early mentor disconnects.** When a browser disconnects before the runner is ready, interrupt the persisted turn immediately instead of waiting for an impossible completion. Failed startup releases its subscription and evicts only poisoned sandboxes; active turns retain their existing drain behavior.
- **Sequence Version PR maintenance after successful current-main CI.** Ignore failed, foreign, non-push, and overtaken completions. Keep every release validation and the non-cancelling mutation lock.
- **Reuse prepared database prerequisites.** Local upgrade verification uses the existing task dependency; CI reuses restored Maven artifacts and its resolved PostgreSQL 18 image. Database contracts and the upgrade drill have separate step timings on the same runner.
- **Profile unit/architecture verification on demand.** Add JFR, Maven phase timing, resource and JUnit artifacts, retaining coverage. Select integration, verification, or both; weekly diagnostics run sequentially. Verification artifacts stay separate from integration regression history.

Follow-up to #1988. No migration or #1283 changes.

## How to test

With Java 21 and Docker available:

- `MANAGEMENT_PORT=0 SERVER_PORT=0 vp run test:server:verification` — 7,525 tests passed, including coverage and architecture checks; the instrumented invocation also produced a readable JFR recording and Maven profile.
- `MANAGEMENT_PORT=0 SERVER_PORT=0 vp run test:server:integration` — 1,532 tests passed, no failures or skips.
- `vp run test:postgres-upgrade` — real PostgreSQL 17→18 drill passed. The explicit `--target-image` CI path also passed against a locally built current image, and left the borrowed image intact.
- `vp run format` and `vp run check` — passed, including workflow, profiling-validation, Git-fixture, and upgrade-prerequisite regression tests.
- Actionlint 1.7.12 and offline Zizmor 1.29.0 passed for the changed workflows. Hosted CI provides the final workflow/security verification.

## Release impact

[Patch changeset](.changeset/mentor-disconnect-before-start.md): a conversation is released promptly when its browser connection closes before a response starts. No operator action is required.

## Notes for reviewers

The previous early-disconnect testcase took 20.006s in hosted results. The two focused replacement cases completed in 17ms and 9ms locally; these are test-level observations, not an end-to-end CI speed claim. Regression tests also cover disconnects during attach/subscription and both poisoned and non-poisoned handshake failures. Existing post-prompt behavior remains covered.

Version PR maintenance now waits for successful main CI, so an isolated release-validation cycle starts later; during merge bursts, overtaken completions do not launch another versioning cycle. This reduces overlap but does not guarantee runner availability. Its `workflow_run` behavior must be verified after merge, because the listener comes from the default branch.

No architecture assertions, integration contexts, coverage floors, upgrade checks, or latency budgets were removed. The six-minute CI target remains unproven.

Uses native [GitHub workflow completion events](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#workflow_run), the existing Vite task dependency graph, and JFR/Maven profiling rather than a custom scheduler or instrumentation in normal PR jobs.
