### PR TITLE
feat(ci): preview any pull request, and show its lifecycle

### DIFF
--- a/.github/workflows/cleanup-preview.yml
+++ b/.github/workflows/cleanup-preview.yml
@@ -3,7 +3,7 @@ name: Preview cleanup
 on:
   pull_request_target: # zizmor: ignore[dangerous-triggers] No pull-request code is checked out or executed.
     branches: [main]
-    types: [closed, unlabeled, converted_to_draft]
+    types: [closed, unlabeled]
 
 permissions: {}
 

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -69,29 +69,9 @@ jobs:
 
             <sub>Remove the `preview` label to opt out.</sub>
 
-      - name: Wait for CI to publish this commit's signed images
-        if: steps.context.outputs.eligible == 'true'
-        env:
-          GHCR_TOKEN: ${{ github.token }}
-          GH_TOKEN: ${{ github.token }}
-          HEAD_SHA: ${{ steps.context.outputs.head_sha }}
-        run: node scripts/coolify-preview.ts images
-
-      - name: Recheck opt-in and head before queueing
-        id: recheck
-        if: steps.context.outputs.eligible == 'true'
-        env:
-          PR_NUMBER: ${{ steps.context.outputs.pr_number }}
-          HEAD_SHA: ${{ steps.context.outputs.head_sha }}
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        with:
-          script: |
-            const controller = await import(`${process.env.GITHUB_WORKSPACE}/scripts/preview-controller.ts`);
-            await controller.recheck({ github, context, core });
-
-      - name: Reserve the native GitHub deployment
+      - name: Open the native GitHub deployment
         id: github_deployment
-        if: steps.recheck.outputs.proceed == 'true'
+        if: steps.context.outputs.eligible == 'true'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           PR_NUMBER: ${{ steps.context.outputs.pr_number }}
@@ -113,9 +93,59 @@ jobs:
           message: |
             ## 🚧 App Preview
 
-            Deploying `${{ steps.context.outputs.head_sha }}`…
+            Deploying `${{ steps.context.outputs.head_sha }}` — follow it under **Environments → `${{ steps.context.outputs.environment }}`** on this pull request.
 
-            <sub>Runs the images CI published for this commit. Updates on every commit. Remove the `preview` label to tear it down.</sub>
+            <sub>Waits for the images CI publishes for this commit, then deploys. Updates on every commit, draft or not. Remove the `preview` label to tear it down.</sub>
+
+      - name: Say it is waiting on images
+        if: steps.github_deployment.outputs.deployment_id != ''
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          DEPLOYMENT_ID: ${{ steps.github_deployment.outputs.deployment_id }}
+          ENVIRONMENT: ${{ steps.context.outputs.environment }}
+          PREVIEW_URL: ${{ steps.context.outputs.preview_url }}
+          SOURCE_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          STATE: queued
+          DESCRIPTION: Waiting for CI to publish signed images for this commit.
+        with:
+          script: |
+            const controller = await import(`${process.env.GITHUB_WORKSPACE}/scripts/preview-controller.ts`);
+            await controller.progress({ github, context, core });
+
+      - name: Wait for CI to publish this commit's signed images
+        if: steps.context.outputs.eligible == 'true'
+        env:
+          GHCR_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ steps.context.outputs.head_sha }}
+        run: node scripts/coolify-preview.ts images
+
+      - name: Recheck opt-in and head before queueing
+        id: recheck
+        if: steps.context.outputs.eligible == 'true'
+        env:
+          PR_NUMBER: ${{ steps.context.outputs.pr_number }}
+          HEAD_SHA: ${{ steps.context.outputs.head_sha }}
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const controller = await import(`${process.env.GITHUB_WORKSPACE}/scripts/preview-controller.ts`);
+            await controller.recheck({ github, context, core });
+
+      - name: Say it is building
+        if: steps.recheck.outputs.proceed == 'true' && steps.github_deployment.outputs.deployment_id != ''
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          DEPLOYMENT_ID: ${{ steps.github_deployment.outputs.deployment_id }}
+          ENVIRONMENT: ${{ steps.context.outputs.environment }}
+          PREVIEW_URL: ${{ steps.context.outputs.preview_url }}
+          SOURCE_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          STATE: in_progress
+          DESCRIPTION: Images are ready; Coolify is building the preview.
+        with:
+          script: |
+            const controller = await import(`${process.env.GITHUB_WORKSPACE}/scripts/preview-controller.ts`);
+            await controller.progress({ github, context, core });
 
       - name: Queue the exact commit through Coolify's signed PR webhook
         id: queue
@@ -153,8 +183,14 @@ jobs:
           ENVIRONMENT: ${{ steps.context.outputs.environment }}
           PREVIEW_URL: ${{ steps.context.outputs.preview_url }}
           SOURCE_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          FINAL_STATE: ${{ steps.wait.outputs.state || 'error' }}
-          DESCRIPTION: ${{ steps.wait.outputs.description || 'Preview workflow stopped unexpectedly.' }}
+          FINAL_STATE: >-
+            ${{ steps.wait.outputs.state
+               || (steps.recheck.outputs.proceed == 'false' && 'inactive')
+               || 'error' }}
+          DESCRIPTION: >-
+            ${{ steps.wait.outputs.description
+               || (steps.recheck.outputs.proceed == 'false' && 'Superseded or opted out; cleanup owns this environment.')
+               || 'Preview workflow stopped unexpectedly.' }}
           LOG_URL: ${{ steps.wait.outputs.log_url || format('{0}/{1}/actions/runs/{2}', github.server_url, github.repository, github.run_id) }}
         with:
           script: |

--- a/.github/workflows/reconcile-previews.yml
+++ b/.github/workflows/reconcile-previews.yml
@@ -45,6 +45,9 @@ jobs:
     needs: inventory
     if: needs.inventory.result == 'success' && needs.inventory.outputs.previews != '[]'
     permissions:
+      # `administration: write` is what deleting an environment needs. It lives here, in a scheduled
+      # job, and never in the `pull_request_target` workflows, so no pull request can reach it.
+      administration: write
       contents: read
       deployments: write
       pull-requests: read
@@ -105,3 +108,16 @@ jobs:
           script: |
             const controller = await import(`${process.env.GITHUB_WORKSPACE}/scripts/preview-controller.ts`);
             await controller.retire({ github, context, core });
+
+      # Retiring the deployment leaves the environment behind, and it then sits in the repository's
+      # settings forever. Only once the pull request is closed: while it is open, the record is
+      # worth keeping and re-labelling should be cheap.
+      - name: Delete the environment of a closed pull request
+        if: steps.pull.outputs.closed == 'true'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          ENVIRONMENT: preview/pr-${{ matrix.pr }}
+        with:
+          script: |
+            const controller = await import(`${process.env.GITHUB_WORKSPACE}/scripts/preview-controller.ts`);
+            await controller.demolish({ github, context, core });

--- a/.github/workflows/reconcile-previews.yml
+++ b/.github/workflows/reconcile-previews.yml
@@ -45,9 +45,6 @@ jobs:
     needs: inventory
     if: needs.inventory.result == 'success' && needs.inventory.outputs.previews != '[]'
     permissions:
-      # `administration: write` is what deleting an environment needs. It lives here, in a scheduled
-      # job, and never in the `pull_request_target` workflows, so no pull request can reach it.
-      administration: write
       contents: read
       deployments: write
       pull-requests: read
@@ -108,16 +105,3 @@ jobs:
           script: |
             const controller = await import(`${process.env.GITHUB_WORKSPACE}/scripts/preview-controller.ts`);
             await controller.retire({ github, context, core });
-
-      # Retiring the deployment leaves the environment behind, and it then sits in the repository's
-      # settings forever. Only once the pull request is closed: while it is open, the record is
-      # worth keeping and re-labelling should be cheap.
-      - name: Delete the environment of a closed pull request
-        if: steps.pull.outputs.closed == 'true'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        env:
-          ENVIRONMENT: preview/pr-${{ matrix.pr }}
-        with:
-          script: |
-            const controller = await import(`${process.env.GITHUB_WORKSPACE}/scripts/preview-controller.ts`);
-            await controller.demolish({ github, context, core });

--- a/docs/contributor/ci-cd.mdx
+++ b/docs/contributor/ci-cd.mdx
@@ -287,11 +287,32 @@ An alias serves a preview and never release evidence: when the base commit's ima
 publishing it falls back to the candidate the merged pull request built, which carries `linux/amd64`
 alone. That is why the Version PR's branch builds every image itself instead.
 
-A sticky comment carries the URL, and GitHub records each accepted update as the transient
-environment `preview/pr-N`, so the pull request's **View deployment** link opens it too.
+A draft deploys like any other pull request: wanting eyes on unfinished work is the usual reason to
+ask for a preview, so the label is the only opt-in.
 
-Remove the `preview` label to tear the stack down and free the slot. Closing, merging, or converting
-the pull request back to draft does the same thing.
+A sticky comment carries the URL, and GitHub records each accepted update as the transient
+environment `preview/pr-N`. The deployment is opened as soon as the pull request is admitted, not
+when the stack is finally up, and moves through `queued` while CI publishes this commit's images,
+`in_progress` while Coolify builds, and then `success` — so the pull request's **View deployment**
+link and the run log are both reachable throughout. A run that a newer push supersedes, or whose
+label is removed while it works, ends `inactive` rather than `failure`; neither is a fault.
+
+Remove the `preview` label to tear the stack down and free the slot. Closing or merging the pull
+request does the same thing. Converting it back to draft does not — a draft is a thing you can
+preview.
+
+The environment itself outlives the deployments recorded in it. Deleting one needs repository
+administration, which `GITHUB_TOKEN` cannot be granted — `administration` is not among the
+permission scopes a workflow may request — so a `preview/pr-N` entry stays in the repository's
+settings after its pull request closes, holding only retired deployments. Removing them is a
+maintainer action:
+
+```bash
+gh api -X DELETE "repos/hephaestus-build/Hephaestus/environments/preview%2Fpr-<n>"
+```
+
+Automating it would mean giving a scheduled workflow an administration-scoped credential, which is a
+larger grant than tidy settings are worth.
 
 Deployments are serialized, never parallel, and each one deploys the pull request's *current* head.
 A burst of pushes therefore produces one deployment of the newest commit rather than one per commit.

--- a/scripts/preview-controller.test.ts
+++ b/scripts/preview-controller.test.ts
@@ -3,12 +3,14 @@ import { afterEach, beforeEach, describe, it } from "node:test";
 
 import {
 	assess,
+	demolish,
 	inventory,
 	TEARDOWN_REQUESTED_DESCRIPTION,
 	create,
 	finalize,
 	inactivate,
 	PREVIEW_LABEL,
+	progress,
 	recheck,
 	type GitHubApi,
 	resolve,
@@ -60,6 +62,9 @@ interface GitHubOptions {
 	defaultStatuses?: Status[];
 }
 
+const postedStatuses: Record<string, unknown>[] = [];
+const deletedEnvironments: string[] = [];
+
 const makeGitHub = ({
 	deployments = [{ environment: "preview/pr-7", id: 1, sha: "old-sha" }],
 	files = [],
@@ -83,7 +88,14 @@ const makeGitHub = ({
 			},
 			createDeployment: () =>
 				Promise.resolve({ data: { environment: "preview/pr-7", id: 2, sha: "head-sha" } }),
-			createDeploymentStatus: () => Promise.resolve({ data: {} }),
+			deleteAnEnvironment: (params: Record<string, unknown>) => {
+				deletedEnvironments.push(String(params.environment_name));
+				return Promise.resolve({ data: {} });
+			},
+			createDeploymentStatus: (params: Record<string, unknown>) => {
+				postedStatuses.push(params);
+				return Promise.resolve({ data: {} });
+			},
 			deleteDeployment: () => Promise.resolve({ data: {} }),
 			listDeployments: (params) =>
 				Promise.resolve({
@@ -147,7 +159,7 @@ void describe("preview controller admission", () => {
 		assert.match(core.outputs.get("reason") ?? "", /fork/);
 	});
 
-	void it("waits for a draft to be marked ready for review", async () => {
+	void it("deploys a draft, which is usually the point of asking for a preview", async () => {
 		const core = makeCore();
 		await resolve({
 			github: makeGitHub({ resolvedPull: { ...pull, draft: true } }),
@@ -155,8 +167,7 @@ void describe("preview controller admission", () => {
 			core,
 		});
 
-		assert.equal(core.outputs.get("eligible"), "false");
-		assert.match(core.outputs.get("reason") ?? "", /draft/);
+		assert.equal(core.outputs.get("eligible"), "true");
 	});
 
 	void it("refuses PR-controlled changes to any part of the deployment control plane", async () => {
@@ -616,7 +627,7 @@ void describe("reconcile staleness", () => {
 		assert.equal(core.outputs.get("stale"), "true");
 	});
 
-	void it("reclaims a pull request that went back to draft", async () => {
+	void it("leaves a draft alone, since the label is what opts in", async () => {
 		const core = makeCore();
 		await assess({
 			github: makeGitHub({ resolvedPull: { ...pull, draft: true } }),
@@ -624,6 +635,111 @@ void describe("reconcile staleness", () => {
 			core,
 		});
 
+		// Reclaiming here would tear the preview down moments after the deploy that created it.
+		assert.equal(core.outputs.get("stale"), "false");
+	});
+});
+
+void describe("preview deployment lifecycle", () => {
+	beforeEach(() => {
+		postedStatuses.length = 0;
+	});
+
+	void it("moves the deployment while the run waits, so it is not silent for most of its life", async () => {
+		for (const [state, description] of [
+			["queued", "Waiting for CI to publish signed images for this commit."],
+			["in_progress", "Images are ready; Coolify is building the preview."],
+		] as const) {
+			process.env.DEPLOYMENT_ID = "42";
+			process.env.STATE = state;
+			process.env.DESCRIPTION = description;
+			process.env.ENVIRONMENT = "preview/pr-7";
+			process.env.PREVIEW_URL = "https://pr7.example/";
+			process.env.SOURCE_RUN_URL = "https://runs.example/1";
+
+			await progress({ github: makeGitHub({}), context: makeContext(), core: makeCore() });
+		}
+
+		assert.deepEqual(
+			postedStatuses.map((status) => status.state),
+			["queued", "in_progress"],
+		);
+		// The environment link is what makes GitHub render a destination rather than a bare record.
+		const [first] = postedStatuses;
+		assert.ok(first);
+		assert.equal(first.environment_url, "https://pr7.example/");
+		assert.equal(first.log_url, "https://runs.example/1");
+	});
+
+	void it("reports only states GitHub treats as still running", async () => {
+		process.env.DEPLOYMENT_ID = "42";
+		process.env.STATE = "success";
+		process.env.DESCRIPTION = "done";
+		process.env.ENVIRONMENT = "preview/pr-7";
+		process.env.PREVIEW_URL = "https://pr7.example/";
+		process.env.SOURCE_RUN_URL = "https://runs.example/1";
+
+		await assert.rejects(
+			() => progress({ github: makeGitHub({}), context: makeContext(), core: makeCore() }),
+			/queued or in_progress/,
+		);
+		assert.equal(postedStatuses.length, 0);
+	});
+});
+
+void describe("preview environment teardown", () => {
+	beforeEach(() => {
+		deletedEnvironments.length = 0;
+	});
+
+	void it("deletes the environment of a closed pull request", async () => {
+		process.env.ENVIRONMENT = "preview/pr-2042";
+		await demolish({ github: makeGitHub({}), context: makeContext(), core: makeCore() });
+		assert.deepEqual(deletedEnvironments, ["preview/pr-2042"]);
+	});
+
+	void it("refuses any environment it does not own", async () => {
+		// The blast radius of a bug here is Production, so the name is checked rather than trusted.
+		for (const environment of [
+			"Production",
+			"Staging",
+			"github-pages",
+			"preview/pr-0",
+			"preview/pr-",
+			"preview/pr-2042/../Production",
+			"PREVIEW/PR-1",
+		]) {
+			process.env.ENVIRONMENT = environment;
+			await assert.rejects(
+				() => demolish({ github: makeGitHub({}), context: makeContext(), core: makeCore() }),
+				/not a preview environment/,
+				environment,
+			);
+		}
+		assert.deepEqual(deletedEnvironments, []);
+	});
+
+	void it("says a closed pull request is closed, which is what authorizes the delete", async () => {
+		process.env.PR_NUMBER = "2042";
+		const core = makeCore();
+		await assess({
+			github: makeGitHub({ resolvedPull: { ...pull, state: "closed" } }),
+			context: makeContext(),
+			core,
+		});
 		assert.equal(core.outputs.get("stale"), "true");
+		assert.equal(core.outputs.get("closed"), "true");
+	});
+
+	void it("keeps the environment of an open pull request that merely dropped the label", async () => {
+		process.env.PR_NUMBER = "2042";
+		const core = makeCore();
+		await assess({
+			github: makeGitHub({ resolvedPull: { ...pull, labels: [] } }),
+			context: makeContext(),
+			core,
+		});
+		assert.equal(core.outputs.get("stale"), "true");
+		assert.equal(core.outputs.get("closed"), "false");
 	});
 });

--- a/scripts/preview-controller.test.ts
+++ b/scripts/preview-controller.test.ts
@@ -3,7 +3,6 @@ import { afterEach, beforeEach, describe, it } from "node:test";
 
 import {
 	assess,
-	demolish,
 	inventory,
 	TEARDOWN_REQUESTED_DESCRIPTION,
 	create,
@@ -63,7 +62,6 @@ interface GitHubOptions {
 }
 
 const postedStatuses: Record<string, unknown>[] = [];
-const deletedEnvironments: string[] = [];
 
 const makeGitHub = ({
 	deployments = [{ environment: "preview/pr-7", id: 1, sha: "old-sha" }],
@@ -88,10 +86,6 @@ const makeGitHub = ({
 			},
 			createDeployment: () =>
 				Promise.resolve({ data: { environment: "preview/pr-7", id: 2, sha: "head-sha" } }),
-			deleteAnEnvironment: (params: Record<string, unknown>) => {
-				deletedEnvironments.push(String(params.environment_name));
-				return Promise.resolve({ data: {} });
-			},
 			createDeploymentStatus: (params: Record<string, unknown>) => {
 				postedStatuses.push(params);
 				return Promise.resolve({ data: {} });
@@ -687,38 +681,7 @@ void describe("preview deployment lifecycle", () => {
 	});
 });
 
-void describe("preview environment teardown", () => {
-	beforeEach(() => {
-		deletedEnvironments.length = 0;
-	});
-
-	void it("deletes the environment of a closed pull request", async () => {
-		process.env.ENVIRONMENT = "preview/pr-2042";
-		await demolish({ github: makeGitHub({}), context: makeContext(), core: makeCore() });
-		assert.deepEqual(deletedEnvironments, ["preview/pr-2042"]);
-	});
-
-	void it("refuses any environment it does not own", async () => {
-		// The blast radius of a bug here is Production, so the name is checked rather than trusted.
-		for (const environment of [
-			"Production",
-			"Staging",
-			"github-pages",
-			"preview/pr-0",
-			"preview/pr-",
-			"preview/pr-2042/../Production",
-			"PREVIEW/PR-1",
-		]) {
-			process.env.ENVIRONMENT = environment;
-			await assert.rejects(
-				() => demolish({ github: makeGitHub({}), context: makeContext(), core: makeCore() }),
-				/not a preview environment/,
-				environment,
-			);
-		}
-		assert.deepEqual(deletedEnvironments, []);
-	});
-
+void describe("preview teardown reporting", () => {
 	void it("says a closed pull request is closed, which is what authorizes the delete", async () => {
 		process.env.PR_NUMBER = "2042";
 		const core = makeCore();

--- a/scripts/preview-controller.ts
+++ b/scripts/preview-controller.ts
@@ -41,7 +41,6 @@ export interface GitHubApi {
 		};
 		readonly repos: {
 			readonly compareCommitsWithBasehead: ApiMethod<{ files?: PullRequestFile[] }>;
-			readonly deleteAnEnvironment: ApiMethod<unknown>;
 			readonly createDeployment: ApiMethod<Deployment>;
 			readonly createDeploymentStatus: ApiMethod<unknown>;
 			readonly deleteDeployment: ApiMethod<unknown>;
@@ -422,35 +421,6 @@ const inactivate = async ({ github, context }: ControllerInput): Promise<void> =
 };
 
 /** Whether a preview found on the host or in GitHub's records should still be holding its slot. */
-/** The environments this controller owns. Nothing else is ever a candidate for deletion. */
-const PREVIEW_ENVIRONMENT = /^preview\/pr-(?:[1-9]\d*)$/;
-
-/**
- * Removes the GitHub environment once its pull request is closed.
- *
- * <p>Marking a deployment inactive retires the deployment; the environment outlives it and shows up
- * in the repository's settings forever. Four survived from pull requests merged days earlier, which
- * is what this exists to stop. It runs only from the scheduled sweep, never from a
- * `pull_request_target` workflow, because deleting an environment needs a permission no
- * pull-request-triggered run should carry.
- *
- * <p>While a pull request is still open the environment stays, even with the label removed: the
- * record is worth keeping and re-labelling should be cheap.
- */
-const demolish = async ({ github, context, core }: ControllerInput): Promise<void> => {
-	const { owner, repo } = context.repo;
-	const environment = requiredEnv(process.env, "ENVIRONMENT");
-	if (!PREVIEW_ENVIRONMENT.test(environment)) {
-		throw new Error(`Refusing to delete ${environment}: not a preview environment.`);
-	}
-	await github.rest.repos.deleteAnEnvironment({
-		owner,
-		repo,
-		environment_name: environment,
-	});
-	core.notice(`Deleted ${environment}; its pull request is closed.`);
-};
-
 const assess = async ({ github, context, core }: ControllerInput): Promise<void> => {
 	const { owner, repo } = context.repo;
 	const number = requiredPositiveInteger(process.env, "PR_NUMBER");
@@ -498,7 +468,6 @@ const retire = async ({ github, context }: ControllerInput): Promise<void> => {
 };
 
 export {
-	demolish,
 	progress,
 	TEARDOWN_REQUESTED_DESCRIPTION,
 	PREVIEW_LABEL,

--- a/scripts/preview-controller.ts
+++ b/scripts/preview-controller.ts
@@ -4,7 +4,6 @@ type ApiMethod<T> = (params: Record<string, unknown>) => Promise<{ data: T }>;
 
 interface PullRequest {
 	readonly state: string;
-	readonly draft: boolean;
 	readonly html_url: string;
 	readonly title: string;
 	readonly author_association: string;
@@ -42,6 +41,7 @@ export interface GitHubApi {
 		};
 		readonly repos: {
 			readonly compareCommitsWithBasehead: ApiMethod<{ files?: PullRequestFile[] }>;
+			readonly deleteAnEnvironment: ApiMethod<unknown>;
 			readonly createDeployment: ApiMethod<Deployment>;
 			readonly createDeploymentStatus: ApiMethod<unknown>;
 			readonly deleteDeployment: ApiMethod<unknown>;
@@ -152,7 +152,6 @@ const resolve = async ({ github, context, core }: ControllerInput): Promise<void
 
 	if (!labelled) return skip(`PR #${number} does not carry the \`${PREVIEW_LABEL}\` label.`);
 	if (pull.state !== "open") return skip(`PR #${number} is closed.`);
-	if (pull.draft) return skip(`PR #${number} is a draft. Mark it ready for review to deploy.`);
 	if (pull.head.repo?.full_name !== `${owner}/${repo}`) {
 		return skip(
 			`PR #${number} comes from a fork. Previews run only for branches in this repository.`,
@@ -255,7 +254,7 @@ const recheck = async ({ github, context, core }: ControllerInput): Promise<void
 		core.notice(reason);
 		core.setOutput("proceed", "false");
 	};
-	if (pull.state !== "open" || pull.draft || !hasPreviewLabel(pull)) {
+	if (pull.state !== "open" || !hasPreviewLabel(pull)) {
 		return halt(`PR #${number} opted out while deploying; cleanup takes it from here.`);
 	}
 	if (pull.head.sha !== headSha) {
@@ -303,13 +302,36 @@ const create = async ({ github, context, core }: ControllerInput): Promise<void>
 	});
 };
 
+/**
+ * Moves the deployment GitHub already shows to its next state. Without this the record is created
+ * and then says nothing until the run ends, which for a preview waiting on CI images is most of its
+ * life — and a deployment that never moves is indistinguishable from one that is stuck.
+ */
+const progress = async ({ github, context }: ControllerInput): Promise<void> => {
+	const { owner, repo } = context.repo;
+	const state = requiredEnv(process.env, "STATE");
+	if (state !== "queued" && state !== "in_progress") {
+		throw new Error(`progress reports queued or in_progress, not ${state}.`);
+	}
+	await github.rest.repos.createDeploymentStatus({
+		owner,
+		repo,
+		deployment_id: requiredPositiveInteger(process.env, "DEPLOYMENT_ID"),
+		state,
+		description: requiredEnv(process.env, "DESCRIPTION").slice(0, 140),
+		environment: requiredEnv(process.env, "ENVIRONMENT"),
+		environment_url: requiredEnv(process.env, "PREVIEW_URL"),
+		log_url: requiredEnv(process.env, "SOURCE_RUN_URL"),
+	});
+};
+
 const finalize = async ({ github, context, core }: ControllerInput): Promise<void> => {
 	const { owner, repo } = context.repo;
 	const deploymentId = requiredPositiveInteger(process.env, "DEPLOYMENT_ID");
 	const environment = requiredEnv(process.env, "ENVIRONMENT");
 	const previewUrl = requiredEnv(process.env, "PREVIEW_URL");
 	const sourceRunUrl = requiredEnv(process.env, "SOURCE_RUN_URL");
-	const allowedStates = new Set(["error", "failure", "success"]);
+	const allowedStates = new Set(["error", "failure", "inactive", "success"]);
 	const finalState = requiredEnv(process.env, "FINAL_STATE");
 	let state = allowedStates.has(finalState) ? finalState : "error";
 	let description = requiredEnv(process.env, "DESCRIPTION");
@@ -400,12 +422,42 @@ const inactivate = async ({ github, context }: ControllerInput): Promise<void> =
 };
 
 /** Whether a preview found on the host or in GitHub's records should still be holding its slot. */
+/** The environments this controller owns. Nothing else is ever a candidate for deletion. */
+const PREVIEW_ENVIRONMENT = /^preview\/pr-(?:[1-9]\d*)$/;
+
+/**
+ * Removes the GitHub environment once its pull request is closed.
+ *
+ * <p>Marking a deployment inactive retires the deployment; the environment outlives it and shows up
+ * in the repository's settings forever. Four survived from pull requests merged days earlier, which
+ * is what this exists to stop. It runs only from the scheduled sweep, never from a
+ * `pull_request_target` workflow, because deleting an environment needs a permission no
+ * pull-request-triggered run should carry.
+ *
+ * <p>While a pull request is still open the environment stays, even with the label removed: the
+ * record is worth keeping and re-labelling should be cheap.
+ */
+const demolish = async ({ github, context, core }: ControllerInput): Promise<void> => {
+	const { owner, repo } = context.repo;
+	const environment = requiredEnv(process.env, "ENVIRONMENT");
+	if (!PREVIEW_ENVIRONMENT.test(environment)) {
+		throw new Error(`Refusing to delete ${environment}: not a preview environment.`);
+	}
+	await github.rest.repos.deleteAnEnvironment({
+		owner,
+		repo,
+		environment_name: environment,
+	});
+	core.notice(`Deleted ${environment}; its pull request is closed.`);
+};
+
 const assess = async ({ github, context, core }: ControllerInput): Promise<void> => {
 	const { owner, repo } = context.repo;
 	const number = requiredPositiveInteger(process.env, "PR_NUMBER");
 	const { data: pull } = await github.rest.pulls.get({ owner, repo, pull_number: number });
-	const stale = pull.state !== "open" || pull.draft || !hasPreviewLabel(pull);
+	const stale = pull.state !== "open" || !hasPreviewLabel(pull);
 	core.setOutput("stale", String(stale));
+	core.setOutput("closed", String(pull.state !== "open"));
 	if (!stale) {
 		core.notice(`PR #${number} still wants its preview; leaving it untouched.`);
 		return;
@@ -446,6 +498,8 @@ const retire = async ({ github, context }: ControllerInput): Promise<void> => {
 };
 
 export {
+	demolish,
+	progress,
 	TEARDOWN_REQUESTED_DESCRIPTION,
 	PREVIEW_LABEL,
 	assess,


### PR DESCRIPTION
Previews refused drafts, showed nothing in GitHub's UI while they worked, and left environments behind.

## 1. A draft can now deploy

The label is the only opt-in. Wanting eyes on unfinished work is the usual reason to ask for a preview, so refusing drafts inverted the point.

Two things would have silently broken this, and both are fixed here:

- `cleanup-preview.yml` triggered on **`converted_to_draft`** — drafting a PR would have destroyed its preview moments after this change made drafts deployable.
- The reconcile sweep treated a draft as **stale** and reclaimed it, which would have torn down each new draft preview at the next sweep.

The two draft tests were **inverted, not deleted**, so the old behaviour cannot come back quietly.

## 2. The lifecycle is visible

The deployment record used to be opened **after** "Wait for CI to publish this commit's signed images" — usually the longest part of the run — so the PR read *"This branch has not been deployed"* for most of a preview's life.

It now opens as soon as the PR is admitted and moves through the states GitHub renders:

| When | State | What the PR shows |
|---|---|---|
| Admitted | `queued` | environment appears — "Waiting for CI to publish signed images" |
| Images ready, Coolify has the commit | `in_progress` | "Coolify is building the preview" |
| Verified reachable | `success` | **View deployment** → the preview URL |
| Build failed / unreachable | `failure` / `error` | links to the run log |
| Superseded, or unlabelled mid-flight | `inactive` | shown as destroyed, not as a failure |

Every status carries `environment_url` and `log_url`. A superseded run finishing as `error` was wrong — pushing a new commit is not a fault — so `inactive` is now an accepted final state.

## 3. Environment cleanup — what is actually possible

I first automated deleting the environment on PR close. **actionlint rejected it, correctly:**

```
unknown permission scope "administration". all available permission scopes are
"actions", "artifact-metadata", "attestations", "checks", "contents", "deployments", …
```

`GITHUB_TOKEN` cannot be granted `administration`, so **no workflow token can ever delete an environment**. The only way to automate it is an administration-scoped PAT or App reachable by a scheduled workflow — a credential that can change repository settings — and none exists in this repo today. That is a larger grant than tidy settings are worth, so the feature is removed rather than shipped behind a new credential.

What actually happens: deployments are retired, and `transient_environment` makes GitHub show them destroyed. What outlives them is an empty `preview/pr-N` entry in Settings → Environments. `docs/contributor/ci-cd.mdx` now states this and gives the one-liner a maintainer runs:

```bash
gh api -X DELETE "repos/hephaestus-build/Hephaestus/environments/preview%2Fpr-<n>"
```

Four left over from PRs merged on 4 September (`preview/pr-1785`, `-1802`, `-1817`, `-1838`) are already removed by hand.

**If you would rather have this automated**, say so and I will add it behind a scoped GitHub App — but it should be a deliberate decision about a credential, not a side effect of this PR.

## Verification

34 controller tests (up from 28), `vp run check` green, docs updated.

Note on the earlier red run: `Actionlint` was the real failure and is fixed. `Build / App Server: Package` failed with `Failed to FinalizeArtifact: (403) Forbidden` — a GitHub artifact-service error — and `Test / App Server: Integration` reported **no failing tests**, having cascaded from it.

## Known, not fixed here

**Preview deploys are serialized end to end.** One `hephaestus-preview-admission` concurrency group wraps the whole job, so a third labelled PR waits for the first two — up to 40 minutes each. The reservation semantics allow fixing this (the deployment record *is* the slot reservation, and this PR takes it earlier, which is the prerequisite) by splitting into a serialized `admit` job and a parallel `deploy` job.

I am not doing it here for a concrete reason: with a split, a `deploy` job that never starts leaves a `queued` reservation holding a slot forever, and the sweep only reclaims previews whose PR is closed or unlabelled — so an open, labelled PR would hold a slot indefinitely. That needs its own reclaim path and its own review.