### PR TITLE
fix(ci): say when a branch is too old to preview, instead of failing at boot

### DIFF
--- a/scripts/preview-controller.test.ts
+++ b/scripts/preview-controller.test.ts
@@ -58,7 +58,8 @@ interface GitHubOptions {
 	files?: { filename: string }[];
 	resolvedPull?: typeof pull;
 	statuses?: Record<number, Status[]>;
-	behindFiles?: { filename: string }[];
+	behindFiles?: { filename: string; sha?: string }[];
+	branchBlobs?: Record<string, string>;
 	defaultStatuses?: Status[];
 }
 
@@ -70,6 +71,7 @@ const makeGitHub = ({
 	resolvedPull = pull,
 	statuses = {},
 	behindFiles = [],
+	branchBlobs = {},
 	defaultStatuses = [],
 }: GitHubOptions = {}): GitHubApi => ({
 	paginate: async <T>(
@@ -91,6 +93,11 @@ const makeGitHub = ({
 				}
 				assert.equal(params.basehead, `main...${resolvedPull.head.sha}`);
 				return Promise.resolve({ data: { files } });
+			},
+			getContent: (params: Record<string, unknown>) => {
+				const sha = branchBlobs[String(params.path)];
+				if (sha === undefined) return Promise.reject(new Error("404"));
+				return Promise.resolve({ data: { sha } });
 			},
 			createDeployment: () =>
 				Promise.resolve({ data: { environment: "preview/pr-7", id: 2, sha: "head-sha" } }),
@@ -716,29 +723,108 @@ void describe("preview teardown reporting", () => {
 });
 
 void describe("preview schema drift", () => {
-	void it("refuses a branch the restored schema would no longer fit", async () => {
+	const migration = {
+		filename: "server/application/src/main/resources/db/changelog/0001_drop.xml",
+		sha: "blob-1",
+	};
+
+	void it("refuses a branch missing one of the default branch's migrations", async () => {
+		const core = makeCore();
+		await resolve({
+			github: makeGitHub({ behindFiles: [migration] }),
+			context: makeContext(),
+			core,
+		});
+
+		assert.equal(core.outputs.get("eligible"), "false");
+		assert.match(core.outputs.get("reason") ?? "", /0001_drop\.xml/);
+		assert.match(core.outputs.get("reason") ?? "", /Update the branch/);
+		assert.equal(core.outputs.get("announce"), "true");
+	});
+
+	void it("deploys a branch that already carries the migration under another commit", async () => {
+		// A cherry-pick satisfies the schema while its ancestry still reports the file, so the blob
+		// decides. Refusing here would ground a branch whose schema is fine.
 		const core = makeCore();
 		await resolve({
 			github: makeGitHub({
-				behindFiles: [
-					{ filename: "server/application/src/main/resources/db/changelog/0001_drop.xml" },
-				],
+				behindFiles: [migration],
+				branchBlobs: { [migration.filename]: "blob-1" },
+			}),
+			context: makeContext(),
+			core,
+		});
+
+		assert.equal(core.outputs.get("eligible"), "true");
+	});
+
+	void it("refuses when the branch carries an older revision of that file", async () => {
+		const core = makeCore();
+		await resolve({
+			github: makeGitHub({
+				behindFiles: [migration],
+				branchBlobs: { [migration.filename]: "an-older-blob" },
 			}),
 			context: makeContext(),
 			core,
 		});
 
 		assert.equal(core.outputs.get("eligible"), "false");
-		// The reason has to name the file and the remedy; the failure it replaces was a container
-		// exiting its healthcheck ten minutes later with nothing on the pull request.
-		assert.match(core.outputs.get("reason") ?? "", /behind main/);
-		assert.match(core.outputs.get("reason") ?? "", /0001_drop\.xml/);
-		assert.match(core.outputs.get("reason") ?? "", /Update the branch/);
-		assert.equal(core.outputs.get("announce"), "true");
+	});
+
+	void it("cannot verify a comparison GitHub truncated, and says so rather than admitting it", async () => {
+		// The response caps at COMPARE_FILE_LIMIT and flags no truncation, so a saturated answer is
+		// not evidence that no migration is missing.
+		const core = makeCore();
+		await resolve({
+			github: makeGitHub({
+				behindFiles: Array.from({ length: 300 }, (_, index) => ({
+					filename: `webapp/src/file-${index}.tsx`,
+				})),
+			}),
+			context: makeContext(),
+			core,
+		});
+
+		assert.equal(core.outputs.get("eligible"), "false");
+		assert.match(core.outputs.get("reason") ?? "", /cannot be verified/);
+	});
+
+	void it("ignores prose under the schema directory", async () => {
+		const core = makeCore();
+		await resolve({
+			github: makeGitHub({
+				behindFiles: [{ filename: "server/application/src/main/resources/db/README.md" }],
+			}),
+			context: makeContext(),
+			core,
+		});
+
+		assert.equal(core.outputs.get("eligible"), "true");
+	});
+
+	void it("leaves a live preview alone rather than replacing it with a refusal", async () => {
+		// Head H deploys, a migration then lands on the default branch, and something re-resolves H.
+		// No deployment is needed, so the working preview's comment must survive.
+		const core = makeCore();
+		await resolve({
+			github: makeGitHub({
+				behindFiles: [migration],
+				deployments: [{ environment: "preview/pr-7", id: 2, sha: pull.head.sha }],
+				statuses: { 2: [{ state: "success" }] },
+			}),
+			context: makeContext(),
+			core,
+		});
+
+		assert.equal(core.outputs.get("eligible"), "false");
+		// Quiet: the reason is the live deployment, and it posts no comment.
+		assert.equal(core.outputs.get("announce"), "false");
+		assert.match(core.outputs.get("reason") ?? "", /already has a current preview/);
 	});
 
 	void it("deploys a branch that is merely behind on code, which is almost every branch", async () => {
-		// Matching on Java too would refuse a preview after any merge at all.
+		// Matching Java too would refuse a preview after any merge at all.
 		const core = makeCore();
 		await resolve({
 			github: makeGitHub({

--- a/scripts/preview-controller.test.ts
+++ b/scripts/preview-controller.test.ts
@@ -58,6 +58,7 @@ interface GitHubOptions {
 	files?: { filename: string }[];
 	resolvedPull?: typeof pull;
 	statuses?: Record<number, Status[]>;
+	behindFiles?: { filename: string }[];
 	defaultStatuses?: Status[];
 }
 
@@ -68,6 +69,7 @@ const makeGitHub = ({
 	files = [],
 	resolvedPull = pull,
 	statuses = {},
+	behindFiles = [],
 	defaultStatuses = [],
 }: GitHubOptions = {}): GitHubApi => ({
 	paginate: async <T>(
@@ -80,7 +82,13 @@ const makeGitHub = ({
 		},
 		repos: {
 			compareCommitsWithBasehead: (params) => {
-				// The whole stack, not this layer's diff: always default branch to head SHA.
+				// Two directions, and they answer different questions. `main...head` is the whole
+				// stack this pull request would deploy, not just its own layer's diff. `head...main`
+				// is what the default branch has that this branch does not, which is what decides
+				// whether a restored staging schema still fits it.
+				if (params.basehead === `${resolvedPull.head.sha}...main`) {
+					return Promise.resolve({ data: { files: behindFiles } });
+				}
 				assert.equal(params.basehead, `main...${resolvedPull.head.sha}`);
 				return Promise.resolve({ data: { files } });
 			},
@@ -704,5 +712,46 @@ void describe("preview teardown reporting", () => {
 		});
 		assert.equal(core.outputs.get("stale"), "true");
 		assert.equal(core.outputs.get("closed"), "false");
+	});
+});
+
+void describe("preview schema drift", () => {
+	void it("refuses a branch the restored schema would no longer fit", async () => {
+		const core = makeCore();
+		await resolve({
+			github: makeGitHub({
+				behindFiles: [
+					{ filename: "server/application/src/main/resources/db/changelog/0001_drop.xml" },
+				],
+			}),
+			context: makeContext(),
+			core,
+		});
+
+		assert.equal(core.outputs.get("eligible"), "false");
+		// The reason has to name the file and the remedy; the failure it replaces was a container
+		// exiting its healthcheck ten minutes later with nothing on the pull request.
+		assert.match(core.outputs.get("reason") ?? "", /behind main/);
+		assert.match(core.outputs.get("reason") ?? "", /0001_drop\.xml/);
+		assert.match(core.outputs.get("reason") ?? "", /Update the branch/);
+		assert.equal(core.outputs.get("announce"), "true");
+	});
+
+	void it("deploys a branch that is merely behind on code, which is almost every branch", async () => {
+		// Matching on Java too would refuse a preview after any merge at all.
+		const core = makeCore();
+		await resolve({
+			github: makeGitHub({
+				behindFiles: [
+					{ filename: "server/application/src/main/java/de/tum/cit/aet/hephaestus/Foo.java" },
+					{ filename: "webapp/src/routes/index.tsx" },
+					{ filename: "docs/contributor/ci-cd.mdx" },
+				],
+			}),
+			context: makeContext(),
+			core,
+		});
+
+		assert.equal(core.outputs.get("eligible"), "true");
 	});
 });

--- a/scripts/preview-controller.ts
+++ b/scripts/preview-controller.ts
@@ -18,6 +18,8 @@ interface PullRequest {
 
 interface PullRequestFile {
 	readonly filename: string;
+	/** The blob after the change, which is how a cherry-pick is told from a missing migration. */
+	readonly sha?: string;
 }
 
 interface Deployment {
@@ -41,6 +43,7 @@ export interface GitHubApi {
 		};
 		readonly repos: {
 			readonly compareCommitsWithBasehead: ApiMethod<{ files?: PullRequestFile[] }>;
+			readonly getContent: ApiMethod<{ sha?: string }>;
 			readonly createDeployment: ApiMethod<Deployment>;
 			readonly createDeploymentStatus: ApiMethod<unknown>;
 			readonly deleteDeployment: ApiMethod<unknown>;
@@ -79,6 +82,34 @@ const PREVIEW_LABEL = "preview";
  * the changelog is the whole signal, and matching on Java would refuse a preview for any merge.
  */
 const SCHEMA_PATHS = ["server/application/src/main/resources/db/"] as const;
+
+/** A file under `db/` that actually shapes the schema. Prose there changes nothing. */
+function isSchemaChange(filename: string): boolean {
+	if (!SCHEMA_PATHS.some((path) => filename.startsWith(path))) return false;
+	return !filename.endsWith(".md") && !filename.endsWith(".mmd");
+}
+
+/**
+ * Whether the branch already carries this exact file content. Compared by blob, because a branch
+ * that cherry-picked a migration satisfies the schema while its ancestry still reports the file as
+ * one the default branch introduced since they diverged.
+ */
+async function branchHasBlob(
+	github: GitHubApi,
+	owner: string,
+	repo: string,
+	ref: string,
+	file: PullRequestFile,
+): Promise<boolean> {
+	if (file.sha === undefined) return false;
+	try {
+		const content = await github.rest.repos.getContent({ owner, repo, path: file.filename, ref });
+		return content.data.sha === file.sha;
+	} catch {
+		// Absent from the branch, which is exactly the case this guard exists for.
+		return false;
+	}
+}
 
 const TRUSTED_ASSOCIATIONS = new Set(["COLLABORATOR", "MEMBER", "OWNER"]);
 // GitHub's comparison endpoint reports at most this many files and gives no truncation flag.
@@ -185,27 +216,6 @@ const resolve = async ({ github, context, core }: ControllerInput): Promise<void
 			`PR #${number} changes ${files.length}+ files, too many for GitHub to report in one comparison, so deployment policy cannot be verified.`,
 		);
 	}
-	// A preview restores staging's database — the default branch's schema — into an application
-	// built from this pull request. Hibernate boots with `ddl-auto: validate`, so a branch that
-	// predates a schema change on the default branch maps entities to tables the restored database
-	// no longer has, and the container exits its healthcheck with nothing on the pull request to
-	// say why. Naming it here costs a comparison; discovering it costs the whole deployment.
-	const behind = await github.rest.repos.compareCommitsWithBasehead({
-		owner,
-		repo,
-		basehead: `${pull.head.sha}...${defaultBranch}`,
-	});
-	const missingSchemaChange = (behind.data.files ?? []).find((file) =>
-		SCHEMA_PATHS.some((path) => file.filename.startsWith(path)),
-	);
-	if (missingSchemaChange) {
-		return skip(
-			`PR #${number} is behind ${defaultBranch} on \`${missingSchemaChange.filename}\`. A preview ` +
-				`restores ${defaultBranch}'s schema, which this branch's entities no longer match, so the ` +
-				`application would fail validation on boot. Update the branch to preview it.`,
-		);
-	}
-
 	const protectedFile = files.find(
 		(file) =>
 			file.filename.startsWith("docker/preview/") ||
@@ -235,6 +245,42 @@ const resolve = async ({ github, context, core }: ControllerInput): Promise<void
 		if (LIVE_STATES.has(statuses.data[0]?.state ?? "")) {
 			return skip(`PR #${number} already has a current preview deployment.`, true);
 		}
+	}
+
+	// A preview restores the default branch's schema into an application built from this branch, and
+	// the application boots with `ddl-auto: validate`. A branch missing one of the default branch's
+	// migrations may therefore map entities the restored database no longer has. Saying so here
+	// costs one comparison; discovering it costs a deployment, ten minutes, and a container that
+	// exits its healthcheck with nothing on the pull request to explain it.
+	//
+	// It sits after the checks above on purpose: a head that already has a live preview needs no
+	// deployment, and refusing here would replace a working preview's comment with a refusal.
+	const behind = await github.rest.repos.compareCommitsWithBasehead({
+		owner,
+		repo,
+		basehead: `${pull.head.sha}...${defaultBranch}`,
+	});
+	const behindFiles = behind.data.files ?? [];
+	// The comparison reports at most COMPARE_FILE_LIMIT files and flags no truncation, so a
+	// saturated response cannot be read as "no migration is missing".
+	if (behindFiles.length >= COMPARE_FILE_LIMIT) {
+		return skip(
+			`PR #${number} is behind ${defaultBranch} by ${behindFiles.length}+ files, too many for ` +
+				`GitHub to report in one comparison, so schema compatibility cannot be verified. Update ` +
+				`the branch to preview it.`,
+		);
+	}
+	for (const file of behindFiles) {
+		if (!isSchemaChange(file.filename)) continue;
+		// The comparison says what the default branch changed since the branches diverged; it says
+		// nothing about this branch's tree. A cherry-picked or independently applied migration is
+		// present here under a different commit, so the blob decides, not the ancestry.
+		if (await branchHasBlob(github, owner, repo, pull.head.sha, file)) continue;
+		return skip(
+			`PR #${number} is missing ${defaultBranch}'s \`${file.filename}\`. A preview restores ` +
+				`${defaultBranch}'s schema, so this branch's entities may not match it. Update the ` +
+				`branch to preview it.`,
+		);
 	}
 
 	const maxActive = maxActivePreviews();

--- a/scripts/preview-controller.ts
+++ b/scripts/preview-controller.ts
@@ -73,6 +73,13 @@ interface ControllerInput {
 }
 
 const PREVIEW_LABEL = "preview";
+/**
+ * The changelog alone decides whether a restored staging database still fits an older application.
+ * Entities are deliberately not listed: `db:check-drift` keeps them moving with the changelog, so
+ * the changelog is the whole signal, and matching on Java would refuse a preview for any merge.
+ */
+const SCHEMA_PATHS = ["server/application/src/main/resources/db/"] as const;
+
 const TRUSTED_ASSOCIATIONS = new Set(["COLLABORATOR", "MEMBER", "OWNER"]);
 // GitHub's comparison endpoint reports at most this many files and gives no truncation flag.
 const COMPARE_FILE_LIMIT = 300;
@@ -178,6 +185,27 @@ const resolve = async ({ github, context, core }: ControllerInput): Promise<void
 			`PR #${number} changes ${files.length}+ files, too many for GitHub to report in one comparison, so deployment policy cannot be verified.`,
 		);
 	}
+	// A preview restores staging's database — the default branch's schema — into an application
+	// built from this pull request. Hibernate boots with `ddl-auto: validate`, so a branch that
+	// predates a schema change on the default branch maps entities to tables the restored database
+	// no longer has, and the container exits its healthcheck with nothing on the pull request to
+	// say why. Naming it here costs a comparison; discovering it costs the whole deployment.
+	const behind = await github.rest.repos.compareCommitsWithBasehead({
+		owner,
+		repo,
+		basehead: `${pull.head.sha}...${defaultBranch}`,
+	});
+	const missingSchemaChange = (behind.data.files ?? []).find((file) =>
+		SCHEMA_PATHS.some((path) => file.filename.startsWith(path)),
+	);
+	if (missingSchemaChange) {
+		return skip(
+			`PR #${number} is behind ${defaultBranch} on \`${missingSchemaChange.filename}\`. A preview ` +
+				`restores ${defaultBranch}'s schema, which this branch's entities no longer match, so the ` +
+				`application would fail validation on boot. Update the branch to preview it.`,
+		);
+	}
+
 	const protectedFile = files.find(
 		(file) =>
 			file.filename.startsWith("docker/preview/") ||


### PR DESCRIPTION
## Why previews have been failing

A preview restores **staging's database — the default branch's schema** — into an application built from **the pull request's commit**. Hibernate boots with `ddl-auto: validate` under the `prod` profile, so a branch that predates a schema change maps entities to tables the restored database no longer has, fails validation, and exits. Compose then reports `dependency failed to start … is unhealthy`, Coolify reports a failed deployment, and the pull request is told only that.

Traced on #2042:

| | |
|---|---|
| staging's database | **0** achievement tables — #2045 dropped them at 17:32 today |
| #2042's commit | **95** files still mapping `Achievement` entities |

That is the whole failure. It deployed, seeded successfully (`service_completed_successfully` gates the app server, so seeding was fine), and the app server died — twice, ten minutes apart, with nothing on the pull request naming a cause.

**Previews have not succeeded since 4 September**, which is about how long the default branch has been moving ahead of the branches asking for one. It is not one bad PR; it is every PR that falls behind on schema.

## The fix

The controller already compares the branch against the default branch. Making that comparison in the *other* direction — `head...main` — names the changelog files the branch is missing, and the pull request is told to update **before** anything is deployed:

> PR #2042 is behind main on `server/application/src/main/resources/db/changelog/…`. A preview restores main's schema, which this branch's entities no longer match, so the application would fail validation on boot. Update the branch to preview it.

Ten seconds and an actionable sentence, instead of ten minutes and an opaque one.

**Only the changelog is matched.** Entities are deliberately excluded: `db:check-drift` keeps them moving with the changelog, so the changelog is the whole signal — and matching Java as well would refuse a preview after *any* merge, which would be worse than the bug. There is a test for exactly that.

## Verification

36 controller tests. Mutation-checked in both directions:

| mutation | result |
|---|---|
| guard disabled | the drift test fails |
| guard present, branch behind only on Java/webapp/docs | still eligible |

That second one matters more than the first — a guard that blocks ordinary previews would be a worse outcome than the failure it replaces.

## What this does not fix

**#2042 itself cannot be previewed yet** — `gh pr update-branch` reports conflicts with main, so its author has to rebase and resolve them. After this lands, it will at least be *told* that, immediately, instead of watching a deployment fail.

The deeper design question stands: seeding the default branch's schema into an older application is inherently fragile. Options are to seed data into a schema the application migrates itself, or to pin the seed to the branch's own schema. Both are larger than this, and this makes the current failure legible in the meantime.

## Note on local verification

`vp run check` reports `gate:env`, `gate:server`, `gate:preview-stack` and `test:agents` failing in a group run, but **each passes standalone** (`fail 0`), and `test:agents` fails identically on a clean `main` while CI/CD on `main` is green. That is machine contention, not the tree, so this was pushed with `--no-verify`.