### PR TITLE
fix(ci): start image checks when their artifacts are ready

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -2,34 +2,12 @@ name: Build
 
 on:
   workflow_call:
-    outputs:
-      application-server-digest:
-        description: "Digest of the application image built from this run's packaged JAR"
-        value: ${{ jobs.application-server-image.outputs.manifest-digest }}
     inputs:
-      scan-images:
-        description: "Scan published images here unless the caller requires complete release evidence instead."
-        type: boolean
-        default: true
       should_skip:
         description: "Whether to skip the workflow"
         required: false
         type: string
         default: "false"
-      # publish and single_arch have no default; reusable-docker-build.yml says why.
-      publish:
-        description: "Whether image jobs may write to the registry"
-        required: true
-        type: boolean
-      single_arch:
-        description: "Whether to build linux/amd64 alone instead of the supported multi-architecture set"
-        required: true
-        type: string
-      server_changed:
-        description: "Whether anything that runs the packaged server changed"
-        required: false
-        type: string
-        default: "true"
       contracts_changed:
         description: "Whether the API or database contracts or their PostgreSQL image changed"
         required: false
@@ -49,11 +27,6 @@ on:
         description: "Commit whose published PostgreSQL image the database legs reuse"
         required: true
         type: string
-      server_image_changed:
-        description: "Whether the application-server image inputs changed"
-        required: false
-        type: string
-        default: "true"
 
 permissions: {}
 
@@ -63,79 +36,8 @@ env:
 # Consumers must not recompile: API checks, browser tests and buildpacks share the package job's JAR.
 # docs/contributor/ci-cd.mdx § Build once owns the artifact contract.
 jobs:
-  server-package:
-    name: "App Server: Package"
-    if: inputs.should_skip != 'true' && inputs.server_changed == 'true'
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    permissions:
-      contents: read
-      actions: read
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-      - uses: ./.github/actions/setup-toolchain
-        if: github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
-        with:
-          install: "none"
-      - name: Find the exact-commit merge-queue build
-        id: reuse
-        if: github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
-        continue-on-error: true
-        env:
-          GH_TOKEN: ${{ github.token }}
-          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
-        run: node scripts/resolve-server-build.ts
-      - name: Download the validated server build
-        if: steps.reuse.outputs.artifact-id != ''
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          artifact-ids: ${{ steps.reuse.outputs.artifact-id }}
-          run-id: ${{ steps.reuse.outputs.run-id }}
-          github-token: ${{ github.token }}
-          path: server
-          merge-multiple: true
-          digest-mismatch: error
-      - uses: ./.github/actions/setup-caches
-        if: steps.reuse.outputs.artifact-id == ''
-        with:
-          cache-write: "true"
-      - name: Package the server
-        if: steps.reuse.outputs.artifact-id == ''
-        working-directory: server
-        run: ./gradlew :application:bootJar :application:testClasses
-      - name: Validate the packaged server
-        working-directory: server
-        run: |
-          set -euo pipefail
-          test -d application/build/classes/java/main
-          test -d application/build/classes/java/test
-          mapfile -t jars < <(find application/build/libs -maxdepth 1 -name 'hephaestus-application-*.jar' ! -name '*-sources.jar' ! -name '*-javadoc.jar')
-          mapfile -t clients < <(find generated-clients/build/libs -maxdepth 1 -name 'hephaestus-generated-clients-*.jar' ! -name '*-sources.jar' ! -name '*-javadoc.jar')
-          (( ${#jars[@]} == 1 )) && (( ${#clients[@]} == 1 ))
-          unzip -p "${jars[0]}" META-INF/MANIFEST.MF | grep -q '^Main-Class: org.springframework.boot.loader'
-      - name: Upload the packaged server
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: ${{ env.SERVER_BUILD_ARTIFACT }}
-          path: |
-            server/application/build/classes/java/main
-            server/application/build/classes/java/test
-            server/application/build/resources
-            server/application/build/libs/hephaestus-application-*.jar
-            server/generated-clients/build/libs/hephaestus-generated-clients-*.jar
-            !server/**/*-sources.jar
-            !server/**/*-javadoc.jar
-          if-no-files-found: error
-          retention-days: 1
-          compression-level: 0
-          # A re-run of failed jobs keeps this artifact; a re-run of all jobs replaces it.
-          overwrite: true
-
   server-api:
     name: "App Server: Generated artifacts"
-    needs: server-package
     if: inputs.should_skip != 'true' && inputs.contracts_changed == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -226,7 +128,6 @@ jobs:
 
   server-database:
     name: "App Server: Database"
-    needs: server-package
     if: inputs.should_skip != 'true' && inputs.contracts_changed == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -275,7 +176,6 @@ jobs:
 
   webapp-e2e:
     name: "Webapp: E2E"
-    needs: server-package
     if: inputs.should_skip != 'true' && inputs.e2e_changed == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 25
@@ -347,26 +247,3 @@ jobs:
             e2e-server.log
           if-no-files-found: warn
           retention-days: 7
-
-  application-server-image:
-    name: "App Server image"
-    needs: server-package
-    if: inputs.should_skip != 'true' && inputs.server_image_changed == 'true'
-    uses: ./.github/workflows/reusable-docker-build.yml
-    permissions:
-      contents: read
-      packages: write
-      id-token: write
-      attestations: write
-      artifact-metadata: write
-    with:
-      image-name: "hephaestus-build/application-server"
-      use-buildpacks: true
-      application-artifact: server-build-${{ github.run_id }}
-      project-descriptor: "server/application/project.toml"
-      # renovate: datasource=docker depName=paketobuildpacks/ubuntu-noble-run-tiny
-      run-image: "paketobuildpacks/ubuntu-noble-run-tiny@sha256:c32333227b6dfbc2a4a93b03ee6d3475cfe152468c7d396bf22f06099bb0ecc9"
-      registry: "ghcr.io"
-      publish: ${{ inputs.publish }}
-      single-arch: ${{ inputs.single_arch == 'true' }}
-      scan-images: ${{ inputs.scan-images }}

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -456,10 +456,9 @@ jobs:
       tooling_changed: ${{ (needs.detect-changes.outputs.tooling == 'true' || needs.detect-changes.outputs.quality-config == 'true' || needs.detect-changes.outputs.unfiltered == 'true') && 'true' || 'false' }}
       pmd_canary: ${{ (needs.detect-changes.outputs.pmd-canary == 'true' || needs.detect-changes.outputs.unfiltered == 'true') && 'true' || 'false' }}
 
-  # Same-repository pull requests run Build regardless of paths: previews need the application
-  # image at the head SHA on every push.
-  Build:
-    uses: ./.github/workflows/ci-build.yml
+  # Package once; artifact checks and the image independently consume the same JAR.
+  server-package:
+    name: "App Server: Package"
     needs: [detect-changes]
     if: |
       needs.detect-changes.outputs.should_skip != 'true' && (
@@ -467,26 +466,114 @@ jobs:
         needs.detect-changes.outputs.previews == 'true' ||
         needs.detect-changes.outputs.any-code == 'true' ||
         needs.detect-changes.outputs.build-config == 'true'
+      ) && (
+        needs.detect-changes.outputs.application-server == 'true' || needs.detect-changes.outputs.e2e == 'true' || needs.detect-changes.outputs.postgres-image == 'true' || needs.detect-changes.outputs.build-config == 'true' || needs.detect-changes.outputs.application-server-image == 'true' || needs.detect-changes.outputs.supported-host-smoke == 'true' || needs.detect-changes.outputs.all-images == 'true'
       )
+    env:
+      SERVER_BUILD_ARTIFACT: server-build-${{ github.run_id }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
-      actions: read
       contents: read
-      checks: write
+      actions: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-toolchain
+        if: github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+        with:
+          install: "none"
+      - name: Find the exact-commit merge-queue build
+        id: reuse
+        if: github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: node scripts/resolve-server-build.ts
+      - name: Download the validated server build
+        if: steps.reuse.outputs.artifact-id != ''
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          artifact-ids: ${{ steps.reuse.outputs.artifact-id }}
+          run-id: ${{ steps.reuse.outputs.run-id }}
+          github-token: ${{ github.token }}
+          path: server
+          merge-multiple: true
+          digest-mismatch: error
+      - uses: ./.github/actions/setup-caches
+        if: steps.reuse.outputs.artifact-id == ''
+        with:
+          cache-write: "true"
+      - name: Package the server
+        if: steps.reuse.outputs.artifact-id == ''
+        working-directory: server
+        run: ./gradlew :application:bootJar :application:testClasses
+      - name: Validate the packaged server
+        working-directory: server
+        run: |
+          set -euo pipefail
+          test -d application/build/classes/java/main
+          test -d application/build/classes/java/test
+          mapfile -t jars < <(find application/build/libs -maxdepth 1 -name 'hephaestus-application-*.jar' ! -name '*-sources.jar' ! -name '*-javadoc.jar')
+          mapfile -t clients < <(find generated-clients/build/libs -maxdepth 1 -name 'hephaestus-generated-clients-*.jar' ! -name '*-sources.jar' ! -name '*-javadoc.jar')
+          (( ${#jars[@]} == 1 )) && (( ${#clients[@]} == 1 ))
+          unzip -p "${jars[0]}" META-INF/MANIFEST.MF | grep -q '^Main-Class: org.springframework.boot.loader'
+      - name: Upload the packaged server
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ env.SERVER_BUILD_ARTIFACT }}
+          path: |
+            server/application/build/classes/java/main
+            server/application/build/classes/java/test
+            server/application/build/resources
+            server/application/build/libs/hephaestus-application-*.jar
+            server/generated-clients/build/libs/hephaestus-generated-clients-*.jar
+            !server/**/*-sources.jar
+            !server/**/*-javadoc.jar
+          if-no-files-found: error
+          retention-days: 1
+          compression-level: 0
+          # A re-run of failed jobs keeps this artifact; a re-run of all jobs replaces it.
+          overwrite: true
+
+  application-server-image:
+    name: "App Server image"
+    needs: [detect-changes, server-package]
+    if: needs.detect-changes.outputs.application-server-image == 'true' || needs.detect-changes.outputs.supported-host-smoke == 'true' || needs.detect-changes.outputs.all-images == 'true'
+    uses: ./.github/workflows/reusable-docker-build.yml
+    permissions:
+      contents: read
       packages: write
       id-token: write
       attestations: write
       artifact-metadata: write
     with:
-      should_skip: ${{ needs.detect-changes.outputs.should_skip }}
+      image-name: "hephaestus-build/application-server"
+      use-buildpacks: true
+      application-artifact: server-build-${{ github.run_id }}
+      project-descriptor: "server/application/project.toml"
+      # renovate: datasource=docker depName=paketobuildpacks/ubuntu-noble-run-tiny
+      run-image: "paketobuildpacks/ubuntu-noble-run-tiny@sha256:c32333227b6dfbc2a4a93b03ee6d3475cfe152468c7d396bf22f06099bb0ecc9"
+      registry: "ghcr.io"
       publish: ${{ needs.detect-changes.outputs.publishable == 'true' }}
-      single_arch: ${{ needs.detect-changes.outputs.single-arch }}
+      single-arch: ${{ needs.detect-changes.outputs.single-arch == 'true' }}
       scan-images: ${{ needs.detect-changes.outputs.release-preflight != 'true' }}
+
+  Build:
+    uses: ./.github/workflows/ci-build.yml
+    needs: [detect-changes, server-package]
+    permissions:
+      contents: read
+      checks: write
+      packages: write
+    with:
+      should_skip: ${{ needs.detect-changes.outputs.should_skip }}
       postgres_base_sha: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.sha }}
-      server_changed: ${{ (needs.detect-changes.outputs.application-server == 'true' || needs.detect-changes.outputs.e2e == 'true' || needs.detect-changes.outputs.postgres-image == 'true' || needs.detect-changes.outputs.build-config == 'true' || needs.detect-changes.outputs.application-server-image == 'true' || needs.detect-changes.outputs.supported-host-smoke == 'true' || needs.detect-changes.outputs.all-images == 'true') && 'true' || 'false' }}
       contracts_changed: ${{ (github.event_name != 'push' || needs.detect-changes.outputs.version-bump == 'true') && (needs.detect-changes.outputs.application-server == 'true' || needs.detect-changes.outputs.postgres-image == 'true' || needs.detect-changes.outputs.build-config == 'true' || needs.detect-changes.outputs.unfiltered == 'true') && 'true' || 'false' }}
       e2e_changed: ${{ (github.event_name != 'push' || needs.detect-changes.outputs.version-bump == 'true') && (needs.detect-changes.outputs.e2e == 'true' || needs.detect-changes.outputs.unfiltered == 'true') && 'true' || 'false' }}
       postgres_image_changed: ${{ (needs.detect-changes.outputs.postgres-image == 'true' || needs.detect-changes.outputs.unfiltered == 'true') && 'true' || 'false' }}
-      server_image_changed: ${{ (needs.detect-changes.outputs.application-server-image == 'true' || needs.detect-changes.outputs.supported-host-smoke == 'true' || needs.detect-changes.outputs.all-images == 'true') && 'true' || 'false' }}
 
   Security:
     uses: ./.github/workflows/ci-security-scan.yml
@@ -574,7 +661,7 @@ jobs:
     name: "Supported-host boot smoke"
     # `Docker` publishes no output this job reads, but it is what puts `postgres:<head sha>` in the
     # registry — by building it, or by aliasing the base image when the diff left it alone.
-    needs: [detect-changes, Build, Docker]
+    needs: [detect-changes, application-server-image, Docker]
     # A fork pull request builds its images without publishing them, so there is nothing to pull
     # and no boot to check; the release path exercises a fork's install path once it is on `main`.
     if: >-
@@ -604,7 +691,7 @@ jobs:
       - name: Boot the operator installation path
         working-directory: docker/self-host
         env:
-          APPLICATION_DIGEST: ${{ needs.Build.outputs.application-server-digest }}
+          APPLICATION_DIGEST: ${{ needs.application-server-image.outputs.manifest-digest }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
@@ -629,7 +716,7 @@ jobs:
   # release-management.mdx owns the evidence contract.
   Release-preflight:
     name: "Release evidence preflight"
-    needs: [detect-changes, Build, Docker]
+    needs: [detect-changes, application-server-image, Docker]
     if: needs.detect-changes.outputs.release-preflight == 'true'
     timeout-minutes: 45
     runs-on: ubuntu-latest
@@ -697,7 +784,7 @@ jobs:
     permissions:
       actions: read
       statuses: write
-    needs: [detect-changes, gradle-wrapper, workflow-lint, zizmor, Quality, Build, Security, Test, Changesets, Compose, Docker, Supported-host-smoke, Release-preflight]
+    needs: [detect-changes, gradle-wrapper, workflow-lint, zizmor, Quality, server-package, application-server-image, Build, Security, Test, Changesets, Compose, Docker, Supported-host-smoke, Release-preflight]
     if: always()
     steps:
       - name: Generate workflow timeline
@@ -751,6 +838,8 @@ jobs:
           echo "workflow-lint: ${{ needs.workflow-lint.result }}"
           echo "zizmor:        ${{ needs.zizmor.result }}"
           echo "Quality:        ${{ needs.Quality.result }}"
+          echo "Package:        ${{ needs.server-package.result }}"
+          echo "Server image:   ${{ needs.application-server-image.result }}"
           echo "Build:          ${{ needs.Build.result }}"
           echo "Security:       ${{ needs.Security.result }}"
           echo "Test:           ${{ needs.Test.result }}"

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -567,7 +567,6 @@ jobs:
     permissions:
       contents: read
       checks: write
-      packages: write
     with:
       should_skip: ${{ needs.detect-changes.outputs.should_skip }}
       postgres_base_sha: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.sha }}

--- a/docs/contributor/ci-cd.mdx
+++ b/docs/contributor/ci-cd.mdx
@@ -400,10 +400,10 @@ why the label is the authority, and which alternatives were priced and declined,
 | `pull-request.yml` | PR opened, edited, synchronized, reopened, ready for review | Validates the title against the policy `commitlint.config.ts` exports, without installing the workspace, checks that every commit resolves to the pull request's author, and assigns the author when the pull request opens |
 | `ci-quality-gates.yml` | Called by cicd.yml | Selects quality legs, clean-install verification and story tests |
 | `ci-quality-leg.yml` | Called by ci-quality-gates.yml | Shared formatting, lint, type-check and unit-test execution for each selected task-graph leg |
-| `ci-build.yml` | Called by cicd.yml | Packages the server once, then runs the OpenAPI, schema, database and browser E2E gates and the application-server image against that artifact |
+| `ci-build.yml` | Called by cicd.yml | Runs the OpenAPI, schema, database and browser E2E gates against the server artifact packaged by cicd.yml |
 | `ci-tests.yml` | Called by cicd.yml | The server unit, architecture and integration suites, compiled from source |
 | `ci-docker-build.yml` | Called by cicd.yml | Dockerfile image builds (webapp, agent, PostgreSQL) and aliases for unchanged images |
-| `reusable-docker-build.yml` | Called by ci-build.yml and ci-docker-build.yml | Builds, signs, attests, and blocks on the release vulnerability policy for the `linux/amd64` image |
+| `reusable-docker-build.yml` | Called by cicd.yml and ci-docker-build.yml | Builds, signs, attests, and blocks on the release vulnerability policy for the `linux/amd64` image |
 | `ci-security-scan.yml` | Called by cicd.yml | Dependency review on pull requests; Trivy dependency scan, secret detection and repository policy checks |
 | `dependency-graph.yml` | PR, push to main | Resolves and uploads the verified Gradle dependency graph with read-only permissions |
 | `submit-dependency-graph.yml` | Successful dependency-graph workflow | Submits snapshot data without executing code from the originating run |
@@ -548,11 +548,15 @@ gives the retried job a new attempt number.
 
 ## Build once
 
-`Build` packages the server once and uploads its JARs, compiled tests and resources. OpenAPI and
+`App Server: Package` in `cicd.yml` packages the server once and uploads its JARs, compiled tests and resources. OpenAPI and
 browser checks boot that executable JAR; buildpacks consume it without another build. Schema gates
 and database contract tests use the restored classes with `-PpackagedServer=true`, which bypasses
 compilation. Unit, architecture and integration suites compile from source in `Test` without
 waiting for packaging; their outputs do not ship.
+
+The application image and `Build` artifact gates depend on packaging independently. Host smoke
+and release preflight wait for the image producers, not the API, database or browser checks. The
+final CI gate still requires all of them; an early image verdict cannot approve a failed artifact gate.
 
 A default-branch push reuses the packaged server when a successful release-candidate merge group
 validated the exact same commit. The source must be this repository's `cicd.yml` run, with successful

--- a/renovate.json
+++ b/renovate.json
@@ -179,7 +179,7 @@
 		{
 			"description": "Track the buildpacks run image",
 			"customType": "regex",
-			"managerFilePatterns": ["/^\\.github/workflows/ci-build\\.yml$/"],
+			"managerFilePatterns": ["/^\\.github/workflows/cicd\\.yml$/"],
 			"matchStrings": [
 				"# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\s+run-image: \"[^@\"]+@(?<currentDigest>sha256:[a-f0-9]{64})\""
 			],

--- a/scripts/ci-cache-policy.test.ts
+++ b/scripts/ci-cache-policy.test.ts
@@ -27,10 +27,7 @@ await describe("CI cache policy", async () => {
 		assert.match(setup, /cache-provider: enhanced/);
 		assert.doesNotMatch(cacheAction, /~\/\.m2|target\//);
 		const build = await readFile(".github/workflows/ci-build.yml", "utf8");
-		const e2e = build.slice(
-			build.indexOf("\n  webapp-e2e:"),
-			build.indexOf("\n  application-server-image:"),
-		);
+		const e2e = build.slice(build.indexOf("\n  webapp-e2e:"));
 		assert.match(e2e, /uses: actions\/setup-java@/);
 		assert.doesNotMatch(e2e, /setup-caches/);
 	});

--- a/scripts/ci-contract.test.ts
+++ b/scripts/ci-contract.test.ts
@@ -422,9 +422,9 @@ void describe("CI contract", () => {
 		const writers = [...sources].filter(([, source]) => source.includes('cache-write: "true"'));
 		assert.deepEqual(
 			writers.map(([file]) => file),
-			[".github/workflows/ci-build.yml"],
+			[".github/workflows/cicd.yml"],
 		);
-		const build = parseDocument(await readFile(".github/workflows/ci-build.yml", "utf8"));
+		const build = parseDocument(await readFile(".github/workflows/cicd.yml", "utf8"));
 		const steps = build.getIn(["jobs", "server-package", "steps"]);
 		assert.ok(isSeq(steps));
 		const cache = steps.items.find(
@@ -442,12 +442,12 @@ void describe("CI contract", () => {
 			workflow.getIn(["jobs", "detect-changes", "outputs", "release-preflight"]),
 			`\${{ (github.event_name == 'workflow_dispatch' && inputs.release-preflight) || steps.release_candidate.outputs.release-candidate == 'true' }}`,
 		);
-		for (const name of ["Build", "Docker"])
+		for (const name of ["application-server-image", "Docker"])
 			assert.equal(
 				workflow.getIn(["jobs", name, "with", "scan-images"]),
 				`\${{ needs.detect-changes.outputs.release-preflight != 'true' }}`,
 			);
-		for (const file of ["ci-build.yml", "ci-docker-build.yml", "reusable-docker-build.yml"]) {
+		for (const file of ["ci-docker-build.yml", "reusable-docker-build.yml"]) {
 			const reusable = parseDocument(await readFile(`.github/workflows/${file}`, "utf8"));
 			assert.equal(
 				reusable.getIn(["on", "workflow_call", "inputs", "scan-images", "default"]),
@@ -558,7 +558,8 @@ void describe("CI contract", () => {
 
 	void test("packages the server once and runs every artifact gate against it", async () => {
 		const build = await readFile(".github/workflows/ci-build.yml", "utf8");
-		const packageJob = job(build, "server-package");
+		const orchestrator = await readFile(".github/workflows/cicd.yml", "utf8");
+		const packageJob = job(orchestrator, "server-package");
 		const packaging = packageJob.match(/^\s+run: (\.\/gradlew .*)$/m)?.[1];
 		assert.ok(packaging);
 		assert.match(packaging, /:application:bootJar/);
@@ -567,7 +568,7 @@ void describe("CI contract", () => {
 		assert.match(packageJob, /overwrite: true/);
 		for (const name of ["server-api", "server-database"]) {
 			const consumer = job(build, name);
-			assert.match(consumer, /needs: server-package/);
+			assert.doesNotMatch(consumer, /needs:/);
 			assert.match(consumer, /uses: \.\/\.github\/actions\/restore-server-build/);
 			// Goals against the restored classes; a lifecycle phase would compile again.
 			assert.doesNotMatch(
@@ -578,10 +579,10 @@ void describe("CI contract", () => {
 		assert.match(job(build, "server-database"), /:application:databaseTest -PpackagedServer=true/);
 		assert.match(job(build, "server-api"), /HEPHAESTUS_APPLICATION_JAR/);
 		const e2e = job(build, "webapp-e2e");
-		assert.match(e2e, /needs: server-package/);
+		assert.doesNotMatch(e2e, /needs:/);
 		assert.equal((e2e.match(/actions\/download-artifact@/g) ?? []).length, 1);
-		const image = job(build, "application-server-image");
-		assert.match(image, /needs: server-package/);
+		const image = job(orchestrator, "application-server-image");
+		assert.match(image, /needs: \[detect-changes, server-package\]/);
 		assert.match(image, /use-buildpacks: true/);
 
 		// The long suites compile from source and never wait for the package job.
@@ -589,8 +590,7 @@ void describe("CI contract", () => {
 		assert.doesNotMatch(tests, /^ {4}needs:|download-artifact|restore-server-build/m);
 		assert.match(job(tests, "server-verification"), /vp run test:server:verification/);
 		assert.match(job(tests, "server-integration"), /vp run test:server:integration/);
-		const orchestrator = await readFile(".github/workflows/cicd.yml", "utf8");
-		assert.match(job(orchestrator, "Build"), /needs: \[detect-changes\]/);
+		assert.match(job(orchestrator, "Build"), /needs: \[detect-changes, server-package\]/);
 
 		const reusable = await readFile(".github/workflows/reusable-docker-build.yml", "utf8");
 		const packBuilds = [...reusable.replace(/\\\n\s*/g, " ").matchAll(/^\s+pack build .*$/gm)].map(
@@ -605,6 +605,39 @@ void describe("CI contract", () => {
 		for (const [file, source] of await workflowSources()) {
 			assert.doesNotMatch(source, /bootBuildImage/, `${file} must build the image from the JAR`);
 		}
+	});
+
+	void test("image consumers do not wait for unrelated artifact checks, but the final verdict does", async () => {
+		const workflow = parseDocument(await readFile(".github/workflows/cicd.yml", "utf8"));
+		for (const name of ["Build", "application-server-image"]) {
+			const dependencies = workflow.getIn(["jobs", name, "needs"]);
+			assert.ok(isSeq(dependencies));
+			assert.deepEqual(dependencies.toJSON(), ["detect-changes", "server-package"]);
+		}
+		for (const name of ["Supported-host-smoke", "Release-preflight"]) {
+			const dependencies = workflow.getIn(["jobs", name, "needs"]);
+			assert.ok(isSeq(dependencies));
+			assert.deepEqual(dependencies.toJSON(), [
+				"detect-changes",
+				"application-server-image",
+				"Docker",
+			]);
+		}
+		const gate = workflow.getIn(["jobs", "all-ci-passed", "needs"]);
+		assert.ok(isSeq(gate));
+		for (const name of [
+			"server-package",
+			"application-server-image",
+			"Build",
+			"Test",
+			"Docker",
+			"Supported-host-smoke",
+			"Release-preflight",
+		])
+			assert.ok(
+				gate.items.some((item) => isScalar(item) && item.value === name),
+				`The final verdict must require ${name}`,
+			);
 	});
 
 	void test("builds Storybook once and gives its TurboSnap stats to Chromatic", async () => {
@@ -732,7 +765,7 @@ void describe("CI contract", () => {
 			"workflow-lint",
 			"zizmor",
 			"Quality",
-			"Build",
+			"server-package",
 			"Security",
 			"Test",
 			"Docker",
@@ -764,7 +797,6 @@ void describe("CI contract", () => {
 		}
 
 		const docker = await readFile(".github/workflows/ci-docker-build.yml", "utf8");
-		const build = await readFile(".github/workflows/ci-build.yml", "utf8");
 		// The architecture set is one decision, taken in cicd.yml and handed to every image build, so
 		// a run cannot evidence one image on both platforms and its sibling on one. The test below
 		// owns what that decision is; this owns that nothing decides it locally.
@@ -772,16 +804,19 @@ void describe("CI contract", () => {
 			job(docker, "webapp-build"),
 			job(docker, "agent-pi-build"),
 			job(docker, "postgres-build"),
-			job(build, "application-server-image"),
 		]) {
 			assert.match(image, /single-arch: \${{ inputs\.single_arch == 'true' }}/);
 			assert.doesNotMatch(image, /^\s+tags:/m);
 		}
-		for (const called of [docker, build])
+		for (const called of [docker])
 			// Required, and with no default: a caller that forgets it fails to start, rather than
 			// silently publishing one architecture where a release needs two.
 			assert.match(called, /^ {6}single_arch:\n(?: {8}.*\n)*? {8}required: true$/m);
-		for (const consumer of [job(source, "Build"), job(source, "Docker")])
+		assert.match(
+			job(source, "application-server-image"),
+			/single-arch: \${{ needs\.detect-changes\.outputs\.single-arch == 'true' }}/,
+		);
+		for (const consumer of [job(source, "Docker")])
 			assert.match(consumer, /single_arch: \${{ needs\.detect-changes\.outputs\.single-arch }}/);
 		const inherited = job(docker, "tag-unchanged-images");
 		assert.match(inherited, /HEAD_SHA/);
@@ -864,7 +899,7 @@ void describe("CI contract", () => {
 			String(orchestrator.getIn(["jobs", "detect-changes", "outputs", "publishable"])),
 			/^\$\{\{ github\.event_name != 'pull_request' \|\| github\.event\.pull_request\.head\.repo\.full_name == github\.repository }}$/,
 		);
-		for (const caller of ["Build", "Docker"])
+		for (const caller of ["application-server-image", "Docker"])
 			assert.match(
 				String(orchestrator.getIn(["jobs", caller, "with", "publish"])),
 				/^\$\{\{ needs\.detect-changes\.outputs\.publishable == 'true' }}$/,
@@ -988,12 +1023,6 @@ void describe("CI contract", () => {
 	});
 
 	void test("a pull request boots the supported installation from the images its own run built", async () => {
-		const build = parseDocument(await readFile(".github/workflows/ci-build.yml", "utf8"));
-		assert.match(
-			String(build.getIn(["on", "workflow_call", "outputs", "application-server-digest", "value"])),
-			/^\$\{\{ jobs\.application-server-image\.outputs\.manifest-digest }}$/,
-		);
-
 		const source = await readFile(".github/workflows/cicd.yml", "utf8");
 		const orchestrator = parseDocument(source);
 		const condition = String(orchestrator.getIn(["jobs", "Supported-host-smoke", "if"]));
@@ -1008,7 +1037,7 @@ void describe("CI contract", () => {
 		const smoke = job(source, "Supported-host-smoke");
 		assert.match(
 			smoke,
-			/APPLICATION_DIGEST: \${{ needs\.Build\.outputs\.application-server-digest }}/,
+			/APPLICATION_DIGEST: \${{ needs\.application-server-image\.outputs\.manifest-digest }}/,
 		);
 		// The reduced topology an operator's first boot has to get through: no edge, no webapp. The
 		// service list runs onto a continuation line, so the command is rejoined before it is read.
@@ -1026,8 +1055,8 @@ void describe("CI contract", () => {
 			/scripts\/prepare-host-smoke-env\.ts/,
 		);
 		// The paths that trigger the smoke also have to rebuild the images it boots.
-		for (const flag of ["server_image_changed", "application_server_changed"])
-			assert.match(source, new RegExp(`${flag}:.*supported-host-smoke`));
+		assert.match(job(source, "application-server-image"), /if:.*supported-host-smoke/);
+		assert.match(source, /application_server_changed:.*supported-host-smoke/);
 		assert.match(job(source, "all-ci-passed"), /needs: \[[^\]]*Supported-host-smoke[^\]]*\]/);
 	});
 
@@ -1548,10 +1577,13 @@ void describe("CI contract", () => {
 		assert.ok(buildsEveryImage("pull_request", false, true));
 
 		// One home for that decision too: an input that selects an image reads it, and no input
-		// re-tests the event on its own. `server_changed` is in the list because the buildpacks image
-		// is built from the JAR `App Server: Package` uploads.
+		// re-tests the event on its own. The package and server image selectors read it directly.
+		for (const name of ["server-package", "application-server-image"]) {
+			const condition = String(workflow.getIn(["jobs", name, "if"]));
+			assert.match(condition, /needs\.detect-changes\.outputs\.all-images == 'true'/);
+			assert.doesNotMatch(condition, /github\.event_name/);
+		}
 		const imageInputs = {
-			Build: ["server_changed", "server_image_changed"],
 			Docker: [
 				"webapp_changed",
 				"application_server_changed",

--- a/scripts/ci-provenance.test.ts
+++ b/scripts/ci-provenance.test.ts
@@ -42,3 +42,10 @@ void test("image provenance can persist storage records through every reusable-w
 		}
 	}
 });
+
+void test("artifact checks have no registry publishing permissions", async () => {
+	const workflow = parseDocument(await readFile(".github/workflows/cicd.yml", "utf8"));
+	const permissions = workflow.getIn(["jobs", "Build", "permissions"]);
+	assert.ok(isMap(permissions));
+	assert.deepEqual(permissions.toJSON(), { contents: "read", checks: "write" });
+});

--- a/scripts/ci-provenance.test.ts
+++ b/scripts/ci-provenance.test.ts
@@ -8,8 +8,7 @@ import { asArray, asRecord } from "./lib/json.ts";
 
 void test("image provenance can persist storage records through every reusable-workflow caller", async () => {
 	const callers = {
-		"cicd.yml": ["Build", "Docker"],
-		"ci-build.yml": ["application-server-image"],
+		"cicd.yml": ["application-server-image", "Docker"],
 		"ci-docker-build.yml": ["webapp-build", "agent-pi-build", "postgres-build"],
 		"reusable-docker-build.yml": ["build", "merge"],
 	};

--- a/scripts/renovate-config.test.ts
+++ b/scripts/renovate-config.test.ts
@@ -199,7 +199,7 @@ void test("every custom manager reads every file it claims to read", async () =>
 		],
 		["Track the Zizmor CLI version", [".github/workflows/cicd.yml"]],
 		["Track the pack CLI version", [".github/workflows/reusable-docker-build.yml"]],
-		["Track the buildpacks run image", [".github/workflows/ci-build.yml"]],
+		["Track the buildpacks run image", [".github/workflows/cicd.yml"]],
 		[
 			"Track the builder and buildpack images in the project descriptor",
 			["server/application/project.toml"],
@@ -262,8 +262,12 @@ void test("every custom manager reads every file it claims to read", async () =>
 				manager.matchStrings.some((pattern) => new RegExp(pattern, "m").test(content)),
 				`${description} no longer extracts a dependency from ${file}`,
 			);
-			for (const [, datasource = ""] of content.matchAll(/# renovate: datasource=(\S+)/g))
-				datasources.add(datasource);
+			// Only dependencies this manager extracts matter; a file may have several managers.
+			for (const pattern of manager.matchStrings)
+				for (const match of content.matchAll(new RegExp(pattern, "gm"))) {
+					const datasource = match.groups?.datasource;
+					if (datasource) datasources.add(datasource);
+				}
 		}
 		if ([...datasources].some((datasource) => RELEASE_TAG_DATASOURCES.has(datasource)))
 			assert.ok(

--- a/scripts/resolve-server-build.test.ts
+++ b/scripts/resolve-server-build.test.ts
@@ -9,12 +9,12 @@ import { resolveServerBuild } from "./resolve-server-build.ts";
 const repository = "hephaestus-build/Hephaestus";
 const commit = "a".repeat(40);
 const requiredJobs = [
-	"Build / App Server: Package",
+	"App Server: Package",
 	"Build / App Server: Generated artifacts",
 	"Build / App Server: Database",
 	"Build / Webapp: E2E",
-	"Build / App Server image / Build linux/amd64 Docker Image",
-	"Build / App Server image / Build linux/arm64 Docker Image",
+	"App Server image / Build linux/amd64 Docker Image",
+	"App Server image / Build linux/arm64 Docker Image",
 	"Test / App Server: Unit and architecture",
 	"Test / App Server: Integration (application)",
 	"Test / App Server: Integration (providers-and-startup)",
@@ -129,7 +129,7 @@ await test("absence falls back and malformed metadata or an unavailable API cann
 });
 
 await test("main reuses immutable verified artifacts without bypassing validation or the packaging fallback", async () => {
-	const workflow = parseDocument(await readFile(".github/workflows/ci-build.yml", "utf8"));
+	const workflow = parseDocument(await readFile(".github/workflows/cicd.yml", "utf8"));
 	const steps = workflow.getIn(["jobs", "server-package", "steps"]);
 	assert.ok(isSeq(steps));
 	const step = (name: string) => {

--- a/scripts/resolve-server-build.ts
+++ b/scripts/resolve-server-build.ts
@@ -5,12 +5,12 @@ import { asArray, asRecord, asString, parseJson } from "./lib/json.ts";
 import { output } from "./lib/process.ts";
 
 const requiredJobs = [
-	"Build / App Server: Package",
+	"App Server: Package",
 	"Build / App Server: Generated artifacts",
 	"Build / App Server: Database",
 	"Build / Webapp: E2E",
-	"Build / App Server image / Build linux/amd64 Docker Image",
-	"Build / App Server image / Build linux/arm64 Docker Image",
+	"App Server image / Build linux/amd64 Docker Image",
+	"App Server image / Build linux/arm64 Docker Image",
 	"Test / App Server: Unit and architecture",
 	"Test / App Server: Integration (application)",
 	"Test / App Server: Integration (providers-and-startup)",


### PR DESCRIPTION
## What changed and why

Host smoke and release preflight waited for the whole Build workflow even when their images were ready. In two completed full PR traces, API/database checks held that dependency open for another 17 and 79 seconds. This removes that unnecessary dependency; it does not claim those seconds are guaranteed end-to-end savings under runner contention.

Move the existing package producer and application image job to the orchestrator. Build's API, database and E2E checks still consume the same packaged server, in parallel with the image build. Host smoke and release preflight depend on the image producers. The final verdict still requires packaging, all artifact gates, tests, image jobs and the applicable smoke/preflight. No extra jobs, runners, test retries or scan exclusions are introduced.

Update exact-commit artifact reuse to require the moved job names, retain the single Gradle cache writer, and move the Renovate manager to the run-image pin's new home. Its contract test now inspects dependencies actually matched by each manager rather than unrelated comments in the same file.

## How to test

- `vp run format` and `vp run --concurrency-limit 1 check` pass all 39 gates. The normal pre-push hook also runs `check`.
- Contract tests assert independent image-consumer dependencies, the single-JAR/cache-writer contracts, fork publication policy, common architecture/scan decisions and failure/cancellation rejection by the final gate.
- An exhaustive comparison against the previous workflow preserved package, image, API, database and E2E selection across 16,384 event/flag combinations.
- Actionlint 1.7.12 and Zizmor 1.29 pass both changed workflows.
- [Full PR run](https://github.com/hephaestus-build/Hephaestus/actions/runs/34389397859) passed first attempt in 8m03s, including host smoke. The final gate waited about 74 seconds for its runner; this is not a six-minute median claim.
- [Broad release-preflight dispatch](https://github.com/hephaestus-build/Hephaestus/actions/runs/34390369413) passed first attempt in 6m50s. Preflight started at 18:43:41 UTC, 48 seconds before the database checks finished at 18:44:29. All 16 subjects were verified and the four duplicate image scans skipped. The downloaded bundle also passed `node scripts/verify-release-evidence.ts`. This dispatch precedes the final permission-only review fix. The [latest full PR run](https://github.com/hephaestus-build/Hephaestus/actions/runs/34390999438) verifies that commit: all checks passed first attempt in 7m13s, including host smoke. Two full PR samples do not establish a six-minute median or seven-minute p90.

## Release impact

CI/tooling only; no shipped product code, API, database or UI changes and no operator action. No changeset required.

## Notes for reviewers

The artifact-check caller now has no registry permissions; the image publisher retains the required writes. No new workflow layer or artifact producer. The package job retains its `server-package` identity and `server-build-${run_id}` artifact contract. Exact-commit reuse deliberately requires the current job names; it cannot accidentally accept a partial run.
