### PR TITLE
perf(ci): reduce test database I/O and compare hosted runners

### DIFF
--- a/.github/workflows/ci-profile.yml
+++ b/.github/workflows/ci-profile.yml
@@ -6,10 +6,10 @@ on:
   workflow_dispatch:
     inputs:
       suite:
-        description: "Server tier to profile"
+        description: "Server profile or application-integration runner comparison"
         type: choice
         default: all
-        options: [all, integration, verification]
+        options: [all, integration, verification, runner-comparison]
 
 concurrency:
   group: ci-profile-${{ github.ref }}
@@ -20,7 +20,7 @@ permissions: {}
 jobs:
   server-integration:
     name: "Server integration profile"
-    if: github.event_name != 'workflow_dispatch' || inputs.suite != 'verification'
+    if: github.event_name != 'workflow_dispatch' || (inputs.suite != 'verification' && inputs.suite != 'runner-comparison')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -149,7 +149,7 @@ jobs:
   server-verification:
     name: "Server unit and architecture profile"
     needs: server-integration
-    if: ${{ !cancelled() && (github.event_name != 'workflow_dispatch' || inputs.suite != 'integration') }}
+    if: ${{ !cancelled() && (github.event_name != 'workflow_dispatch' || (inputs.suite != 'integration' && inputs.suite != 'runner-comparison')) }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -228,3 +228,60 @@ jobs:
           path: tmp/ci-metrics/ci-latency.json
           if-no-files-found: error
           retention-days: 30
+
+  runner-comparison:
+    name: "Application integration (${{ matrix.runner }}, sample ${{ matrix.sample }})"
+    if: github.event_name == 'workflow_dispatch' && inputs.suite == 'runner-comparison'
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 25
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        include:
+          - runner: ubuntu-24.04
+            sample: 1
+          - runner: ubuntu-24.04-arm
+            sample: 1
+          - runner: ubuntu-24.04-arm
+            sample: 2
+          - runner: ubuntu-24.04
+            sample: 2
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-toolchain
+        with:
+          install: "frozen"
+      - uses: ./.github/actions/setup-caches
+      - name: Record runner hardware
+        run: |
+          mkdir -p ci-metrics
+          lscpu > ci-metrics/cpu.txt
+          free -m > ci-metrics/memory.txt
+      - name: Prepare compiled tests
+        working-directory: server
+        run: ./gradlew :application:testClasses --profile
+      - name: Run application integration tests
+        env:
+          HEPHAESTUS_INTEGRATION_SHARD: application
+        run: vp run test:server:integration --profile
+      - name: Summarize test results
+        if: ${{ !cancelled() }}
+        run: >-
+          vp run report:test-results "Application integration runner comparison"
+          server/application/build/test-results/integrationTest ci-metrics/test-results.json
+      - name: Retain comparison evidence
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: runner-comparison-${{ matrix.runner }}-${{ matrix.sample }}-${{ github.run_attempt }}
+          path: |
+            ci-metrics
+            server/application/build/test-results/integrationTest
+            server/build/reports/profile
+          if-no-files-found: error
+          retention-days: 14

--- a/docs/contributor/ci-cd.mdx
+++ b/docs/contributor/ci-cd.mdx
@@ -656,6 +656,13 @@ measurements. GNU time's CPU/RSS accounting does not reliably include Gradle's d
 values are not reported as suite metrics or compared against budgets. Inspect the retained JFR recordings
 for JVM CPU, allocation and GC diagnostics instead.
 
+The manual `runner-comparison` selection runs the application integration shard twice each on standard
+Ubuntu 24.04 x64 and ARM64 runners, one job at a time. Preparation is a separate step so cold dependency
+and compilation caches are not mistaken for test execution speed. Each sample retains runner hardware,
+JUnit results and Gradle task profiles. Compare actual job ordering, test counts and execution time as
+well as end-to-end latency; matrix declaration order is not a scheduling guarantee. These samples do
+not enter full-suite JFR history and do not change the runners used for required CI.
+
 The integration profile additionally records Spring context-cache metrics. It warns about
 a sustained regression after three consecutive profiles exceed variance limits against five earlier
 default-branch profiles or absolute Spring-context limits. Only successful test runs with a readable

--- a/docs/contributor/testing.mdx
+++ b/docs/contributor/testing.mdx
@@ -99,6 +99,10 @@ Generation and compilation dependencies are automatic. Test tasks always execute
 compilation remains incremental and cacheable. `--no-build-cache` prevents output restoration;
 combine it with `clean` when measuring a cold build.
 
+The shared integration PostgreSQL container keeps its ephemeral data directory on tmpfs. Database
+cleanup still truncates every application table transactionally; SQL constraints and isolation checks
+remain enabled. This container does not prove storage durability across container restarts.
+
 `vp run test:server:selection` asks Gradle/JUnit to discover tests without executing them. It proves
 that non-live tests belong to a required tier and that integration shards are disjoint and complete.
 Required PR verification and `vp run verify` run this proof before the real suites. Discovery writes

--- a/scripts/ci-profile-history.test.ts
+++ b/scripts/ci-profile-history.test.ts
@@ -141,3 +141,27 @@ void test("both profile tiers use a fresh Gradle process", () => {
 		assert.match(String(profile.get("run")), /--no-daemon/);
 	}
 });
+
+void test("runner comparisons are manual, sequential and separate from profile history", () => {
+	const benchmark = workflow.getIn(["jobs", "runner-comparison"]);
+	assert.ok(isMap(benchmark));
+	assert.match(
+		String(benchmark.get("if")),
+		/github\.event_name == 'workflow_dispatch' && inputs\.suite == 'runner-comparison'/,
+	);
+	assert.equal(benchmark.getIn(["strategy", "max-parallel"]), 1);
+	assert.equal(benchmark.getIn(["strategy", "fail-fast"]), false);
+	const matrix = benchmark.getIn(["strategy", "matrix", "include"]);
+	assert.ok(isSeq(matrix));
+	assert.deepEqual(matrix.toJSON(), [
+		{ runner: "ubuntu-24.04", sample: 1 },
+		{ runner: "ubuntu-24.04-arm", sample: 1 },
+		{ runner: "ubuntu-24.04-arm", sample: 2 },
+		{ runner: "ubuntu-24.04", sample: 2 },
+	]);
+	for (const job of ["server-integration", "server-verification"])
+		assert.match(
+			String(workflow.getIn(["jobs", job, "if"])),
+			/inputs\.suite != 'runner-comparison'/,
+		);
+});

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/testconfig/PostgreSQLTestContainer.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/testconfig/PostgreSQLTestContainer.java
@@ -5,6 +5,7 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.Map;
 import java.util.regex.Pattern;
 import liquibase.Contexts;
 import liquibase.Liquibase;
@@ -125,7 +126,8 @@ public final class PostgreSQLTestContainer {
                         .asCompatibleSubstituteFor("postgres"))
                 .withDatabaseName(DEFAULT_TEST_DB)
                 .withUsername(DEFAULT_TEST_USER)
-                .withPassword(DEFAULT_TEST_PASSWORD);
+                .withPassword(DEFAULT_TEST_PASSWORD)
+                .withTmpFs(Map.of("/var/lib/postgresql", "rw"));
 
         newContainer.start();
         ensureExtensions(


### PR DESCRIPTION
## What changed and why

The integration profile attributes substantial time to resetting the test database. Keep the same PostgreSQL image, schema, constraints and transactional full-table cleanup, but put the shared test container's ephemeral data directory on Testcontainers' native tmpfs mount.

Also add an opt-in runner comparison to the existing CI profile workflow: two application-integration samples each on standard Ubuntu 24.04 x64 and ARM64. Samples run one at a time, compile preparation is measured separately, and runner hardware, JUnit results and Gradle profiles are retained. Required CI runners and full-suite profile history are unchanged.

## How to test

- `vp run format` and `vp run check` passed.
- `vp run test:server:unit` passed.
- Four local application-integration runs (disk → tmpfs → tmpfs → disk) each passed exactly the same 1,010 test identities, without skips or errors. Cleanup totals were 50.35s / 30.09s / 29.35s / 42.27s for 942 calls each; summed JUnit suite times were 194.06s / 150.24s / 146.46s / 161.78s. Against the final warmed disk run, tmpfs reduced cleanup time by 29–31% and summed suite time by 7–9.5%. These local results are not a promised end-to-end CI reduction.
- [PR CI](https://github.com/hephaestus-build/Hephaestus/actions/runs/34318292431) passed; the CI Status Gate completed 9m45s after run creation. The [free hosted runner comparison](https://github.com/hephaestus-build/Hephaestus/actions/runs/34318286593) passed all four samples: each ran exactly the same 1,010 test identities, without failures or skips.
- Docker inspection confirmed the PostgreSQL data directory is actually on tmpfs. The test cluster used approximately 258 MiB during the run.
- Actionlint and Zizmor passed; workflow contracts ensure the comparison is manual, sequential and separate from full-suite profiles.
- Manual smoke: dispatch `CI profile` with `suite=runner-comparison` on the PR branch. Compare all four artifacts, checking identical test identities, no failures, runner hardware, preparation time and execution time separately.

## Release impact

Test and diagnostic tooling only. No production image, storage configuration, runtime behavior or release-policy changes; no user-facing changeset is needed. The shared ephemeral integration container does not prove durability across container restarts.

## Notes for reviewers

The capacity audit found 19–20 concurrent jobs through the delayed interval. Manual full CI runs consumed approximately 56% of measured runner time; merge groups accounted for about 4%. Increasing merge-queue speculation would not fix the demonstrated constraint, and no ruleset change or cancellation of other branches is included.

GitHub reports that larger hosted runners are not supported for this organization. No additional capacity or paid runners will be allocated. This comparison uses the available standard public-repository ARM64 runner. Ubuntu 24.04 labels keep the experiment on the same OS release; they do not select individual machines. Required test jobs retain ubuntu-latest, and no custom runner pool or fallback scheduler is introduced.

Sources: [Docker tmpfs mounts](https://docs.docker.com/engine/storage/tmpfs/), [GitHub standard hosted runners](https://docs.github.com/en/actions/reference/runners/github-hosted-runners), [Actions concurrency limits](https://docs.github.com/en/actions/reference/limits#job-concurrency-limits-for-github-hosted-runners).

### Hosted runner comparison result

Actual scheduling order was x64 → ARM64 → ARM64 → x64:

| Runner | Sample | Compile preparation | Integration test step |
| --- | --- | --- | --- |
| Ubuntu 24.04 x64 | 1 | 1m46s | 5m02s |
| Ubuntu 24.04 ARM64 | 1 | 3m55s | 4m45s |
| Ubuntu 24.04 ARM64 | 2 | 3m42s | 4m39s |
| Ubuntu 24.04 x64 | 2 | 2m01s | 4m14s |

The test-step averages are effectively tied (x64 4m38s; ARM64 4m42s), and two samples cannot establish a stable performance distribution. Preparation is not a hardware-only comparison: the first x64 sample restored six Gradle task outputs while ARM64 executed all nine preparation tasks. Both test steps executed three tasks with nine up-to-date prerequisites. Container startup remains part of the measured test step.

**Decision:** retain the existing shared `ubuntu-latest` runner for required tests. There is no demonstrated test-phase benefit to justify ARM64 routing or a separate warmed-cache lane. No paid capacity, individual-machine pinning, custom fallback scheduler, additional CI sharding, or weaker test coverage was introduced.
