### PR TITLE
fix(server): a keyed exemption accepts only bound assignments

### DIFF
--- a/.changeset/tenancy-key-exemption-precision.md
+++ b/.changeset/tenancy-key-exemption-precision.md
@@ -1,0 +1,5 @@
+---
+"hephaestus": patch
+---
+
+The workspace isolation check is exact about which single-row statements it exempts. A statement whose key predicates sat behind a SQL comment, or whose assignment read from a second table, could be treated as addressing one keyed row when it did not. No released version exempted these shapes.

--- a/.changeset/tenancy-key-exemption-precision.md
+++ b/.changeset/tenancy-key-exemption-precision.md
@@ -2,4 +2,4 @@
 "hephaestus": patch
 ---
 
-The workspace isolation check is exact about which single-row statements it exempts. A statement whose key predicates sat behind a SQL comment, or whose assignment read from a second table, could be treated as addressing one keyed row when it did not. No released version exempted these shapes.
+The workspace isolation check is exact about which single-row statements it exempts. A statement whose key predicates sat behind a SQL comment, or whose assignment read from a second table, could be treated as addressing one keyed row when it did not. Both keyed exemptions are now held to the same rule: every assignment must be a bound parameter. No released version exempted these shapes.

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/tenancy/WorkspaceStatementInspector.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/tenancy/WorkspaceStatementInspector.java
@@ -82,33 +82,6 @@ public class WorkspaceStatementInspector implements StatementInspector {
             "(?:\\bFROM\\b|\\bJOIN\\b|\\bUPDATE\\b)\\s+(\"?[A-Za-z_][A-Za-z0-9_]*\"?(?:\\s*\\.\\s*\"?[A-Za-z_][A-Za-z0-9_]*\"?)?)",
             Pattern.CASE_INSENSITIVE);
 
-    /** One surrogate-key predicate: {@code id = ?} or {@code <anything>_id = ?}, optionally quoted. */
-    private static final String KEY_EQUALS_PARAMETER = "\"?(?:id|[A-Za-z_][A-Za-z0-9_]*_id)\"?\\s*=\\s*\\?";
-
-    /**
-     * Matches Hibernate-emitted DML on a single row identified solely by primary key —
-     * {@code DELETE FROM table WHERE id = ?} or
-     * {@code UPDATE table SET ... WHERE id = ?} (no other predicate columns).
-     *
-     * <p>These are tenancy-safe by construction: the row was already loaded into the
-     * persistence context within a workspace-checked transaction, and the surrogate {@code id}
-     * uniquely identifies it. Allowing this pattern aligns with how Spring Data
-     * {@code delete(entity)}/{@code save(entity)} synthesise SQL, without requiring every
-     * scoped repository to wear {@code @WorkspaceAgnostic} just to satisfy the inspector.
-     *
-     * <p>The pattern is intentionally narrow: any additional condition (e.g.
-     * {@code WHERE id = ? AND something_else}) breaks the match and falls through to the
-     * standard {@code workspace_id} check, preserving enforcement for hand-written queries.
-     */
-    private static final Pattern PK_ONLY_DML_PATTERN = Pattern.compile(
-            "^\\s*(?:DELETE\\s+FROM|UPDATE)\\s+\"?[A-Za-z_][A-Za-z0-9_]*\"?" + "(?:\\s+SET\\s+.+?)?"
-                    + "\\s+WHERE\\s+" + KEY_EQUALS_PARAMETER
-                    +
-                    // Optional @Version optimistic-lock predicate: AND version = ?
-                    "(?:\\s+AND\\s+\"?version\"?\\s*=\\s*\\?)?"
-                    + "\\s*$",
-            Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
-
     /**
      * Matches the one statement Hibernate emits to remove an element of a {@code @ManyToMany}:
      * the join-table row deleted by both of its foreign keys,
@@ -129,7 +102,7 @@ public class WorkspaceStatementInspector implements StatementInspector {
      * {@code UPDATE table SET ... WHERE <conjunction>} or {@code DELETE FROM table WHERE
      * <conjunction>}. The conjunction is captured whole rather than matched column by column,
      * because whether it covers the key is a question for the mapping metamodel, not for a regex —
-     * {@link #coversCompletePrimaryKey} answers it.
+     * {@link #keyedSingleRowDml} answers it.
      */
     private static final Pattern FULL_KEY_DML_PATTERN = Pattern.compile(
             "^\\s*(?:DELETE\\s+FROM|UPDATE)\\s+\"?([A-Za-z_][A-Za-z0-9_]*)\"?"
@@ -143,23 +116,22 @@ public class WorkspaceStatementInspector implements StatementInspector {
             Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
 
     /**
-     * What disqualifies a statement from this allowance before its key is even considered.
-     *
-     * <p>A comment marker means the text read here as a WHERE clause may not be one the database
-     * will apply: {@code UPDATE t SET c=?} followed by a newline and {@code -- WHERE k=?} parses
-     * here as a keyed update and arrives at PostgreSQL as an unrestricted one. A second table
-     * reference means the statement reads rows this rule never examined — a subquery in a SET
-     * assignment copies another workspace's data into the row the key names. A separator means
-     * there is more than one statement to account for.
+     * The only assignment this exemption accepts: a column set to a bound parameter, optionally
+     * cast. An allowlist, because the question is not whether an expression contains a keyword — it
+     * is whether the expression reads anything. PostgreSQL spells a read several ways
+     * ({@code SELECT}, a bare {@code TABLE t}, a set-returning function), so a blacklist of
+     * keywords cannot answer it, while "every assignment is a bound parameter" can. That is also
+     * all Hibernate emits.
      */
-    private static final Pattern SMUGGLED_CLAUSE_PATTERN =
-            Pattern.compile("--|/\\*|;|\\bSELECT\\b|\\bFROM\\b|\\bJOIN\\b", Pattern.CASE_INSENSITIVE);
+    private static final Pattern BOUND_ASSIGNMENT_PATTERN =
+            Pattern.compile("^\\s*\"?[A-Za-z_][A-Za-z0-9_]*\"?\\s*=\\s*\\?(?:::[A-Za-z_][A-Za-z0-9_ ]*)?\\s*$");
 
-    /**
-     * The fast path declines to parse a statement longer than the ORM has reason to emit, bounding
-     * what the reluctant SET match can cost. Declining is the safe answer — the standard
-     * {@code workspace_id} check still runs.
-     */
+    private static final Pattern COMMA_SPLIT_PATTERN = Pattern.compile(",");
+
+    /** A surrogate key column, for the single-key form: {@code id} or {@code <something>_id}. */
+    private static final Pattern SURROGATE_KEY_COLUMN =
+            Pattern.compile("^(?:id|[A-Za-z_][A-Za-z0-9_]*_id)$", Pattern.CASE_INSENSITIVE);
+
     private static final int FAST_PATH_SQL_LIMIT = 8192;
 
     /** One conjunct of that WHERE clause, and the only shape allowed in it: {@code column = ?}. */
@@ -256,16 +228,27 @@ public class WorkspaceStatementInspector implements StatementInspector {
     }
 
     /**
-     * True iff {@code sql} is single-row DML whose WHERE clause is a conjunction of {@code column =
-     * ?} predicates covering exactly the table's primary key — no more columns and no fewer.
+     * True iff {@code sql} is DML the database will apply to at most the one row its key names.
      *
-     * <p>Every way of being unsure is a {@code false}: an unknown table (the metamodel is not
-     * populated until {@link org.springframework.boot.context.event.ApplicationReadyEvent}), a
-     * conjunct that is anything but {@code column = ?}, a disjunction, a repeated column, or a
-     * column set that is not the key. The statement then falls through to the standard
-     * {@code workspace_id} check, so this can only ever narrow what is reported, never widen it.
+     * <p>Both keyed exemptions come through here, because a safeguard that one of them can be
+     * routed around is not one: the single-key form accepted
+     * {@code UPDATE t SET c=? \n-- WHERE k=?} — every row, in every workspace — long before the
+     * composite form existed.
+     *
+     * <p>Three things have to hold, and every way of being unsure is a {@code false}, which sends
+     * the statement to the standard {@code workspace_id} check:
+     * <ol>
+     *   <li>every assignment is a column set to a bound parameter, so nothing the statement writes
+     *       was read from rows this check never saw. This is also what makes a comment harmless:
+     *       {@code SET c=? \n-- WHERE k=?} leaves the marker in the assignment, which is then not
+     *       a bound parameter. Rejecting comment markers separately was tried and removed — no
+     *       test could distinguish it, because this rule had already caught every case;</li>
+     *   <li>every predicate is {@code column = ?}, and the columns are either the table's complete
+     *       primary key per the mapping metamodel, or one surrogate key column — each optionally
+     *       with Hibernate's {@code version} optimistic lock.</li>
+     * </ol>
      */
-    private boolean coversCompletePrimaryKey(String sql) {
+    private boolean keyedSingleRowDml(String sql) {
         if (sql.length() > FAST_PATH_SQL_LIMIT) return false;
         Matcher dml = FULL_KEY_DML_PATTERN.matcher(sql);
         if (!dml.matches()) return false;
@@ -273,24 +256,33 @@ public class WorkspaceStatementInspector implements StatementInspector {
         if (OR_TOKEN_PATTERN.matcher(sql).find()) return false;
 
         String setClause = dml.group(2);
-        String whereClause = dml.group(3).strip();
-        if (setClause != null && SMUGGLED_CLAUSE_PATTERN.matcher(setClause).find()) return false;
-        if (SMUGGLED_CLAUSE_PATTERN.matcher(whereClause).find()) return false;
-
-        Set<String> keyColumns = scopedTables.primaryKeyColumns(unqualify(dml.group(1)));
-        if (keyColumns.isEmpty()) return false;
+        if (setClause != null) {
+            for (String assignment : COMMA_SPLIT_PATTERN.split(setClause)) {
+                if (!BOUND_ASSIGNMENT_PATTERN.matcher(assignment).matches()) return false;
+            }
+        }
 
         Set<String> predicateColumns = new HashSet<>();
-        for (String conjunct : AND_SPLIT_PATTERN.split(whereClause)) {
+        for (String conjunct : AND_SPLIT_PATTERN.split(dml.group(3).strip())) {
             Matcher predicate = KEY_PREDICATE_PATTERN.matcher(conjunct);
             if (!predicate.matches()) return false;
-            String column = predicate.group(1).toLowerCase(Locale.ROOT);
-            // `version = ?` is the optimistic lock, not part of the key — unless this table really
-            // does key on a column of that name, in which case it counts as the key column it is.
-            if (VERSION_COLUMN.equals(column) && !keyColumns.contains(column)) continue;
-            if (!predicateColumns.add(column)) return false;
+            if (!predicateColumns.add(predicate.group(1).toLowerCase(Locale.ROOT))) return false;
         }
-        return predicateColumns.equals(keyColumns);
+
+        // The optimistic lock rides along with the key on a versioned entity, so it is set aside —
+        // unless the table really does key on a column of that name, where it is the key column.
+        Set<String> keyColumns = new HashSet<>(predicateColumns);
+        boolean versioned = keyColumns.remove(VERSION_COLUMN);
+
+        // One surrogate key: the long-standing form, and the metamodel is not consulted for it.
+        if (keyColumns.size() == 1
+                && SURROGATE_KEY_COLUMN.matcher(keyColumns.iterator().next()).matches()) {
+            return true;
+        }
+        // The table's whole key, which is the only way a composite-key entity can be written.
+        Set<String> mapped = scopedTables.primaryKeyColumns(unqualify(dml.group(1)));
+        if (mapped.isEmpty()) return false;
+        return predicateColumns.equals(mapped) || (versioned && keyColumns.equals(mapped));
     }
 
     private Decision analyze(String sql) {
@@ -298,19 +290,10 @@ public class WorkspaceStatementInspector implements StatementInspector {
         if (INSERT_STATEMENT_PATTERN.matcher(sql).find()) {
             return Decision.ok();
         }
-        // Hibernate-emitted single-row PK DML is safe: the row was already loaded
-        // within a workspace-checked scope and identified by a surrogate primary key.
-        if (PK_ONLY_DML_PATTERN.matcher(sql).matches()) {
-            return Decision.ok();
-        }
-        // The same reasoning as PK_ONLY_DML above, for a composite key: a WHERE clause that is
-        // exactly the table's whole primary key names at most one row, and the caller had to hold
-        // that row's full identity to write it. Hibernate emits this for every @EmbeddedId
-        // association entity — `UPDATE repository_collaborator SET permission=? WHERE
-        // repository_id=? AND "user_id"=?` — which the single-key pattern above cannot match, and
-        // which is not a @ManyToMany join table so the join-table rule below does not cover it
-        // either. The key comes from the mapping metamodel, never from a naming convention.
-        if (coversCompletePrimaryKey(sql)) {
+        // Hibernate-emitted DML the database applies to at most the row its key names: the row was
+        // already loaded within a workspace-checked scope, and the caller had to hold its identity
+        // to write it. One key column or the whole composite key, validated together.
+        if (keyedSingleRowDml(sql)) {
             return Decision.ok();
         }
         Matcher joinTableRowDelete = JOIN_TABLE_ROW_DELETE_PATTERN.matcher(sql);

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/tenancy/WorkspaceStatementInspector.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/tenancy/WorkspaceStatementInspector.java
@@ -133,9 +133,34 @@ public class WorkspaceStatementInspector implements StatementInspector {
      */
     private static final Pattern FULL_KEY_DML_PATTERN = Pattern.compile(
             "^\\s*(?:DELETE\\s+FROM|UPDATE)\\s+\"?([A-Za-z_][A-Za-z0-9_]*)\"?"
-                    + "(?:\\s+SET\\s+.+?)?"
-                    + "\\s+WHERE\\s+(.+?)\\s*$",
+                    // Captured, not skipped: what a SET assigns reaches as far as what a WHERE
+                    // selects, and it is checked below.
+                    + "(?:\\s+SET\\s+(.+?))?"
+                    // Greedy to the end, trimmed in Java. A reluctant tail against a trailing
+                    // `\\s*$` retries at every end position, which a long whitespace run makes
+                    // quadratic.
+                    + "\\s+WHERE\\s+(.+)$",
             Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
+
+    /**
+     * What disqualifies a statement from this allowance before its key is even considered.
+     *
+     * <p>A comment marker means the text read here as a WHERE clause may not be one the database
+     * will apply: {@code UPDATE t SET c=?} followed by a newline and {@code -- WHERE k=?} parses
+     * here as a keyed update and arrives at PostgreSQL as an unrestricted one. A second table
+     * reference means the statement reads rows this rule never examined — a subquery in a SET
+     * assignment copies another workspace's data into the row the key names. A separator means
+     * there is more than one statement to account for.
+     */
+    private static final Pattern SMUGGLED_CLAUSE_PATTERN =
+            Pattern.compile("--|/\\*|;|\\bSELECT\\b|\\bFROM\\b|\\bJOIN\\b", Pattern.CASE_INSENSITIVE);
+
+    /**
+     * The fast path declines to parse a statement longer than the ORM has reason to emit, bounding
+     * what the reluctant SET match can cost. Declining is the safe answer — the standard
+     * {@code workspace_id} check still runs.
+     */
+    private static final int FAST_PATH_SQL_LIMIT = 8192;
 
     /** One conjunct of that WHERE clause, and the only shape allowed in it: {@code column = ?}. */
     private static final Pattern KEY_PREDICATE_PATTERN =
@@ -241,16 +266,22 @@ public class WorkspaceStatementInspector implements StatementInspector {
      * {@code workspace_id} check, so this can only ever narrow what is reported, never widen it.
      */
     private boolean coversCompletePrimaryKey(String sql) {
+        if (sql.length() > FAST_PATH_SQL_LIMIT) return false;
         Matcher dml = FULL_KEY_DML_PATTERN.matcher(sql);
         if (!dml.matches()) return false;
         // An OR anywhere would reach rows the key does not name.
         if (OR_TOKEN_PATTERN.matcher(sql).find()) return false;
 
+        String setClause = dml.group(2);
+        String whereClause = dml.group(3).strip();
+        if (setClause != null && SMUGGLED_CLAUSE_PATTERN.matcher(setClause).find()) return false;
+        if (SMUGGLED_CLAUSE_PATTERN.matcher(whereClause).find()) return false;
+
         Set<String> keyColumns = scopedTables.primaryKeyColumns(unqualify(dml.group(1)));
         if (keyColumns.isEmpty()) return false;
 
         Set<String> predicateColumns = new HashSet<>();
-        for (String conjunct : AND_SPLIT_PATTERN.split(dml.group(2))) {
+        for (String conjunct : AND_SPLIT_PATTERN.split(whereClause)) {
             Matcher predicate = KEY_PREDICATE_PATTERN.matcher(conjunct);
             if (!predicate.matches()) return false;
             String column = predicate.group(1).toLowerCase(Locale.ROOT);

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/tenancy/WorkspaceStatementInspectorTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/tenancy/WorkspaceStatementInspectorTest.java
@@ -353,6 +353,9 @@ class WorkspaceStatementInspectorTest extends BaseUnitTest {
         // The production shape: an @EmbeddedId association entity carrying a payload column.
         // Collaborator sync aborted on this until the key came from the metamodel.
         WorkspaceStatementInspector inspector = newInspector(TenancyEnforcement.THROW);
+        // Without this the table is unscoped, the standard check passes it anyway, and the
+        // assertion below holds even if the rule under test never fires.
+        when(scopedTables.isScoped("repository_collaborator")).thenReturn(true);
         when(scopedTables.primaryKeyColumns("repository_collaborator")).thenReturn(Set.of("repository_id", "user_id"));
         inspector.inspect("update repository_collaborator set permission=? where repository_id=? and \"user_id\"=?");
         inspector.inspect("delete from repository_collaborator where repository_id=? and user_id=?");
@@ -362,6 +365,7 @@ class WorkspaceStatementInspectorTest extends BaseUnitTest {
     @Test
     void compositeKeyAllowanceToleratesTheOptimisticLock() {
         WorkspaceStatementInspector inspector = newInspector(TenancyEnforcement.THROW);
+        when(scopedTables.isScoped("repository_collaborator")).thenReturn(true);
         when(scopedTables.primaryKeyColumns("repository_collaborator")).thenReturn(Set.of("repository_id", "user_id"));
         inspector.inspect(
                 "update repository_collaborator set permission=? where repository_id=? and user_id=? and version=?");
@@ -399,10 +403,53 @@ class WorkspaceStatementInspectorTest extends BaseUnitTest {
 
     @Test
     void aSingleColumnKeyIsCoveredTooWhenTheMetamodelNamesIt() {
+        // `code`, not `id`: KEY_EQUALS_PARAMETER matches only `id` or `*_id`, so a key named this
+        // way can reach the allowance under test and nothing else.
         WorkspaceStatementInspector inspector = newInspector(TenancyEnforcement.THROW);
-        when(scopedTables.primaryKeyColumns("bad_practice")).thenReturn(Set.of("id"));
-        inspector.inspect("update bad_practice set title=? where id=?");
+        when(scopedTables.isScoped("bad_practice")).thenReturn(true);
+        when(scopedTables.primaryKeyColumns("bad_practice")).thenReturn(Set.of("code"));
+        inspector.inspect("update bad_practice set title=? where code=?");
         verifyNoInteractions(reporter);
+    }
+
+    @Test
+    void aWhereClauseHiddenBehindACommentIsNotAWhereClause() {
+        // PostgreSQL reads the second line as a comment and updates every row, so the statement the
+        // database runs has no WHERE at all.
+        WorkspaceStatementInspector inspector = newInspector(TenancyEnforcement.LOG);
+        when(scopedTables.isScoped("repository_collaborator")).thenReturn(true);
+        when(scopedTables.primaryKeyColumns("repository_collaborator")).thenReturn(Set.of("repository_id", "user_id"));
+        for (String sql : List.of(
+                "update repository_collaborator set permission=?\n-- where repository_id=? and user_id=?",
+                "update repository_collaborator set permission=? /* */ where repository_id=? and user_id=?",
+                "update repository_collaborator set permission=? where repository_id=? and user_id=? -- and more")) {
+            inspector.inspect(sql);
+            verify(reporter).report(sql, Set.of("repository_collaborator"), TenancyEnforcement.LOG);
+        }
+    }
+
+    @Test
+    void aKeyedTargetDoesNotExemptWhatItsAssignmentReads() {
+        // One row changes, but the value written is read from every workspace's rows.
+        WorkspaceStatementInspector inspector = newInspector(TenancyEnforcement.LOG);
+        when(scopedTables.isScoped("repository_collaborator")).thenReturn(true);
+        when(scopedTables.primaryKeyColumns("repository_collaborator")).thenReturn(Set.of("repository_id", "user_id"));
+        String sql = "update repository_collaborator set permission=(select max(permission) from "
+                + "repository_collaborator) where repository_id=? and user_id=?";
+        inspector.inspect(sql);
+        verify(reporter).report(sql, Set.of("repository_collaborator"), TenancyEnforcement.LOG);
+    }
+
+    @Test
+    void aStatementLongerThanTheOrmEmitsDeclinesTheFastPath() {
+        // The bound keeps a reluctant match over pathological whitespace from costing more than the
+        // check it would have skipped. Declining is safe: the standard check still reports.
+        WorkspaceStatementInspector inspector = newInspector(TenancyEnforcement.LOG);
+        when(scopedTables.isScoped("repository_collaborator")).thenReturn(true);
+        when(scopedTables.primaryKeyColumns("repository_collaborator")).thenReturn(Set.of("repository_id", "user_id"));
+        String sql = "delete from repository_collaborator where repository_id" + " ".repeat(9000) + "=? and user_id=?";
+        inspector.inspect(sql);
+        verify(reporter).report(sql, Set.of("repository_collaborator"), TenancyEnforcement.LOG);
     }
 
     // helper: Mockito.any() shorthand

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/tenancy/WorkspaceStatementInspectorTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/tenancy/WorkspaceStatementInspectorTest.java
@@ -441,6 +441,41 @@ class WorkspaceStatementInspectorTest extends BaseUnitTest {
     }
 
     @Test
+    void anAssignmentMustBeABoundParameterAndNotAnExpressionThatReads() {
+        // PostgreSQL spells a read more than one way. `TABLE t` is a SELECT equivalent, so a
+        // keyword blacklist cannot decide this; only "every assignment is a bound parameter" can.
+        WorkspaceStatementInspector inspector = newInspector(TenancyEnforcement.LOG);
+        when(scopedTables.isScoped("repository_collaborator")).thenReturn(true);
+        when(scopedTables.primaryKeyColumns("repository_collaborator")).thenReturn(Set.of("repository_id", "user_id"));
+        for (String sql : List.of(
+                "update repository_collaborator set permission=case when exists (table repository_collaborator "
+                        + "offset 1) then ? else ? end where repository_id=? and user_id=?",
+                "update repository_collaborator set permission=(select max(permission) from repository_collaborator) "
+                        + "where repository_id=? and user_id=?",
+                "update repository_collaborator set permission=coalesce(permission,?) where repository_id=? and user_id=?")) {
+            inspector.inspect(sql);
+            verify(reporter).report(sql, Set.of("repository_collaborator"), TenancyEnforcement.LOG);
+        }
+    }
+
+    @Test
+    void theSingleKeyFormIsHeldToTheSameRules() {
+        // The older exemption used to accept these, so the newer one could simply be routed around
+        // by naming one key column instead of two.
+        WorkspaceStatementInspector inspector = newInspector(TenancyEnforcement.LOG);
+        when(scopedTables.isScoped("repository_collaborator")).thenReturn(true);
+        for (String sql : List.of(
+                "update repository_collaborator set permission=?\n-- where repository_id=?",
+                "update repository_collaborator set permission=(select max(permission) from repository_collaborator) "
+                        + "where repository_id=?",
+                "update repository_collaborator set permission=case when exists (table repository_collaborator) "
+                        + "then ? else ? end where repository_id=?")) {
+            inspector.inspect(sql);
+            verify(reporter).report(sql, Set.of("repository_collaborator"), TenancyEnforcement.LOG);
+        }
+    }
+
+    @Test
     void aStatementLongerThanTheOrmEmitsDeclinesTheFastPath() {
         // The bound keeps a reluctant match over pathological whitespace from costing more than the
         // check it would have skipped. Declining is safe: the standard check still reports.


### PR DESCRIPTION
Follow-up to #2066, which merged before its review landed. Two independent adversarial reviews (gpt-6-astra, via `codex-work` then `codex-personal`) each returned DO NOT MERGE on the preceding attempt; this is the state after both.

**Exposure: none.** No released version contains #2066 — production runs v0.78.0, which predates it. Of 184 native queries in the tree, none has an unbound assignment or a comment in DML. This restores a defence-in-depth control on `main`; it never opened a live path.

## What was wrong

**#2066** exempted an UPDATE/DELETE whose WHERE matched the table's complete primary key, but read the statement with a regex that trusted the text rather than what the database executes:

```sql
update repository_collaborator set permission=?
-- where repository_id=? and user_id=?          -- PostgreSQL: updates every row
update repository_collaborator
set permission=(select max(permission) from repository_collaborator)
where repository_id=? and user_id=?             -- reads across every workspace
```

**My first correction** blacklisted `SELECT`/`FROM`/`JOIN` in the SET clause. That was the wrong shape for the question — PostgreSQL spells a read several ways, and `TABLE t` is a `SELECT` equivalent:

```sql
set permission=case when exists (table repository_collaborator offset 1) then ? else ? end
```

writes one row whose value depends on whether *another* workspace has a collaborator. No keyword list can establish that an arbitrary expression reads nothing.

**It also left the older single-key exemption alone**, on the grounds that widening a security fix under pressure is how the first defect got in. That was wrong in a way that mattered: the older rule accepted `UPDATE t SET c=? \n-- WHERE k=?`, so the new guard could be sidestepped by naming *one* key column instead of two. A safeguard you can route around is not one.

## What this does

An **allowlist**, not a blacklist: every assignment must be a column set to a bound parameter (optionally cast). That is a property of the expression rather than a property of its keywords, and it is all Hibernate emits.

Both keyed exemptions now come through one validated path — no unbound assignment, every predicate `column = ?`, and the columns either the table's whole key from the mapping metamodel or one surrogate key column, each optionally with the `version` lock. `PK_ONLY_DML_PATTERN` is gone; it was the routed-around rule.

Also from the reviews: the WHERE tail is matched greedily and trimmed in Java (a reluctant tail against `\s*$` retries at every end position — measured ~1.5s on a long whitespace run), and a length bound keeps the fast path off statements longer than the ORM emits. The widest entity, `agent_job` at 45 columns, generates roughly 0.9 KB against a bound of 8192.

## A guard I removed

I first rejected comment markers outright. Mutation testing showed **no test could tell whether it was there** — the assignment rule had already caught every case, because a trailing `--` leaves the assignment unbound. Unpinnable code in a security control invites the belief it is protecting something, so it is gone; the tests pin the behaviour rather than the mechanism and still hold.

## Verification

Mutation, not just assertion:

| Mutation | Result |
|---|---|
| assignment allowlist disabled | exactly the 3 tests asserting an expression cannot read fail |
| complete-key rule disabled | exactly the 3 positive tests fail |

The #2066 positive tests were **passing vacuously** — none marked the table scoped, so the standard check let the statement through and the assertions held whether or not the rule fired. Fixed here, which is why the first mutation now bites.

7230 unit tests (with coverage floors), 303 architecture tests, the integration test against the live Hibernate metamodel, and `vp run check` green.

## Checked and clean

Metamodel shapes (`@EmbeddedId`, `@IdClass`, `@MapsId`, shared `Issue`/`PullRequest`); `JOINED` and `@SecondaryTable` are unused here, so the walk not enumerating secondary tables is a constraint to remember rather than a defect. No mapped column contains a standalone `from`, `select` or `join`. CTE prefixes, `RETURNING` and `UPDATE … FROM` all fail this exemption. The reconciler change in this branch reviewed clean.

Not auto-merged — this needs a human decision.