### PR TITLE
fix(ci): give the preview deployment the title and link it claims to carry

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -78,6 +78,10 @@ jobs:
           HEAD_SHA: ${{ steps.context.outputs.head_sha }}
           ENVIRONMENT: ${{ steps.context.outputs.environment }}
           PREVIEW_URL: ${{ steps.context.outputs.preview_url }}
+          # `create` puts both in the deployment: the title in the description that tells one
+          # environment from another, the URL in the payload that rides on every status event.
+          PR_TITLE: ${{ steps.context.outputs.pr_title }}
+          PR_URL: ${{ steps.context.outputs.pr_url }}
           SOURCE_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         with:
           script: |

--- a/scripts/preview-controller.test.ts
+++ b/scripts/preview-controller.test.ts
@@ -364,10 +364,14 @@ void it("registers GitHub deployments against the immutable head SHA", async () 
 		ENVIRONMENT: "preview/pr-7",
 		PR_NUMBER: "7",
 		PREVIEW_URL: "https://pr7.example",
+		PR_TITLE: "feat(webapp): a readable title",
+		PR_URL: "https://github.example/pull/7",
 		SOURCE_RUN_URL: "https://github.example/runs/50",
 	});
 	let deploymentRef = "";
 	let initialState = "";
+	let description = "";
+	let payload: unknown;
 	const baseGitHub = makeGitHub();
 	const github: GitHubApi = {
 		...baseGitHub,
@@ -381,6 +385,8 @@ void it("registers GitHub deployments against the immutable head SHA", async () 
 				},
 				createDeployment: (params: Record<string, unknown>) => {
 					deploymentRef = String(params.ref);
+					description = String(params.description);
+					payload = params.payload;
 					assert.equal(params.task, "deploy:preview");
 					assert.equal(params.transient_environment, true);
 					return Promise.resolve({
@@ -397,6 +403,34 @@ void it("registers GitHub deployments against the immutable head SHA", async () 
 	assert.equal(deploymentRef, "head-sha");
 	assert.equal(initialState, "queued");
 	assert.equal(core.outputs.get("deployment_id"), "2");
+	// GitHub renders the environment name on the pull request and the description where every
+	// environment is listed together, so the description is what tells one preview from another.
+	assert.equal(description, "PR #7 · feat(webapp): a readable title");
+	assert.ok(typeof payload === "object" && payload !== null);
+	assert.equal(Reflect.get(payload, "pull_request_url"), "https://github.example/pull/7");
+	assert.equal(Reflect.get(payload, "title"), "feat(webapp): a readable title");
+});
+
+void it("refuses to open a deployment that would carry no title or pull request link", async () => {
+	// A deployment that describes itself as a bare number, or carries an empty link in the payload
+	// that rides on every status event, is worse than one that never opened: it reports success and
+	// identifies nothing.
+	for (const missing of ["PR_TITLE", "PR_URL"]) {
+		Object.assign(process.env, {
+			HEAD_SHA: "head-sha",
+			ENVIRONMENT: "preview/pr-7",
+			PR_NUMBER: "7",
+			PREVIEW_URL: "https://pr7.example",
+			PR_TITLE: "feat(webapp): a readable title",
+			PR_URL: "https://github.example/pull/7",
+			SOURCE_RUN_URL: "https://github.example/runs/50",
+		});
+		delete process.env[missing];
+		await assert.rejects(
+			() => create({ github: makeGitHub(), context: makeContext(), core: makeCore() }),
+			new RegExp(missing),
+		);
+	}
 });
 
 void it("stands down without failing when the head moved during preflight", async () => {

--- a/scripts/preview-controller.ts
+++ b/scripts/preview-controller.ts
@@ -380,12 +380,15 @@ const create = async ({ github, context, core }: ControllerInput): Promise<void>
 	const headSha = requiredEnv(process.env, "HEAD_SHA");
 	const environment = requiredEnv(process.env, "ENVIRONMENT");
 	const number = requiredPositiveInteger(process.env, "PR_NUMBER");
-	const title = process.env.PR_TITLE ?? "";
+	// Required, not defaulted. Every pull request has both, so a caller without them is a caller
+	// with a bug, and a deployment that opens anyway identifies nothing while looking correct.
+	const title = requiredEnv(process.env, "PR_TITLE");
+	const pullRequestUrl = requiredEnv(process.env, "PR_URL");
 	const previewUrl = requiredEnv(process.env, "PREVIEW_URL");
 	// The deployments page lists every environment together, where `preview/pr-2042` alone says
 	// nothing about what is in it. The title is what tells one preview from another at a glance;
 	// GitHub renders this as plain text, so the link lives in the payload rather than here.
-	const described = title ? `PR #${number} · ${title}` : `PR #${number}`;
+	const described = `PR #${number} · ${title}`;
 	const response = await github.rest.repos.createDeployment({
 		owner,
 		repo,
@@ -399,7 +402,7 @@ const create = async ({ github, context, core }: ControllerInput): Promise<void>
 		// a future notifier — can reach the pull request and the preview without another API call.
 		payload: {
 			pull_request: number,
-			pull_request_url: process.env.PR_URL ?? "",
+			pull_request_url: pullRequestUrl,
 			title,
 			preview_url: previewUrl,
 			head_sha: headSha,


### PR DESCRIPTION
## What changed and why

The live deployment for #2042 identifies nothing:

```json
{"environment":"preview/pr-2042","description":"PR #2042",
 "payload":{"pull_request":2042,"pull_request_url":"","title":"", …}}
```

The description was meant to read `PR #2042 · <title>`, and the payload was meant to carry the pull request's URL so anything watching `deployment_status` can reach it without another API call. Neither happened: the step that opens the deployment never passed `PR_TITLE` or `PR_URL`, and `create` read both with a default — `process.env.PR_TITLE ?? ""` — so the missing wiring produced a deployment that looked correct and said less than it promised.

Pass them from the step, and require them rather than defaulting. A pull request always has a title and a URL, so a caller that omits either has a bug and the step should stop instead of publishing an anonymous deployment.

## How to test

```sh
node --test scripts/preview-controller.test.ts
```

42 pass. The existing deployment test opened one without a title and asserted only the ref, which is exactly why nothing caught this; it now asserts the description and both payload fields. A second case supplies everything, drops one variable at a time, and requires the refusal to name the missing one — it fails against `main`.

## Release impact

No changeset: repository automation, not shipped code.

## Notes for reviewers

Worth knowing while reading, both verified but out of scope here:

- **GitHub does not render the description on the pull request.** The timeline shows only `github-actions Bot deployed to preview/pr-2042 · View deployment`. The description distinguishes environments where they are listed together, which is what it was written for — but the environment name is the tag on the pull request itself.
- **Nothing marks the running preview as a preview.** `https://pr2042.…` serves `<title>Hephaestus</title>` and no badge. The facts are already in the browser — `window.__ENV__` carries `APPLICATION_VERSION: "preview"`, `GIT_BRANCH`, `GIT_COMMIT` and `DEPLOYED_AT` — but no component reads them. Making the page say what it is needs a webapp change, not deployment metadata.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Preview deployments now include the pull request title and URL in deployment details.
  * Deployment registration requires both pull request values, preventing incomplete preview deployment records.

* **Tests**
  * Added coverage verifying pull request metadata is passed through and missing values are rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->