### PR TITLE
perf(ci): cache generated clients and avoid database work during image training

### DIFF
--- a/.changeset/faster-container-training.md
+++ b/.changeset/faster-container-training.md
@@ -1,0 +1,5 @@
+---
+"hephaestus": patch
+---
+
+Container builds no longer wait for an unavailable database during startup optimization. Production startup continues to reject unsealed signing keys.

--- a/.github/actions/download-trivy-db/action.yml
+++ b/.github/actions/download-trivy-db/action.yml
@@ -1,8 +1,12 @@
 name: Download the Trivy database
 description: >-
   Fetches the Trivy vulnerability database once, with the retries and registry fallback a gate
-  needs, and optionally asserts its freshness and records its metadata.
+  needs, optionally asserts its freshness and records its metadata, and can prepare the Java index.
 inputs:
+  java-db:
+    description: Prepare the Java index before concurrent Java image scans.
+    required: false
+    default: "false"
   max-age-hours:
     description: >-
       Fail when the downloaded database is older than this many whole hours. Empty skips the
@@ -20,6 +24,7 @@ runs:
     - name: Download the Trivy database
       shell: bash
       env:
+        JAVA_DB: ${{ inputs.java-db }}
         MAX_AGE_HOURS: ${{ inputs.max-age-hours }}
         METADATA_PATH: ${{ inputs.metadata-path }}
         # GHCR answers TOOMANYREQUESTS often enough that Harbor, Rancher and New Relic all
@@ -29,6 +34,10 @@ runs:
         TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db:2,public.ecr.aws/aquasecurity/trivy-db:2
       run: |
         set -euo pipefail
+        case "$JAVA_DB" in
+          true|false) ;;
+          *) echo "::error::java-db must be true or false"; exit 1 ;;
+        esac
         if [ -n "$MAX_AGE_HOURS" ] && ! [[ "$MAX_AGE_HOURS" =~ ^[0-9]+$ ]]; then
           echo "::error::max-age-hours must be a whole number of hours"
           exit 1
@@ -41,6 +50,16 @@ runs:
           fi
           sleep $((attempt * 5))
         done
+        if [ "$JAVA_DB" = true ]; then
+          for attempt in 1 2 3; do
+            trivy image --timeout 5m --download-java-db-only && break
+            if [ "$attempt" -eq 3 ]; then
+              echo "::error::Trivy Java database download failed after $attempt attempts"
+              exit 1
+            fi
+            sleep $((attempt * 5))
+          done
+        fi
         db_metadata="${TRIVY_CACHE_DIR:-$HOME/.cache/trivy}/db/metadata.json"
         if [ -n "$MAX_AGE_HOURS" ]; then
           jq -e --argjson max "$((MAX_AGE_HOURS * 3600))" \

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -352,6 +352,7 @@ jobs:
       packages: write
       id-token: write
       attestations: write
+      artifact-metadata: write
     with:
       image-name: "hephaestus-build/application-server"
       use-buildpacks: true

--- a/.github/workflows/ci-docker-build.yml
+++ b/.github/workflows/ci-docker-build.yml
@@ -62,6 +62,7 @@ jobs:
       packages: write
       id-token: write
       attestations: write
+      artifact-metadata: write
     secrets:
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
       SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
@@ -93,6 +94,7 @@ jobs:
       packages: write
       id-token: write
       attestations: write
+      artifact-metadata: write
     with:
       image-name: "hephaestus-build/agent-pi"
       docker-file: "./docker/agents/pi/Dockerfile"
@@ -119,6 +121,7 @@ jobs:
       packages: write
       id-token: write
       attestations: write
+      artifact-metadata: write
     with:
       image-name: "hephaestus-build/postgres"
       docker-file: "./docker/postgres/Dockerfile"

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -459,6 +459,7 @@ jobs:
       packages: write
       id-token: write
       attestations: write
+      artifact-metadata: write
     with:
       should_skip: ${{ needs.detect-changes.outputs.should_skip }}
       publish: ${{ needs.detect-changes.outputs.publishable == 'true' }}
@@ -540,6 +541,7 @@ jobs:
       packages: write
       id-token: write
       attestations: write
+      artifact-metadata: write
     with:
       should_skip: ${{ needs.detect-changes.outputs.should_skip }}
       publish: ${{ needs.detect-changes.outputs.publishable == 'true' }}
@@ -632,6 +634,7 @@ jobs:
       - uses: ./.github/actions/download-trivy-db
         with:
           max-age-hours: "24"
+          java-db: "true"
 
       - uses: ./.github/actions/ghcr-login
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,6 +146,7 @@ jobs:
       - uses: ./.github/actions/download-trivy-db
         with:
           max-age-hours: "24"
+          java-db: "true"
           metadata-path: evidence/trivy-db.json
 
       - name: Generate and enforce release evidence

--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -100,6 +100,7 @@ jobs:
       packages: write
       id-token: write
       attestations: write
+      artifact-metadata: write
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -290,7 +291,9 @@ jobs:
 
       - name: Generate build provenance attestation
         if: inputs.publish && inputs.single-arch
-        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+        env:
+          NODE_OPTIONS: "--max-http-header-size=32768"
         with:
           subject-name: ${{ inputs.registry }}/${{ inputs.image-name }}
           subject-digest: ${{ steps.single-digest.outputs.manifest-digest }}
@@ -333,6 +336,7 @@ jobs:
       packages: write
       id-token: write
       attestations: write
+      artifact-metadata: write
     outputs:
       manifest-digest: ${{ steps.digest.outputs.manifest-digest }}
     steps:
@@ -427,7 +431,9 @@ jobs:
           echo "Multi-arch manifest digest: $DIGEST"
 
       - name: Generate build provenance attestation
-        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+        env:
+          NODE_OPTIONS: "--max-http-header-size=32768"
         with:
           subject-name: ${{ inputs.registry }}/${{ inputs.image-name }}
           subject-digest: ${{ steps.digest.outputs.manifest-digest }}

--- a/docs/contributor/ci-cd.mdx
+++ b/docs/contributor/ci-cd.mdx
@@ -442,6 +442,9 @@ published only by trusted default-branch push, schedule and dispatch runs; the p
 also saves only from `main`. The JDK is pinned once, in `.java-version`.
 
 Java quality verdicts are not stored in the Vite task cache: Gradle owns their task inputs and outputs.
+GraphQL generation opts into Gradle's build cache using the plugin's declared inputs and outputs.
+Its optional timestamped `@Generated` class marker is disabled so unchanged schemas produce identical
+sources and compilation can also be restored. Test tasks always execute; their results are not cached.
 The [local verification contract](./local-verification.mdx#java-checks-and-caching) describes the shared
 local/CI command and how to distinguish Vite, Gradle build and Gradle configuration caches.
 

--- a/docs/contributor/release-management.mdx
+++ b/docs/contributor/release-management.mdx
@@ -156,7 +156,7 @@ findings, scheduled rescans, and exceptions.
 
 ### Nothing may fail for the first time at a release
 
-Pre-merge validation covers the same image subjects and evidence checks as release publication.
+Pre-merge validation covers the same image subjects and shared evidence checks as release publication.
 `scripts/generate-release-evidence.ts` is the one generator and
 `scripts/verify-release-evidence.ts` the one verifier; `release.yml` and the `Release evidence
 preflight` job in `cicd.yml` both run them, and the preflight runs the verifier in its default mode,

--- a/docs/contributor/release-management.mdx
+++ b/docs/contributor/release-management.mdx
@@ -131,6 +131,14 @@ conversions; then the SPDX predicate is attached as a Cosign attestation and the
 build provenance are verified. SBOMs, reports, the policy, checksums and `manifest.json` are release
 assets.
 
+Evidence capture processes two subjects at a time and waits for both before starting the next pair.
+A failed capture blocks the bundle after its in-flight peer finishes. Trivy uses its
+[memory scan cache](https://trivy.dev/latest/docs/configuration/cache/) because the filesystem cache
+locks out concurrent processes; the vulnerability database and Java index remain shared and are
+prepared before capture. Both workflow callers request `java-db: "true"` from `download-trivy-db`; direct generator
+invocations also need both databases prepared because capture disables their updates. Each subject
+still receives the same SBOM formats and combined vulnerability/license scan.
+
 Each subject also has a `.timings.json` diagnostic with its digest, platform and elapsed Syft and
 Trivy time, including failed invocations. Timings use a monotonic clock around the existing scans;
 they add no scanner work or latency threshold. They are advisory, not security evidence: failure to
@@ -139,18 +147,17 @@ save them warns without changing the scan result. The same durations appear in t
 Upstream NATS, Traefik, nginx, and Alpine images are versioned and digest-pinned in the production
 Compose topology. They receive the same per-platform SBOM, license, vulnerability, and index-membership
 evidence as first-party images. Hephaestus requires its own signatures and build provenance only for
-images it builds.
+images it builds. Image publishing uses GitHub's native attestation action to record provenance and
+registry storage metadata. Only publishing jobs and their reusable-workflow callers receive
+`artifact-metadata: write`, alongside the signing and attestation permissions.
 
 [Vulnerability remediation](./vulnerability-remediation.mdx) is the normative policy for blocking
 findings, scheduled rescans, and exceptions.
 
 ### Nothing may fail for the first time at a release
 
-For a long time a release was the only thing that ever produced an evidence bundle, so it was also
-the only thing that could evaluate a check over one. v0.75.0 failed twice on findings no earlier
-gate had ever looked at. The fix for the *subjects* was to scan the pinned upstream images before the
-release; the fix for the *checks* is that the same bundle is now produced and judged before a release
-exists. `scripts/generate-release-evidence.ts` is the one generator and
+Pre-merge validation covers the same image subjects and evidence checks as release publication.
+`scripts/generate-release-evidence.ts` is the one generator and
 `scripts/verify-release-evidence.ts` the one verifier; `release.yml` and the `Release evidence
 preflight` job in `cicd.yml` both run them, and the preflight runs the verifier in its default mode,
 which performs every check except signature verification.

--- a/scripts/ci-contract.test.ts
+++ b/scripts/ci-contract.test.ts
@@ -1545,6 +1545,19 @@ void describe("CI contract", () => {
 		// is why this action exists at all.
 		assert.match(action, /public\.ecr\.aws\/aquasecurity\/trivy-db/);
 		assert.match(action, /--download-db-only/);
+		assert.match(action, /--download-java-db-only/);
+		for (const file of [".github/workflows/cicd.yml", ".github/workflows/release.yml"]) {
+			const workflow = parseDocument(await readFile(file, "utf8"));
+			const evidenceJob = file.endsWith("cicd.yml") ? "Release-preflight" : "tag-images";
+			const steps = workflow.getIn(["jobs", evidenceJob, "steps"]);
+			assert.ok(isSeq(steps));
+			const prepare = steps.items.find(
+				(entry) => isMap(entry) && entry.get("uses") === "./.github/actions/download-trivy-db",
+			);
+			assert.ok(isMap(prepare));
+			assert.equal(prepare.getIn(["with", "java-db"]), "true");
+		}
+
 		for (const [file, source] of await workflowSources())
 			assert.doesNotMatch(
 				source,

--- a/scripts/ci-provenance.test.ts
+++ b/scripts/ci-provenance.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { test } from "node:test";
+
+import { isMap, isSeq, parseDocument } from "yaml";
+
+import { asArray, asRecord } from "./lib/json.ts";
+
+void test("image provenance can persist storage records through every reusable-workflow caller", async () => {
+	const callers = {
+		"cicd.yml": ["Build", "Docker"],
+		"ci-build.yml": ["application-server-image"],
+		"ci-docker-build.yml": ["webapp-build", "agent-pi-build", "postgres-build"],
+		"reusable-docker-build.yml": ["build", "merge"],
+	};
+	for (const [file, jobs] of Object.entries(callers)) {
+		const workflow = parseDocument(await readFile(`.github/workflows/${file}`, "utf8"));
+		const permissions = workflow.get("permissions");
+		assert.ok(isMap(permissions));
+		assert.deepEqual(permissions.toJSON(), {});
+		for (const job of jobs) {
+			for (const permission of ["id-token", "attestations", "artifact-metadata"]) {
+				assert.equal(
+					workflow.getIn(["jobs", job, "permissions", permission]),
+					"write",
+					`${file}: ${job}: ${permission}`,
+				);
+			}
+		}
+		if (file !== "reusable-docker-build.yml") continue;
+		for (const job of jobs) {
+			const steps = workflow.getIn(["jobs", job, "steps"]);
+			assert.ok(isSeq(steps));
+			const attestation = asArray(steps.toJSON(), "steps")
+				.map((step) => asRecord(step, "step"))
+				.find((step) => step.name === "Generate build provenance attestation");
+			assert.ok(attestation);
+			assert.match(String(attestation.uses), /^actions\/attest@[a-f0-9]{40}$/);
+			const inputs = asRecord(attestation.with, "attestation inputs");
+			assert.equal(inputs["push-to-registry"], true);
+			assert.notEqual(inputs["create-storage-record"], false);
+			assert.match(String(inputs["subject-digest"]), /outputs\.(manifest-digest|digest)/);
+		}
+	}
+});

--- a/scripts/download-trivy-db.test.ts
+++ b/scripts/download-trivy-db.test.ts
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import { spawnSync, type SpawnSyncReturns } from "node:child_process";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import { parseDocument } from "yaml";
+
+void test(
+	"prepares Java metadata only when requested and fails if it cannot be prepared",
+	{
+		skip: process.platform === "win32",
+	},
+	async (context) => {
+		const action = parseDocument(
+			await readFile(".github/actions/download-trivy-db/action.yml", "utf8"),
+		);
+		const script: unknown = action.getIn(["runs", "steps", 0, "run"]);
+		if (typeof script !== "string") throw new Error("Database action has no executable step");
+		const directory = await mkdtemp(path.join(tmpdir(), "trivy-download-"));
+		context.after(() => rm(directory, { recursive: true, force: true }));
+		await writeFile(
+			path.join(directory, "trivy"),
+			`#!/bin/sh
+printf '%s\\n' "$*" >> "$SCAN_LOG"
+case "$*" in *--download-java-db-only*) exit "$JAVA_EXIT" ;; esac
+`,
+			{ mode: 0o755 },
+		);
+		await writeFile(path.join(directory, "sleep"), "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+		const log = path.join(directory, "calls");
+		for (const [javaDb, exit, expectedCalls] of [
+			["false", "0", 1],
+			["true", "0", 2],
+			["true", "17", 4],
+			["invalid", "0", 0],
+		] as const) {
+			await writeFile(log, "");
+			const env = {
+				...process.env,
+				PATH: `${directory}${path.delimiter}${process.env.PATH ?? ""}`,
+				JAVA_DB: javaDb,
+				JAVA_EXIT: exit,
+				MAX_AGE_HOURS: "",
+				METADATA_PATH: "",
+				SCAN_LOG: log,
+			};
+			const expectedSuccess = exit === "0" && javaDb !== "invalid";
+			const { status, stderr }: SpawnSyncReturns<string> = spawnSync("bash", ["-c", script], {
+				encoding: "utf8",
+				env,
+			});
+			assert.equal(status === 0, expectedSuccess, stderr);
+			const calls = (await readFile(log, "utf8")).trim().split("\n").filter(Boolean);
+			assert.equal(calls.length, expectedCalls);
+			if (expectedCalls > 0) assert.match(calls[0] ?? "", /--download-db-only$/);
+			for (const call of calls.slice(1)) assert.match(call, /--download-java-db-only$/);
+		}
+	},
+);

--- a/scripts/generate-release-evidence.test.ts
+++ b/scripts/generate-release-evidence.test.ts
@@ -7,6 +7,7 @@ import { describe, test } from "node:test";
 
 import {
 	buildManifest,
+	captureSubjects,
 	evidenceStem,
 	PLATFORMS,
 	planEvidenceImages,
@@ -105,11 +106,12 @@ void test(
 		await writeFile(
 			path.join(directory, "trivy"),
 			`#!/bin/sh
-[ "$1" = image ] && [ "$2" = --skip-db-update ] && [ "$3" = --scanners ] && [ "$4" = vuln,license ] || exit 90
-[ "$5" = --format ] && [ "$6" = json ] && [ "$7" = --output ] || exit 91
+[ "$1" = image ] && [ "$2" = --skip-db-update ] && [ "$3" = --skip-java-db-update ] && [ "$4" = --cache-backend ] && [ "$5" = memory ] || exit 90
+shift 5
+[ "$1" = --scanners ] && [ "$2" = vuln,license ] && [ "$3" = --format ] && [ "$4" = json ] && [ "$5" = --output ] || exit 91
 printf 'scan\\n' >> "$SCAN_LOG"
 [ "$SCAN_EXIT" = 0 ] || exit "$SCAN_EXIT"
-printf '%s' '{"Results":[{"Vulnerabilities":[{"VulnerabilityID":"CVE-example"}],"Licenses":[{"Name":"MIT"}]}]}' > "$8"
+printf '%s' '{"Results":[{"Vulnerabilities":[{"VulnerabilityID":"CVE-example"}],"Licenses":[{"Name":"MIT"}]}]}' > "$6"
 `,
 			{ mode: 0o755 },
 		);
@@ -189,3 +191,46 @@ await captureSubject(${JSON.stringify(subject)}, ${JSON.stringify(directory)});
 		assert.notEqual(invoke("0").status, 0, "A successful scanner without a report must fail");
 	},
 );
+
+void test("captures every subject with at most two in flight", async () => {
+	const subjects = planEvidenceSubjects(await evidenceImages(), platformDigest);
+	const completed: string[] = [];
+	let active = 0;
+	let peak = 0;
+	await captureSubjects(subjects, async (subject) => {
+		active += 1;
+		peak = Math.max(peak, active);
+		await Promise.resolve();
+		completed.push(evidenceStem(subject));
+		active -= 1;
+	});
+	assert.equal(peak, 2);
+	assert.deepEqual(completed.toSorted(), subjects.map(evidenceStem).toSorted());
+});
+
+void test("waits for in-flight capture after failure and never starts another batch", async () => {
+	const subjects = planEvidenceSubjects(await evidenceImages(), platformDigest);
+	const inFlight = Promise.withResolvers<undefined>();
+	const started = Promise.withResolvers<undefined>();
+	const failure = new Error("scanner failed");
+	let captures = 0;
+	let settled = false;
+	const capture = captureSubjects(subjects, async () => {
+		captures += 1;
+		if (captures === 1) throw failure;
+		started.resolve(undefined);
+		await inFlight.promise;
+	});
+	const rejected = assert.rejects(capture, (error: unknown) => {
+		assert.ok(error instanceof AggregateError);
+		assert.deepEqual(error.errors, [failure]);
+		settled = true;
+		return true;
+	});
+	await started.promise;
+	await Promise.resolve();
+	assert.equal(settled, false);
+	inFlight.resolve(undefined);
+	await rejected;
+	assert.equal(captures, 2);
+});

--- a/scripts/generate-release-evidence.ts
+++ b/scripts/generate-release-evidence.ts
@@ -135,6 +135,22 @@ async function resolvePlatformDigests(
 	return digests;
 }
 
+export async function captureSubjects(
+	subjects: readonly Subject[],
+	capture: (subject: Subject) => Promise<void>,
+): Promise<void> {
+	for (let offset = 0; offset < subjects.length; offset += 2) {
+		const results = await Promise.allSettled(subjects.slice(offset, offset + 2).map(capture));
+		const failures = results.filter((result) => result.status === "rejected");
+		if (failures.length > 0) {
+			throw new AggregateError(
+				failures.map((result): unknown => result.reason),
+				"Release evidence capture failed",
+			);
+		}
+	}
+}
+
 export async function captureSubject(subject: Subject, directory: string): Promise<void> {
 	const reference = `${subject.repository}@${subject.digest}`;
 	const stem = path.join(directory, evidenceStem(subject));
@@ -175,6 +191,9 @@ export async function captureSubject(subject: Subject, directory: string): Promi
 		await scan("trivy", [
 			"image",
 			"--skip-db-update",
+			"--skip-java-db-update",
+			"--cache-backend",
+			"memory",
 			"--scanners",
 			"vuln,license",
 			"--format",
@@ -233,7 +252,7 @@ export async function generateReleaseEvidence(options: {
 		images,
 		(image, platform) => digests.get(`${image.image}\0${platform}`) ?? "",
 	);
-	for (const subject of subjects) await captureSubject(subject, directory);
+	await captureSubjects(subjects, (subject) => captureSubject(subject, directory));
 	const manifest = buildManifest(subjects, {
 		commit,
 		durationSeconds: Math.round((Date.now() - startedAt) / 1000),

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/auth/config/AuthJwtConfig.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/auth/config/AuthJwtConfig.java
@@ -12,6 +12,7 @@ import jakarta.annotation.PostConstruct;
 import java.time.Clock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.boot.ApplicationRunner;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cache.CacheManager;
 import org.springframework.context.annotation.Bean;
@@ -19,14 +20,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import org.springframework.security.oauth2.server.resource.web.BearerTokenResolver;
 
-/**
- * Wires the JWT issuance + verification primitives for our own ES256 cookie-session JWTs (ADR 0017).
- *
- * <h2>Boot order</h2>
- * {@link #seedKeysOnStartup} runs in {@code @PostConstruct} after the JPA EntityManagerFactory
- * is ready, so the {@code jwt_signing_key} table has at least one row before the first request
- * lands. Production deploys can pre-seed via Liquibase if deterministic kids are needed.
- */
+/** Wires issuance and verification for ES256 cookie-session JWTs (ADR 0017). */
 @ConditionalOnServerRole
 @Configuration
 @EnableConfigurationProperties(AuthProperties.class)
@@ -83,20 +77,20 @@ public class AuthJwtConfig {
         return cookieBearerTokenResolver;
     }
 
-    /**
-     * Best-effort key bootstrap. Wrapped so a DB-less boot (e.g. the {@code specs} OpenAPI
-     * profile, or a worker-only pod) never fails to start — the first real token issuance
-     * will seed the key if this didn't.
-     */
     @PostConstruct
-    void seedKeysOnStartup() {
-        try {
-            keyService.ensureActiveKey();
-        } catch (RuntimeException e) {
-            log.warn("auth.jwt: deferred signing-key bootstrap (will seed on first issuance): {}", e.toString());
-        }
-        // SECURITY: the bootstrap above is best-effort, but an unsealed signing key in prod is a
-        // forge-any-token risk — that condition must NOT be swallowed. Fail the boot loudly.
+    void assertSigningKeysSealed() {
         keyService.assertProdKeysSealed();
+    }
+
+    // CDS training exits at context refresh, before runners can perform database writes.
+    @Bean
+    ApplicationRunner seedKeysOnStartup() {
+        return args -> {
+            try {
+                keyService.ensureActiveKey();
+            } catch (RuntimeException e) {
+                log.warn("auth.jwt: deferred signing-key bootstrap (will seed on first issuance): {}", e.toString());
+            }
+        };
     }
 }

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/auth/config/AuthJwtConfigTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/auth/config/AuthJwtConfigTest.java
@@ -1,0 +1,73 @@
+package de.tum.cit.aet.hephaestus.core.auth.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import de.tum.cit.aet.hephaestus.core.auth.jwt.IssuedJwtRepository;
+import de.tum.cit.aet.hephaestus.core.auth.jwt.JwtSigningKeyService;
+import de.tum.cit.aet.hephaestus.core.auth.metrics.AuthMetrics;
+import de.tum.cit.aet.hephaestus.testconfig.BaseUnitTest;
+import java.time.Clock;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.boot.DefaultApplicationArguments;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+
+class AuthJwtConfigTest extends BaseUnitTest {
+
+    private final JwtSigningKeyService keyService = mock(JwtSigningKeyService.class);
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withUserConfiguration(AuthJwtConfig.class)
+            .withBean(JwtSigningKeyService.class, () -> keyService)
+            .withBean(IssuedJwtRepository.class, () -> mock(IssuedJwtRepository.class))
+            .withBean(AuthMetrics.class, () -> mock(AuthMetrics.class))
+            .withBean(CacheManager.class, ConcurrentMapCacheManager::new)
+            .withBean(Clock.class, Clock::systemUTC);
+
+    @Test
+    void shouldNotSeedSigningKeysDuringCdsContextRefresh() {
+        contextRunner.withPropertyValues("spring.profiles.active=cds-training").run(context -> {
+            assertThat(context).hasNotFailed().hasSingleBean(ApplicationRunner.class);
+            verify(keyService, never()).ensureActiveKey();
+        });
+    }
+
+    @Test
+    void shouldSeedSigningKeysDuringProductionStartup() {
+        contextRunner.withPropertyValues("spring.profiles.active=prod").run(context -> {
+            assertThat(context).hasNotFailed();
+            verify(keyService).assertProdKeysSealed();
+            context.getBean(ApplicationRunner.class).run(new DefaultApplicationArguments());
+            verify(keyService).ensureActiveKey();
+        });
+    }
+
+    @Test
+    void shouldDeferSeedingWhenTheDatabaseIsUnavailable() {
+        doThrow(new IllegalStateException("database unavailable"))
+                .when(keyService)
+                .ensureActiveKey();
+        contextRunner.run(context -> {
+            context.getBean(ApplicationRunner.class).run(new DefaultApplicationArguments());
+            verify(keyService).ensureActiveKey();
+        });
+    }
+
+    @Test
+    void shouldRejectUnsealedProductionKeysDuringContextRefresh() {
+        doThrow(new IllegalStateException("unsealed signing key"))
+                .when(keyService)
+                .assertProdKeysSealed();
+        contextRunner.withPropertyValues("spring.profiles.active=prod").run(context -> {
+            assertThat(context).hasFailed();
+            assertThat(context.getStartupFailure()).hasRootCauseMessage("unsealed signing key");
+            verify(keyService, never()).ensureActiveKey();
+        });
+    }
+}

--- a/server/generated-clients/build.gradle.kts
+++ b/server/generated-clients/build.gradle.kts
@@ -15,6 +15,8 @@ dependencies {
 }
 
 tasks.withType<GraphQLCodegenGradleTask>().configureEach {
+    // The plugin declares its inputs and outputs but does not opt into the build cache.
+    outputs.cacheIf { true }
     generateClient = true
     generateApis = false
     generateDataFetchingEnvironmentArgumentInApis = false
@@ -25,8 +27,8 @@ tasks.withType<GraphQLCodegenGradleTask>().configureEach {
     generateModelsForRootTypes = false
     generateAllMethodInProjection = true
     generatedLanguage = GeneratedLanguage.JAVA
-    addGeneratedAnnotation = true
-    generatedAnnotation = "jakarta.annotation.Generated"
+    // Its SOURCE-retained class marker embeds the wall clock and defeats compilation caching.
+    addGeneratedAnnotation = false
     modelValidationAnnotation = "@jakarta.annotation.Generated(\"graphql-codegen\")"
     modelNameSuffix = ""
     requestSuffix = "Request"


### PR DESCRIPTION
## What changed and why

The Gradle migration exposed two avoidable costs: timestamped generated sources defeated compilation-cache reuse, and CDS image training waited 45 seconds for a database while initializing JWT signing keys. Release evidence was also collected sequentially, and image provenance could not persist its registry storage metadata.

- Make GraphQL generation deterministic with the plugin's native annotation option, then enable Gradle task-output caching over its declared schema/template inputs. Tests still execute; their results are not cached.
- Move best-effort key initialization to Spring Boot's `ApplicationRunner`, after the context-refresh point where CDS training exits. Keep the production sealing assertion in context initialization so unsafe keys still fail startup.
- Capture two release-evidence subjects at a time, waiting for both before propagating failures. Prepare both Trivy databases once and use its native memory analysis cache to avoid concurrent filesystem-cache locking. No evidence formats, image platforms, policy checks, or signatures are removed.
- Use the same native `actions/attest` pin as release publication and grant artifact-metadata writes only through image-publishing jobs and their callers.

## How to test

- `vp run format` and `vp run check` passed on the merged Gradle baseline.
- `vp run test:server:unit`: **7,218 tests passed**, including four new lifecycle tests; coverage verification passed.
- `node --test scripts/ci-provenance.test.ts scripts/download-trivy-db.test.ts scripts/generate-release-evidence.test.ts scripts/verify-release-evidence.test.ts scripts/ci-contract.test.ts` exercises workflow permissions, database preparation, bounded execution, failure draining and evidence contracts.
- Gradle cache experiment: schema and template edits reran generation; reverting restored cached output and removed obsolete generated types. Independent uncached generation reproduced all 12,010 Java sources byte for byte. Clean packaging restored generators and compilation from cache in 9.24 seconds locally; this is not a CI latency promise.
- Native scanner ABBA comparison over all 16 immutable subjects: sequential 189s, parallel 112s, parallel 132s, sequential 134s. Registry and cache warming matter. Compared with the final warm baseline, the candidate was 1.6–16.2% faster, with sampled peak process-tree memory rising from approximately 743 MiB to 1,405 MiB. Vulnerability/license report content and package inventories matched; candidate SBOMs passed the production validator and both database hashes stayed unchanged.
- [Final PR CI](https://github.com/hephaestus-build/Hephaestus/actions/runs/34273549621) passed on `87d890597`. [Full dual-platform release preflight](https://github.com/hephaestus-build/Hephaestus/actions/runs/34275211502) also passed on that commit: all 16 subjects evidenced in 81 seconds and the production evidence verifier passed. The full preflight workflow took 10m53s; evidence database preparation took about 21s. The retained artifact contains per-subject timings.
- Hosted image smoke: the earlier follow-up run reduced the Buildpacks/CDS command from about 136s to 81s, without the 45s database timeout. The resulting immutable image retains its 162 MB CDS archive and native runtime activation; provenance storage registration succeeded. These are observed samples, not a steady-state CI latency guarantee.

## Release impact

[Patch changeset](.changeset/faster-container-training.md): container builds avoid unnecessary database work during startup optimization. No operator action, API, schema, runtime-role, or UI change. Production key-sealing enforcement remains fail-closed.

## Notes for reviewers

This follows [Spring Boot's startup-task guidance](https://docs.spring.io/spring-boot/reference/features/spring-application.html), [Gradle's native task-output cache](https://docs.gradle.org/current/userguide/build_cache.html#sec:task_output_caching), and [Trivy's documented cache concurrency constraints](https://trivy.dev/latest/docs/configuration/cache/). The pinned GraphQL task declares schema files and template directories as inputs; no custom source rewriting or cache format was added.

The observed 45-second image-build stall is a concrete target, not a guaranteed end-to-end reduction. Native Gradle cache publication remains restricted to trusted default-branch runs. Release policy, provenance verification, coverage floors, and merge-queue checks are not bypassed.
