### PR TITLE
fix(server): collaborator permission sync no longer aborts on its own key

### DIFF
--- a/.changeset/collaborator-sync-composite-key.md
+++ b/.changeset/collaborator-sync-composite-key.md
@@ -1,0 +1,5 @@
+---
+"hephaestus": patch
+---
+
+Repository collaborator permissions now sync again. Workspaces whose repositories use collaborator permissions saw the sync abort partway with a tenancy error, leaving the permissions Hephaestus held for that repository stale until the next full resync.

--- a/.changeset/reconciler-unpromoted-host.md
+++ b/.changeset/reconciler-unpromoted-host.md
@@ -1,0 +1,5 @@
+---
+"hephaestus": patch
+---
+
+A host that has not been promoted yet now says so. The deployment reconciler reported the missing channel as an unhandled error, so the first thing a new self-hosted instance logged was a stack trace rather than the sentence naming the environment and the workflow that publishes it.

--- a/scripts/reconcile-deployment.test.ts
+++ b/scripts/reconcile-deployment.test.ts
@@ -745,6 +745,29 @@ await main(${JSON.stringify(units)});\n`,
 }
 
 await test(
+	"a host waiting for its first promotion says so, without a stack trace",
+	reconcilerSubprocess,
+	async () => {
+		const directory = await mkdtemp(join(tmpdir(), "reconcile-unpromoted-"));
+		try {
+			const fixture = await reconcilerFixture(directory);
+			// `cli: true` runs the real entry point, which is where the two failure classes part.
+			const result = fixture.run({ cli: true, channel: "production" });
+
+			assert.notEqual(result.status, 0, "an unpromoted host must not report success");
+			assert.match(result.stderr, /channels\/production\.json/);
+			assert.match(result.stderr, /has not been promoted yet/);
+			assert.match(result.stderr, /Run the Promote workflow/);
+			// The whole point: the journal gets the sentence, not a Node stack.
+			assert.doesNotMatch(result.stderr, /^\s+at /mu);
+			assert.doesNotMatch(result.stderr, /OperatorActionRequired:/u);
+		} finally {
+			await rm(directory, { recursive: true, force: true });
+		}
+	},
+);
+
+await test(
 	"startup adopts the recorded release before attempting to read the channel",
 	reconcilerSubprocess,
 	async () => {

--- a/scripts/reconcile-deployment.ts
+++ b/scripts/reconcile-deployment.ts
@@ -42,6 +42,19 @@ const FETCH_TIMEOUT_MS = 5 * 60_000;
 const UNIT_FILES = ["hephaestus-reconcile.service", "hephaestus-reconcile.timer"] as const;
 const SYSTEMD_UNITS = "/etc/systemd/system";
 
+/**
+ * A condition an operator resolves rather than a defect to diagnose — a host waiting for its first
+ * promotion is the one that reaches production. The entry point prints the message and exits
+ * non-zero; a stack trace would say a failure happened here, when what happened is that nothing has
+ * been promoted yet.
+ */
+export class OperatorActionRequired extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "OperatorActionRequired";
+	}
+}
+
 export interface Channel {
 	/** What this channel asks the host to run: a release tag, or the commit a build came from. */
 	release: string;
@@ -470,7 +483,7 @@ export async function main(unitsDirectory = SYSTEMD_UNITS): Promise<void> {
 			cwd: config.checkout,
 		}))
 	)
-		throw new Error(
+		throw new OperatorActionRequired(
 			`no ${channelPath} on deploy-state: the "${config.channel}" environment has not been ` +
 				"promoted yet. Run the Promote workflow for it and this host applies it on the next tick.",
 		);
@@ -930,6 +943,14 @@ if (import.meta.main) {
 	} catch (error) {
 		// An unwritable metric must not replace the error that caused the failure.
 		await reportFailure().catch(() => {});
-		throw error;
+		// A host waiting to be promoted is a state an operator resolves, not a defect: the journal
+		// gets the sentence that says what to do. Everything else keeps its stack, because a stack is
+		// what a defect is diagnosed from.
+		if (error instanceof OperatorActionRequired) {
+			console.error(error.message);
+			process.exitCode = 1;
+		} else {
+			throw error;
+		}
 	}
 }

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/tenancy/WorkspaceScopedTables.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/tenancy/WorkspaceScopedTables.java
@@ -2,12 +2,16 @@ package de.tum.cit.aet.hephaestus.core.tenancy;
 
 import jakarta.persistence.EntityManagerFactory;
 import jakarta.persistence.metamodel.EntityType;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 import org.hibernate.SessionFactory;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.metamodel.MappingMetamodel;
+import org.hibernate.metamodel.mapping.TableDetails;
 import org.hibernate.persister.entity.EntityPersister;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -93,6 +97,7 @@ public class WorkspaceScopedTables {
 
     private volatile Set<String> scopedTables = Set.of();
     private volatile Set<String> manyToManyJoinTables = Set.of();
+    private volatile Map<String, Set<String>> primaryKeyColumns = Map.of();
     private final ObjectProvider<EntityManagerFactory> entityManagerFactoryProvider;
 
     /**
@@ -116,11 +121,14 @@ public class WorkspaceScopedTables {
         Set<EntityType<?>> entities = entityManagerFactory.getMetamodel().getEntities();
 
         Set<String> tables = new TreeSet<>();
+        Map<String, Set<String>> keys = new HashMap<>();
         for (EntityType<?> entity : entities) {
             Class<?> javaType = entity.getJavaType();
             if (javaType == null) continue;
             EntityPersister persister = metamodel.getEntityDescriptor(javaType);
-            addIfScoped(tables, persister.getMappedTableDetails().getTableName());
+            var tableDetails = persister.getMappedTableDetails();
+            addIfScoped(tables, tableDetails.getTableName());
+            recordPrimaryKey(keys, tableDetails);
         }
         // Many-to-many join tables + element-collection tables: physical tables with no
         // workspace_id column of their own. They inherit the parent's tenancy boundary,
@@ -145,19 +153,41 @@ public class WorkspaceScopedTables {
         }
         this.scopedTables = Set.copyOf(tables);
         this.manyToManyJoinTables = Set.copyOf(joinTables);
+        this.primaryKeyColumns = Map.copyOf(keys);
         log.info(
                 "WorkspaceScopedTables populated: {} workspace-scoped tables (incl. join tables), {} global",
                 scopedTables.size(),
                 GLOBAL_TABLES.size());
     }
 
+    /**
+     * The table's complete primary key, as the physical column names the inspector will read out of
+     * a WHERE clause. An entity whose key columns cannot all be named contributes nothing, so the
+     * inspector's lookup comes back empty and the statement falls through to the normal check.
+     */
+    private static void recordPrimaryKey(Map<String, Set<String>> keys, TableDetails tableDetails) {
+        String table = normalize(tableDetails.getTableName());
+        if (table.isEmpty()) return;
+        Set<String> columns = new HashSet<>();
+        for (TableDetails.KeyColumn column : tableDetails.getKeyDetails().getKeyColumns()) {
+            String name = normalize(column.getColumnName());
+            if (name.isEmpty()) return;
+            columns.add(name);
+        }
+        if (!columns.isEmpty()) keys.put(table, Set.copyOf(columns));
+    }
+
+    /** Bare, unquoted, lowercase — the form the inspector compares against. */
+    private static String normalize(String rawName) {
+        if (rawName == null) return "";
+        return rawName.substring(rawName.lastIndexOf('.') + 1).replace("\"", "").toLowerCase(Locale.ROOT);
+    }
+
     private static void addIfScoped(Set<String> tables, String rawName) {
         if (rawName == null || rawName.isBlank()) return;
         // The inspector compares bare, lowercase names; a schema-qualified or quoted metamodel
         // name must land in the same form or it never matches.
-        String name = rawName.substring(rawName.lastIndexOf('.') + 1)
-                .replace("\"", "")
-                .toLowerCase(Locale.ROOT);
+        String name = normalize(rawName);
         if (!GLOBAL_TABLES.contains(name)) {
             tables.add(name);
         }
@@ -166,6 +196,17 @@ public class WorkspaceScopedTables {
     /** Workspace-scoped physical table names (lowercase). Empty until ApplicationReady fires. */
     public Set<String> scopedTables() {
         return scopedTables;
+    }
+
+    /**
+     * The table's complete primary-key columns per the mapping metamodel, or empty when the table is
+     * unknown — before {@link ApplicationReadyEvent}, or for a table no entity maps. Empty is the
+     * fail-closed answer: a caller comparing a WHERE clause against it can never conclude the clause
+     * covers the whole key.
+     */
+    public Set<String> primaryKeyColumns(String tableName) {
+        if (tableName == null) return Set.of();
+        return primaryKeyColumns.getOrDefault(tableName.toLowerCase(Locale.ROOT), Set.of());
     }
 
     /** True iff the table is a {@code @ManyToMany} join table, per the mapping metamodel. */

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/tenancy/WorkspaceStatementInspector.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/tenancy/WorkspaceStatementInspector.java
@@ -125,6 +125,28 @@ public class WorkspaceStatementInspector implements StatementInspector {
             Pattern.CASE_INSENSITIVE);
 
     /**
+     * The shape of a single-row DML whose WHERE clause might be a complete primary key:
+     * {@code UPDATE table SET ... WHERE <conjunction>} or {@code DELETE FROM table WHERE
+     * <conjunction>}. The conjunction is captured whole rather than matched column by column,
+     * because whether it covers the key is a question for the mapping metamodel, not for a regex —
+     * {@link #coversCompletePrimaryKey} answers it.
+     */
+    private static final Pattern FULL_KEY_DML_PATTERN = Pattern.compile(
+            "^\\s*(?:DELETE\\s+FROM|UPDATE)\\s+\"?([A-Za-z_][A-Za-z0-9_]*)\"?"
+                    + "(?:\\s+SET\\s+.+?)?"
+                    + "\\s+WHERE\\s+(.+?)\\s*$",
+            Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
+
+    /** One conjunct of that WHERE clause, and the only shape allowed in it: {@code column = ?}. */
+    private static final Pattern KEY_PREDICATE_PATTERN =
+            Pattern.compile("^\\s*\"?([A-Za-z_][A-Za-z0-9_]*)\"?\\s*=\\s*\\?\\s*$");
+
+    private static final Pattern AND_SPLIT_PATTERN = Pattern.compile("\\s+AND\\s+", Pattern.CASE_INSENSITIVE);
+
+    /** Hibernate's optimistic-lock predicate, which rides along with the key on a versioned entity. */
+    private static final String VERSION_COLUMN = "version";
+
+    /**
      * Matches a Hibernate-emitted load that pins the result set to a single row (or a
      * parent-FK-bounded set) via a surrogate-key predicate. Three concrete shapes:
      * <ul>
@@ -208,6 +230,38 @@ public class WorkspaceStatementInspector implements StatementInspector {
         return sql;
     }
 
+    /**
+     * True iff {@code sql} is single-row DML whose WHERE clause is a conjunction of {@code column =
+     * ?} predicates covering exactly the table's primary key — no more columns and no fewer.
+     *
+     * <p>Every way of being unsure is a {@code false}: an unknown table (the metamodel is not
+     * populated until {@link org.springframework.boot.context.event.ApplicationReadyEvent}), a
+     * conjunct that is anything but {@code column = ?}, a disjunction, a repeated column, or a
+     * column set that is not the key. The statement then falls through to the standard
+     * {@code workspace_id} check, so this can only ever narrow what is reported, never widen it.
+     */
+    private boolean coversCompletePrimaryKey(String sql) {
+        Matcher dml = FULL_KEY_DML_PATTERN.matcher(sql);
+        if (!dml.matches()) return false;
+        // An OR anywhere would reach rows the key does not name.
+        if (OR_TOKEN_PATTERN.matcher(sql).find()) return false;
+
+        Set<String> keyColumns = scopedTables.primaryKeyColumns(unqualify(dml.group(1)));
+        if (keyColumns.isEmpty()) return false;
+
+        Set<String> predicateColumns = new HashSet<>();
+        for (String conjunct : AND_SPLIT_PATTERN.split(dml.group(2))) {
+            Matcher predicate = KEY_PREDICATE_PATTERN.matcher(conjunct);
+            if (!predicate.matches()) return false;
+            String column = predicate.group(1).toLowerCase(Locale.ROOT);
+            // `version = ?` is the optimistic lock, not part of the key — unless this table really
+            // does key on a column of that name, in which case it counts as the key column it is.
+            if (VERSION_COLUMN.equals(column) && !keyColumns.contains(column)) continue;
+            if (!predicateColumns.add(column)) return false;
+        }
+        return predicateColumns.equals(keyColumns);
+    }
+
     private Decision analyze(String sql) {
         // INSERTs cannot leak data across workspaces — they create new rows.
         if (INSERT_STATEMENT_PATTERN.matcher(sql).find()) {
@@ -216,6 +270,16 @@ public class WorkspaceStatementInspector implements StatementInspector {
         // Hibernate-emitted single-row PK DML is safe: the row was already loaded
         // within a workspace-checked scope and identified by a surrogate primary key.
         if (PK_ONLY_DML_PATTERN.matcher(sql).matches()) {
+            return Decision.ok();
+        }
+        // The same reasoning as PK_ONLY_DML above, for a composite key: a WHERE clause that is
+        // exactly the table's whole primary key names at most one row, and the caller had to hold
+        // that row's full identity to write it. Hibernate emits this for every @EmbeddedId
+        // association entity — `UPDATE repository_collaborator SET permission=? WHERE
+        // repository_id=? AND "user_id"=?` — which the single-key pattern above cannot match, and
+        // which is not a @ManyToMany join table so the join-table rule below does not cover it
+        // either. The key comes from the mapping metamodel, never from a naming convention.
+        if (coversCompletePrimaryKey(sql)) {
             return Decision.ok();
         }
         Matcher joinTableRowDelete = JOIN_TABLE_ROW_DELETE_PATTERN.matcher(sql);

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/tenancy/TenancyCompositeKeyIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/tenancy/TenancyCompositeKeyIntegrationTest.java
@@ -1,0 +1,60 @@
+package de.tum.cit.aet.hephaestus.core.tenancy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import de.tum.cit.aet.hephaestus.testconfig.BaseIntegrationTest;
+import io.micrometer.core.instrument.Counter;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * The composite-key allowance against the real Hibernate mapping metamodel rather than a stubbed
+ * one. {@link WorkspaceStatementInspectorTest} proves the rule reads a key correctly; this proves
+ * the key it reads is the one Hibernate actually maps, which is what decides whether collaborator
+ * sync runs in production.
+ */
+class TenancyCompositeKeyIntegrationTest extends BaseIntegrationTest {
+
+    @Autowired
+    private WorkspaceScopedTables scopedTables;
+
+    @Test
+    void anEmbeddedIdAssociationReportsBothOfItsKeyColumns() {
+        assertThat(scopedTables.primaryKeyColumns("repository_collaborator"))
+                .containsExactlyInAnyOrder("repository_id", "user_id");
+    }
+
+    @Test
+    void theStatementCollaboratorSyncEmitsIsAllowed() {
+        // Verbatim from the production log that aborted `prompt-edu`'s collaborator sync.
+        String sql = "update repository_collaborator set permission=? where repository_id=? and \"user_id\"=?";
+        TenancyViolationReporter reporter = mock(TenancyViolationReporter.class);
+        WorkspaceStatementInspector inspector =
+                new WorkspaceStatementInspector(scopedTables, TenancyEnforcement.THROW, reporter, mock(Counter.class));
+
+        inspector.inspect(sql);
+
+        verifyNoInteractions(reporter);
+    }
+
+    @Test
+    void aWhereClauseThatIsNotTheKeyIsStillReported() {
+        // The allowance is the whole key and nothing else. A non-key column alongside a key column
+        // is the shape this rule must not accept, and the metamodel is what settles it.
+        //
+        // Note `WHERE repository_id = ?` on its own is NOT the case to test here: the pre-existing
+        // single-key rule already admits any `*_id = ?` predicate, which is how Hibernate's
+        // cascade-delete-by-parent-FK is allowed.
+        String sql = "update repository_collaborator set permission=? where repository_id=? and permission=?";
+        TenancyViolationReporter reporter = mock(TenancyViolationReporter.class);
+        WorkspaceStatementInspector inspector =
+                new WorkspaceStatementInspector(scopedTables, TenancyEnforcement.LOG, reporter, mock(Counter.class));
+
+        inspector.inspect(sql);
+
+        org.mockito.Mockito.verify(reporter)
+                .report(sql, java.util.Set.of("repository_collaborator"), TenancyEnforcement.LOG);
+    }
+}

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/tenancy/WorkspaceStatementInspectorTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/tenancy/WorkspaceStatementInspectorTest.java
@@ -346,6 +346,65 @@ class WorkspaceStatementInspectorTest extends BaseUnitTest {
         verifyNoInteractions(reporter, scopedTables);
     }
 
+    // composite primary keys: the mapping metamodel decides, never a naming convention
+
+    @Test
+    void updateByCompleteCompositeKeyIsAllowed() {
+        // The production shape: an @EmbeddedId association entity carrying a payload column.
+        // Collaborator sync aborted on this until the key came from the metamodel.
+        WorkspaceStatementInspector inspector = newInspector(TenancyEnforcement.THROW);
+        when(scopedTables.primaryKeyColumns("repository_collaborator")).thenReturn(Set.of("repository_id", "user_id"));
+        inspector.inspect("update repository_collaborator set permission=? where repository_id=? and \"user_id\"=?");
+        inspector.inspect("delete from repository_collaborator where repository_id=? and user_id=?");
+        verifyNoInteractions(reporter);
+    }
+
+    @Test
+    void compositeKeyAllowanceToleratesTheOptimisticLock() {
+        WorkspaceStatementInspector inspector = newInspector(TenancyEnforcement.THROW);
+        when(scopedTables.primaryKeyColumns("repository_collaborator")).thenReturn(Set.of("repository_id", "user_id"));
+        inspector.inspect(
+                "update repository_collaborator set permission=? where repository_id=? and user_id=? and version=?");
+        verifyNoInteractions(reporter);
+    }
+
+    @Test
+    void aPartialOrPaddedKeyIsNotACompleteKey() {
+        // Fewer columns than the key reaches more than one row; more columns is a hand-written
+        // query the standard check must still see.
+        WorkspaceStatementInspector inspector = newInspector(TenancyEnforcement.LOG);
+        when(scopedTables.isScoped("repository_collaborator")).thenReturn(true);
+        when(scopedTables.primaryKeyColumns("repository_collaborator")).thenReturn(Set.of("repository_id", "user_id"));
+        for (String sql : List.of(
+                "update repository_collaborator set permission=? where repository_id=? and permission=?",
+                "delete from repository_collaborator where repository_id=? and user_id=? and permission=?",
+                "delete from repository_collaborator where repository_id=? or user_id=?",
+                "delete from repository_collaborator where repository_id=? and repository_id=?",
+                "delete from repository_collaborator where repository_id=? and user_id in (select id from \"user\")")) {
+            inspector.inspect(sql);
+            verify(reporter).report(sql, Set.of("repository_collaborator"), TenancyEnforcement.LOG);
+        }
+    }
+
+    @Test
+    void aTableTheMetamodelDoesNotKnowFailsClosed() {
+        // Before ApplicationReady the key map is empty. Unsure must mean reported, not allowed.
+        WorkspaceStatementInspector inspector = newInspector(TenancyEnforcement.LOG);
+        when(scopedTables.isScoped("repository_collaborator")).thenReturn(true);
+        when(scopedTables.primaryKeyColumns("repository_collaborator")).thenReturn(Set.of());
+        String sql = "update repository_collaborator set permission=? where repository_id=? and user_id=?";
+        inspector.inspect(sql);
+        verify(reporter).report(sql, Set.of("repository_collaborator"), TenancyEnforcement.LOG);
+    }
+
+    @Test
+    void aSingleColumnKeyIsCoveredTooWhenTheMetamodelNamesIt() {
+        WorkspaceStatementInspector inspector = newInspector(TenancyEnforcement.THROW);
+        when(scopedTables.primaryKeyColumns("bad_practice")).thenReturn(Set.of("id"));
+        inspector.inspect("update bad_practice set title=? where id=?");
+        verifyNoInteractions(reporter);
+    }
+
     // helper: Mockito.any() shorthand
     private static <T> T any() {
         return ArgumentMatchers.any();


### PR DESCRIPTION
## Problem

Production has been aborting collaborator sync for a workspace on every attempt:

```
Tenancy violation (throw): scoped tables [repository_collaborator] queried without workspace_id predicate.
SQL: update repository_collaborator set permission=? where repository_id=? and "user_id"=?
→ Aborting collaborator sync: repoName=<workspace>/<repo>
```

`RepositoryCollaborator` is an `@EmbeddedId` association entity — `@MapsId("repositoryId")` and `@MapsId("userId")`, so the physical key is `(repository_id, user_id)` — and it carries a `permission` payload. Hibernate therefore updates it by its whole composite key, and the inspector had no rule for that shape:

- `PK_ONLY_DML_PATTERN` matches **one** key predicate, not two.
- `JOIN_TABLE_ROW_DELETE_PATTERN` is **DELETE only**, and applies to `@ManyToMany` join tables per the metamodel — which this is not, because it has a payload column.

So the statement fell through to the standard `workspace_id` check and threw. The collaborator permissions Hephaestus holds for those repositories go stale silently.

## Fix

Allow single-row DML whose WHERE clause covers the table's **complete primary key**, with the key read from the mapping metamodel rather than inferred from column names — the same discipline `JOIN_TABLE_ROW_DELETE_PATTERN` already applies to its two-key DELETE.

This is the existing security model applied to composite keys, not a widening of it: `PK_ONLY_DML_PATTERN` already accepts `WHERE id = ?` on exactly the reasoning that a complete key names at most one row and the caller had to hold that row's identity to write it.

Every way of being unsure is a rejection, so the rule can only narrow what is reported, never widen it:

| Shape | Result |
|---|---|
| WHERE is exactly the metamodel's key | allowed |
| table unknown to the metamodel (e.g. before `ApplicationReadyEvent`) | reported |
| a conjunct that is not `column = ?` (subquery, literal, function) | reported |
| an `OR` anywhere | reported |
| the same column twice | reported |
| any column set that is not exactly the key | reported |

`version = ?` is tolerated as Hibernate's optimistic lock — unless the table genuinely keys on a column of that name, in which case it counts as the key column it is.

**Two things a reviewer should look at deliberately:**

1. With a real metamodel, `UPDATE issue_label SET label_id=? WHERE issue_id=? AND label_id=?` is now allowed by this new rule. `joinTableAllowanceIsDeleteByBothKeysAndNothingElse` still passes (it stubs no key), and that test's subject — the narrowness of the join-table rule — is unchanged. But the overall behaviour for that statement does change, by the same full-key reasoning.
2. Pre-existing and **not** touched here: `KEY_EQUALS_PARAMETER` accepts any `*_id = ?` column, not only a key one, so `WHERE repository_id = ?` alone was already allowed before this change. That is deliberate — it is how Hibernate's cascade-delete-by-parent-FK passes — but it is worth knowing it is a separate, looser rule sitting next to this one.

## Also here

The reconciler reported a host awaiting its first promotion as an unhandled error, so a new self-hosted instance's first journal line was a Node stack trace rather than the sentence naming the environment and the workflow that publishes it. The message already existed; it now exits non-zero with the sentence alone, and unexpected failures keep their stack.

## Verification

- **7225** server unit tests (with coverage floors) and **303** architecture tests, including `MultiTenancyArchitectureTest` and `DataIsolationArchitectureTest`.
- A new **integration test against the real metamodel** — not a stub — asserts that `repository_collaborator`'s key is `{repository_id, user_id}`, that the exact SQL from the production log is allowed, and that a non-key predicate on the same table is still reported.
- 5 new unit tests covering each rejection row in the table above.
- A new reconciler test drives the real entry point for an unpromoted channel and asserts the output carries the reason and **no** stack frames.
- `vp run check` green.