### PR TITLE
fix(ci): say why a schema-behind preview fails, now that it is known

### DIFF
--- a/scripts/preview-controller.test.ts
+++ b/scripts/preview-controller.test.ts
@@ -741,11 +741,12 @@ void describe("preview schema drift", () => {
 		const reason = core.outputs.get("reason") ?? "";
 		// The three things the author needs: which file, what goes wrong, and what to do about it.
 		assert.match(reason, /0001_drop\.xml/);
-		assert.match(reason, /have failed to start/);
+		assert.match(reason, /have failed against it/);
 		assert.match(reason, /Merge main in/);
-		// Both mechanisms were reproduced against a restored database, so the reason names them.
-		assert.match(reason, /Liquibase/);
-		assert.match(reason, /a later migration dropped/);
+		// Both mechanisms were reproduced against a restored database, so the reason names them —
+		// and keeps them apart, because only one of the two stops the boot.
+		assert.match(reason, /Liquibase stops the boot/);
+		assert.match(reason, /starts and then fails the first query/);
 		// It still reports what has gone wrong, never what this branch is guaranteed to hit: a
 		// migration that only adds a table this branch never queries breaks nothing. The two
 		// phrasings that overclaimed — Hibernate validation, which `prod` disables, and a schema
@@ -803,9 +804,11 @@ void describe("preview schema drift", () => {
 		// Every branch that has reached this was genuinely incompatible, so the reason says what will
 		// happen and how to fix it rather than reporting the comparison's own limit.
 		assert.match(reason, /behind main/);
-		// Truncation is the one case where the check genuinely could not run, so the reason says so.
+		// Truncation is the one case where the check genuinely could not run, so the reason says so,
+		// and says which check: whether the branch still carries the default branch's migrations.
+		assert.match(reason, /carries main's migrations/);
 		assert.match(reason, /cannot be checked/);
-		assert.match(reason, /have failed to start/);
+		assert.match(reason, /have failed against it/);
 		assert.match(reason, /Merge main in/);
 		assert.doesNotMatch(reason, /would fail|never produced|no longer match|cannot boot/);
 	});

--- a/scripts/preview-controller.test.ts
+++ b/scripts/preview-controller.test.ts
@@ -806,8 +806,6 @@ void describe("preview schema drift", () => {
 		// the reason names the check that could not run, what branches behind on schema have run
 		// into, and how to clear it.
 		assert.match(reason, /behind main/);
-		// Truncation is the one case where the check genuinely could not run, so the reason says so,
-		// and says which check: whether the branch still carries the default branch's migrations.
 		assert.match(reason, /carries main's migrations/);
 		assert.match(reason, /cannot be checked/);
 		assert.match(reason, /have failed to start against it/);

--- a/scripts/preview-controller.test.ts
+++ b/scripts/preview-controller.test.ts
@@ -747,11 +747,11 @@ void describe("preview schema drift", () => {
 		// names the step each one stops at: neither branch reaches a started application.
 		assert.match(reason, /Liquibase re-runs migrations/);
 		assert.match(reason, /startup then fails on a column/);
-		// It still reports what has gone wrong, never what this branch is guaranteed to hit: a
-		// migration that only adds a table this branch never queries breaks nothing. The two
-		// phrasings that overclaimed — Hibernate validation, which `prod` disables, and a schema
-		// mismatch a differing blob does not prove — may not come back.
-		assert.doesNotMatch(reason, /would fail|never produced|no longer match|cannot boot/);
+		// It reports what has gone wrong, never what this branch is guaranteed to hit: a migration
+		// that only adds a table this branch never queries breaks nothing. Two causes it may not
+		// claim are Hibernate validation, which `prod` disables, and a schema mismatch that a
+		// differing blob does not prove.
+		assert.doesNotMatch(reason, /would fail|never produced|no longer match|cannot boot|Hibernate/);
 		assert.equal(core.outputs.get("announce"), "true");
 	});
 
@@ -801,8 +801,10 @@ void describe("preview schema drift", () => {
 
 		assert.equal(core.outputs.get("eligible"), "false");
 		const reason = core.outputs.get("reason") ?? "";
-		// A saturated comparison establishes nothing about this branch, so the reason names the check
-		// that could not run, what branches behind on schema have run into, and how to clear it.
+		// At the comparison's limit, whether this branch carries every one of the default branch's
+		// migrations cannot be established — a saturated response does not even prove truncation. So
+		// the reason names the check that could not run, what branches behind on schema have run
+		// into, and how to clear it.
 		assert.match(reason, /behind main/);
 		// Truncation is the one case where the check genuinely could not run, so the reason says so,
 		// and says which check: whether the branch still carries the default branch's migrations.

--- a/scripts/preview-controller.test.ts
+++ b/scripts/preview-controller.test.ts
@@ -741,13 +741,16 @@ void describe("preview schema drift", () => {
 		const reason = core.outputs.get("reason") ?? "";
 		// The three things the author needs: which file, what goes wrong, and what to do about it.
 		assert.match(reason, /0001_drop\.xml/);
-		assert.match(reason, /cannot be checked/);
 		assert.match(reason, /have failed to start/);
 		assert.match(reason, /Merge main in/);
-		// The refusal reports an observation. Claiming a cause is what it got wrong twice: first
-		// Hibernate validation, which `prod` disables, then a schema mismatch a differing blob does
-		// not prove. Neither phrasing may come back.
-		assert.doesNotMatch(reason, /would fail|never produced|no longer match/);
+		// Both mechanisms were reproduced against a restored database, so the reason names them.
+		assert.match(reason, /Liquibase/);
+		assert.match(reason, /a later migration dropped/);
+		// It still reports what has gone wrong, never what this branch is guaranteed to hit: a
+		// migration that only adds a table this branch never queries breaks nothing. The two
+		// phrasings that overclaimed — Hibernate validation, which `prod` disables, and a schema
+		// mismatch a differing blob does not prove — may not come back.
+		assert.doesNotMatch(reason, /would fail|never produced|no longer match|cannot boot/);
 		assert.equal(core.outputs.get("announce"), "true");
 	});
 
@@ -800,10 +803,11 @@ void describe("preview schema drift", () => {
 		// Every branch that has reached this was genuinely incompatible, so the reason says what will
 		// happen and how to fix it rather than reporting the comparison's own limit.
 		assert.match(reason, /behind main/);
+		// Truncation is the one case where the check genuinely could not run, so the reason says so.
 		assert.match(reason, /cannot be checked/);
 		assert.match(reason, /have failed to start/);
 		assert.match(reason, /Merge main in/);
-		assert.doesNotMatch(reason, /would fail|never produced|no longer match/);
+		assert.doesNotMatch(reason, /would fail|never produced|no longer match|cannot boot/);
 	});
 
 	void it("ignores prose under the schema directory", async () => {

--- a/scripts/preview-controller.test.ts
+++ b/scripts/preview-controller.test.ts
@@ -741,12 +741,12 @@ void describe("preview schema drift", () => {
 		const reason = core.outputs.get("reason") ?? "";
 		// The three things the author needs: which file, what goes wrong, and what to do about it.
 		assert.match(reason, /0001_drop\.xml/);
-		assert.match(reason, /have failed against it/);
+		assert.match(reason, /have failed to start against it/);
 		assert.match(reason, /Merge main in/);
-		// Both mechanisms were reproduced against a restored database, so the reason names them —
-		// and keeps them apart, because only one of the two stops the boot.
-		assert.match(reason, /Liquibase stops the boot/);
-		assert.match(reason, /starts and then fails the first query/);
+		// Both mechanisms were reproduced against a restored database, so the reason names them, and
+		// names the step each one stops at: neither branch reaches a started application.
+		assert.match(reason, /Liquibase re-runs migrations/);
+		assert.match(reason, /startup then fails on a column/);
 		// It still reports what has gone wrong, never what this branch is guaranteed to hit: a
 		// migration that only adds a table this branch never queries breaks nothing. The two
 		// phrasings that overclaimed — Hibernate validation, which `prod` disables, and a schema
@@ -801,14 +801,14 @@ void describe("preview schema drift", () => {
 
 		assert.equal(core.outputs.get("eligible"), "false");
 		const reason = core.outputs.get("reason") ?? "";
-		// Every branch that has reached this was genuinely incompatible, so the reason says what will
-		// happen and how to fix it rather than reporting the comparison's own limit.
+		// A saturated comparison establishes nothing about this branch, so the reason names the check
+		// that could not run, what branches behind on schema have run into, and how to clear it.
 		assert.match(reason, /behind main/);
 		// Truncation is the one case where the check genuinely could not run, so the reason says so,
 		// and says which check: whether the branch still carries the default branch's migrations.
 		assert.match(reason, /carries main's migrations/);
 		assert.match(reason, /cannot be checked/);
-		assert.match(reason, /have failed against it/);
+		assert.match(reason, /have failed to start against it/);
 		assert.match(reason, /Merge main in/);
 		assert.doesNotMatch(reason, /would fail|never produced|no longer match|cannot boot/);
 	});

--- a/scripts/preview-controller.ts
+++ b/scripts/preview-controller.ts
@@ -268,11 +268,12 @@ const resolve = async ({ github, context, core }: ControllerInput): Promise<void
 	// What these messages may claim is bounded by what is actually known. Two mechanisms are, each
 	// reproduced by booting a released branch image against a database restored from the default
 	// branch. A branch from before a changelog was rewritten does not find its changeset ids
-	// recorded, so Liquibase re-runs them, PostgreSQL refuses the relation that already exists, and
-	// the boot stops there. A branch missing a migration that dropped a column its entities still
-	// map boots without complaint — `prod` sets `ddl-auto: none`, so nothing validates the mapping —
-	// and fails on the first query that reads it. They fail at different points, and the reason
-	// keeps them apart.
+	// recorded, so Liquibase re-runs those migrations and PostgreSQL refuses the relation that
+	// already exists. A branch missing a migration that dropped a column its entities still map
+	// passes Liquibase untouched and gets as far as a started web server, then fails a startup query
+	// for that column — `prod` sets `ddl-auto: none`, so nothing validates the mapping ahead of it.
+	// Both end in a container that never finished starting, at different steps, and the reason keeps
+	// the steps apart.
 	//
 	// Neither makes every missing migration fatal: one that only adds a table this branch never
 	// queries is harmless, and two changelogs can reach one schema by different text. So the reason
@@ -283,8 +284,8 @@ const resolve = async ({ github, context, core }: ControllerInput): Promise<void
 			`PR #${number} is ${behindFiles.length}+ files behind ${defaultBranch} — too many for GitHub ` +
 				`to compare in full, so whether this branch still carries ${defaultBranch}'s migrations ` +
 				`cannot be checked. A preview restores ${defaultBranch}'s database, and branches behind ` +
-				`on schema have failed against it. Merge ${defaultBranch} in; the next push previews ` +
-				`automatically.`,
+				`on schema have failed to start against it. Merge ${defaultBranch} in; the next push ` +
+				`previews automatically.`,
 		);
 	}
 	for (const file of behindFiles) {
@@ -299,10 +300,10 @@ const resolve = async ({ github, context, core }: ControllerInput): Promise<void
 		if (await branchHasBlob(github, owner, repo, pull.head.sha, file)) continue;
 		return skip(
 			`PR #${number} does not have ${defaultBranch}'s \`${file.filename}\`. A preview restores ` +
-				`${defaultBranch}'s database, and branches in that state have failed against it: ` +
-				`Liquibase stops the boot on changesets that database already recorded under other ` +
-				`ids, or the application starts and then fails the first query that reads a column a ` +
-				`later migration dropped. Merge ${defaultBranch} in; the next push previews ` +
+				`${defaultBranch}'s database, and branches in that state have failed to start against ` +
+				`it: Liquibase re-runs migrations that database has no record of and stops on a ` +
+				`relation that already exists, or Liquibase passes and startup then fails on a column ` +
+				`one of those migrations dropped. Merge ${defaultBranch} in; the next push previews ` +
 				`automatically.`,
 		);
 	}

--- a/scripts/preview-controller.ts
+++ b/scripts/preview-controller.ts
@@ -262,8 +262,9 @@ const resolve = async ({ github, context, core }: ControllerInput): Promise<void
 		basehead: `${pull.head.sha}...${defaultBranch}`,
 	});
 	const behindFiles = behind.data.files ?? [];
-	// The comparison reports at most COMPARE_FILE_LIMIT files and flags no truncation, so a saturated
-	// response cannot be read as "no migration is missing".
+	// The comparison reports at most COMPARE_FILE_LIMIT files and flags no truncation. A response at
+	// that count may be complete or cut off, and nothing distinguishes them, so it cannot be read as
+	// "no migration is missing".
 	//
 	// What these messages may claim is bounded by what is actually known. Two mechanisms are, each
 	// reproduced by booting a released branch image against a database restored from the default
@@ -281,11 +282,11 @@ const resolve = async ({ github, context, core }: ControllerInput): Promise<void
 	// is guaranteed to hit.
 	if (behindFiles.length >= COMPARE_FILE_LIMIT) {
 		return skip(
-			`PR #${number} is ${behindFiles.length}+ files behind ${defaultBranch} — too many for GitHub ` +
-				`to compare in full, so whether this branch still carries ${defaultBranch}'s migrations ` +
-				`cannot be checked. A preview restores ${defaultBranch}'s database, and branches behind ` +
-				`on schema have failed to start against it. Merge ${defaultBranch} in; the next push ` +
-				`previews automatically.`,
+			`PR #${number} is ${behindFiles.length} files behind ${defaultBranch}, the most one GitHub ` +
+				`comparison reports, so whether this branch still carries ${defaultBranch}'s ` +
+				`migrations cannot be checked. A preview restores ${defaultBranch}'s database, and ` +
+				`branches behind on schema have failed to start against it. Merge ${defaultBranch} ` +
+				`in; the next push previews automatically.`,
 		);
 	}
 	for (const file of behindFiles) {

--- a/scripts/preview-controller.ts
+++ b/scripts/preview-controller.ts
@@ -250,9 +250,9 @@ const resolve = async ({ github, context, core }: ControllerInput): Promise<void
 
 	// A preview restores the default branch's database into an application built from this branch, so
 	// a branch missing one of the default branch's migrations runs against a database built from a
-	// changelog other than its own. Saying so here costs one comparison; discovering it costs a
-	// deployment and a container that exits its healthcheck with nothing on the pull request to
-	// explain it.
+	// changelog other than its own. Checking that here costs one comparison and can name the reason
+	// on the pull request. Leaving it to the deployment costs the deployment, and the failure it
+	// reports says only that the preview did not come up.
 	//
 	// It sits after the checks above on purpose: a head that already has a live preview needs no
 	// deployment, and refusing here would replace a working preview's comment with a refusal.

--- a/scripts/preview-controller.ts
+++ b/scripts/preview-controller.ts
@@ -248,11 +248,11 @@ const resolve = async ({ github, context, core }: ControllerInput): Promise<void
 		}
 	}
 
-	// A preview restores the default branch's schema into an application built from this branch, and
-	// the application boots with `ddl-auto: validate`. A branch missing one of the default branch's
-	// migrations may therefore map entities the restored database no longer has. Saying so here
-	// costs one comparison; discovering it costs a deployment, ten minutes, and a container that
-	// exits its healthcheck with nothing on the pull request to explain it.
+	// A preview restores the default branch's database into an application built from this branch, so
+	// a branch missing one of the default branch's migrations runs against a database its own
+	// changelog never produced. Saying so here costs one comparison; discovering it costs a
+	// deployment, ten minutes, and a container that exits its healthcheck with nothing on the pull
+	// request to explain it.
 	//
 	// It sits after the checks above on purpose: a head that already has a live preview needs no
 	// deployment, and refusing here would replace a working preview's comment with a refusal.
@@ -265,20 +265,24 @@ const resolve = async ({ github, context, core }: ControllerInput): Promise<void
 	// The comparison reports at most COMPARE_FILE_LIMIT files and flags no truncation, so a saturated
 	// response cannot be read as "no migration is missing".
 	//
-	// What these messages may claim is bounded by what is actually known. Previews of branches behind
-	// on schema have failed — the container never became healthy — but the mechanism is not
-	// established: `prod` sets `ddl-auto: none`, so Hibernate does not validate, and the earlier
-	// claim that it did was wrong. Liquibase runs the branch's own changelog over the restored dump,
-	// and the preview's PostgreSQL image is built from the branch's commit while the dump comes from
-	// the default branch's server, so a version skew is possible too. Until one is demonstrated the
-	// reason states the observation and the remedy, not a cause.
+	// What these messages may claim is bounded by what is actually known. Two mechanisms are, each
+	// reproduced by booting a released branch image against a database restored from the default
+	// branch: a branch from before a changelog was rewritten does not find its changeset ids
+	// recorded, so Liquibase re-runs them and PostgreSQL refuses the relation that already exists;
+	// and a branch missing a migration that dropped a column its entities still map boots without
+	// complaint — `prod` sets `ddl-auto: none`, so nothing validates, correcting an earlier claim
+	// that Hibernate did — then fails on the first query that reads it.
+	//
+	// Neither makes every missing migration fatal: one that only adds a table this branch never
+	// queries is harmless. So the reason names the mechanisms as what has gone wrong, never as what
+	// this branch is guaranteed to hit.
 	if (behindFiles.length >= COMPARE_FILE_LIMIT) {
 		return skip(
 			`PR #${number} is ${behindFiles.length}+ files behind ${defaultBranch} — too many for GitHub ` +
-				`to compare in full, so whether this branch still matches ${defaultBranch}'s schema ` +
-				`cannot be checked. A preview restores ${defaultBranch}'s database, and previews of ` +
-				`branches behind on schema have failed to start. Merge ${defaultBranch} in; the next ` +
-				`push previews automatically.`,
+				`to compare in full, so whether this branch still carries ${defaultBranch}'s migrations ` +
+				`cannot be checked. A preview restores ${defaultBranch}'s database, and branches behind ` +
+				`on schema have failed to start against it. Merge ${defaultBranch} in; the next push ` +
+				`previews automatically.`,
 		);
 	}
 	for (const file of behindFiles) {
@@ -293,9 +297,10 @@ const resolve = async ({ github, context, core }: ControllerInput): Promise<void
 		if (await branchHasBlob(github, owner, repo, pull.head.sha, file)) continue;
 		return skip(
 			`PR #${number} does not have ${defaultBranch}'s \`${file.filename}\`. A preview restores ` +
-				`${defaultBranch}'s database, so whether this branch matches that schema cannot be ` +
-				`checked, and previews in that state have failed to start. Merge ${defaultBranch} in; ` +
-				`the next push previews automatically.`,
+				`${defaultBranch}'s database, and branches in that state have failed to start against ` +
+				`it — Liquibase re-running changesets the restored database already recorded under ` +
+				`other ids, or a query reading a column a later migration dropped. Merge ` +
+				`${defaultBranch} in; the next push previews automatically.`,
 		);
 	}
 

--- a/scripts/preview-controller.ts
+++ b/scripts/preview-controller.ts
@@ -249,10 +249,10 @@ const resolve = async ({ github, context, core }: ControllerInput): Promise<void
 	}
 
 	// A preview restores the default branch's database into an application built from this branch, so
-	// a branch missing one of the default branch's migrations runs against a database its own
-	// changelog never produced. Saying so here costs one comparison; discovering it costs a
-	// deployment, ten minutes, and a container that exits its healthcheck with nothing on the pull
-	// request to explain it.
+	// a branch missing one of the default branch's migrations runs against a database built from a
+	// changelog other than its own. Saying so here costs one comparison; discovering it costs a
+	// deployment and a container that exits its healthcheck with nothing on the pull request to
+	// explain it.
 	//
 	// It sits after the checks above on purpose: a head that already has a live preview needs no
 	// deployment, and refusing here would replace a working preview's comment with a refusal.
@@ -267,22 +267,24 @@ const resolve = async ({ github, context, core }: ControllerInput): Promise<void
 	//
 	// What these messages may claim is bounded by what is actually known. Two mechanisms are, each
 	// reproduced by booting a released branch image against a database restored from the default
-	// branch: a branch from before a changelog was rewritten does not find its changeset ids
-	// recorded, so Liquibase re-runs them and PostgreSQL refuses the relation that already exists;
-	// and a branch missing a migration that dropped a column its entities still map boots without
-	// complaint — `prod` sets `ddl-auto: none`, so nothing validates, correcting an earlier claim
-	// that Hibernate did — then fails on the first query that reads it.
+	// branch. A branch from before a changelog was rewritten does not find its changeset ids
+	// recorded, so Liquibase re-runs them, PostgreSQL refuses the relation that already exists, and
+	// the boot stops there. A branch missing a migration that dropped a column its entities still
+	// map boots without complaint — `prod` sets `ddl-auto: none`, so nothing validates the mapping —
+	// and fails on the first query that reads it. They fail at different points, and the reason
+	// keeps them apart.
 	//
 	// Neither makes every missing migration fatal: one that only adds a table this branch never
-	// queries is harmless. So the reason names the mechanisms as what has gone wrong, never as what
-	// this branch is guaranteed to hit.
+	// queries is harmless, and two changelogs can reach one schema by different text. So the reason
+	// names the mechanisms as what branches in this state have run into, never as what this branch
+	// is guaranteed to hit.
 	if (behindFiles.length >= COMPARE_FILE_LIMIT) {
 		return skip(
 			`PR #${number} is ${behindFiles.length}+ files behind ${defaultBranch} — too many for GitHub ` +
 				`to compare in full, so whether this branch still carries ${defaultBranch}'s migrations ` +
 				`cannot be checked. A preview restores ${defaultBranch}'s database, and branches behind ` +
-				`on schema have failed to start against it. Merge ${defaultBranch} in; the next push ` +
-				`previews automatically.`,
+				`on schema have failed against it. Merge ${defaultBranch} in; the next push previews ` +
+				`automatically.`,
 		);
 	}
 	for (const file of behindFiles) {
@@ -292,15 +294,16 @@ const resolve = async ({ github, context, core }: ControllerInput): Promise<void
 		// present here under a different commit, so the blob decides, not the ancestry.
 		//
 		// A differing blob is still only unverifiable, never proof: two changelogs can reach the same
-		// schema by different text. The reason says so rather than asserting a mismatch it cannot
-		// demonstrate — the same overreach that claimed Hibernate validation, one sentence along.
+		// schema by different text. So the reason reports what branches in this state have run into
+		// and stops short of asserting a mismatch this comparison cannot demonstrate.
 		if (await branchHasBlob(github, owner, repo, pull.head.sha, file)) continue;
 		return skip(
 			`PR #${number} does not have ${defaultBranch}'s \`${file.filename}\`. A preview restores ` +
-				`${defaultBranch}'s database, and branches in that state have failed to start against ` +
-				`it — Liquibase re-running changesets the restored database already recorded under ` +
-				`other ids, or a query reading a column a later migration dropped. Merge ` +
-				`${defaultBranch} in; the next push previews automatically.`,
+				`${defaultBranch}'s database, and branches in that state have failed against it: ` +
+				`Liquibase stops the boot on changesets that database already recorded under other ` +
+				`ids, or the application starts and then fails the first query that reads a column a ` +
+				`later migration dropped. Merge ${defaultBranch} in; the next push previews ` +
+				`automatically.`,
 		);
 	}
 


### PR DESCRIPTION
## What changed and why

The preview refusal told the author that whether their branch matched the restored schema *"cannot be checked"*, and that previews in that state *"have failed to start"*. That wording was deliberate: two earlier attempts to name a cause were wrong — first Hibernate validation, which `prod` disables with `ddl-auto: none`, then a schema mismatch a differing blob does not prove — so the message retreated to the observation.

The mechanism is now established, by experiment rather than by reading. Both cases were reproduced by booting a released branch image against a PostgreSQL 18 database restored from the default branch's own migrations:

**1. A branch from before the changelog was rewritten.** The restored database records the v0.77.4 baseline; the branch's `master.xml` still starts at the pre-squash initial schema, whose changeset ids are not in `DATABASECHANGELOG`. Liquibase re-runs them:

```
Migration failed for changeset db/changelog/0000000000000_initial_schema.xml::1730730860388-1
Caused by: org.postgresql.util.PSQLException: ERROR: relation "issue_comment" already exists
```

**2. A branch missing a migration that dropped a column.** Liquibase is perfectly happy and applies nothing — extra rows in `DATABASECHANGELOG` are ignored — and startup gets as far as a started Tomcat, since `prod` sets `ddl-auto: none` and nothing validates the mapping. A startup query then fails:

```
ERROR: column w1_0.achievements_enabled does not exist
```

That second case also settles the earlier correction properly: the absence of Hibernate validation does not make a schema-behind branch safe. It only moves the failure to a later step of the same startup — the application never reports itself started, and the container exits, which is why these previews die at the healthcheck with nothing to explain them.

So the reason now names both mechanisms. It still stops short of claiming this branch will certainly hit one, because it will not always: a migration that only adds a table this branch never queries breaks nothing. The truncated-comparison message keeps `cannot be checked` — there the check genuinely could not run.

## How to test

```sh
node --test scripts/preview-controller.test.ts
```

41 pass. Reverting `scripts/preview-controller.ts` alone fails the refusal test, so the new assertions are not vacuous.

## Release impact

No changeset: repository automation, not shipped code.

## Notes for reviewers

The guard itself is unchanged — this is what it says, not what it decides. I set out to narrow it, on the theory that it refuses branches that would preview fine; the experiment disproved that. Both refused categories genuinely fail, in the two different ways above.

The remaining root fix is unchanged and larger: a preview seeded from the default branch's database can never be right for a branch that changes the schema. Decoupling preview seeding from that database is what deletes this guard rather than rewording it.

Part of #2090.


### After adversarial review

An intermediate version of this message split the two on the theory that only the Liquibase one stops the boot. Re-running the reproduction disproved that: the column-drop branch starts Tomcat and then fails a startup query, and never reports itself started. Both are startup failures, and the reason now separates them by the step each stops at rather than by a boundary one of them never crosses. The Liquibase clause was reworded too — Liquibase does not observe that a changeset is "recorded under other ids"; it finds no record of the migration, re-runs it, and PostgreSQL refuses a relation that already exists.

Also from that review: the truncated-comparison assertions all still passed against the old message, so that wording was unprotected — both wording tests now fail against `main`'s messages. And the comments carried a measured duration and an account of what earlier versions of this file got wrong, neither of which `AGENTS.md` allows in a comment.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated preview validation messages to more clearly explain why branches missing default-branch migrations may be skipped.
  - Clarified that the check verifies whether a branch carries the default branch’s migrations.
  - Added clearer guidance to merge the default branch before retrying.
  - Improved safeguards against misleading “cannot boot” wording in validation messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->