### PR TITLE
fix(ci): apply path exclusions without selecting unrelated files

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -143,6 +143,7 @@ jobs:
       - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: filter
         with:
+          predicate-quantifier: some-with-excludes
           filters: |
             webapp:
               - 'webapp/**'
@@ -351,6 +352,7 @@ jobs:
       - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: webapp_image_source
         with:
+          predicate-quantifier: some-with-excludes
           filters: |
             webapp-image-source:
               - 'webapp/src/**'

--- a/scripts/ci-contract.test.ts
+++ b/scripts/ci-contract.test.ts
@@ -415,6 +415,17 @@ void describe("CI contract", () => {
 		);
 	});
 
+	void test("path exclusions cannot select unrelated files for server tests or webapp images", async () => {
+		const workflow = parseDocument(await readFile(".github/workflows/cicd.yml", "utf8"));
+		for (const id of ["filter", "webapp_image_source"]) {
+			const steps = workflow.getIn(["jobs", "detect-changes", "steps"]);
+			assert.ok(isSeq(steps));
+			const filter = steps.items.find((item) => isMap(item) && item.get("id") === id);
+			assert.ok(isMap(filter));
+			assert.equal(filter.getIn(["with", "predicate-quantifier"]), "some-with-excludes");
+		}
+	});
+
 	void test("Gradle lock changes rebuild and verify the shipped server", async () => {
 		const build = await readFile("server/build.gradle.kts", "utf8");
 		assert.match(build, /lockAllConfigurations\(\)/);


### PR DESCRIPTION
## What changed and why

The default `dorny/paths-filter` predicate treats every pattern as an alternative, including negations. As a result, unrelated preview/tooling changes selected the server suite and webapp image build. Excluded server instruction files and webapp stories could also select the jobs they were intended to avoid.

Use the pinned action's native `some-with-excludes` predicate in both filter steps: a file must match a positive pattern and no exclusion. No runner changes, custom matching implementation, or test-suite reductions.

## How to test

- `vp run format` and `vp run check` passed.
- The workflow contract guards both filter steps against reverting to the default predicate.
- Executed the exact pinned upstream filter implementation against source, configuration, excluded, and unrelated paths. Both old defaults reproduced the preview-controller false positive; the new predicate rejected it while retaining server source/build/dependency and webapp source inputs.
- On a tooling-only PR, inspect Detect changes: server tests and webapp image builds should not be selected unless another changed file requires them. Server source and shared dependency changes must still select server checks; webapp source must still select its image build.

## Release impact

CI configuration and its contract test only. No shipped application behavior, operator action, or changeset.

## Notes for reviewers

The false positive is visible in [this run's Detect changes log](https://github.com/hephaestus-build/Hephaestus/actions/runs/34352597354/job/102469740174): preview-controller files matched the application-server filter. The server jobs consumed over 20 runner-minutes in that run; this fix avoids that work on genuinely unrelated changes, not on server changes.

The predicate is supported by the [exact pinned action version](https://github.com/dorny/paths-filter/blob/ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d/action.yml). A change to the CI workflow itself still selects its required validation jobs.
