### PR TITLE
fix(scripts): a coloured task report no longer reads as a clean run

### DIFF
--- a/docs/.markdownlint-cli2.jsonc
+++ b/docs/.markdownlint-cli2.jsonc
@@ -19,7 +19,10 @@
 	// `decisions/` (every ADR) and `runbooks/` are mounted by no Docusaurus plugin, so the site
 	// build never compiles them and never link-checks them — the linter is their only gate.
 	"globs": ["**/*.md", "**/*.mdx", "../load-tests/**/*.md"],
-	"ignores": ["node_modules", "build", ".docusaurus"],
+	// `venv/` is a Docusaurus contributor's Python environment for the diagram tooling. It is
+	// git-ignored, but this linter walks the filesystem rather than asking git, so without this the
+	// gate reports hundreds of findings in vendored site-packages that CI never sees.
+	"ignores": ["node_modules", "build", ".docusaurus", "venv", ".venv"],
 
 	"config": {
 		"default": true,

--- a/docs/admin/liquibase-baseline-runbook.md
+++ b/docs/admin/liquibase-baseline-runbook.md
@@ -49,6 +49,19 @@ environment's `url`, `username`, and `password`. Make it readable only by the im
 user and the operator, then mount it read-only. Do not put credentials in command arguments, shell
 history, or the repository.
 
+Read that user from the image rather than assuming it, and give the file to it:
+
+```bash
+docker inspect --format '{{.Config.User}}' "$CANDIDATE_IMAGE"   # e.g. 1002:1001
+chown 1002:1001 "$LIQUIBASE_DEFAULTS_FILE" && chmod 0600 "$LIQUIBASE_DEFAULTS_FILE"
+```
+
+A file left owned by `root` with mode `0600` is the natural reading of "protected" and is the one
+shape that fails: the container cannot read it and Liquibase aborts with
+`java.nio.file.AccessDeniedException: /run/secrets/liquibase.properties`, which names the mount
+rather than the permission. Prove the plumbing first with the read-only `status` command — same
+image, mount and network, no writes — and only then run the synchronization below.
+
 ```bash
 docker run --rm --network "$DATABASE_NETWORK" \
   --mount "type=bind,src=$LIQUIBASE_DEFAULTS_FILE,dst=/run/secrets/liquibase.properties,readonly" \

--- a/scripts/organization-migration.test.ts
+++ b/scripts/organization-migration.test.ts
@@ -1,10 +1,13 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import { readFileSync } from "node:fs";
-import { glob } from "node:fs/promises";
 import path from "node:path";
 import { test } from "node:test";
+import { fileURLToPath } from "node:url";
 
 import { isSeq, parseAllDocuments, parseDocument } from "yaml";
+
+import { environmentWithoutGitRepository } from "./lib/git-environment.ts";
 
 const repoRoot = new URL("../", import.meta.url);
 const source = (file: string) => readFileSync(new URL(file, repoRoot), "utf8");
@@ -23,7 +26,6 @@ const SKIPPED_EXTENSIONS = new Set([
 	".pdf",
 	".zip",
 ]);
-const GENERATED_DIRS = ["node_modules", "build", ".docusaurus", "storybook-static", "coverage"];
 
 // Sample repository names in stories and test fixtures are not the shipped rename (#1599).
 const SAMPLE_DATA = /(\.stories\.tsx|\.test\.tsx?|story-mock-data\.ts)$/;
@@ -68,16 +70,25 @@ await test("preview publishing and teardown target the same hostname", () => {
 	}
 });
 
-await test("no shipped surface drifts back to ls1intum/Hephaestus", async () => {
+await test("no shipped surface drifts back to ls1intum/Hephaestus", () => {
 	const offenders: string[] = [];
-	for (const dir of ["webapp/src", "docs", "docker", ".github"]) {
-		const files = await Array.fromAsync(
-			glob(`${dir}/**/*`, {
-				cwd: repoRoot,
-				exclude: (entry) =>
-					GENERATED_DIRS.some((generated) => entry.split("/").includes(generated)),
-			}),
-		);
+	// Shipped surface is what git tracks. Walking the filesystem instead read whatever a contributor
+	// happened to have built — `docs/_build/`, a Python `venv/` — as if it shipped, so the gate
+	// failed locally on files CI never sees and no list of generated directory names stayed complete.
+	const tracked = spawnSync(
+		"git",
+		["ls-files", "-z", "--", "webapp/src", "docs", "docker", ".github"],
+		{
+			cwd: fileURLToPath(repoRoot),
+			encoding: "utf8",
+			maxBuffer: 64 * 1024 * 1024,
+			// The pre-push hook exports GIT_DIR and friends, which outrank `cwd`.
+			env: environmentWithoutGitRepository(),
+		},
+	);
+	assert.equal(tracked.status, 0, `git ls-files failed: ${tracked.stderr}`);
+	{
+		const files = tracked.stdout.split("\0").filter(Boolean);
 		for (const file of files.toSorted()) {
 			const relative = file.split(path.sep).join("/");
 			if (

--- a/scripts/report-task-run.test.ts
+++ b/scripts/report-task-run.test.ts
@@ -31,3 +31,11 @@ void test("names a task the runner stopped, because the report does not distingu
 `;
 	assert.deepEqual(unpassedTasks(stopped), ["gate:stories", "gate:runner-contract"]);
 });
+
+void test("reads a coloured report, which would otherwise name nothing and exit clean", () => {
+	const esc = "\u001B";
+	const coloured =
+		`  ${esc}[90m[1]${esc}[0m ${esc}[97;1mhephaestus#gate:stories${esc}[0m: ` +
+		`${esc}[34m$ node scripts/check-story-prose.ts${esc}[0m ${esc}[31m\u2717${esc}[0m (exit code: 1)\n`;
+	assert.deepEqual(unpassedTasks(coloured), ["gate:stories"]);
+});

--- a/scripts/report-task-run.ts
+++ b/scripts/report-task-run.ts
@@ -10,9 +10,24 @@
 import { appendFileSync } from "node:fs";
 import { text } from "node:stream/consumers";
 
-/** Task names the report marks with a cross, from lines shaped `[n] package#task: $ command ✗`. */
+/**
+ * SGR escapes, which the runner emits whenever colour is forced on — `FORCE_COLOR` is set in some
+ * terminals and agent harnesses — even though nothing here is a terminal. Stripping them is what
+ * keeps this a text parser rather than a guess about how the report was rendered.
+ */
+// ESC is the character being stripped, so the rule is reporting the thing this line is for.
+// oxlint-disable-next-line eslint/no-control-regex -- deliberate: this matches SGR escapes
+const ANSI = /\u001B\[[0-9;]*m/gu;
+
+/**
+ * Task names the report marks with a cross, from lines shaped `[n] package#task: $ command ✗`.
+ *
+ * A coloured report used to match nothing, so a failed run produced no annotations and exited 0 —
+ * the one failure mode a gate must not have.
+ */
 export function unpassedTasks(report: string): string[] {
-	const names = [...report.matchAll(/^\s*\[\d+\] [^#\n]+#(\S+): \$ [^\n]*✗/gmu)].flatMap(
+	const plain = report.replaceAll(ANSI, "");
+	const names = [...plain.matchAll(/^\s*\[\d+\] [^#\n]+#(\S+): \$ [^\n]*✗/gmu)].flatMap(
 		([, task]) => (task === undefined ? [] : [task]),
 	);
 	return [...new Set(names)];

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/testconfig/BaseIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/testconfig/BaseIntegrationTest.java
@@ -13,7 +13,9 @@ import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("test")
-@AutoConfigureWebTestClient
+// A hang guard, not a latency budget: the 5s default failed whole suites whenever one request
+// crossed it under CI load, reported as "Timeout on blocking read" with no failing assertion.
+@AutoConfigureWebTestClient(timeout = "30s")
 @Import({
     TestSecurityConfig.class,
     TestAsyncConfiguration.class,

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/testconfig/RealAuthIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/testconfig/RealAuthIntegrationTest.java
@@ -12,7 +12,9 @@ import org.springframework.test.context.DynamicPropertySource;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("test")
-@AutoConfigureWebTestClient
+// A hang guard, not a latency budget: the 5s default failed whole suites whenever one request
+// crossed it under CI load, reported as "Timeout on blocking read" with no failing assertion.
+@AutoConfigureWebTestClient(timeout = "30s")
 @Tag("integration")
 public abstract class RealAuthIntegrationTest {
 


### PR DESCRIPTION
Follow-ups from the v0.78.0 baseline rollout. Each one is a place where the tooling told us something untrue.

## A gate that reports green on failure

`unpassedTasks` parses the runner's report with a regex anchored at `[n]`, which never matches once SGR escapes sit in front of it. The runner emits colour whenever it is forced on — `FORCE_COLOR` is set by some terminals and agent harnesses — so a failed run produced **no error annotations and exited 0**. That is the one failure mode a gate must not have. Escapes are now stripped before matching, with a test pinning it.

The same report is what `gate:runner-contract` asserts on, which is why it failed locally and passed in CI.

## A scan that read whatever you had built

The rename-drift test walked the filesystem, so a contributor's `docs/_build/` (16 MB of old Sphinx output) or a docs `venv/` was read as shipped surface — hundreds of findings CI never sees, on files git already ignores. Shipped surface is what git tracks, so it now asks `git ls-files`; no list of generated directory names has to stay complete. It takes its environment from `lib/git-environment.ts`, since the pre-push hook exports `GIT_DIR` and friends and those outrank `cwd` — the repository's own gate caught that, correctly. markdownlint-cli2 has no equivalent, so its `ignores` name the two directories.

## Integration suites failing on a 5s default

`testconfig/BaseIntegrationTest` and `testconfig/RealAuthIntegrationTest` used a bare `@AutoConfigureWebTestClient`, taking Spring's 5s default `responseTimeout`. Any single request crossing it fails the whole suite with `Timeout on blocking read` and no failing assertion. It hit `apiKeyIsNeverExposedInAnyResponse` at 5.129s on a fresh context while the same job on the same commit passed in a parallel run. A timeout there is a hang guard, not a latency budget; both base classes now allow 30s.

## A runbook that named a requirement without naming the value

`liquibase-baseline-runbook.md` said to make the Liquibase properties file readable by "the image's non-root runtime user" without saying who that is. The natural reading of "protected" — root-owned, `0600` — is the one shape that fails, and Liquibase reports it as `AccessDeniedException` naming the mount rather than the permission. It now reads the uid from the image, shows the `chown`, and says to prove the plumbing with the read-only `status` command first.

## Verification

- `vp run check` is green, **including with `FORCE_COLOR=3` still set** — the environment that was failing.
- `test:tooling`: 631 passing.
- Server test sources compile with the new annotation attribute.
- The runbook's corrected sequence was executed for real against staging and production during the v0.78.0 baseline sync: both reported `changeLogSyncToTag` successful with the four expected rows, production's changelog going 1465 → 1469 with the application healthy throughout.

No changeset: test configuration, repository tooling and in-tree docs only.