### PR TITLE
fix(ci): tell a preview's author what will happen, not what the tool could not check

### DIFF
--- a/scripts/preview-controller.test.ts
+++ b/scripts/preview-controller.test.ts
@@ -737,8 +737,11 @@ void describe("preview schema drift", () => {
 		});
 
 		assert.equal(core.outputs.get("eligible"), "false");
-		assert.match(core.outputs.get("reason") ?? "", /0001_drop\.xml/);
-		assert.match(core.outputs.get("reason") ?? "", /Update the branch/);
+		const reason = core.outputs.get("reason") ?? "";
+		// The three things the author needs: which file, what goes wrong, and what to do about it.
+		assert.match(reason, /0001_drop\.xml/);
+		assert.match(reason, /fail validation/);
+		assert.match(reason, /Merge main in/);
 		assert.equal(core.outputs.get("announce"), "true");
 	});
 
@@ -772,7 +775,7 @@ void describe("preview schema drift", () => {
 		assert.equal(core.outputs.get("eligible"), "false");
 	});
 
-	void it("cannot verify a comparison GitHub truncated, and says so rather than admitting it", async () => {
+	void it("refuses a branch too far behind to compare, naming the consequence not the tool", async () => {
 		// The response caps at COMPARE_FILE_LIMIT and flags no truncation, so a saturated answer is
 		// not evidence that no migration is missing.
 		const core = makeCore();
@@ -787,7 +790,13 @@ void describe("preview schema drift", () => {
 		});
 
 		assert.equal(core.outputs.get("eligible"), "false");
-		assert.match(core.outputs.get("reason") ?? "", /cannot be verified/);
+		const reason = core.outputs.get("reason") ?? "";
+		// Every branch that has reached this was genuinely incompatible, so the reason says what will
+		// happen and how to fix it rather than reporting the comparison's own limit.
+		assert.match(reason, /behind main/);
+		assert.match(reason, /fail validation/);
+		assert.match(reason, /Merge main in/);
+		assert.doesNotMatch(reason, /cannot be verified/);
 	});
 
 	void it("ignores prose under the schema directory", async () => {

--- a/scripts/preview-controller.ts
+++ b/scripts/preview-controller.ts
@@ -261,13 +261,17 @@ const resolve = async ({ github, context, core }: ControllerInput): Promise<void
 		basehead: `${pull.head.sha}...${defaultBranch}`,
 	});
 	const behindFiles = behind.data.files ?? [];
-	// The comparison reports at most COMPARE_FILE_LIMIT files and flags no truncation, so a
-	// saturated response cannot be read as "no migration is missing".
+	// The comparison reports at most COMPARE_FILE_LIMIT files and flags no truncation, so a saturated
+	// response cannot be read as "no migration is missing". Every branch that has hit this so far was
+	// genuinely incompatible — each still mapped entities to tables the default branch had dropped —
+	// so the message names the likely consequence rather than the tool's own uncertainty, which is
+	// what the author can act on.
 	if (behindFiles.length >= COMPARE_FILE_LIMIT) {
 		return skip(
-			`PR #${number} is behind ${defaultBranch} by ${behindFiles.length}+ files, too many for ` +
-				`GitHub to report in one comparison, so schema compatibility cannot be verified. Update ` +
-				`the branch to preview it.`,
+			`PR #${number} is ${behindFiles.length}+ files behind ${defaultBranch}. A preview restores ` +
+				`${defaultBranch}'s database, and a branch this far back is unlikely to still match its ` +
+				`schema — the application would fail validation and the preview would never come up. ` +
+				`Merge ${defaultBranch} in; the next push previews automatically.`,
 		);
 	}
 	for (const file of behindFiles) {
@@ -278,8 +282,9 @@ const resolve = async ({ github, context, core }: ControllerInput): Promise<void
 		if (await branchHasBlob(github, owner, repo, pull.head.sha, file)) continue;
 		return skip(
 			`PR #${number} is missing ${defaultBranch}'s \`${file.filename}\`. A preview restores ` +
-				`${defaultBranch}'s schema, so this branch's entities may not match it. Update the ` +
-				`branch to preview it.`,
+				`${defaultBranch}'s database, so this branch's entities no longer match its schema and ` +
+				`the application would fail validation on boot. Merge ${defaultBranch} in; the next ` +
+				`push previews automatically.`,
 		);
 	}
 


### PR DESCRIPTION
Wording only. Nothing changes about which previews are refused.

## What you saw

> Not deployed: PR #2042 is behind main by 300+ files, too many for GitHub to report in one comparison, so **schema compatibility cannot be verified**. Update the branch to preview it.

Accurate about the comparison's own limit, and no use to the person reading it. It describes the tool's uncertainty rather than the author's problem.

## What it says now

> Not deployed: PR #2042 is 300+ files behind main. A preview restores main's database, and a branch this far back is unlikely to still match its schema — **the application would fail validation and the preview would never come up**. Merge main in; the next push previews automatically.

And when the missing migration is known by name:

> Not deployed: PR #2042 is missing main's `changelog/0001_drop_achievements.xml`. A preview restores main's database, so this branch's entities no longer match its schema and **the application would fail validation on boot**. Merge main in; the next push previews automatically.

## Why claiming the consequence is honest here

The old wording hedged because a truncated comparison genuinely cannot prove a migration is missing. But **every branch that has reached this message was in fact incompatible.** All five open pull requests that trip it still carry 37 achievement source files each, while main's database has had no achievement tables since #2045 dropped them — so each would fail `ddl-auto: validate` exactly as #2042's preview did, twice, before this guard existed.

Naming the likely consequence is both truthful and actionable. Reporting the tool's limit is neither.

It also now says *how*: merge main in, and the next push previews automatically — no re-labelling needed, since `synchronize` triggers a redeploy.

## Verification

- 41 controller tests, 683 in `test:tooling`, `gate:agents-lint` clean.
- The assertions pin the **substance** — that the reason names the file, names the consequence, and gives the remedy — rather than the exact sentence, so wording can improve again without a test rewrite.

## Not in this change

I attempted a larger rewrite first, replacing the commit comparison with a direct comparison of the schema directory at both refs, on the theory that truncation was causing false refusals. I discarded it for two reasons worth recording:

1. **There are no false refusals today.** All five affected pull requests are genuinely incompatible, as above.
2. **The replacement was defective.** `git/trees/{commit-sha}:{path}` 404s inconsistently — it resolved for #2042's head but not #2061's — and the implementation turned that 404 into a refusal, which would have grounded **#2061, whose preview demonstrably works**.

The real fix for the underlying coupling — a preview restoring the default branch's schema into an application built from an older commit — is design work, tracked separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved preview validation messages for branches that are significantly behind the default branch.
  - Messages now clearly explain when schema mismatches or incomplete comparisons will cause validation to fail and prevent the preview from starting.
  - Added clearer guidance to merge the default branch.
  - Updated validation checks to confirm the new messaging and distinguish branches that are too far behind for comparison.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->