### PR TITLE
fix(ci): make a preview honest about what it knows, and clear about what it is

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -93,9 +93,9 @@ jobs:
           message: |
             ## 🚧 App Preview
 
-            Deploying `${{ steps.context.outputs.head_sha }}` — follow it under **Environments → `${{ steps.context.outputs.environment }}`** on this pull request.
+            Deploying [`${{ steps.context.outputs.head_sha }}`](${{ github.server_url }}/${{ github.repository }}/commit/${{ steps.context.outputs.head_sha }}) to [`${{ steps.context.outputs.environment }}`](${{ steps.context.outputs.environment_page }}) — [watch the run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).
 
-            <sub>Waits for the images CI publishes for this commit, then deploys. Updates on every commit, draft or not. Remove the `preview` label to tear it down.</sub>
+            <sub>Waits for the images CI publishes for this commit, then deploys. Updates on every push, draft or not. Remove the `preview` label to tear it down.</sub>
 
       - name: Say it is waiting on images
         if: steps.github_deployment.outputs.deployment_id != ''
@@ -206,9 +206,15 @@ jobs:
           message: |
             ## 🚀 App Preview
 
-            🔗 **[Open preview](${{ steps.context.outputs.preview_url }})**
+            ### 🔗 [${{ steps.context.outputs.preview_url }}](${{ steps.context.outputs.preview_url }})
 
-            <sub>Preview for commit ${{ steps.context.outputs.head_sha }}. Updates on every commit. Remove the `preview` label to tear it down.</sub>
+            | | |
+            |---|---|
+            | Commit | [`${{ steps.context.outputs.head_sha }}`](${{ github.server_url }}/${{ github.repository }}/commit/${{ steps.context.outputs.head_sha }}) |
+            | Environment | [`${{ steps.context.outputs.environment }}`](${{ steps.context.outputs.environment_page }}) |
+            | Deployed by | [this run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) |
+
+            <sub>Every push redeploys this preview. Remove the `preview` label to tear it down.</sub>
 
       # An opted-in pull request must not learn about a red preview only from the Actions tab.
       - name: Report a failed preview

--- a/docs/contributor/ci-cd.mdx
+++ b/docs/contributor/ci-cd.mdx
@@ -366,7 +366,7 @@ redeploy preserves an already-seeded database — and configure its AI access ag
 | Comment says | What to do |
 | --- | --- |
 | does not carry the `preview` label | Add the label |
-| is a draft | Mark it ready for review |
+| is behind `main` on schema, or too far behind to compare | Merge `main` in; the next push previews automatically |
 | comes from a fork | Push the branch to this repository |
 | was opened by a … , not a repository collaborator | Nothing; previews need push access |
 | changes trusted deployment policy | Land that change first — a preview never runs a pull request's own edits to `.github/workflows/**`, `.github/actions/**` or `docker/preview/**` |
@@ -419,8 +419,8 @@ why the label is the authority, and which alternatives were priced and declined,
 | `ci-server-clean-reference.yml` | Weekly, manual | Records cold server phases and compares generated JARs |
 | `scorecard-ratchet.yml` | Push to main, branch-protection change, weekly, manual | Fails when a Scorecard check drops below the committed baseline; a push fails only for the checks its own commit decides |
 | `deploy-preview.yml` | `preview` label added, or a push, reopen or ready-for-review on a labelled PR | Waits for this commit's attested CI images, deploys them, and registers the native GitHub deployment |
-| `cleanup-preview.yml` | Label removed, PR closed or drafted | Removes and verifies resources, then retains a cleanup tombstone |
-| `reconcile-previews.yml` | Nightly, manual | Re-sends teardown for any preview environment whose pull request is closed, drafted or unlabelled |
+| `cleanup-preview.yml` | Label removed, or PR closed | Removes and verifies resources, then retains a cleanup tombstone |
+| `reconcile-previews.yml` | Nightly, manual | Re-sends teardown for any preview environment whose pull request is closed or unlabelled |
 | `cd-docs.yml`, `cd-docs-teardown.yml` | `docs/**` on push and pull requests; PR closed | Publishes the docs site and its pull-request previews |
 | `version-pr.yml` | Successful CI/CD completion for the current main tip | Maintains the accumulating Version PR (changesets) and dispatches CI/CD on its branch, release evidence preflight included |
 | `release.yml` | Successful CI/CD push on `main` | Publishes the release and promotes the moving series and latest image tags |

--- a/scripts/check-scorecard.test.ts
+++ b/scripts/check-scorecard.test.ts
@@ -24,7 +24,7 @@ const assessment = () => ({
  * the scoring each check is charged under, so that reclassifying one is a deliberate edit as well.
  */
 const enforced: Record<string, { score: number; scoredOver: string }> = {
-	"Binary-Artifacts": { score: 10, scoredOver: "configuration" },
+	"Binary-Artifacts": { score: 10, scoredOver: "history" },
 	"CI-Tests": { score: 10, scoredOver: "history" },
 	"Code-Review": { score: 10, scoredOver: "history" },
 	"Dangerous-Workflow": { score: 10, scoredOver: "configuration" },

--- a/scripts/preview-controller.test.ts
+++ b/scripts/preview-controller.test.ts
@@ -46,6 +46,7 @@ const makeCore = () => {
 };
 
 const makeContext = () => ({
+	serverUrl: "https://github.com",
 	repo: { owner: "owner", repo: "repo" },
 	payload: { repository: { default_branch: "main" }, pull_request: { number: 7 } },
 });

--- a/scripts/preview-controller.test.ts
+++ b/scripts/preview-controller.test.ts
@@ -740,7 +740,7 @@ void describe("preview schema drift", () => {
 		const reason = core.outputs.get("reason") ?? "";
 		// The three things the author needs: which file, what goes wrong, and what to do about it.
 		assert.match(reason, /0001_drop\.xml/);
-		assert.match(reason, /fail validation/);
+		assert.match(reason, /have failed to start/);
 		assert.match(reason, /Merge main in/);
 		assert.equal(core.outputs.get("announce"), "true");
 	});
@@ -794,7 +794,8 @@ void describe("preview schema drift", () => {
 		// Every branch that has reached this was genuinely incompatible, so the reason says what will
 		// happen and how to fix it rather than reporting the comparison's own limit.
 		assert.match(reason, /behind main/);
-		assert.match(reason, /fail validation/);
+		assert.match(reason, /cannot be checked/);
+		assert.match(reason, /have failed to start/);
 		assert.match(reason, /Merge main in/);
 		assert.doesNotMatch(reason, /cannot be verified/);
 	});

--- a/scripts/preview-controller.test.ts
+++ b/scripts/preview-controller.test.ts
@@ -741,8 +741,13 @@ void describe("preview schema drift", () => {
 		const reason = core.outputs.get("reason") ?? "";
 		// The three things the author needs: which file, what goes wrong, and what to do about it.
 		assert.match(reason, /0001_drop\.xml/);
+		assert.match(reason, /cannot be checked/);
 		assert.match(reason, /have failed to start/);
 		assert.match(reason, /Merge main in/);
+		// The refusal reports an observation. Claiming a cause is what it got wrong twice: first
+		// Hibernate validation, which `prod` disables, then a schema mismatch a differing blob does
+		// not prove. Neither phrasing may come back.
+		assert.doesNotMatch(reason, /would fail|never produced|no longer match/);
 		assert.equal(core.outputs.get("announce"), "true");
 	});
 
@@ -798,7 +803,7 @@ void describe("preview schema drift", () => {
 		assert.match(reason, /cannot be checked/);
 		assert.match(reason, /have failed to start/);
 		assert.match(reason, /Merge main in/);
-		assert.doesNotMatch(reason, /cannot be verified/);
+		assert.doesNotMatch(reason, /would fail|never produced|no longer match/);
 	});
 
 	void it("ignores prose under the schema directory", async () => {

--- a/scripts/preview-controller.ts
+++ b/scripts/preview-controller.ts
@@ -262,16 +262,22 @@ const resolve = async ({ github, context, core }: ControllerInput): Promise<void
 	});
 	const behindFiles = behind.data.files ?? [];
 	// The comparison reports at most COMPARE_FILE_LIMIT files and flags no truncation, so a saturated
-	// response cannot be read as "no migration is missing". Every branch that has hit this so far was
-	// genuinely incompatible — each still mapped entities to tables the default branch had dropped —
-	// so the message names the likely consequence rather than the tool's own uncertainty, which is
-	// what the author can act on.
+	// response cannot be read as "no migration is missing".
+	//
+	// What these messages may claim is bounded by what is actually known. Previews of branches behind
+	// on schema have failed — the container never became healthy — but the mechanism is not
+	// established: `prod` sets `ddl-auto: none`, so Hibernate does not validate, and the earlier
+	// claim that it did was wrong. Liquibase runs the branch's own changelog over the restored dump,
+	// and the preview's PostgreSQL image is built from the branch's commit while the dump comes from
+	// the default branch's server, so a version skew is possible too. Until one is demonstrated the
+	// reason states the observation and the remedy, not a cause.
 	if (behindFiles.length >= COMPARE_FILE_LIMIT) {
 		return skip(
-			`PR #${number} is ${behindFiles.length}+ files behind ${defaultBranch}. A preview restores ` +
-				`${defaultBranch}'s database, and a branch this far back is unlikely to still match its ` +
-				`schema — the application would fail validation and the preview would never come up. ` +
-				`Merge ${defaultBranch} in; the next push previews automatically.`,
+			`PR #${number} is ${behindFiles.length}+ files behind ${defaultBranch} — too many for GitHub ` +
+				`to compare in full, so whether this branch still matches ${defaultBranch}'s schema ` +
+				`cannot be checked. A preview restores ${defaultBranch}'s database, and previews of ` +
+				`branches behind on schema have failed to start. Merge ${defaultBranch} in; the next ` +
+				`push previews automatically.`,
 		);
 	}
 	for (const file of behindFiles) {
@@ -281,10 +287,10 @@ const resolve = async ({ github, context, core }: ControllerInput): Promise<void
 		// present here under a different commit, so the blob decides, not the ancestry.
 		if (await branchHasBlob(github, owner, repo, pull.head.sha, file)) continue;
 		return skip(
-			`PR #${number} is missing ${defaultBranch}'s \`${file.filename}\`. A preview restores ` +
-				`${defaultBranch}'s database, so this branch's entities no longer match its schema and ` +
-				`the application would fail validation on boot. Merge ${defaultBranch} in; the next ` +
-				`push previews automatically.`,
+			`PR #${number} does not have ${defaultBranch}'s \`${file.filename}\`. A preview restores ` +
+				`${defaultBranch}'s database, so this branch would run against a schema its own ` +
+				`migrations never produced, and previews in that state have failed to start. Merge ` +
+				`${defaultBranch} in; the next push previews automatically.`,
 		);
 	}
 

--- a/scripts/preview-controller.ts
+++ b/scripts/preview-controller.ts
@@ -286,12 +286,16 @@ const resolve = async ({ github, context, core }: ControllerInput): Promise<void
 		// The comparison says what the default branch changed since the branches diverged; it says
 		// nothing about this branch's tree. A cherry-picked or independently applied migration is
 		// present here under a different commit, so the blob decides, not the ancestry.
+		//
+		// A differing blob is still only unverifiable, never proof: two changelogs can reach the same
+		// schema by different text. The reason says so rather than asserting a mismatch it cannot
+		// demonstrate — the same overreach that claimed Hibernate validation, one sentence along.
 		if (await branchHasBlob(github, owner, repo, pull.head.sha, file)) continue;
 		return skip(
 			`PR #${number} does not have ${defaultBranch}'s \`${file.filename}\`. A preview restores ` +
-				`${defaultBranch}'s database, so this branch would run against a schema its own ` +
-				`migrations never produced, and previews in that state have failed to start. Merge ` +
-				`${defaultBranch} in; the next push previews automatically.`,
+				`${defaultBranch}'s database, so whether this branch matches that schema cannot be ` +
+				`checked, and previews in that state have failed to start. Merge ${defaultBranch} in; ` +
+				`the next push previews automatically.`,
 		);
 	}
 

--- a/scripts/preview-controller.ts
+++ b/scripts/preview-controller.ts
@@ -56,6 +56,7 @@ export interface GitHubApi {
 }
 
 interface ActionsContext {
+	readonly serverUrl: string;
 	readonly repo: { readonly owner: string; readonly repo: string };
 	readonly payload: {
 		readonly repository: { readonly default_branch: string };
@@ -322,6 +323,13 @@ const resolve = async ({ github, context, core }: ControllerInput): Promise<void
 	core.setOutput("base_ref", defaultBranch);
 	core.setOutput("head_sha", pull.head.sha);
 	core.setOutput("preview_url", previewUrl.href);
+	// The environment's own page on GitHub, in the form the API reports as its `html_url` — the
+	// obvious `/deployments/<name>` guess is a 404, and the query parameter is `environments_filter`.
+	core.setOutput(
+		"environment_page",
+		`${context.serverUrl}/${owner}/${repo}/deployments/activity_log` +
+			`?environments_filter=${encodeURIComponent(environment)}`,
+	);
 };
 
 /**
@@ -357,6 +365,13 @@ const create = async ({ github, context, core }: ControllerInput): Promise<void>
 	const { owner, repo } = context.repo;
 	const headSha = requiredEnv(process.env, "HEAD_SHA");
 	const environment = requiredEnv(process.env, "ENVIRONMENT");
+	const number = requiredPositiveInteger(process.env, "PR_NUMBER");
+	const title = process.env.PR_TITLE ?? "";
+	const previewUrl = requiredEnv(process.env, "PREVIEW_URL");
+	// The deployments page lists every environment together, where `preview/pr-2042` alone says
+	// nothing about what is in it. The title is what tells one preview from another at a glance;
+	// GitHub renders this as plain text, so the link lives in the payload rather than here.
+	const described = title ? `PR #${number} · ${title}` : `PR #${number}`;
 	const response = await github.rest.repos.createDeployment({
 		owner,
 		repo,
@@ -365,7 +380,16 @@ const create = async ({ github, context, core }: ControllerInput): Promise<void>
 		auto_merge: false,
 		required_contexts: [],
 		environment,
-		description: `Coolify preview for PR #${requiredEnv(process.env, "PR_NUMBER")}`,
+		description: described.length > 140 ? `${described.slice(0, 139)}…` : described,
+		// Rides on every deployment_status event, so anything watching them — a dashboard, a bot,
+		// a future notifier — can reach the pull request and the preview without another API call.
+		payload: {
+			pull_request: number,
+			pull_request_url: process.env.PR_URL ?? "",
+			title,
+			preview_url: previewUrl,
+			head_sha: headSha,
+		},
 		transient_environment: true,
 		production_environment: false,
 	});
@@ -379,9 +403,9 @@ const create = async ({ github, context, core }: ControllerInput): Promise<void>
 		repo,
 		deployment_id: deploymentId,
 		state: "queued",
-		description: "Admission reserved; Coolify queue follows.",
+		description: `Reserved for PR #${number}; Coolify queue follows.`,
 		environment,
-		environment_url: requiredEnv(process.env, "PREVIEW_URL"),
+		environment_url: previewUrl,
 		log_url: requiredEnv(process.env, "SOURCE_RUN_URL"),
 	});
 };

--- a/security/scorecard-baseline.json
+++ b/security/scorecard-baseline.json
@@ -5,8 +5,8 @@
 		{
 			"name": "Binary-Artifacts",
 			"score": 10,
-			"scoredOver": "configuration",
-			"reason": "Executables committed to the tree as it stands."
+			"scoredOver": "history",
+			"reason": "Executables committed to the tree, and for the committed Gradle wrapper the successful validation run that vouches for it. That run is what makes this a window: on a push the wrapper job is still executing, so the commit cannot yet answer for itself."
 		},
 		{
 			"name": "CI-Tests",


### PR DESCRIPTION
Three things, found by an adversarial review (gpt-6-astra) of the whole preview workflow.

## 1. The refusal claimed a mechanism that does not exist

The message said the application *would fail Hibernate validation*. It would not:

```yaml
# application-prod.yml — previews run SPRING_PROFILES_ACTIVE: prod
ddl-auto: none
```

I asserted the mechanism without checking the profile that governs it, and #2081 then made the wrong claim more specific and more confident.

**What is actually known** is a correlation from three observations: previews of branches behind on schema failed twice (#2042), and a preview of a branch level with main succeeded (#2061, HTTP 200). Two candidate causes remain untested — Liquibase running the branch's changelog over a dump whose recorded history is main's, and PostgreSQL version skew, since the preview's postgres image is built from *the branch's* commit while the dump comes from staging at 18.6. Every container and volume from the failed runs is gone, so neither can be confirmed without a deliberate experiment.

The messages now state the observation and the remedy. The refusal itself is unchanged; only what it claims to know is. The comment above the check records both candidates so the next person starts from the open question rather than my wrong answer.

## 2. A preview now says what it is

The deployments page lists every environment together, where `preview/pr-2042` and "Coolify preview for PR #2042" tell you nothing about what is in it.

- **Deployment description** carries the pull request title.
- **Deployment payload** carries the number, URL, title, preview URL and head SHA. It rides on every `deployment_status` event, so anything watching them reaches the pull request and the preview without another API call.
- **The comment** leads with the preview URL on its own line, then gives the commit, the environment and the run as links:

> ### 🔗 https://pr2042.hephaestus.felixdietrich.com/
>
> | | |
> |---|---|
> | Commit | [`9ff971ac1…`](…/commit/…) |
> | Environment | [`preview/pr-2042`](…/deployments/activity_log?environments_filter=preview%2Fpr-2042) |
> | Deployed by | [this run](…/actions/runs/…) |

The commit is a link rather than forty characters of hex. The environment link is the form the REST API reports as the environment's own `html_url` — the obvious `/deployments/<name>` is a **404** and the query parameter is `environments_filter`, not `environment`, so a test pins the shape.

**The pull request title is deliberately absent from the comment.** It is already at the top of the page the comment sits on, and a title containing a `|` would break the table it would sit in.

## 3. Documentation contradicted itself

Three rows still described pre-draft behaviour — the refusal table offered "mark it ready for review", the workflow table said a draft tears a preview down — while the prose above them says the opposite. That is the conflict `AGENTS.md` means by one home per fact. The refusal table also gains a row for the reason previews are most often refused now.

## Verification

41 controller tests, 684 in `test:tooling`, `gate:agents-lint` clean, docs lint clean. The environment-page URL is pinned by test because it cannot be derived by guessing.

## Not in this change

The review found four further defects worth their own work: slot accounting frees a slot when Coolify merely *accepts* a teardown and then excludes that tombstone from reconciliation; admission is not first-come without `queue: max`; verified digests are handed to Compose as tags; and preview containers hold staging's read credential. Each is reported separately rather than bundled here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated CI/CD guidance to reflect that draft pull requests deploy previews like other pull requests.
  - Added troubleshooting guidance for branches that are behind the main branch schema.

- **Bug Fixes**
  - Clarified preview status messages when schema differences prevent a preview from starting.

- **Improvements**
  - Enhanced deployment comments with linked commit, environment, run, and deployer details.
  - Added environment activity-log links and richer preview deployment information.

- **Tests**
  - Updated automated checks to match revised preview messaging and scoring criteria.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->