### PR TITLE
fix(ci): isolate browser dependencies and avoid duplicate scans

### DIFF
--- a/.github/actions/setup-browsers/action.yml
+++ b/.github/actions/setup-browsers/action.yml
@@ -11,6 +11,9 @@ runs:
       with:
         path: ~/.cache/ms-playwright
         key: ${{ runner.os }}-playwright-${{ steps.playwright.outputs.version }}
+    - name: Install Chromium system dependencies
+      shell: bash
+      run: node scripts/install-browser-deps.ts
     - name: Install Chromium
       shell: bash
-      run: vp -C webapp exec playwright install chromium --with-deps
+      run: vp -C webapp exec playwright install chromium

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -7,6 +7,10 @@ on:
         description: "Digest of the application image built from this run's packaged JAR"
         value: ${{ jobs.application-server-image.outputs.manifest-digest }}
     inputs:
+      scan-images:
+        description: "Scan published images here unless the caller requires complete release evidence instead."
+        type: boolean
+        default: true
       should_skip:
         description: "Whether to skip the workflow"
         required: false
@@ -365,3 +369,4 @@ jobs:
       registry: "ghcr.io"
       publish: ${{ inputs.publish }}
       single-arch: ${{ inputs.single_arch == 'true' }}
+      scan-images: ${{ inputs.scan-images }}

--- a/.github/workflows/ci-docker-build.yml
+++ b/.github/workflows/ci-docker-build.yml
@@ -10,6 +10,10 @@ on:
       SENTRY_PROJECT:
         required: false
     inputs:
+      scan-images:
+        description: "Scan published images here unless the caller requires complete release evidence instead."
+        type: boolean
+        default: true
       should_skip:
         description: "Whether to skip the workflow"
         required: false
@@ -78,6 +82,7 @@ jobs:
         COOLIFY_BRANCH=${{ github.head_ref || github.ref_name }}
       publish: ${{ inputs.publish }}
       single-arch: ${{ inputs.single_arch == 'true' }}
+      scan-images: ${{ inputs.scan-images }}
       labels: |
         org.opencontainers.image.title=Hephaestus Webapp
         org.opencontainers.image.description=Web client for Hephaestus
@@ -105,6 +110,7 @@ jobs:
         SOURCE_COMMIT=${{ github.sha }}
       publish: ${{ inputs.publish }}
       single-arch: ${{ inputs.single_arch == 'true' }}
+      scan-images: ${{ inputs.scan-images }}
       labels: |
         org.opencontainers.image.title=Hephaestus Agent - Pi
         org.opencontainers.image.description=Sandboxed Pi coding agent for AI-powered code review
@@ -132,6 +138,7 @@ jobs:
         SOURCE_COMMIT=${{ github.sha }}
       publish: ${{ inputs.publish }}
       single-arch: ${{ inputs.single_arch == 'true' }}
+      scan-images: ${{ inputs.scan-images }}
       labels: |
         org.opencontainers.image.title=Hephaestus Postgres
         org.opencontainers.image.description=PostgreSQL + pg_partman for all environments (dev/preview/prod)

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -56,6 +56,7 @@ jobs:
       version-bump: ${{ steps.version_bump.outputs.changed }}
       version: ${{ steps.version.outputs.version }}
       release-candidate: ${{ steps.release_candidate.outputs.release-candidate }}
+      release-preflight: ${{ (github.event_name == 'workflow_dispatch' && inputs.release-preflight) || steps.release_candidate.outputs.release-candidate == 'true' }}
       any-code: ${{ steps.filter.outputs.webapp == 'true' || steps.filter.outputs.application-server == 'true' || steps.filter.outputs.tooling == 'true' || steps.filter.outputs.agent-images == 'true' || steps.filter.outputs.postgres-image == 'true' }}
       # The vulnerability policy's match key includes the platform, so an arm64-only finding has to
       # be found before the release rather than by it, and only a manifest that exists can carry it.
@@ -477,6 +478,7 @@ jobs:
       should_skip: ${{ needs.detect-changes.outputs.should_skip }}
       publish: ${{ needs.detect-changes.outputs.publishable == 'true' }}
       single_arch: ${{ needs.detect-changes.outputs.single-arch }}
+      scan-images: ${{ needs.detect-changes.outputs.release-preflight != 'true' }}
       postgres_base_sha: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.sha }}
       server_changed: ${{ (needs.detect-changes.outputs.application-server == 'true' || needs.detect-changes.outputs.e2e == 'true' || needs.detect-changes.outputs.postgres-image == 'true' || needs.detect-changes.outputs.build-config == 'true' || needs.detect-changes.outputs.application-server-image == 'true' || needs.detect-changes.outputs.supported-host-smoke == 'true' || needs.detect-changes.outputs.all-images == 'true') && 'true' || 'false' }}
       contracts_changed: ${{ (github.event_name != 'push' || needs.detect-changes.outputs.version-bump == 'true') && (needs.detect-changes.outputs.application-server == 'true' || needs.detect-changes.outputs.postgres-image == 'true' || needs.detect-changes.outputs.build-config == 'true' || needs.detect-changes.outputs.unfiltered == 'true') && 'true' || 'false' }}
@@ -559,6 +561,7 @@ jobs:
       should_skip: ${{ needs.detect-changes.outputs.should_skip }}
       publish: ${{ needs.detect-changes.outputs.publishable == 'true' }}
       single_arch: ${{ needs.detect-changes.outputs.single-arch }}
+      scan-images: ${{ needs.detect-changes.outputs.release-preflight != 'true' }}
       webapp_changed: ${{ (needs.detect-changes.outputs.webapp-image == 'true' || needs.detect-changes.outputs.docker-config == 'true' || needs.detect-changes.outputs.all-images == 'true') && 'true' || 'false' }}
       application_server_changed: ${{ (needs.detect-changes.outputs.application-server-image == 'true' || needs.detect-changes.outputs.supported-host-smoke == 'true' || needs.detect-changes.outputs.all-images == 'true') && 'true' || 'false' }}
       agent_images_changed: ${{ (needs.detect-changes.outputs.agent-images == 'true' || needs.detect-changes.outputs.docker-config == 'true' || needs.detect-changes.outputs.all-images == 'true') && 'true' || 'false' }}
@@ -625,7 +628,7 @@ jobs:
   Release-preflight:
     name: "Release evidence preflight"
     needs: [detect-changes, Build, Docker]
-    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.release-preflight) || needs.detect-changes.outputs.release-candidate == 'true' }}
+    if: needs.detect-changes.outputs.release-preflight == 'true'
     timeout-minutes: 45
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -159,6 +159,7 @@ jobs:
               - 'scripts/check-presentational-components.ts'
               - 'scripts/check-story-prose.ts'
               - 'scripts/check-story-sort.ts'
+              - 'scripts/install-browser-deps.ts'
               - 'package.json'
               - 'pnpm-lock.yaml'
               - 'pnpm-workspace.yaml'
@@ -237,6 +238,7 @@ jobs:
               - 'server/gradle/**'
               - 'server/gradlew*'
             e2e:
+              - 'scripts/install-browser-deps.ts'
               - '.java-version'
               - 'webapp/e2e/**'
               - 'webapp/src/**'

--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -10,6 +10,10 @@ on:
       SENTRY_PROJECT:
         required: false
     inputs:
+      scan-images:
+        description: "Scan published images here unless the caller requires complete release evidence instead."
+        type: boolean
+        default: true
       image-name:
         type: string
         required: true
@@ -460,15 +464,13 @@ jobs:
             > /dev/null
           gh attestation verify "oci://$IMAGE_REF" --owner "${{ github.repository_owner }}"
 
-  # linux/amd64 only: the base images ship the same packages on every architecture, and the
-  # release scans every published platform where the evidence bundle must be complete.
   scan:
     name: Scan linux/amd64 Image
     needs: [build, merge]
     # `merge` is skipped for single-architecture builds, which would skip this job too
     # without a status-check function to suppress the implicit success() over every need.
     if: >-
-      ${{ inputs.publish && !cancelled() && needs.build.result == 'success' &&
+      ${{ inputs.scan-images && inputs.publish && !cancelled() && needs.build.result == 'success' &&
       needs.merge.result != 'failure' && needs.merge.result != 'cancelled' }}
     timeout-minutes: 20
     runs-on: ubuntu-24.04

--- a/docs/contributor/ci-cd.mdx
+++ b/docs/contributor/ci-cd.mdx
@@ -455,6 +455,11 @@ credential is still `GITHUB_TOKEN`, so these commits start no further workflow r
 | `download-trivy-db` | Fetches the vulnerability database with retries and a mirror fallback; optionally refuses one over `max-age-hours` old and records its metadata |
 | `ghcr-login` | Authenticates Docker to GHCR |
 
+Browser jobs install Playwright's system dependencies using the runner's Ubuntu package sources,
+with APT configuration scoped to that installation process. Unrelated vendor repositories do not
+participate; repository signatures and package hashes remain enforced. The pinned Playwright CLI
+then installs Chromium as the runner user so the browser cache retains its normal ownership.
+
 ### Caches
 
 A run restores caches from its own branch and from `main`, never from a sibling branch. Task-cache

--- a/docs/contributor/ci-cd.mdx
+++ b/docs/contributor/ci-cd.mdx
@@ -523,6 +523,10 @@ to both image workflows. That build compiles the image and stops: no login, no p
 no attestation, no policy scan and no alias moves. Forks therefore get no preview and no boot smoke;
 the release path exercises their code once it is on `main`.
 
+When release preflight is required, it owns image vulnerability scanning for both architectures;
+the image-build workflows omit their duplicate amd64 scans. Other published builds retain those
+scans. The final gate rejects a required preflight that is skipped, cancelled or unsuccessful.
+
 ## Image identity
 
 Every consumer resolves an image through the commit the run built it from, and

--- a/scripts/ci-cache-policy.test.ts
+++ b/scripts/ci-cache-policy.test.ts
@@ -41,6 +41,8 @@ await describe("CI cache policy", async () => {
 			/key: \${{ runner\.os }}-playwright-\${{ steps\.playwright\.outputs\.version }}/,
 		);
 		assert.doesNotMatch(browserAction, /restore-keys:/);
-		assert.match(browserAction, /playwright install chromium --with-deps/);
+		assert.match(browserAction, /playwright install chromium/);
+		assert.match(browserAction, /node scripts\/install-browser-deps\.ts/);
+		assert.doesNotMatch(browserAction, /--with-deps/);
 	});
 });

--- a/scripts/ci-contract.test.ts
+++ b/scripts/ci-contract.test.ts
@@ -436,6 +436,38 @@ void describe("CI contract", () => {
 		assert.match(source, /inputs.cache-write != 'true' \|\| github.ref != format/);
 	});
 
+	void test("image scans are delegated only to required release preflight", async () => {
+		const workflow = parseDocument(await readFile(".github/workflows/cicd.yml", "utf8"));
+		assert.equal(
+			workflow.getIn(["jobs", "detect-changes", "outputs", "release-preflight"]),
+			`\${{ (github.event_name == 'workflow_dispatch' && inputs.release-preflight) || steps.release_candidate.outputs.release-candidate == 'true' }}`,
+		);
+		for (const name of ["Build", "Docker"])
+			assert.equal(
+				workflow.getIn(["jobs", name, "with", "scan-images"]),
+				`\${{ needs.detect-changes.outputs.release-preflight != 'true' }}`,
+			);
+		for (const file of ["ci-build.yml", "ci-docker-build.yml", "reusable-docker-build.yml"]) {
+			const reusable = parseDocument(await readFile(`.github/workflows/${file}`, "utf8"));
+			assert.equal(
+				reusable.getIn(["on", "workflow_call", "inputs", "scan-images", "default"]),
+				true,
+			);
+			const jobs = reusable.get("jobs");
+			assert.ok(isMap(jobs));
+			for (const { value } of jobs.items)
+				if (isMap(value) && value.get("uses") === "./.github/workflows/reusable-docker-build.yml")
+					assert.equal(value.getIn(["with", "scan-images"]), `\${{ inputs.scan-images }}`);
+		}
+		const docker = parseDocument(
+			await readFile(".github/workflows/reusable-docker-build.yml", "utf8"),
+		);
+		assert.match(
+			String(docker.getIn(["jobs", "scan", "if"])),
+			/inputs.scan-images && inputs.publish/,
+		);
+	});
+
 	void test("path exclusions cannot select unrelated files for server tests or webapp images", async () => {
 		const workflow = parseDocument(await readFile(".github/workflows/cicd.yml", "utf8"));
 		const steps = workflow.getIn(["jobs", "detect-changes", "steps"]);
@@ -1273,10 +1305,7 @@ void describe("CI contract", () => {
 		// documents are re-derived and compared exactly as the release re-derives them.
 		assert.match(preflight, /node scripts\/verify-release-evidence\.ts evidence\n/);
 		assert.match(preflight, /max-age-hours: "24"/);
-		assert.match(
-			preflight,
-			/if: \$\{\{ \(github\.event_name == 'workflow_dispatch' && inputs\.release-preflight\) \|\| needs\.detect-changes\.outputs\.release-candidate == 'true' \}\}/,
-		);
+		assert.match(preflight, /if: needs\.detect-changes\.outputs\.release-preflight == 'true'/);
 		assert.match(cicd, /^ {6}release-preflight:$/m);
 		assert.match(job(cicd, "all-ci-passed"), /needs: \[[^\]]*Release-preflight\]/);
 
@@ -1393,7 +1422,7 @@ void describe("CI contract", () => {
 		// every event, and a duplicate-run skip must not take the image builds it needs away.
 		assert.match(
 			String(workflow.getIn(["jobs", "Release-preflight", "if"])),
-			/needs\.detect-changes\.outputs\.release-candidate == 'true'/,
+			/needs\.detect-changes\.outputs\.release-preflight == 'true'/,
 		);
 		assert.match(
 			String(workflow.getIn([...detection, "outputs", "should_skip"])),

--- a/scripts/install-browser-deps.ts
+++ b/scripts/install-browser-deps.ts
@@ -1,0 +1,27 @@
+import { copyFile, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+import { run } from "./lib/process.ts";
+
+const directory = await mkdtemp(join(tmpdir(), "playwright-apt-"));
+try {
+	const sources = join(directory, "sources");
+	await mkdir(sources);
+	await copyFile("/etc/apt/sources.list.d/ubuntu.sources", join(sources, "ubuntu.sources"));
+	const config = join(directory, "apt.conf");
+	await writeFile(
+		config,
+		`Dir::Etc::sourcelist "/dev/null";\nDir::Etc::sourceparts ${JSON.stringify(sources)};\n`,
+	);
+	await run("sudo", [
+		"env",
+		`APT_CONFIG=${config}`,
+		process.execPath,
+		resolve("webapp/node_modules/playwright/cli.js"),
+		"install-deps",
+		"chromium",
+	]);
+} finally {
+	await rm(directory, { recursive: true, force: true });
+}


### PR DESCRIPTION
## What changed and why

Browser jobs failed before running tests because Playwright's dependency installation refreshed an unrelated vendor repository with inconsistent package hashes. Install system dependencies from the runner's existing Ubuntu sources using process-scoped APT configuration, then install pinned Chromium as the runner user. No runner repositories are removed and no integrity checks are disabled.

Release candidates currently wait for per-image amd64 vulnerability scans, then scan those same digests again while generating the mandatory two-platform release evidence bundle. Both paths enforce the same vulnerability policy.

Use one detection output to select scan ownership. When complete release preflight is required, image builds omit their duplicate scans and preflight owns scanning. Otherwise, published image builds retain their existing scans. Reusable workflows default to scanning; the final CI gate still rejects a required preflight that is skipped, cancelled or unsuccessful.

No scan results are cached or trusted from an older run. Platform coverage, digest binding, vulnerability policy, freshness checks, signatures and test coverage are unchanged.

## How to test

- `vp run format` and `vp run --concurrency-limit 1 check` passed. The reduced local concurrency avoids competing with other work on the shared development host; no CI concurrency setting changed.
- Actionlint 1.7.12 and Zizmor 1.29.0 passed.
- Browser dependency installation still uses Playwright's native CLI and Ubuntu's supplied source configuration. Hosted Storybook and browser E2E jobs passed on this revision; dependency logs contain only the Ubuntu sources.
- Workflow contracts validate the ownership decision, default-on scanning, propagation through every image caller, and rejection of missing/failed/cancelled required preflight. Existing evidence tests remain green.
- On ordinary PR CI, confirm per-image scans still execute for published builds.
- Dispatch CI/CD on this branch with `release-preflight=true`: per-image scans should skip, the complete preflight bundle must pass, and every inventory image must have amd64 and arm64 evidence. [Hosted verification](https://github.com/hephaestus-build/Hephaestus/actions/runs/34386175063) confirmed all four duplicate scans skipped and preflight passed for all 16 image/platform subjects. The downloaded bundle also passed an independent local verifier run.

## Release impact

CI orchestration only. No policy relaxation, runtime change, operator action or changeset.

## Notes for reviewers

The inspected release-candidate run spent 2m21s on evidence preflight after waiting for its build workflows. This change removes duplicate scan jobs from those prerequisites, but does not promise a six-minute run. The actual effect must be measured on hosted CI.

Evidence capture already limits scanner concurrency to two. Retained subject timings showed the paired platforms were well balanced, so no custom worker pool or additional parallelism was added.

The initial hosted run and one failed-job retry both stopped on Google's Chrome APT index hash mismatch before story/E2E execution. The browser change addresses that dependency boundary rather than adding another retry or suppressing validation.

The manual run initially encountered an unrelated Reactor Netty connection-acquisition IOException in `FeedbackResponseControllerIntegrationTest`. The focused test passed locally and the failed application job passed on rerun. No transport/pooling setting or test retry was changed; the underlying intermittent failure is not claimed fixed. This rerun is validation evidence, not a clean latency benchmark.
