### PR TITLE
test(server): give the precompute child a resolved temporary root

### DIFF
--- a/server/application/src/test/resources/agent/pi-precompute-limits.spec.ts
+++ b/server/application/src/test/resources/agent/pi-precompute-limits.spec.ts
@@ -1,6 +1,14 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import {
+	existsSync,
+	mkdtempSync,
+	realpathSync,
+	readFileSync,
+	rmSync,
+	statSync,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "node:test";
@@ -47,7 +55,10 @@ void test("production precompute limits", { skip: process.platform !== "linux" }
 		},
 	]) {
 		await t.test(scenario.name, async () => {
-			const root = mkdtempSync(join(tmpdir(), "precompute-limits-"));
+			// Resolved for the same reason as in `pi-precompute.spec.ts`: the runner is loaded as a
+			// module under a path granted to `--allow-fs-read`, and a `TMPDIR` reached through a symlink
+			// satisfies no such grant.
+			const root = realpathSync(mkdtempSync(join(tmpdir(), "precompute-limits-")));
 			try {
 				writeFileSync(
 					join(root, "pi-precompute.ts"),

--- a/server/application/src/test/resources/agent/pi-precompute.spec.ts
+++ b/server/application/src/test/resources/agent/pi-precompute.spec.ts
@@ -1,6 +1,14 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import {
+	mkdtempSync,
+	mkdirSync,
+	realpathSync,
+	readFileSync,
+	rmSync,
+	symlinkSync,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { mock, test } from "node:test";
@@ -29,7 +37,10 @@ if (scenarioRoot) {
 	await import("../../../main/resources/agent/pi-precompute.ts");
 } else {
 	void test("precompute stages only regular scripts and executes the image runner with task-declared locations", () => {
-		const root = mkdtempSync(join(tmpdir(), "task-precompute-#"));
+		// The child runs under Node's permission model, which resolves a path before matching it
+		// against --allow-fs-read. On macOS the temporary directory is reached through a symlink, so an
+		// unresolved root grants the child nothing and every script fails to read its own inputs.
+		const root = realpathSync(mkdtempSync(join(tmpdir(), "task-precompute-#")));
 		try {
 			const context = "areas/changed work";
 			const scripts = "catalog/scripts";

--- a/server/application/src/test/resources/agent/pi-precompute.spec.ts
+++ b/server/application/src/test/resources/agent/pi-precompute.spec.ts
@@ -37,9 +37,11 @@ if (scenarioRoot) {
 	await import("../../../main/resources/agent/pi-precompute.ts");
 } else {
 	void test("precompute stages only regular scripts and executes the image runner with task-declared locations", () => {
-		// The child runs under Node's permission model, which resolves a path before matching it
-		// against --allow-fs-read. On macOS the temporary directory is reached through a symlink, so an
-		// unresolved root grants the child nothing and every script fails to read its own inputs.
+		// The staged scripts are loaded as modules, and Node's permission model admits a module load
+		// only when the granted path and the loaded path are the same resolved path — unlike an ordinary
+		// read, which an unresolved grant satisfies. macOS reaches the temporary directory through a
+		// symlink, so an unresolved root fails every script's import while the rest of the scenario
+		// looks like it ran.
 		const root = realpathSync(mkdtempSync(join(tmpdir(), "task-precompute-#")));
 		try {
 			const context = "areas/changed work";


### PR DESCRIPTION
## What changed and why

`vp run check` cannot pass on macOS, so the pre-push hook blocks every push from a Mac.

The precompute scenario spawns its child under Node's permission model, granting `--allow-fs-read` for a root from `mkdtempSync(join(tmpdir(), …))`. Node resolves a path before matching it against that grant. On macOS `os.tmpdir()` is reached through a symlink (`/var/folders/…` → `/private/var/folders/…`), so the child was granted a path it never sees: every staged script failed to read its own inputs, and the assertion that the good script reports `ok` saw `error` instead.

Resolving the root before it is handed out is the whole fix. Linux CI was never affected, which is why the suite is green there.

## How to test

```sh
node --test server/application/src/test/resources/agent/pi-precompute.spec.ts
```

On macOS this fails on `main` and passes here. The same command already passed on `main` under a `TMPDIR` that is not a symlink — that contrast is what identified the cause.

## Release impact

No changeset: this changes a test, not shipped code.

## Notes for reviewers

One line plus the comment explaining why the resolution is required, since the next reader will otherwise see `realpathSync` as redundant.
