### PR TITLE
refactor(ci): detect changed files once

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -36,7 +36,7 @@ jobs:
       contents: read
     outputs:
       webapp: ${{ steps.filter.outputs.webapp }}
-      webapp-image: ${{ steps.filter.outputs.webapp-image == 'true' || steps.webapp_image_source.outputs.webapp-image-source == 'true' }}
+      webapp-image: ${{ steps.filter.outputs.webapp-image }}
       application-server: ${{ steps.filter.outputs.application-server }}
       tooling: ${{ steps.filter.outputs.tooling }}
       application-server-image: ${{ steps.filter.outputs.application-server-image == 'true' || steps.filter.outputs.docker-config == 'true' || steps.filter.outputs.build-config == 'true' }}
@@ -162,6 +162,10 @@ jobs:
               - 'pnpm-lock.yaml'
               - 'pnpm-workspace.yaml'
             webapp-image:
+              - 'webapp/src/**'
+              - '!webapp/src/**/*.test.*'
+              - '!webapp/src/**/*.stories.*'
+              - '!webapp/src/test/**'
               - '.oxfmtrc.json'
               - 'patches/**'
               - 'webapp/public/**'
@@ -348,17 +352,6 @@ jobs:
               - 'scripts/run-gradlew.ts'
               - '.github/workflows/ci-quality-gates.yml'
               - '.github/workflows/ci-quality-leg.yml'
-
-      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
-        id: webapp_image_source
-        with:
-          predicate-quantifier: some-with-excludes
-          filters: |
-            webapp-image-source:
-              - 'webapp/src/**'
-              - '!webapp/src/**/*.test.*'
-              - '!webapp/src/**/*.stories.*'
-              - '!webapp/src/test/**'
 
   # `Actionlint` is a required context, and a required context that skips still satisfies the
   # ruleset — docs/contributor/ci-cd.mdx § Merge policy says why.

--- a/scripts/ci-contract.test.ts
+++ b/scripts/ci-contract.test.ts
@@ -417,13 +417,15 @@ void describe("CI contract", () => {
 
 	void test("path exclusions cannot select unrelated files for server tests or webapp images", async () => {
 		const workflow = parseDocument(await readFile(".github/workflows/cicd.yml", "utf8"));
-		for (const id of ["filter", "webapp_image_source"]) {
-			const steps = workflow.getIn(["jobs", "detect-changes", "steps"]);
-			assert.ok(isSeq(steps));
-			const filter = steps.items.find((item) => isMap(item) && item.get("id") === id);
-			assert.ok(isMap(filter));
-			assert.equal(filter.getIn(["with", "predicate-quantifier"]), "some-with-excludes");
-		}
+		const steps = workflow.getIn(["jobs", "detect-changes", "steps"]);
+		assert.ok(isSeq(steps));
+		const filters = steps.items.filter(
+			(item) => isMap(item) && String(item.get("uses")).startsWith("dorny/paths-filter@"),
+		);
+		assert.equal(filters.length, 1);
+		const filter = filters[0];
+		assert.ok(isMap(filter));
+		assert.equal(filter.getIn(["with", "predicate-quantifier"]), "some-with-excludes");
 	});
 
 	void test("Gradle lock changes rebuild and verify the shipped server", async () => {


### PR DESCRIPTION
## What changed and why

Change detection fetched and filtered the same changed-file list twice, then combined the webapp image results. With the native exclusion-aware predicate introduced in #2084, that separation is unnecessary.

Put webapp source paths and their test/story exclusions in the existing webapp image filter. One action invocation now owns all change detection, and the image output comes directly from it. Job selection is unchanged.

## How to test

- `vp run format` and `vp run check` passed.
- Executed the pinned upstream matcher before and after the change over all 5,743 tracked paths plus four source/exclusion probes: every filter output matched the previous behavior.
- The workflow contract requires one exclusion-aware filter invocation.
- On tooling-only PRs, server tests and webapp image builds remain unselected unless another changed input requires them; webapp source changes still select their image build.

## Release impact

CI configuration and contract tests only; no application behavior change, changeset or operator action.

## Notes for reviewers

This is a small structural cleanup, not a claim of minutes saved. It removes one duplicate changed-file API pass and one combined output expression. The consequential selection fix is #2084; a subsequent tooling PR passed in 4m43s and its merge-queue validation in 4m12s without server test jobs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI/CD**
  * Consolidated web app image change detection into a single path filter.
  * Updated change detection to exclude test, story, and test-support files from web app image builds.

* **Tests**
  * Updated CI contract validation to verify the consolidated path-filter configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->