### PR TITLE
perf(ci): publish Gradle caches from the package producer

### DIFF
--- a/.github/actions/setup-caches/action.yml
+++ b/.github/actions/setup-caches/action.yml
@@ -1,6 +1,10 @@
 name: "Set up the Java build"
 description: "Provision the pinned JDK and Gradle's native dependency and build caches."
 inputs:
+  cache-write:
+    description: "Allow a trusted default-branch producer to publish Gradle caches."
+    required: false
+    default: "false"
   dependency-graph:
     description: "Whether to capture and upload a dependency snapshot from the caller's Gradle invocation."
     required: false
@@ -19,6 +23,6 @@ runs:
       with:
         cache-provider: enhanced
         # Untrusted pull requests and merge groups never publish shared build outputs.
-        cache-read-only: ${{ github.ref != format('refs/heads/{0}', github.event.repository.default_branch) || !contains(fromJSON('["push","schedule","workflow_dispatch"]'), github.event_name) }}
+        cache-read-only: ${{ inputs.cache-write != 'true' || github.ref != format('refs/heads/{0}', github.event.repository.default_branch) || !contains(fromJSON('["push","schedule","workflow_dispatch"]'), github.event_name) }}
         validate-wrappers: true
         dependency-graph: ${{ inputs.dependency-graph }}

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -95,6 +95,8 @@ jobs:
           digest-mismatch: error
       - uses: ./.github/actions/setup-caches
         if: steps.reuse.outputs.artifact-id == ''
+        with:
+          cache-write: "true"
       - name: Package the server
         if: steps.reuse.outputs.artifact-id == ''
         working-directory: server

--- a/docs/contributor/ci-cd.mdx
+++ b/docs/contributor/ci-cd.mdx
@@ -448,7 +448,7 @@ credential is still `GITHUB_TOKEN`, so these commits start no further workflow r
 | Action | Contract |
 | --- | --- |
 | `setup-toolchain` | Installs the Node.js version pinned in `package.json`, and nothing else when `install` is `none`, so a job that only runs `node scripts/…` reaches no package registry; `frozen` adds the pinned pnpm — caching its executable by runner platform and pinned version and retrying the download twice on a miss — restores the pnpm store cache, and installs the launcher through the SHA-pinned `setup-vp` with `node-manager: false`, which then runs the lockfile's `vite-plus` |
-| `setup-caches` | Sets up the JDK from `.java-version`, validates the wrapper and uses the official Gradle action for dependency and build caches; only default-branch push, schedule and dispatch runs may publish caches |
+| `setup-caches` | Sets up the JDK from `.java-version`, validates the wrapper and uses the official Gradle action for dependency and build caches; the trusted package job publishes caches; consumers are read-only |
 | `restore-server-build` | Downloads and validates the packaged JARs, compiled tests and resources; outputs the executable JAR path without recompiling or installing local artifacts |
 | `setup-browsers` | Restores the exact Playwright browser version and installs Chromium system dependencies |
 | `setup-release-security-tools` | Installs Cosign, Trivy, and optionally Syft for release-evidence jobs |
@@ -459,8 +459,10 @@ credential is still `GITHUB_TOKEN`, so these commits start no further workflow r
 
 A run restores caches from its own branch and from `main`, never from a sibling branch. Task-cache
 entries are content-addressed, so a pull request saves them for its own reruns. Gradle caches are
-published only by trusted default-branch push, schedule and dispatch runs; the pnpm executable cache
-also saves only from `main`. The JDK is pinned once, in `.java-version`.
+published only by the server package job on trusted default-branch push, schedule and dispatch runs.
+Other jobs are read-only consumers: the Gradle action prefers an older same-job cache over a newer
+producer cache, so consumers must not publish snapshots that become stale between their main-branch runs.
+The pnpm executable cache also saves only from `main`. The JDK is pinned once, in `.java-version`.
 
 Java quality verdicts are not stored in the Vite task cache: Gradle owns their task inputs and outputs.
 GraphQL generation opts into Gradle's build cache using the plugin's declared inputs and outputs.

--- a/scripts/ci-contract.test.ts
+++ b/scripts/ci-contract.test.ts
@@ -415,6 +415,27 @@ void describe("CI contract", () => {
 		);
 	});
 
+	void test("the server package job is the only Gradle cache producer", async () => {
+		const action = parseDocument(await readFile(".github/actions/setup-caches/action.yml", "utf8"));
+		assert.equal(action.getIn(["inputs", "cache-write", "default"]), "false");
+		const sources = await workflowSources();
+		const writers = [...sources].filter(([, source]) => source.includes('cache-write: "true"'));
+		assert.deepEqual(
+			writers.map(([file]) => file),
+			[".github/workflows/ci-build.yml"],
+		);
+		const build = parseDocument(await readFile(".github/workflows/ci-build.yml", "utf8"));
+		const steps = build.getIn(["jobs", "server-package", "steps"]);
+		assert.ok(isSeq(steps));
+		const cache = steps.items.find(
+			(item) => isMap(item) && item.get("uses") === "./.github/actions/setup-caches",
+		);
+		assert.ok(isMap(cache));
+		assert.equal(cache.getIn(["with", "cache-write"]), "true");
+		const source = await readFile(".github/actions/setup-caches/action.yml", "utf8");
+		assert.match(source, /inputs.cache-write != 'true' \|\| github.ref != format/);
+	});
+
 	void test("path exclusions cannot select unrelated files for server tests or webapp images", async () => {
 		const workflow = parseDocument(await readFile(".github/workflows/cicd.yml", "utf8"));
 		const steps = workflow.getIn(["jobs", "detect-changes", "steps"]);


### PR DESCRIPTION
## What changed and why

Gradle's hosted cache restores a same-job entry before falling back to newer entries from other jobs. Our test jobs usually do not execute on main, leaving old test-job caches preferred over the package job's current compiled outputs. The inspected integration run restored a main cache from September 8 despite newer package caches, then compiled application and test sources again.

Make cache publication opt-in, with only the server package job opting in. All consumers remain read-only; the existing default-branch and event restrictions still apply even to an opted-in producer. The producer already compiles application and test classes. Test execution and result-caching policy are unchanged.

## How to test

- `vp run format` and `vp run check` passed.
- The workflow contract checks that cache writes default off and that only the package job opts in.
- PR and merge-group jobs must still report read-only Gradle caches, including the package job.
- After merge, remove obsolete default-branch Gradle home index entries from non-producer jobs, preserving the package entries and shared cache data. Inspect a consumer's requested **and restored** keys and task outcomes; the action's earlier log line can display the requested key, so it is not sufficient evidence of which entry was used.

## Release impact

CI cache policy only. No application behavior, test coverage, changeset, or operator action.

## Notes for reviewers

This follows the Gradle action's documented [producer/consumer cache guidance](https://github.com/gradle/actions/blob/main/docs/setup-gradle.md#select-which-jobs-should-write-to-the-cache) and [restore-key precedence](https://github.com/gradle/actions/blob/main/docs/setup-gradle.md#finding-a-matching-cache-entry). No custom cache keys, internal action inputs, external cache service, or new warming job are introduced.

The obsolete cache indexes need a one-time migration after this policy is merged; deleting them alone would not prevent consumer jobs from publishing stale snapshots again. Shared content caches and package-job entries must remain intact. Runtime-only dependencies absent from the producer may still need downloading; cache hits and end-to-end savings must be measured rather than assumed.
