### PR TITLE
ci: report performance budgets without masking diagnostic failures

### DIFF
--- a/.github/workflows/ci-profile.yml
+++ b/.github/workflows/ci-profile.yml
@@ -109,14 +109,14 @@ jobs:
           server/application/target/surefire-reports ci-metrics/server-integration-profile.json
           ci-metrics/server-integration.log ci-metrics/server-integration-resource.txt
 
-      - name: Enforce performance budgets
+      - name: Report performance budgets
         if: success() && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
         run: |
           # Do not compare a rerun against its own previous attempt.
           rm -f "ci-profile-history/${{ github.run_id }}.json"
           node scripts/check-ci-performance.ts ci-metrics/server-integration-profile.json ci-profile-history
 
-      # Keep budget failures in history so sustained regressions remain detectable.
+      # Retain valid out-of-budget samples so sustained regressions remain detectable.
       - name: Record completed profile
         id: record
         if: ${{ !cancelled() && steps.profile.outcome == 'success' && steps.recording.outcome == 'success' && steps.summary.outcome == 'success' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
@@ -210,7 +210,7 @@ jobs:
 
   pr-latency:
     if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
-    name: Pull-request latency budget
+    name: Pull-request latency report
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:

--- a/docs/contributor/ci-cd.mdx
+++ b/docs/contributor/ci-cd.mdx
@@ -369,7 +369,7 @@ why the label is the authority, and which alternatives were priced and declined,
 | `semgrep.yml` | Pull request, push to main, merge group | Tests and scans the repository's own TLS rule pack |
 | `rescan-main-images.yml` | Weekly, manual | Rescans main's published images against the release vulnerability policy and keeps one tracking issue in step with the findings |
 | `rescan-release-images.yml` | Weekly, manual | Rescans the latest published release's images and reports drift on the vulnerability response issue |
-| `ci-profile.yml` | Weekly, manual | Enforces PR latency budgets and profiles server integration tests and Spring contexts |
+| `ci-profile.yml` | Weekly, manual | Reports advisory performance budgets and profiles server test tiers |
 | `ci-server-clean-reference.yml` | Weekly, manual | Records cold server phases and compares generated JARs |
 | `scorecard-ratchet.yml` | Push to main, branch-protection change, weekly, manual | Fails when a Scorecard check drops below the committed baseline; a push fails only for the checks its own commit decides |
 | `deploy-preview.yml` | `preview` label added, or a push, reopen or ready-for-review on a labelled PR | Waits for this commit's attested CI images, deploys them, and registers the native GitHub deployment |
@@ -533,8 +533,18 @@ creation to completion of **CI Status Gate**. On the default branch, `CI profile
 first-attempt PR runs with full server and browser verification from the latest 100 completed PR
 runs created in the last 28 days. Lightweight changes and Version-PR runs cannot satisfy this
 cohort. Failed and cancelled counts describe the bounded listing, not a repository-wide failure
-rate. Fewer than ten qualifying runs fails as insufficient evidence; budget failures also retain
-the JSON report.
+rate. Budget misses produce warnings and a job summary, not workflow failures. Fewer than ten
+qualifying runs produces an insufficient-data notice, not a pass or a regression. All observations
+retain the JSON report. Historical latency includes runner waiting and earlier commits, so it is
+not a correctness verdict on the profiled commit.
+
+Performance observations are advisory in this diagnostic workflow; test failures, unreadable
+recordings, invalid metrics, and reporting/API errors still fail it. Do not use `continue-on-error`
+to hide those failures. Investigate sustained warnings using the retained run timelines and profiles.
+A blocking performance gate would need a comparable workload and runner environment, an established
+noise model, and an attributable regression—not a historical fleet-wide target miss. This separation
+follows [SRE guidance on actionable, low-noise monitoring](https://sre.google/sre-book/monitoring-distributed-systems/)
+and uses native [GitHub warnings and job summaries](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands).
 
 Reproduce the observer with an authenticated GitHub CLI:
 
@@ -570,14 +580,14 @@ Deep profiling stays in the manual/weekly workflow, not on the PR critical path.
 runners at once. Each tier retains its JFR recording, Maven phase report, resource usage and JUnit
 results for 14 days. Verification profiles are diagnostic artifacts, not integration-history samples.
 
-The integration profile additionally records Spring context-cache metrics. It signals
+The integration profile additionally records Spring context-cache metrics. It warns about
 a sustained regression after three consecutive profiles exceed variance limits against five earlier
 default-branch profiles or absolute Spring-context limits. Only successful test runs with a readable
-JFR recording and valid summaries enter history, including runs whose performance budget fails.
+JFR recording and valid summaries enter history, including out-of-budget samples.
 History is restored from this repository's default-branch JFR history artifacts, retained for
 90 days; a rerun replaces its own sample. Uninstrumented runs are not baseline candidates. Without seven earlier
 profiles, the sustained-regression check has no verdict. Branch dispatches produce diagnostic
-artifacts without changing or enforcing the baseline.
+artifacts without changing or comparing against the baseline.
 
 The workflow's `Run integration suite with JFR` step owns the invocation. Additional test-JVM flags
 use `-Dhephaestus.test.jvmArgs=...`; Surefire and Failsafe compose these with JaCoCo's late-bound

--- a/scripts/check-ci-performance.test.ts
+++ b/scripts/check-ci-performance.test.ts
@@ -1,5 +1,10 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { test } from "node:test";
+import { fileURLToPath } from "node:url";
 
 import { parseSummary, regressions } from "./check-ci-performance.ts";
 import type { TestSummary } from "./summarize-test-results.ts";
@@ -82,4 +87,39 @@ await test("missing Spring logs cannot appear as a faster profile", () => {
 		current.performance[key] = 0;
 		assert.throws(() => regressions(current, []), /no Spring context measurements/);
 	}
+});
+
+await test("CLI warns on sustained regressions but fails for corrupt or failed-test evidence", async (context) => {
+	const directory = await mkdtemp(path.join(tmpdir(), "profile-advisory-"));
+	context.after(() => rm(directory, { recursive: true, force: true }));
+	const history = path.join(directory, "history");
+	const current = path.join(directory, "current.json");
+	const output = path.join(directory, "summary.md");
+	await mkdir(history);
+	for (let i = 0; i < 7; i++)
+		await writeFile(
+			path.join(history, `${i}.json`),
+			JSON.stringify(summary(100, i < 5 ? 200 : 300)),
+		);
+	const run = () =>
+		spawnSync(
+			process.execPath,
+			[fileURLToPath(new URL("./check-ci-performance.ts", import.meta.url)), current, history],
+			{
+				env: { ...process.env, GITHUB_STEP_SUMMARY: output },
+				encoding: "utf8",
+			},
+		);
+	await writeFile(current, JSON.stringify(summary(100, 300)));
+	const exceeded = run();
+	assert.equal(exceeded.status, 0, exceeded.stderr);
+	assert.match(exceeded.stdout, /::warning title=Integration profile regression::wall time/);
+	assert.match(await readFile(output, "utf8"), /Status: \*\*regression\*\*/);
+	await writeFile(current, JSON.stringify({ ...summary(100), failures: 1 }));
+	assert.notEqual(run().status, 0);
+	await writeFile(current, "not json");
+	assert.notEqual(run().status, 0);
+	await writeFile(current, JSON.stringify(summary(100)));
+	await writeFile(path.join(history, "0.json"), "not json");
+	assert.notEqual(run().status, 0);
 });

--- a/scripts/check-ci-performance.ts
+++ b/scripts/check-ci-performance.ts
@@ -168,12 +168,18 @@ async function main(): Promise<void> {
 		),
 	);
 	const failures = regressions(current, history);
-	const rendered = historyMarkdown([...history, current]);
+	const status =
+		history.length < 7 ? "insufficient-data" : failures.length > 0 ? "regression" : "within-budget";
+	const rendered = `${historyMarkdown([...history, current])}\nStatus: **${status}** (advisory).\n\n${failures.map((failure) => `- ${failure}\n`).join("")}\nCompare retained JFR and Maven profiles before attributing a change to code; shared-runner variation and suite growth can affect these measurements.\n`;
 	process.stdout.write(rendered);
 	if (process.env.GITHUB_STEP_SUMMARY !== undefined)
 		await appendFile(process.env.GITHUB_STEP_SUMMARY, rendered);
-	if (failures.length > 0)
-		throw new Error(`CI performance regression:\n- ${failures.join("\n- ")}`);
+	for (const failure of failures)
+		process.stdout.write(`::warning title=Integration profile regression::${failure}\n`);
+	if (status === "insufficient-data")
+		process.stdout.write(
+			"::notice title=Integration profile baseline incomplete::Eight valid profiles are needed for a sustained-regression verdict.\n",
+		);
 }
 
 if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href)

--- a/scripts/ci-profile-history.test.ts
+++ b/scripts/ci-profile-history.test.ts
@@ -56,7 +56,7 @@ void test("history skips this rerun, foreign sources and incomplete profiles acr
 	);
 });
 
-void test("a budget-failed run's completed profile remains usable", () => {
+void test("a completed profile remains usable when another diagnostic job failed", () => {
 	assert.equal(selectHistory([[{ ...run(9), conclusion: "failure" }]], { 9: [history] }), "9");
 });
 

--- a/scripts/report-ci-latency.test.ts
+++ b/scripts/report-ci-latency.test.ts
@@ -6,7 +6,12 @@ import path from "node:path";
 import { test } from "node:test";
 import { fileURLToPath } from "node:url";
 
-import { isFullVerification, latencyBudget, selectLatencyRuns } from "./report-ci-latency.ts";
+import {
+	isFullVerification,
+	latencyBudget,
+	renderLatencyBudget,
+	selectLatencyRuns,
+} from "./report-ci-latency.ts";
 
 void test("sampling excludes stale/future, retried, failed and release validation", () => {
 	const now = Date.parse("2026-01-30T00:00:00Z");
@@ -71,7 +76,7 @@ void test("the target constrains both the median and tail, and insufficient data
 });
 
 void test(
-	"the CLI saves insufficient-sample evidence before failing",
+	"the CLI reports insufficient evidence without failing but rejects malformed API data",
 	{ skip: process.platform === "win32" },
 	async (context) => {
 		const directory = await mkdtemp(path.join(tmpdir(), "ci-latency-"));
@@ -96,9 +101,38 @@ void test(
 				encoding: "utf8",
 			},
 		);
-		assert.equal(result.status, 1, result.stderr);
+		assert.equal(result.status, 0, result.stderr);
+		assert.match(result.stdout, /::notice title=PR latency baseline incomplete/);
 		const evidence = await readFile(path.join(directory, "tmp/ci-metrics/ci-latency.json"), "utf8");
 		assert.match(evidence, /"status": "insufficient-data"/);
 		assert.match(evidence, /"runs": \[\]/);
+		await writeFile(path.join(directory, "gh"), "#!/bin/sh\necho '{}'\n", { mode: 0o755 });
+		const invalid = spawnSync(
+			process.execPath,
+			[fileURLToPath(new URL("./report-ci-latency.ts", import.meta.url))],
+			{
+				cwd: directory,
+				env: {
+					...process.env,
+					GITHUB_REPOSITORY: "owner/repo",
+					PATH: `${directory}${path.delimiter}${process.env.PATH ?? ""}`,
+				},
+				encoding: "utf8",
+			},
+		);
+		assert.notEqual(invalid.status, 0);
+		assert.match(invalid.stderr, /workflow_runs/);
 	},
 );
+
+void test("latency summaries preserve exceeded targets and distinguish absent evidence", () => {
+	assert.match(
+		renderLatencyBudget(latencyBudget(Array.from({ length: 10 }, () => 900))),
+		/\*\*exceeded\*\*/,
+	);
+	assert.match(renderLatencyBudget(latencyBudget([])), /Not available/);
+	assert.match(
+		renderLatencyBudget(latencyBudget(Array.from({ length: 10 }, () => 300))),
+		/\*\*within-budget\*\*/,
+	);
+});

--- a/scripts/report-ci-latency.ts
+++ b/scripts/report-ci-latency.ts
@@ -1,4 +1,4 @@
-import { mkdir, writeFile } from "node:fs/promises";
+import { appendFile, mkdir, writeFile } from "node:fs/promises";
 
 import { versionBranch } from "./dispatch-version-pr-ci.ts";
 import { asArray, asRecord, asString, parseJson, readJsonFile } from "./lib/json.ts";
@@ -71,6 +71,25 @@ export function latencyBudget(values: number[]) {
 	};
 }
 
+export function renderLatencyBudget(budget: ReturnType<typeof latencyBudget>): string {
+	const seconds = (value: number | null) =>
+		value === null ? "Not available" : `${value.toFixed(1)}s`;
+	return [
+		"## Pull-request latency (advisory)",
+		"",
+		`Status: **${budget.status}** (${budget.count}/10 qualifying runs).`,
+		"",
+		"| Metric | Observed | Target |",
+		"|---|---:|---:|",
+		`| Median | ${seconds(budget.p50Seconds)} | ${budget.p50LimitSeconds}s |`,
+		`| p90 | ${seconds(budget.p90Seconds)} | ${budget.p90LimitSeconds}s |`,
+		"",
+		"Historical timings include runner waiting and earlier commits; this is not a verdict on the current change.",
+		"Inspect the retained ci-latency.json run timelines to distinguish queue delays from execution before changing CI.",
+		"",
+	].join("\n");
+}
+
 if (import.meta.main) {
 	const repository = process.env.GITHUB_REPOSITORY;
 	if (!repository || !/^[\w.-]+\/[\w.-]+$/.test(repository))
@@ -130,6 +149,16 @@ if (import.meta.main) {
 	await mkdir("tmp/ci-metrics", { recursive: true });
 	await writeFile("tmp/ci-metrics/ci-latency.json", `${JSON.stringify(report, null, 2)}\n`);
 	process.stdout.write(`${JSON.stringify(budget, null, 2)}\n`);
-	if (budget.status !== "within-budget")
-		throw new Error(`PR latency budget: ${budget.status}; see tmp/ci-metrics/ci-latency.json`);
+	const rendered = renderLatencyBudget(budget);
+	process.stdout.write(rendered);
+	if (process.env.GITHUB_STEP_SUMMARY !== undefined)
+		await appendFile(process.env.GITHUB_STEP_SUMMARY, rendered);
+	if (budget.status === "exceeded")
+		process.stdout.write(
+			"::warning title=PR latency target exceeded::Historical PR latency exceeds the target; inspect the job summary and retained run timelines.\n",
+		);
+	else if (budget.status === "insufficient-data")
+		process.stdout.write(
+			"::notice title=PR latency baseline incomplete::Fewer than ten qualifying runs; no performance verdict yet.\n",
+		);
 }


### PR DESCRIPTION
## What changed and why

A successful diagnostic profile was marked red because historical PR latency exceeded its target. That mixes performance observations—including queue delays and earlier commits—with failures of the tests or profiling machinery.

- Report latency target misses and sustained integration regressions through native warning annotations and job summaries, without failing the workflow.
- Report insufficient evidence as a notice, not success or regression.
- Keep test failures, invalid current/history metrics, missing recordings, API errors, and report-write failures fatal. No `continue-on-error` or threshold changes.
- Preserve raw artifacts, regression detection, and the six-minute median/seven-minute p90 targets. Document when a controlled performance benchmark would justify a blocking gate.

Follow-up to #2054.

## How to test

- `node --test scripts/check-ci-performance.test.ts scripts/report-ci-latency.test.ts scripts/ci-profile-history.test.ts` — 17 tests passed. CLI regressions warn and exit zero; corrupt history, failed-test evidence, and malformed API responses still fail.
- `vp run format` and `vp run check` — passed.
- Actionlint and offline Zizmor — passed.
- Ran the updated latency reporter against the real GitHub API: median 777s/p90 1571s remained **exceeded**, with a warning, readable summary, retained JSON, and exit zero.

## Release impact

CI diagnostics only; no shipped application changes or operator action. No changeset required.

## Notes for reviewers

Green now means the diagnostic collection and validation succeeded, not that its performance targets were met. The summary explicitly preserves `exceeded`, `regression`, and `insufficient-data` outcomes.

Uses [GitHub warning annotations and job summaries](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands), consistent with [Google SRE guidance on actionable, low-noise monitoring](https://sre.google/sre-book/monitoring-distributed-systems/). This does not imply all performance gates should be advisory: a reproducible, attributable regression benchmark can legitimately block a change.
