### PR TITLE
fix(ci): stop enforcing a Scorecard check that does not describe this tree

### DIFF
--- a/scripts/check-scorecard.test.ts
+++ b/scripts/check-scorecard.test.ts
@@ -35,7 +35,6 @@ const enforced: Record<string, { score: number; scoredOver: string }> = {
 	SAST: { score: 10, scoredOver: "history" },
 	"Security-Policy": { score: 10, scoredOver: "configuration" },
 	"Token-Permissions": { score: 10, scoredOver: "configuration" },
-	Vulnerabilities: { score: 10, scoredOver: "configuration" },
 	"Signed-Releases": { score: 8, scoredOver: "history" },
 	"Branch-Protection": { score: 4, scoredOver: "configuration" },
 };
@@ -109,10 +108,14 @@ void test("a push answers for the configuration its commit left and no other eve
 		});
 });
 
-void test("only the four deliberate exclusions may drop without failure", () => {
+void test("only the deliberate exclusions may drop without failure", () => {
 	const value = assessment();
 	for (const check of value.checks)
-		if (["Contributors", "CII-Best-Practices", "Fuzzing", "Packaging"].includes(String(check.name)))
+		if (
+			["Contributors", "CII-Best-Practices", "Fuzzing", "Packaging", "Vulnerabilities"].includes(
+				String(check.name),
+			)
+		)
 			check.score = -1;
 	assert.deepEqual(checkScorecard(baseline, value, now), passes);
 });

--- a/security/scorecard-baseline.json
+++ b/security/scorecard-baseline.json
@@ -72,7 +72,7 @@
 			"name": "Vulnerabilities",
 			"score": 10,
 			"scoredOver": "configuration",
-			"reason": "Advisories open against the dependencies the checkout resolves."
+			"reason": "Advisories open against the dependencies the checkout resolves. Excluded below: what it reports is not what this checkout resolves."
 		},
 		{
 			"name": "Signed-Releases",
@@ -104,6 +104,7 @@
 		}
 	],
 	"excluded": {
+		"Vulnerabilities": "Reports fourteen advisories against version ranges this tree resolves outside of \u2014 jackson-core 2.21.5, jackson-databind 2.21.5, graphql-java 25.0, pmd-core 7.27.0, commons-lang3 3.20.0, bcprov-lts8on 2.73.11, handlebars 4.5.2 \u2014 while Dependabot reports none. The list did not change when #2075 forced two of them to patched versions, so it does not track what this repository resolves. Enforcing it would report a regression that does not exist. Tracked in #2078.",
 		"Contributors": "Organization diversity is not a repository engineering control.",
 		"CII-Best-Practices": "An OpenSSF badge is a separate adoption decision.",
 		"Fuzzing": "Fuzzing adoption is a separate policy decision.",


### PR DESCRIPTION
Turns `main` green. Closes the last failing check after #2075 fixed `Binary-Artifacts`.

## The check is wrong, not the tree

`Vulnerabilities` has failed since #2062 gave Scorecard a Java dependency tree it had never seen — the baseline recorded `10` on 4 September, when it could see none. Every one of the fourteen advisories it reports names a version range this checkout resolves **outside** of:

| package | resolved | vulnerable range | in range? |
|---|---|---|---|
| `jackson-core` | 2.21.5 | patched at 2.21.1 | no |
| `jackson-databind` | 2.21.5 | patched at 2.21.4 | no |
| `graphql-java` | 25.0 | `<19.11`, `20.0–20.9`, `21.0–21.5` | no |
| `pmd-core` | 7.27.0 | `<= 7.21.0` | no |
| `commons-lang3` | 3.20.0 | `>=3.0, <3.18.0` | no |
| `bcprov-lts8on` | 2.73.11 | `>=2.73.0, <=2.73.10` | no |
| `handlebars` | 4.5.2 (forced in #2075) | `< 4.5.2` | no |

Two independent corroborations:

- **Dependabot reports zero open alerts** against this repository.
- The advisory list was **byte-identical before and after #2075** forced two of these to patched versions — so whatever Scorecard reads did not change when the dependencies did.

## Why exclude rather than lower the minimum

Lowering the minimum would leave a check that still claims to enforce something. Excluding it says plainly that it is not enforced and why, which is what `excluded` exists for — and the reason field carries the evidence so the next reader can re-derive it instead of trusting this PR.

A gate asserting a regression that does not exist is worse than no gate: it teaches people to route around it. That is the same failure mode as the fail-open annotation bug fixed in #2060 earlier today, pointing the other way.

**#2078** carries the real work — establishing whether Scorecard scans the committed lockfiles, the submitted dependency graph, or resolves the build itself, and enforcing the check again once that is known.

## What is not excluded

`Binary-Artifacts` is enforced and scores **10** again, confirmed by re-running the ratchet after #2075: the wrapper validation now runs in `cicd.yml`, a workflow Scorecard can see a successful run for.

## Verification

- The ratchet run against the **real assessment that was failing** now returns `{ failures: [], reported: [] }`.
- 17 tests in `check-scorecard.test.ts`, including the two that pin the enforced policy — both updated deliberately, so removing a check from enforcement stays an explicit edit rather than a silent one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Updated vulnerability scorecard reporting to exclude advisories that do not apply to the versions resolved by the project.
  - Prevented non-actionable advisories from being treated as security regressions.
  - Clarified the handling of excluded vulnerability findings in the security baseline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->