### PR TITLE
fix(server): report a NATS server URI that has no scheme

### DIFF
--- a/.changeset/nats-server-readiness-report.md
+++ b/.changeset/nats-server-readiness-report.md
@@ -1,0 +1,5 @@
+---
+"hephaestus": patch
+---
+
+An instance whose NATS server URI is blank or missing its `nats://` scheme now starts far enough to print the configuration readiness report that names the setting, instead of stopping on an internal error that said nothing about which value was wrong. The shipped default is blank, so this was every first production start that had not set it yet.

--- a/.changeset/nats-server-readiness-report.md
+++ b/.changeset/nats-server-readiness-report.md
@@ -2,4 +2,4 @@
 "hephaestus": patch
 ---
 
-An instance whose NATS server URI is blank or missing its `nats://` scheme now starts far enough to print the configuration readiness report that names the setting, instead of stopping on an internal error that said nothing about which value was wrong. The shipped default is blank, so this was every first production start that had not set it yet.
+An instance whose NATS server URI is blank or missing its `nats://` scheme now starts far enough to print the configuration readiness report that names the setting, instead of stopping on an internal error that said nothing about which value was wrong. The URI is required of the server and webhook roles, and the shipped default is blank, so this was every first production start of those roles that had not set it yet. A NATS URI whose scheme is written in capitals is also no longer reported as needing action, since the client accepts it.

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/configuration/ConfigurationReadinessEvaluator.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/configuration/ConfigurationReadinessEvaluator.java
@@ -393,7 +393,8 @@ public final class ConfigurationReadinessEvaluator {
         try {
             URI uri = URI.create(value);
             int port = uri.getPort();
-            return Set.of("nats", "tls").contains(uri.getScheme())
+            String scheme = uri.getScheme();
+            return ("nats".equalsIgnoreCase(scheme) || "tls".equalsIgnoreCase(scheme))
                     && uri.getHost() != null
                     && (port == -1 || port > 0 && port <= 65535)
                     && (uri.getPath().isEmpty() || "/".equals(uri.getPath()))

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/configuration/ConfigurationReadinessEvaluatorTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/configuration/ConfigurationReadinessEvaluatorTest.java
@@ -88,6 +88,15 @@ class ConfigurationReadinessEvaluatorTest extends BaseUnitTest {
     }
 
     @ParameterizedTest
+    @ValueSource(strings = {"NATS://broker:4222", "TLS://broker:4222"})
+    void shouldAcceptANatsSchemeInAnyCaseBecauseTheClientLowercasesIt(String server) {
+        Map<String, Object> properties = validProperties();
+        properties.put("hephaestus.sync.nats.server", server);
+
+        assertStatus(evaluateReadiness(properties, true), "nats.server", ConfigurationStatus.SATISFIED);
+    }
+
+    @ParameterizedTest
     @ValueSource(strings = {"", "nats", "//broker:4222", "broker:4222"})
     void shouldReportANatsServerWithoutANatsSchemeInsteadOfFailingToEvaluate(String server) {
         Map<String, Object> properties = validProperties();

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/configuration/ConfigurationReadinessEvaluatorTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/configuration/ConfigurationReadinessEvaluatorTest.java
@@ -12,6 +12,8 @@ import java.util.Set;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.test.system.CapturedOutput;
 import org.springframework.boot.test.system.OutputCaptureExtension;
@@ -83,6 +85,15 @@ class ConfigurationReadinessEvaluatorTest extends BaseUnitTest {
         assertStatus(facts, "webhook.shared-secret", ConfigurationStatus.SATISFIED);
         assertStatus(facts, "auth.login-provider", ConfigurationStatus.NOT_APPLICABLE);
         assertStatus(facts, "agent.image-contract", ConfigurationStatus.NOT_APPLICABLE);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", "nats", "//broker:4222", "broker:4222"})
+    void shouldReportANatsServerWithoutANatsSchemeInsteadOfFailingToEvaluate(String server) {
+        Map<String, Object> properties = validProperties();
+        properties.put("hephaestus.sync.nats.server", server);
+
+        assertStatus(evaluateReadiness(properties, true), "nats.server", ConfigurationStatus.ACTION_REQUIRED);
     }
 
     @Test


### PR DESCRIPTION
## What changed and why

An instance whose `hephaestus.sync.nats.server` is blank or has no scheme died at startup with a bare `NullPointerException`, from inside the very component whose job is to explain which setting is wrong:

```
java.lang.NullPointerException: Cannot invoke "Object.equals(Object)" because "<parameter1>" is null
	at …ConfigurationReadinessEvaluator.validNatsUri(ConfigurationReadinessEvaluator.java:396)
	at …ProductionConfigurationEnvironmentPostProcessor.postProcessEnvironment(…:21)
```

`validNatsUri` passed the parsed URI's scheme to `Set.of("nats", "tls").contains(…)`, and an immutable set rejects a null argument. `URI.create("")` — the shipped default in `application.yml` — has a null scheme, as does any value written without one. The check applies to the server and webhook roles, so this was every first production start that had not set the variable yet, and the operator got no indication of which of the ~20 settings was at fault.

The other URI predicates in this file already compare the scheme null-safely (`"https".equalsIgnoreCase(uri.getScheme())`); this one is the only place a possibly-null scheme reaches a null-hostile call. Matching their shape removes the hazard and the `Set` allocation together.

## How to test

Found by booting the released server image against an empty PostgreSQL 18 container with no NATS URI set. Before, the container exited on the stack trace above; after, it reaches the readiness report that names the setting:

```
java.lang.IllegalStateException: Production configuration validation failed;
diagnostic identifiers: nats.server
```

The regression test covers the shipped blank default and three scheme-less spellings:

```sh
cd server && ./gradlew :application:test --tests '*ConfigurationReadinessEvaluatorTest*'
```

Reverting the source change alone fails that test with the `NullPointerException`, so it is not vacuous.

## Release impact

`.changeset/nats-server-readiness-report.md`, patch. No operator action: an instance that starts today is unaffected, and one that did not now gets told why.

## Notes for reviewers

The existing tests all either set a valid URI or disable NATS, so the shipped default was the one shape never exercised. That is the gap the parameterized case closes.


One deliberate behaviour change comes with matching the sibling predicates' shape: the comparison is now case-insensitive, where `Set.of(…).contains` was not. `NATS://broker:4222` used to be reported as needing action even though `io.nats.client.support.NatsUri` lowercases the scheme before matching it against its known protocols and connects with that value — so the old report was wrong about a configuration that works. A second parameterized case pins the new behaviour so it reads as intended rather than incidental.
