### PR TITLE
perf(ci): streamline image publication and repair profiling

### DIFF
--- a/.changeset/restore-profile-context-output.md
+++ b/.changeset/restore-profile-context-output.md
@@ -1,4 +1,4 @@
 ---
 ---
 
-Restore Spring context diagnostics and process resource accounting in opt-in CI test profiles. Production code and ordinary test execution are unchanged.
+Restore Spring context diagnostics and remove unreliable daemon CPU/memory claims in opt-in CI test profiles. Production code and ordinary test execution are unchanged.

--- a/.changeset/restore-profile-context-output.md
+++ b/.changeset/restore-profile-context-output.md
@@ -1,0 +1,4 @@
+---
+---
+
+Restore Spring context diagnostics and process resource accounting in opt-in CI test profiles. Production code and ordinary test execution are unchanged.

--- a/.github/workflows/ci-profile.yml
+++ b/.github/workflows/ci-profile.yml
@@ -58,7 +58,7 @@ jobs:
                   run_id: run.id,
                   per_page: 100,
                 });
-                const history = artifacts.find((artifact) => artifact.name === 'ci-profile-history-jfr' && !artifact.expired);
+                const history = artifacts.find((artifact) => artifact.name === 'ci-profile-history-gradle-jfr' && !artifact.expired);
                 if (history) {
                   core.setOutput('run-id', run.id);
                   return;
@@ -71,7 +71,7 @@ jobs:
         if: steps.history.outputs.run-id != ''
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: ci-profile-history-jfr
+          name: ci-profile-history-gradle-jfr
           run-id: ${{ steps.history.outputs.run-id }}
           github-token: ${{ github.token }}
           path: ci-profile-history
@@ -84,7 +84,7 @@ jobs:
           /usr/bin/time -v -o ci-metrics/server-integration-resource.txt \
             vp run test:server:integration \
             -PprofileTests=true \
-            --profile \
+            --profile --no-daemon \
             2>&1 | tee ci-metrics/server-integration.log
 
       - name: Validate profile artifacts
@@ -123,7 +123,7 @@ jobs:
         if: ${{ !cancelled() && steps.record.outcome == 'success' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: ci-profile-history-jfr
+          name: ci-profile-history-gradle-jfr
           path: ci-profile-history
           if-no-files-found: error
           retention-days: 90
@@ -171,7 +171,7 @@ jobs:
           /usr/bin/time -v -o ci-metrics/server-verification-resource.txt \
             vp run test:server:verification \
             -PprofileTests=true \
-            --profile \
+            --profile --no-daemon \
             2>&1 | tee ci-metrics/server-verification.log
 
       - name: Validate profile artifacts

--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -110,6 +110,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+        with:
+          driver: ${{ inputs.use-buildpacks && 'docker' || 'docker-container' }}
 
       - name: Log in to Container Registry
         if: inputs.publish
@@ -172,9 +174,9 @@ jobs:
           platforms: ${{ matrix.platform }}
           build-args: ${{ inputs.build-args }}
           secrets: |
-            sentry_auth_token=${{ github.event_name == 'push' && matrix.platform == 'linux/amd64' && secrets.SENTRY_AUTH_TOKEN || '' }}
-            sentry_org=${{ github.event_name == 'push' && matrix.platform == 'linux/amd64' && secrets.SENTRY_ORG || '' }}
-            sentry_project=${{ github.event_name == 'push' && matrix.platform == 'linux/amd64' && secrets.SENTRY_PROJECT || '' }}
+            ${{ github.event_name == 'push' && matrix.platform == 'linux/amd64' && secrets.SENTRY_AUTH_TOKEN != '' && format('sentry_auth_token={0}', secrets.SENTRY_AUTH_TOKEN) || '' }}
+            ${{ github.event_name == 'push' && matrix.platform == 'linux/amd64' && secrets.SENTRY_ORG != '' && format('sentry_org={0}', secrets.SENTRY_ORG) || '' }}
+            ${{ github.event_name == 'push' && matrix.platform == 'linux/amd64' && secrets.SENTRY_PROJECT != '' && format('sentry_project={0}', secrets.SENTRY_PROJECT) || '' }}
           labels: ${{ steps.meta.outputs.labels }}
           tags: ${{ inputs.single-arch && steps.meta.outputs.tags || '' }}
           push: ${{ inputs.publish }}
@@ -364,6 +366,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+        with:
+          driver: docker
 
       - name: Prepare tag configuration
         id: tags
@@ -410,11 +414,6 @@ jobs:
         env:
           INPUTS_REGISTRY: ${{ inputs.registry }}
           INPUTS_IMAGE_NAME: ${{ inputs.image-name }}
-
-      - name: Inspect image
-        run: docker buildx imagetools inspect "$IMAGE_REF"
-        env:
-          IMAGE_REF: ${{ inputs.registry }}/${{ inputs.image-name }}:${{ steps.meta.outputs.version }}
 
       - name: Capture manifest digest
         id: digest

--- a/docs/contributor/ci-cd.mdx
+++ b/docs/contributor/ci-cd.mdx
@@ -649,6 +649,13 @@ Deep profiling stays in the manual/weekly workflow, not on the PR critical path.
 runners at once. Each tier retains its JFR recording, Gradle task profile, resource usage and JUnit
 results for 14 days. Verification profiles are diagnostic artifacts, not integration-history samples.
 
+Profile invocations use a single-use Gradle process (`--no-daemon`) so resource accounting includes
+the build and test processes rather than just the client of a persistent daemon. CPU time includes
+waited-for descendants; maximum RSS is the largest process measurement, not aggregate runner memory.
+Gradle streams test output only in these profiles so Spring context diagnostics reach the retained log.
+History uses the `ci-profile-history-gradle-jfr` artifact; profiles with different process accounting
+are not comparable.
+
 The integration profile additionally records Spring context-cache metrics. It warns about
 a sustained regression after three consecutive profiles exceed variance limits against five earlier
 default-branch profiles or absolute Spring-context limits. Only successful test runs with a readable

--- a/docs/contributor/ci-cd.mdx
+++ b/docs/contributor/ci-cd.mdx
@@ -649,12 +649,12 @@ Deep profiling stays in the manual/weekly workflow, not on the PR critical path.
 runners at once. Each tier retains its JFR recording, Gradle task profile, resource usage and JUnit
 results for 14 days. Verification profiles are diagnostic artifacts, not integration-history samples.
 
-Profile invocations use a single-use Gradle process (`--no-daemon`) so resource accounting includes
-the build and test processes rather than just the client of a persistent daemon. CPU time includes
-waited-for descendants; maximum RSS is the largest process measurement, not aggregate runner memory.
+Profile invocations use a single-use Gradle process (`--no-daemon`) for repeatable JVM startup.
 Gradle streams test output only in these profiles so Spring context diagnostics reach the retained log.
-History uses the `ci-profile-history-gradle-jfr` artifact; profiles with different process accounting
-are not comparable.
+History uses the `ci-profile-history-gradle-jfr` artifact and compares wall time, test time and context
+measurements. GNU time's CPU/RSS accounting does not reliably include Gradle's detached JVMs, so those
+values are not reported as suite metrics or compared against budgets. Inspect the retained JFR recordings
+for JVM CPU, allocation and GC diagnostics instead.
 
 The integration profile additionally records Spring context-cache metrics. It warns about
 a sustained regression after three consecutive profiles exceed variance limits against five earlier

--- a/scripts/check-ci-performance.test.ts
+++ b/scripts/check-ci-performance.test.ts
@@ -10,7 +10,7 @@ import { parseSummary, regressions } from "./check-ci-performance.ts";
 import type { TestSummary } from "./summarize-test-results.ts";
 
 const summary = (startup: number, wall = 200): TestSummary => ({
-	schemaVersion: 2,
+	schemaVersion: 3,
 	name: "profile",
 	files: 1,
 	tests: 1,
@@ -21,8 +21,6 @@ const summary = (startup: number, wall = 200): TestSummary => ({
 	slowest: [],
 	performance: {
 		wallTimeSeconds: wall,
-		cpuTimeSeconds: 150,
-		maxRssKilobytes: 500_000,
 		contextStarts: 10,
 		contextStartupSeconds: startup,
 		contextCacheMisses: 10,
@@ -122,4 +120,11 @@ await test("CLI warns on sustained regressions but fails for corrupt or failed-t
 	await writeFile(current, JSON.stringify(summary(100)));
 	await writeFile(path.join(history, "0.json"), "not json");
 	assert.notEqual(run().status, 0);
+});
+
+await test("rejects profiles from the old process-accounting schema", () => {
+	assert.throws(
+		() => parseSummary(JSON.stringify({ ...summary(10), schemaVersion: 2 })),
+		/Invalid CI metrics summary/,
+	);
 });

--- a/scripts/check-ci-performance.ts
+++ b/scripts/check-ci-performance.ts
@@ -25,18 +25,6 @@ const metrics: Metric[] = [
 		value: (summary) => summary.testTimeSeconds,
 		tolerance: 0.15,
 	},
-	{
-		name: "CPU time",
-		unit: "s",
-		value: (summary) => summary.performance?.cpuTimeSeconds ?? 0,
-		tolerance: 0.25,
-	},
-	{
-		name: "max RSS",
-		unit: "KiB",
-		value: (summary) => summary.performance?.maxRssKilobytes ?? 0,
-		tolerance: 0.25,
-	},
 ];
 
 const median = (values: number[]): number => {
@@ -119,14 +107,14 @@ export function parseSummary(json: string): TestSummary {
 	};
 	if (
 		!isRecord(value) ||
-		value.schemaVersion !== 2 ||
+		value.schemaVersion !== 3 ||
 		typeof value.name !== "string" ||
 		!isRecord(value.performance)
 	) {
 		throw new Error("Invalid CI metrics summary");
 	}
 	const summary: TestSummary = {
-		schemaVersion: 2,
+		schemaVersion: 3,
 		name: value.name,
 		files: number(value, "files"),
 		tests: number(value, "tests"),
@@ -137,8 +125,6 @@ export function parseSummary(json: string): TestSummary {
 		slowest: [],
 		performance: {
 			wallTimeSeconds: number(value.performance, "wallTimeSeconds"),
-			cpuTimeSeconds: number(value.performance, "cpuTimeSeconds"),
-			maxRssKilobytes: number(value.performance, "maxRssKilobytes"),
 			contextStarts: number(value.performance, "contextStarts"),
 			contextStartupSeconds: number(value.performance, "contextStartupSeconds"),
 			contextCacheMisses: number(value.performance, "contextCacheMisses"),

--- a/scripts/ci-contract.test.ts
+++ b/scripts/ci-contract.test.ts
@@ -830,6 +830,14 @@ void describe("CI contract", () => {
 				/inputs\.publish/,
 				`${name} writes to the registry and must be gated on publish`,
 			);
+		assert.match(
+			String(namedStep(reusable, build, "Set up Docker Buildx").getIn(["with", "driver"])),
+			/^\$\{\{ inputs\.use-buildpacks && 'docker' \|\| 'docker-container' }}$/,
+		);
+		assert.equal(
+			namedStep(reusable, ["jobs", "merge"], "Set up Docker Buildx").getIn(["with", "driver"]),
+			"docker",
+		);
 		const buildx = namedStep(reusable, build, "Build and push (Dockerfile)");
 		const inputs = buildx.get("with");
 		assert.ok(isMap(inputs));

--- a/scripts/ci-profile-history.test.ts
+++ b/scripts/ci-profile-history.test.ts
@@ -132,7 +132,7 @@ void test("profile history excludes incompatible process-accounting baselines", 
 	);
 });
 
-void test("both profile tiers finish their Gradle process for resource accounting", () => {
+void test("both profile tiers use a fresh Gradle process", () => {
 	for (const job of ["server-integration", "server-verification"]) {
 		const items = workflow.getIn(["jobs", job, "steps"]);
 		assert.ok(isSeq(items));

--- a/scripts/ci-profile-history.test.ts
+++ b/scripts/ci-profile-history.test.ts
@@ -41,7 +41,7 @@ const run = (id: number, headBranch = "main", repository = "owner/repo") => ({
 	head_branch: headBranch,
 	head_repository: { full_name: repository },
 });
-const history = { name: "ci-profile-history-jfr", expired: false };
+const history = { name: "ci-profile-history-gradle-jfr", expired: false };
 
 void test("history skips this rerun, foreign sources and incomplete profiles across pages", () => {
 	assert.equal(
@@ -118,4 +118,26 @@ void test("verification profiling retains coverage and runs separately from inte
 		items.items.some((item) => isMap(item) && item.get("id") === "history"),
 		false,
 	);
+});
+
+void test("only opt-in Gradle profiles stream context diagnostics", async () => {
+	const build = await readFile("server/application/build.gradle.kts", "utf8");
+	assert.match(build, /showStandardStreams = profileTests\.get\(\)/);
+});
+
+void test("profile history excludes incompatible process-accounting baselines", () => {
+	assert.equal(
+		selectHistory([[run(9)]], { 9: [{ name: "ci-profile-history-jfr", expired: false }] }),
+		"",
+	);
+});
+
+void test("both profile tiers finish their Gradle process for resource accounting", () => {
+	for (const job of ["server-integration", "server-verification"]) {
+		const items = workflow.getIn(["jobs", job, "steps"]);
+		assert.ok(isSeq(items));
+		const profile = items.items.find((item) => isMap(item) && item.get("id") === "profile");
+		assert.ok(isMap(profile));
+		assert.match(String(profile.get("run")), /--no-daemon/);
+	}
 });

--- a/scripts/summarize-test-results.test.ts
+++ b/scripts/summarize-test-results.test.ts
@@ -117,7 +117,7 @@ await test("uses XML structure rather than matching tag-like text", () => {
 	]);
 });
 
-await test("extracts process and Spring context metrics", () => {
+await test("extracts wall and context metrics without claiming daemon CPU or memory", () => {
 	const performance = parsePerformance(
 		"Started FirstTest in 4.25 seconds\nDefaultContextCache@abc missCount = 1\nStarted SecondTest in 5.75 seconds\nDefaultContextCache@abc missCount = 2",
 		`User time (seconds): 12.5
@@ -127,31 +127,14 @@ Maximum resident set size (kbytes): 524288`,
 	);
 	assert.deepEqual(performance, {
 		wallTimeSeconds: 63.5,
-		cpuTimeSeconds: 15,
-		maxRssKilobytes: 524288,
 		contextStarts: 2,
 		contextStartupSeconds: 10,
 		contextCacheMisses: 2,
 	});
 });
 
-await test("does not turn missing resource measurements into zeroes", () => {
-	const resources = [
-		"User time (seconds): 12.5",
-		"System time (seconds): 2.5",
-		"Elapsed (wall clock) time (h:mm:ss or m:ss): 1:03.50",
-		"Maximum resident set size (kbytes): 524288",
-	];
-	for (let missing = 0; missing < resources.length; missing++) {
-		assert.throws(
-			() => parsePerformance("", resources.filter((_, index) => index !== missing).join("\n")),
-			/Missing or invalid/,
-		);
-	}
-	assert.throws(
-		() => parsePerformance("", resources.join("\n").replace("12.5", "-12.5")),
-		/Missing or invalid/,
-	);
+await test("does not turn missing wall time into zero", () => {
+	assert.throws(() => parsePerformance("", ""), /Missing or invalid elapsed/);
 });
 
 await test("profile CLI preserves diagnostics and fails when no tests were reported", async (context) => {

--- a/scripts/summarize-test-results.ts
+++ b/scripts/summarize-test-results.ts
@@ -14,7 +14,7 @@ type TestCase = {
 };
 
 export type TestSummary = {
-	schemaVersion: 2;
+	schemaVersion: 3;
 	name: string;
 	files: number;
 	tests: number;
@@ -25,8 +25,6 @@ export type TestSummary = {
 	slowest: Array<{ test: string; seconds: number }>;
 	performance?: {
 		wallTimeSeconds: number;
-		cpuTimeSeconds: number;
-		maxRssKilobytes: number;
 		contextStarts: number;
 		contextStartupSeconds: number;
 		contextCacheMisses: number;
@@ -80,7 +78,7 @@ export function parseJUnit(xml: string): TestCase[] {
 export function summarize(name: string, documents: string[]): TestSummary {
 	const cases = documents.flatMap(parseJUnit);
 	return {
-		schemaVersion: 2,
+		schemaVersion: 3,
 		name,
 		files: documents.length,
 		tests: cases.length,
@@ -114,17 +112,9 @@ export function parsePerformance(
 		/Elapsed \(wall clock\) time .*: (?:(\d+):)?(\d+):(\d+(?:\.\d+)?)/,
 	);
 	if (elapsed === null) throw new Error("Missing or invalid elapsed resource time");
-	const value = (label: string): number => {
-		const match = resourceUsage.match(new RegExp(`${label}: (\\d+(?:\\.\\d+)?)`));
-		if (match === null) throw new Error(`Missing or invalid resource metric: ${label}`);
-		const result = Number(match[1]);
-		if (!Number.isFinite(result)) throw new Error(`Invalid resource metric: ${label}`);
-		return result;
-	};
+
 	return {
 		wallTimeSeconds: Number(elapsed[1] ?? 0) * 3600 + Number(elapsed[2]) * 60 + Number(elapsed[3]),
-		cpuTimeSeconds: value("User time \\(seconds\\)") + value("System time \\(seconds\\)"),
-		maxRssKilobytes: value("Maximum resident set size \\(kbytes\\)"),
 		contextStarts: starts.length,
 		contextStartupSeconds: starts.reduce((total, seconds) => total + seconds, 0),
 		contextCacheMisses: [...cacheMisses.values()].reduce((total, misses) => total + misses, 0),
@@ -150,8 +140,7 @@ export function validateProfile(
 		)
 	)
 		throw new Error("Profile metrics must be finite and nonnegative");
-	if (performance.wallTimeSeconds === 0 || performance.maxRssKilobytes === 0)
-		throw new Error("Profile wall time and resident memory must be positive");
+	if (performance.wallTimeSeconds === 0) throw new Error("Profile wall time must be positive");
 	if (
 		kind === "integration" &&
 		(performance.contextStarts === 0 || performance.contextCacheMisses === 0)
@@ -177,7 +166,7 @@ export function markdown(summary: TestSummary): string {
 		const performance = summary.performance;
 		lines.push(
 			"",
-			`**Wall:** ${performance.wallTimeSeconds.toFixed(1)}s · **CPU:** ${performance.cpuTimeSeconds.toFixed(1)}s · **Max RSS:** ${(performance.maxRssKilobytes / 1024).toFixed(0)} MiB · **Contexts:** ${performance.contextStarts} starts / ${performance.contextCacheMisses} misses / ${performance.contextStartupSeconds.toFixed(1)}s startup`,
+			`**Wall:** ${performance.wallTimeSeconds.toFixed(1)}s · **Contexts:** ${performance.contextStarts} starts / ${performance.contextCacheMisses} misses / ${performance.contextStartupSeconds.toFixed(1)}s startup`,
 		);
 	}
 	return `${lines.join("\n")}\n`;

--- a/server/application/build.gradle.kts
+++ b/server/application/build.gradle.kts
@@ -200,6 +200,7 @@ tasks.withType<Test>().configureEach {
     }
     jvmArgs(testJvmArgs.get().split(" ").filter(String::isNotBlank))
     testLogging {
+        showStandardStreams = profileTests.get()
         events("failed")
         exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
     }


### PR DESCRIPTION
## What changed and why

Image publication started a separate BuildKit container even when the job only used registry manifest commands or built the application with Paketo. In the audited main server manifest job, Buildx setup took 17 seconds while manifest creation took 3 seconds.

- Use the native Docker driver for Buildpacks and manifest jobs. Dockerfile builds retain the container driver needed for their build/cache configuration.
- Remove a duplicate manifest inspection; the remaining lookup still validates and captures the digest used for attestation and signature verification.
- Omit absent optional Sentry secret entries instead of passing empty `name=` values that generate warnings. Existing push-only, amd64-only restrictions remain unchanged.

- Restore Spring context logs with Gradle’s native opt-in test output setting. Use profile-only `--no-daemon` for repeatable JVM startup. GNU time does not reliably account for detached Gradle JVMs, even with that flag, so remove its CPU/RSS claims from summaries and budgets rather than report misleading values. JFR retains JVM diagnostics. Start separate, versioned Gradle profile history.

## How to test

- `vp run format` and `vp run check` passed.
- Actionlint and Zizmor passed on the changed workflow.
- Workflow contract tests cover driver selection, profile-only output, single-use profile processes, history compatibility, and publishing restrictions; provenance contracts still pass.
- **7,223 local server unit tests passed.** A focused integration profile passed the production summary validator. [Hosted integration and verification profiles](https://github.com/hephaestus-build/Hephaestus/actions/runs/34282982136) passed: **1,553 integration tests and 7,525 unit/architecture tests**, with readable JFR. The integration profile recorded 11 context starts/misses and 146.5s startup. The final schema/summary code also successfully reprocessed the complete retained integration evidence.
- Native smoke: `docker buildx --builder default imagetools create --dry-run` successfully resolved the published application image into its amd64/arm64 manifest without creating a separate builder or writing to the registry.
- Hosted validation: run normal PR CI for Dockerfile and single-platform Buildpacks builds, then dispatch `CI/CD` with `release-preflight=true` for dual-platform manifest creation, signatures, provenance verification, and release evidence.

## Release impact

CI/build diagnostics only; an empty changeset documents the absence of a user-facing release change. No operator action, runtime behavior, or image security policy change.

## Notes for reviewers

The pinned [setup-buildx action supports the native Docker driver](https://github.com/docker/setup-buildx-action/blob/v4.3.0/src/main.ts), which skips creating/removing a separate builder. [Docker documents imagetools as registry manifest operations](https://docs.docker.com/reference/cli/docker/buildx/imagetools/).

No test removal, extra test shards, relaxed cache trust, or merge/publication concurrency changes. The existing profiling workflow exposed the missing context output and inaccurate client-only resource accounting; both are fixed here. Native cache reuse was confirmed in package and integration jobs. The earlier shard-rebalance experiment did not demonstrate a benefit and is not included.

The initial PR run passed in [7m58s](https://github.com/hephaestus-build/Hephaestus/actions/runs/34281318321). Its [dual-platform release preflight](https://github.com/hephaestus-build/Hephaestus/actions/runs/34281865886) passed; server manifest Buildx setup took 1s rather than the observed 17s baseline, and the complete manifest job took 32s rather than 65s. These are individual observations, not latency guarantees. Final-head revalidation follows the profiling fix.

Profile isolation follows [Gradle’s documented single-use daemon lifecycle](https://docs.gradle.org/current/userguide/gradle_daemon.html#sec:disabling_the_daemon). Hosted testing disproved reliable descendant CPU/RSS accounting with GNU time, so only trustworthy wall/test/context measurements enter summaries and budgets; native JFR retains JVM diagnostic evidence.
