### PR TITLE
ci: validate queued release candidates and recover blocked dispatches

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -53,18 +53,17 @@ jobs:
       pmd-canary: ${{ steps.filter.outputs.pmd-canary }}
       version-bump: ${{ steps.version_bump.outputs.changed }}
       version: ${{ steps.version.outputs.version }}
-      version-branch: ${{ steps.version_branch.outputs.version-branch }}
+      release-candidate: ${{ steps.release_candidate.outputs.release-candidate }}
       any-code: ${{ steps.filter.outputs.webapp == 'true' || steps.filter.outputs.application-server == 'true' || steps.filter.outputs.tooling == 'true' || steps.filter.outputs.agent-images == 'true' || steps.filter.outputs.postgres-image == 'true' }}
       # The vulnerability policy's match key includes the platform, so an arm64-only finding has to
       # be found before the release rather than by it, and only a manifest that exists can carry it.
-      single-arch: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && steps.version_branch.outputs.version-branch != 'true' }}
+      single-arch: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && steps.release_candidate.outputs.release-candidate != 'true' }}
       # The commit an unchanged image is aliased from; scripts/resolve-alias-base.ts says how it is
       # found and docs/contributor/ci-cd.mdx the rule.
       alias-base: ${{ steps.alias_base.outputs.commit }}
-      # Aliasing an unchanged image falls back to main's own push run, which has published nothing
-      # yet when the Version PR head is written, so that branch builds the whole set itself; so does
-      # a pull request whose chain of bases reaches no published commit at all.
-      all-images: ${{ steps.alias_base.outputs.commit == '' || steps.version_branch.outputs.version-branch == 'true' }}
+      # A release candidate publishes its complete image set under its own commit identity.
+      # Ordinary PRs can reuse unchanged images when their base has published artifacts.
+      all-images: ${{ steps.alias_base.outputs.commit == '' || steps.release_candidate.outputs.release-candidate == 'true' }}
       # A push and a dispatch validate a commit whole; a pull request and a merge group are each a
       # diff, which paths-filter reads for a group from `merge_group.base_sha..head_sha` without
       # being told.
@@ -73,7 +72,7 @@ jobs:
       previews: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
       # A skipped duplicate would skip the image builds the release evidence preflight needs, and
       # the gate refuses to pass the Version PR without one.
-      should_skip: ${{ steps.skip_check.outputs.should_skip == 'true' && steps.version_branch.outputs.version-branch != 'true' }}
+      should_skip: ${{ steps.skip_check.outputs.should_skip == 'true' && steps.release_candidate.outputs.release-candidate != 'true' }}
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -92,18 +91,23 @@ jobs:
         id: version
         run: echo "version=$(jq -r .version package.json)" >> "$GITHUB_OUTPUT"
 
-      # Whether this run is looking at the Version PR's head, whichever event started it. The branch
-      # name is read from the config changesets derives it from rather than restated, so a
-      # base-branch rename cannot quietly turn the release evidence preflight off; ci-contract.test.ts
-      # runs this shell against `versionBranch()` and requires the two to agree.
-      - name: Detect the Version PR branch
-        id: version_branch
+      # Merge groups use synthetic refs, so a version change against the group's base also requires
+      # release evidence. Read the aggregate tree rather than guessing which PRs a group contains.
+      - name: Detect the release candidate
+        id: release_candidate
         env:
           HEAD_BRANCH: ${{ github.head_ref || github.ref_name }}
+          MERGE_BASE_SHA: ${{ github.event.merge_group.base_sha }}
         run: |
           version_branch="changeset-release/$(jq -r .baseBranch .changeset/config.json)"
           [ "$HEAD_BRANCH" = "$version_branch" ] && on_version_branch=true || on_version_branch=false
-          echo "version-branch=$on_version_branch" >> "$GITHUB_OUTPUT"
+          release_candidate="$on_version_branch"
+          if [ -n "$MERGE_BASE_SHA" ]; then
+            base_version=$(git show "$MERGE_BASE_SHA:package.json" | jq -er .version)
+            current_version=$(jq -er .version package.json)
+            [ "$base_version" = "$current_version" ] || release_candidate=true
+          fi
+          echo "release-candidate=$release_candidate" >> "$GITHUB_OUTPUT"
 
       - name: Detect version bump
         id: version_bump
@@ -572,23 +576,13 @@ jobs:
           docker compose --env-file .env --env-file smoke-lock.env up -d --wait \
             --wait-timeout 600 postgres nats-server application-server
 
-  # Everything the release evidence gate checks, against the images this run just built, except the
-  # signatures and attestations that do not exist until a release creates them. A release was the
-  # first and only thing that ever produced an evidence bundle, so the SBOM triple, the licence
-  # report binding, index membership, and the linux/arm64 vulnerability policy for the images we
-  # build could each fail for the first time at the release — the pinned upstream digests need no
-  # build, so ci-security-scan.yml already covers both of their platforms on the pull request that
-  # changes them. release-management.mdx § Nothing may fail for the first time at a release carries
-  # the check-by-check reasoning.
-  #
-  # On the Version PR's branch it runs whatever event started the run. That head is the commit whose
-  # merge cuts a release, and more than one run can report `CI Status Gate` for it — the run
-  # version-pr.yml dispatches, and an approved `pull_request` run — while the ruleset is satisfied by
-  # either. So the answer has to be in every one of them, not in the dispatched one alone.
+  # Validate the built images before release; signatures and attestations are added at publication.
+  # Every release candidate needs evidence for its own tree, including a merge group's aggregate.
+  # release-management.mdx owns the evidence contract.
   Release-preflight:
     name: "Release evidence preflight"
     needs: [detect-changes, Build, Docker]
-    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.release-preflight) || needs.detect-changes.outputs.version-branch == 'true' }}
+    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.release-preflight) || needs.detect-changes.outputs.release-candidate == 'true' }}
     timeout-minutes: 45
     runs-on: ubuntu-latest
     permissions:
@@ -716,7 +710,7 @@ jobs:
           echo "Docker:         ${{ needs.Docker.result }}"
           echo "Host smoke:     ${{ needs.Supported-host-smoke.result }}"
           echo "Preflight:      ${{ needs.Release-preflight.result }}"
-          echo "Version branch: ${{ needs.detect-changes.outputs.version-branch == 'true' }}"
+          echo "Release candidate: ${{ needs.detect-changes.outputs.release-candidate == 'true' }}"
 
           if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]]; then
             echo "status=failure" >> $GITHUB_OUTPUT
@@ -728,11 +722,9 @@ jobs:
             exit 1
           fi
 
-          # The Version PR's merge cuts a release, so its gate is only worth the name if the release
-          # evidence preflight actually ran here. A skipped job is a missing answer, not an
-          # affirmative one, and the checks above read it as neither failed nor cancelled.
-          if [[ "${{ needs.detect-changes.outputs.version-branch == 'true' && needs.Release-preflight.result != 'success' }}" == "true" ]]; then
-            echo "The Version PR requires a successful release evidence preflight; this run's was '${{ needs.Release-preflight.result }}'."
+          # A skipped preflight is a missing release verdict, not a successful one.
+          if [[ "${{ needs.detect-changes.outputs.release-candidate == 'true' && needs.Release-preflight.result != 'success' }}" == "true" ]]; then
+            echo "The release candidate requires a successful release evidence preflight; this run's was '${{ needs.Release-preflight.result }}'."
             echo "status=failure" >> $GITHUB_OUTPUT
             exit 1
           fi
@@ -796,7 +788,7 @@ jobs:
             echo "### 💡 Troubleshooting Guide" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
 
-            if [[ "${{ needs.detect-changes.outputs.version-branch == 'true' && needs.Release-preflight.result != 'success' }}" == "true" ]]; then
+            if [[ "${{ needs.detect-changes.outputs.release-candidate == 'true' && needs.Release-preflight.result != 'success' }}" == "true" ]]; then
               echo "❌ **The release evidence preflight did not pass.** Merging this pull request cuts a release, so its gate requires the preflight to succeed in this run; it was \`${{ needs.Release-preflight.result }}\`." >> $GITHUB_STEP_SUMMARY
               echo "" >> $GITHUB_STEP_SUMMARY
             fi

--- a/docs/contributor/ci-cd.mdx
+++ b/docs/contributor/ci-cd.mdx
@@ -121,6 +121,14 @@ a stacked layer is approved while it still targets the layer below, because reta
 lower layer merges must not depend on receiving a subsequent event. The `edited` trigger also
 re-evaluates explicit base changes.
 
+A merge group uses a synthetic ref, not the Version PR branch name. If its aggregate tree changes
+`package.json`'s version relative to the group's base, it is a release candidate: it builds both
+platforms of every release image and must pass release evidence preflight on that exact tree.
+Missing base/version data fails detection rather than silently skipping release validation.
+
+Cancelled or approval-blocked runs do not suppress the Version PR’s CI dispatch; actual validation
+failures require an explicit rerun.
+
 The Version PR is maintained after CI/CD succeeds for the current tip of `main`; failed or
 overtaken main runs do not update it. It carries checks like any other pull request. Its updates are
 pushed with `GITHUB_TOKEN`, which starts no workflow run, so `version-pr.yml` dispatches CI/CD on the Version

--- a/scripts/ci-contract.test.ts
+++ b/scripts/ci-contract.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
-import { chmod, glob, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { chmod, glob, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { describe, test } from "node:test";
@@ -10,6 +10,7 @@ import { type Document, isMap, isScalar, isSeq, parseDocument, type YAMLMap } fr
 
 import { evaluate as evaluateVulnerabilityPolicy } from "./check-release-vulnerabilities.ts";
 import { versionBranch } from "./dispatch-version-pr-ci.ts";
+import { environmentForGitFixture } from "./lib/git-environment.ts";
 import { asArray, asRecord, asString, isRecord } from "./lib/json.ts";
 import { commandsOf, loadTasks } from "./lib/task-graph.ts";
 import { planRelease, releaseOutputs } from "./plan-release.ts";
@@ -249,7 +250,7 @@ async function runStep(
 	await writeFile(outputFile, "");
 	const run = spawnSync("bash", ["--noprofile", "--norc", "-e", "-c", shell], {
 		encoding: "utf8",
-		env: { ...process.env, ...environment, GITHUB_OUTPUT: outputFile },
+		env: environmentForGitFixture({ ...environment, GITHUB_OUTPUT: outputFile }),
 	});
 	assert.equal(run.error, undefined);
 	const outputs = (await readFile(outputFile, "utf8"))
@@ -1327,7 +1328,7 @@ void describe("CI contract", () => {
 		assert.match(preflight, /max-age-hours: "24"/);
 		assert.match(
 			preflight,
-			/if: \$\{\{ \(github\.event_name == 'workflow_dispatch' && inputs\.release-preflight\) \|\| needs\.detect-changes\.outputs\.version-branch == 'true' \}\}/,
+			/if: \$\{\{ \(github\.event_name == 'workflow_dispatch' && inputs\.release-preflight\) \|\| needs\.detect-changes\.outputs\.release-candidate == 'true' \}\}/,
 		);
 		assert.match(cicd, /^ {6}release-preflight:$/m);
 		assert.match(job(cicd, "all-ci-passed"), /needs: \[[^\]]*Release-preflight\]/);
@@ -1370,23 +1371,73 @@ void describe("CI contract", () => {
 		);
 	});
 
+	void test("merge groups require release evidence when their aggregate tree changes the version", async (context) => {
+		const workflow = parseDocument(await readFile(".github/workflows/cicd.yml", "utf8"));
+		const candidateStep = namedStep(
+			workflow,
+			["jobs", "detect-changes"],
+			"Detect the release candidate",
+		);
+		assert.equal(
+			candidateStep.getIn(["env", "MERGE_BASE_SHA"]),
+			`\${{ github.event.merge_group.base_sha }}`,
+		);
+		const directory = await mkdtemp(path.join(tmpdir(), "release-candidate-"));
+		context.after(() => rm(directory, { recursive: true, force: true }));
+		const env = environmentForGitFixture();
+		const git = (...args: string[]) => {
+			const result = spawnSync("git", args, { cwd: directory, env, encoding: "utf8" });
+			assert.equal(result.status, 0, result.stderr);
+			return result.stdout.trim();
+		};
+		await mkdir(path.join(directory, ".changeset"));
+		await writeFile(path.join(directory, ".changeset/config.json"), '{"baseBranch":"main"}');
+		await writeFile(path.join(directory, "package.json"), '{"version":"0.1.0"}');
+		git("init", "-q");
+		git("add", ".");
+		git("-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-qm", "base");
+		const base = git("rev-parse", "HEAD");
+		const output = path.join(directory, "output");
+		const detect = async (sha: string) => {
+			await writeFile(output, "");
+			const result = spawnSync(
+				"bash",
+				["--noprofile", "--norc", "-e", "-c", String(candidateStep.get("run"))],
+				{
+					cwd: directory,
+					encoding: "utf8",
+					env: {
+						...env,
+						HEAD_BRANCH: "gh-readonly-queue/main/pr-1-example",
+						MERGE_BASE_SHA: sha,
+						GITHUB_OUTPUT: output,
+					},
+				},
+			);
+			return { status: result.status, output: await readFile(output, "utf8") };
+		};
+		assert.deepEqual(await detect(base), { status: 0, output: "release-candidate=false\n" });
+		await writeFile(path.join(directory, "package.json"), '{"version":"0.2.0"}');
+		assert.deepEqual(await detect(base), { status: 0, output: "release-candidate=true\n" });
+		assert.notEqual((await detect("0".repeat(40))).status, 0);
+		await writeFile(path.join(directory, "package.json"), "{}");
+		assert.notEqual((await detect(base)).status, 0);
+	});
+
 	void test("fails the CI gate on the Version PR when its release evidence preflight did not", async () => {
-		// #1745's guarantee is that a green Version PR gate means the release will clear its evidence
-		// gate. Two runs reported that gate for #1757's head — the dispatch, where the preflight
-		// succeeded, and a pull_request run, where it skipped — and the ruleset is satisfied by
-		// either, so the guarantee held only for as long as the dispatch was the sole reporter. Every
-		// run on that branch now runs the preflight, and the gate treats a preflight that is anything
-		// other than successful as the missing answer it is.
+		// Every run that can satisfy the gate must require the candidate's own release evidence.
 		const workflow = parseDocument(await readFile(".github/workflows/cicd.yml", "utf8"));
 		const detection = ["jobs", "detect-changes"];
 
 		// One home for the branch name: the workflow reads it out of the same `.changeset/config.json`
 		// `versionBranch()` reads, so this runs the workflow's own shell and requires the two to agree
 		// rather than restating either. A base-branch rename moves both or fails here.
-		const detect = runScript(workflow, detection, "Detect the Version PR branch");
+		const detect = runScript(workflow, detection, "Detect the release candidate");
 		const branch = versionBranch(JSON.parse(await readFile(".changeset/config.json", "utf8")));
 		const detected = async (head: string): Promise<string | undefined> =>
-			(await runStep(detect, { HEAD_BRANCH: head })).outputs["version-branch"];
+			(await runStep(detect, { HEAD_BRANCH: head, MERGE_BASE_SHA: "" })).outputs[
+				"release-candidate"
+			];
 		assert.equal(await detected(branch), "true");
 		for (const other of ["main", `${branch}-old`, "changeset-release/release-1.0", "renovate/vite"])
 			assert.equal(await detected(other), "false", `${other} is not the Version PR's branch`);
@@ -1395,11 +1446,11 @@ void describe("CI contract", () => {
 		// every event, and a duplicate-run skip must not take the image builds it needs away.
 		assert.match(
 			String(workflow.getIn(["jobs", "Release-preflight", "if"])),
-			/needs\.detect-changes\.outputs\.version-branch == 'true'/,
+			/needs\.detect-changes\.outputs\.release-candidate == 'true'/,
 		);
 		assert.match(
 			String(workflow.getIn([...detection, "outputs", "should_skip"])),
-			/steps\.version_branch\.outputs\.version-branch != 'true'/,
+			/steps\.release_candidate\.outputs\.release-candidate != 'true'/,
 		);
 
 		// The verdict itself, run rather than read. Its needs are the jobs it judges, so a new one is
@@ -1419,7 +1470,11 @@ void describe("CI contract", () => {
 		// something an expected verdict should have to spell out.
 		const verdict = async (results: Record<string, string>, onVersionBranch: boolean) => {
 			const run = await runStep(
-				render(evaluate, { ...green, ...results }, { "version-branch": String(onVersionBranch) }),
+				render(
+					evaluate,
+					{ ...green, ...results },
+					{ "release-candidate": String(onVersionBranch) },
+				),
 			);
 			return { failed: run.failed, outputs: run.outputs };
 		};
@@ -1447,7 +1502,7 @@ void describe("CI contract", () => {
 		// `linux/amd64` alone and could not, which is what blocked v0.75.1.
 		const architectures = String(workflow.getIn([...detection, "outputs", "single-arch"]));
 		const shape =
-			/^\$\{\{ \(github\.event_name == '(\w+)' \|\| github\.event_name == '(\w+)'\) && steps\.version_branch\.outputs\.version-branch != 'true' }}$/.exec(
+			/^\$\{\{ \(github\.event_name == '(\w+)' \|\| github\.event_name == '(\w+)'\) && steps\.release_candidate\.outputs\.release-candidate != 'true' }}$/.exec(
 				architectures,
 			);
 		assert.ok(shape, `this test cannot evaluate \`${architectures}\``);
@@ -1480,7 +1535,7 @@ void describe("CI contract", () => {
 		const complete = String(workflow.getIn([...detection, "outputs", "all-images"]));
 		assert.match(
 			complete,
-			/^\$\{\{ steps\.alias_base\.outputs\.commit == '' \|\| steps\.version_branch\.outputs\.version-branch == 'true' }}$/,
+			/^\$\{\{ steps\.alias_base\.outputs\.commit == '' \|\| steps\.release_candidate\.outputs\.release-candidate == 'true' }}$/,
 		);
 		// A run builds every image when it resolved no commit to alias from, so which events can
 		// resolve one is read from the resolver's own condition rather than restated here.

--- a/scripts/dispatch-version-pr-ci.test.ts
+++ b/scripts/dispatch-version-pr-ci.test.ts
@@ -56,8 +56,16 @@ void describe("dispatching CI for a Version PR head", () => {
 	});
 });
 
-void test("cancelled validation is recoverable but failed validation is not retried blindly", () => {
-	assert.equal(needsDispatch(SHA, [{ headSha: SHA, conclusion: "cancelled" }]), true);
+void test("cancelled and approval-blocked validation recover without retrying real failures", () => {
+	for (const conclusion of ["cancelled", "action_required"])
+		assert.equal(needsDispatch(SHA, [{ headSha: SHA, conclusion }]), true);
+	assert.equal(
+		needsDispatch(SHA, [
+			{ headSha: SHA, conclusion: "action_required" },
+			{ headSha: SHA, conclusion: "success" },
+		]),
+		false,
+	);
 	for (const conclusion of [null, "success", "failure"])
 		assert.equal(needsDispatch(SHA, [{ headSha: SHA, conclusion }]), false);
 });

--- a/scripts/dispatch-version-pr-ci.ts
+++ b/scripts/dispatch-version-pr-ci.ts
@@ -15,9 +15,14 @@ export interface WorkflowRun {
 	readonly conclusion: string | null;
 }
 
-// Failed validation requires an explicit rerun; cancellation does not.
+// Cancelled and approval-blocked runs provide no verdict; actual failures require an explicit rerun.
 export function needsDispatch(headSha: string, runs: readonly WorkflowRun[]): boolean {
-	return !runs.some((run) => run.headSha === headSha && run.conclusion !== "cancelled");
+	return !runs.some(
+		(run) =>
+			run.headSha === headSha &&
+			run.conclusion !== "cancelled" &&
+			run.conclusion !== "action_required",
+	);
 }
 
 export function parseRuns(value: unknown): WorkflowRun[] {


### PR DESCRIPTION
## What changed and why

The recent-run audit exposed two release-validation gaps: an approval-blocked Version PR run could suppress the fallback CI dispatch, and a merge queue's synthetic ref hid release candidates from the release evidence gate.

- Treat `action_required`, like cancellation, as providing no validation verdict. Existing active/successful runs still prevent duplicates; real failures still require explicit reruns.
- Detect release candidates from the Version PR branch or a version change in a merge group's aggregate tree against its base. Require both image platforms, the complete image set, and successful release preflight for that tree.
- Fail closed on missing base/version data, retain ordinary merge groups' existing scope, and remove stale incident-oriented comments from the touched workflow.

Related: #1590. No #1283 changes.

## How to test

- `node --test scripts/dispatch-version-pr-ci.test.ts scripts/ci-contract.test.ts` — 69 tests passed, including a real Git fixture for ordinary/version-changing merge groups, missing bases, and invalid versions; existing gate and image-platform contracts remain enforced.
- `vp run format` and `vp run check` — passed.
- Actionlint and offline Zizmor — passed.

## Release impact

CI-only correctness changes; no application release note or operator action. Release candidates now perform their evidence preflight in the merge queue as well as on the Version PR. This adds necessary validation work for release candidates, not ordinary merge groups.

## Notes for reviewers

Measured recent verdicts: [full PR 8m45s](https://github.com/hephaestus-build/Hephaestus/actions/runs/34208840465), [merge queue 8m27s](https://github.com/hephaestus-build/Hephaestus/actions/runs/34209680229), [Version PR 12m38s](https://github.com/hephaestus-build/Hephaestus/actions/runs/34211301606). These are observations, not a speedup claim. Application integration remains the test critical path; release evidence adds a separate necessary cost.

The [approval-blocked run](https://github.com/hephaestus-build/Hephaestus/actions/runs/34211293803) and [successful dispatch](https://github.com/hephaestus-build/Hephaestus/actions/runs/34211301606) share the same head SHA. Their ordering must not decide whether dispatch recovery works.

Uses the native [merge-group base and aggregate-tree model](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue) and [workflow-run conclusions](https://docs.github.com/en/rest/actions/workflow-runs). Queue build concurrency remains two, ALLGREEN remains required, and approval restrictions are unchanged. No custom queue scheduler or security bypass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **CI/CD**
  - Merge groups that change the package version are now recognized as release candidates.
  - Release candidates build all release images across supported platforms and require release preflight validation on the exact merged code.
  - Missing or invalid version information now fails release detection instead of silently skipping validation.
  - Cancelled or approval-blocked checks no longer suppress required validation dispatches; successful reruns prevent unnecessary repeats.

- **Documentation**
  - Updated merge policy guidance explains release-candidate validation and rerun behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->