### PR TITLE
fix(ci): score Binary-Artifacts over the window it actually needs

### DIFF
--- a/scripts/check-scorecard.test.ts
+++ b/scripts/check-scorecard.test.ts
@@ -24,7 +24,7 @@ const assessment = () => ({
  * the scoring each check is charged under, so that reclassifying one is a deliberate edit as well.
  */
 const enforced: Record<string, { score: number; scoredOver: string }> = {
-	"Binary-Artifacts": { score: 10, scoredOver: "configuration" },
+	"Binary-Artifacts": { score: 10, scoredOver: "history" },
 	"CI-Tests": { score: 10, scoredOver: "history" },
 	"Code-Review": { score: 10, scoredOver: "history" },
 	"Dangerous-Workflow": { score: 10, scoredOver: "configuration" },

--- a/security/scorecard-baseline.json
+++ b/security/scorecard-baseline.json
@@ -5,8 +5,8 @@
 		{
 			"name": "Binary-Artifacts",
 			"score": 10,
-			"scoredOver": "configuration",
-			"reason": "Executables committed to the tree as it stands."
+			"scoredOver": "history",
+			"reason": "Executables committed to the tree, and for the committed Gradle wrapper the successful validation run that vouches for it. That run is what makes this a window: on a push the wrapper job is still executing, so the commit cannot yet answer for itself."
 		},
 		{
 			"name": "CI-Tests",


### PR DESCRIPTION
`Scorecard ratchet` has been red on every push since #2075, and my earlier report that it was fixed was based on one run that passed by luck.

## It cannot pass on a push, structurally

Timings on `08f1f7a61`:

```
Scorecard ratchet:  07:18:35 → 07:18:46  (11s)     FAILURE
OpenSSF Scorecard:  07:18:35 → 07:19:36  (61s)     success
CI/CD:              07:18:36 → 07:23:47  (5m 11s)  success
```

All three start from the same push. The ratchet finishes **five minutes before** the `CI/CD` run completes — and since #2075, Binary-Artifacts is satisfied only by *a successful run of the validating workflow at the latest commit*. On a push, that run is still executing. No push could ever pass.

The one green run I reported earlier was a manual re-run I triggered *after* `CI/CD` had finished. That was the anomaly, not the norm — I should have noticed the difference at the time.

## The check moved from configuration to history and I did not reclassify it

Before #2075 it read the tree: are there committed executables? That is configuration, answerable by the commit itself.

After #2075 it reads a workflow run. That is **history** — and the baseline still called it configuration, so a push asked the commit a question only its own CI could answer.

`scoredOver: "history"` is the mechanism this ratchet already has for exactly this shape. `Signed-Releases`, `CI-Tests`, `Code-Review`, `Maintained` and `SAST` all carry it. From `check-scorecard.ts`:

```ts
(event === "push" && scoring === "history" ? reported : failures).push(regression);
```

## What changes

| event | before | after |
|---|---|---|
| push | **fails** — evidence does not exist yet | reported as an observation |
| schedule (weekly), `branch_protection_rule`, manual | fails | **still fails** |

The check keeps its teeth where it can be answered and stops failing where it structurally cannot. It is not excluded, and its minimum is unchanged at 10.

## Verification

Run against the assessment that is failing right now (`scorecard-ratchet-08f1f7a61…`):

```
as a push:     {"failures":[],"reported":["Binary-Artifacts: 9 (minimum 10)"]}
as any other:  {"failures":["Binary-Artifacts: 9 (minimum 10)"],"reported":[]}
```

17 tests in `check-scorecard.test.ts`, 684 in `test:tooling`. The test that pins the enforced policy required a deliberate edit, so a reclassification stays visible rather than silent.

## What this does not do

It does not make the wrapper validation unnecessary — #2075's job still runs on every push and still fails the `CI Status Gate` if the wrapper is bad. This only changes when the *ratchet* is entitled to a verdict about it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the security scorecard baseline to classify the Binary-Artifacts check against repository history.
  - Clarified the validation rationale for committed Gradle wrapper artifacts while verification is in progress.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->