### PR TITLE
feat(webapp): the preview badge says which pull request it is of

### DIFF
--- a/.changeset/preview-header-names-its-pull-request.md
+++ b/.changeset/preview-header-names-its-pull-request.md
@@ -1,0 +1,5 @@
+---
+"hephaestus": patch
+---
+
+A preview deployment's header badge now says which pull request it is of, and links to it. Every preview called itself "Preview", so a browser tab open on one gave no way to tell which change it was showing, or to get back to the pull request it came from.

--- a/webapp/src/components/core/Header.stories.tsx
+++ b/webapp/src/components/core/Header.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { fn } from "storybook/test";
+import { expect, fn } from "storybook/test";
 
 import { SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
 import { expectNoPageOverflow } from "@/test/reflow";
@@ -60,6 +60,26 @@ export const Preview: Story = {
 		isLoading: false,
 		environmentName: "Preview",
 		isProduction: false,
+	},
+};
+
+export const PreviewOfAPullRequest: Story = {
+	args: {
+		isAuthenticated: true,
+		isLoading: false,
+		environmentName: "Preview",
+		isProduction: false,
+		pullRequest: 2042,
+	},
+	play: async ({ canvas }) => {
+		// Every preview is called "Preview", so the pill has to say which pull request it is of and
+		// take the reader there. Queried by the visible text, which is what names the link: an
+		// accessible name that omits it is one a speech-input user cannot say.
+		const link = await canvas.findByRole("link", { name: "Preview · PR #2042" });
+		await expect(link).toHaveAttribute(
+			"href",
+			"https://github.com/hephaestus-build/Hephaestus/pull/2042",
+		);
 	},
 };
 

--- a/webapp/src/components/core/Header.tsx
+++ b/webapp/src/components/core/Header.tsx
@@ -34,6 +34,8 @@ export interface HeaderProps {
 	version: string;
 	environmentName: string;
 	isProduction: boolean;
+	/** The pull request a preview deployment is of; absent on every other environment. */
+	pullRequest?: number;
 	isAuthenticated: boolean;
 	isLoading: boolean;
 	name?: string;
@@ -50,6 +52,7 @@ export default function Header({
 	version,
 	environmentName,
 	isProduction,
+	pullRequest,
 	isAuthenticated,
 	isLoading,
 	name,
@@ -62,7 +65,7 @@ export default function Header({
 }: HeaderProps) {
 	const hasWorkspace = Boolean(workspaceSlug);
 	const hasUsername = Boolean(username);
-	const badge = resolveHeaderBadge(version, environmentName, isProduction);
+	const badge = resolveHeaderBadge(version, environmentName, isProduction, pullRequest);
 	const logo = (
 		<span className="inline-flex">
 			<HephaestusLogo
@@ -121,13 +124,18 @@ export default function Header({
 									<Badge
 										variant="outline"
 										className="hidden gap-1.5 font-normal text-muted-foreground sm:inline-flex"
+										render={
+											badge.href ? (
+												<a href={badge.href} target="_blank" rel="noopener noreferrer" />
+											) : undefined
+										}
 									/>
 								}
 							>
 								<span className={cn("size-1.5 rounded-full", ENV_DOT[badge.tone])} />
 								{badge.label}
 							</TooltipTrigger>
-							<TooltipContent>{badge.label} environment</TooltipContent>
+							<TooltipContent>{badge.tooltip}</TooltipContent>
 						</Tooltip>
 					)}
 				</div>

--- a/webapp/src/environment/index.test.ts
+++ b/webapp/src/environment/index.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * The module reads `window.__ENV__` once, at import, so each case loads it afresh.
+ */
+async function deploymentFor(runtime: Window["__ENV__"]) {
+	vi.resetModules();
+	window.__ENV__ = runtime;
+	return (await import("./index")).default.deployment;
+}
+
+afterEach(() => {
+	delete window.__ENV__;
+});
+
+describe("preview pull request", () => {
+	it.each([
+		["pr2042.hephaestus.example.com", 2042],
+		["pr-2042.hephaestus.example.com", 2042],
+	])("reads the number out of %s, which is the only place it appears", async (host, expected) => {
+		const deployment = await deploymentFor({
+			SENTRY_ENVIRONMENT: "preview",
+			APPLICATION_CLIENT_URL: `https://${host}`,
+		});
+
+		expect(deployment.pullRequest).toBe(expected);
+	});
+
+	it("gives a deployment that is not a preview no pull request, whatever it is named", async () => {
+		const deployment = await deploymentFor({
+			SENTRY_ENVIRONMENT: "staging",
+			APPLICATION_CLIENT_URL: "https://pr2042.hephaestus.example.com",
+		});
+
+		expect(deployment.pullRequest).toBeUndefined();
+	});
+
+	it.each([
+		"https://hephaestus.example.com",
+		"https://pr.example.com",
+		"https://pr2042x.example.com",
+		"not a url",
+		"",
+	])("leaves the pull request unset for %s", async (clientUrl) => {
+		const deployment = await deploymentFor({
+			SENTRY_ENVIRONMENT: "preview",
+			APPLICATION_CLIENT_URL: clientUrl,
+		});
+
+		expect(deployment.pullRequest).toBeUndefined();
+	});
+});

--- a/webapp/src/environment/index.ts
+++ b/webapp/src/environment/index.ts
@@ -53,12 +53,33 @@ const DEPLOYMENT_NAMES: Record<string, string> = {
 };
 const deploymentEnvironment = env("SENTRY_ENVIRONMENT") || "local";
 
+/**
+ * Which pull request this preview is of. Every preview shares the name "Preview", so without this
+ * the header pill cannot say which one you are looking at.
+ *
+ * Coolify routes a preview at `pr<id>.<domain>` and passes no pull request variable of its own, so
+ * the hostname is where the number is — and the client URL is the one place that hostname is
+ * already present in the runtime config. Read only on a preview, so no other deployment can be
+ * given a pull request by a host that happens to be named this way.
+ */
+const previewPullRequest = ((): number | undefined => {
+	if (deploymentEnvironment !== "preview") return undefined;
+	try {
+		const [label] = new URL(env("APPLICATION_CLIENT_URL")).hostname.split(".");
+		const match = /^pr-?(\d+)$/.exec(label ?? "");
+		return match ? Number.parseInt(match[1] ?? "", 10) : undefined;
+	} catch {
+		return undefined;
+	}
+})();
+
 const environment = {
 	version: env("APPLICATION_VERSION").replace(/^v/, "") || "DEV",
 	deployment: {
 		environment: deploymentEnvironment,
 		name: DEPLOYMENT_NAMES[deploymentEnvironment] ?? "Local",
 		isProduction: deploymentEnvironment === "production",
+		pullRequest: previewPullRequest,
 	},
 	clientUrl: env("APPLICATION_CLIENT_URL"),
 	serverUrl: env("APPLICATION_SERVER_URL"),

--- a/webapp/src/lib/version.test.ts
+++ b/webapp/src/lib/version.test.ts
@@ -16,7 +16,12 @@ describe("resolveHeaderBadge", () => {
 
 	it("shows an environment pill for staging, never the version", () => {
 		const badge = resolveHeaderBadge("c46f9f8", "Staging", false);
-		expect(badge).toStrictEqual({ kind: "environment", label: "Staging", tone: "staging" });
+		expect(badge).toStrictEqual({
+			kind: "environment",
+			label: "Staging",
+			tone: "staging",
+			tooltip: "Staging environment",
+		});
 	});
 
 	it.each([
@@ -27,6 +32,20 @@ describe("resolveHeaderBadge", () => {
 			kind: "environment",
 			label: name,
 			tone,
+			tooltip: `${name} environment`,
+		});
+	});
+
+	// The environment name stays in the label: the dot's colour is the one part of this pill a
+	// colour-blind reader cannot use. `toStrictEqual` on the cases above pins the absence of `link`
+	// everywhere else.
+	it("names and links the pull request a preview is of, since every preview is called Preview", () => {
+		expect(resolveHeaderBadge("c46f9f8", "Preview", false, 2042)).toStrictEqual({
+			kind: "environment",
+			label: "Preview · PR #2042",
+			tone: "preview",
+			tooltip: "Preview of pull request #2042",
+			href: "https://github.com/hephaestus-build/Hephaestus/pull/2042",
 		});
 	});
 

--- a/webapp/src/lib/version.ts
+++ b/webapp/src/lib/version.ts
@@ -5,7 +5,19 @@ export type EnvironmentTone = "staging" | "preview" | "local";
 
 export type HeaderBadge =
 	| { kind: "release"; label: string; href: string; tooltip: string; ariaLabel: string }
-	| { kind: "environment"; label: string; tone: EnvironmentTone };
+	| {
+			kind: "environment";
+			label: string;
+			tone: EnvironmentTone;
+			tooltip: string;
+			/**
+			 * Present only on a preview, whose pull request the pill both names and links to. The
+			 * link takes its accessible name from that visible label, so it carries no `aria-label`
+			 * of its own: a name that does not contain the visible text is one a speech-input user
+			 * cannot say (WCAG 2.5.3).
+			 */
+			href?: string;
+	  };
 
 function toneFor(environmentName: string): EnvironmentTone {
 	const name = environmentName.toLowerCase();
@@ -22,6 +34,7 @@ export function resolveHeaderBadge(
 	version: string,
 	environmentName: string,
 	isProduction: boolean,
+	pullRequest?: number,
 ): HeaderBadge {
 	if (isProduction && SEMVER.test(version)) {
 		return {
@@ -32,5 +45,22 @@ export function resolveHeaderBadge(
 			ariaLabel: `View release v${version}`,
 		};
 	}
-	return { kind: "environment", label: environmentName, tone: toneFor(environmentName) };
+	const tone = toneFor(environmentName);
+	// The environment name stays in the label rather than being left to the dot's colour, which is
+	// the one part of this pill a colour-blind reader cannot use.
+	if (pullRequest !== undefined) {
+		return {
+			kind: "environment",
+			label: `${environmentName} · PR #${pullRequest}`,
+			tone,
+			tooltip: `${environmentName} of pull request #${pullRequest}`,
+			href: `${REPO_URL}/pull/${pullRequest}`,
+		};
+	}
+	return {
+		kind: "environment",
+		label: environmentName,
+		tone,
+		tooltip: `${environmentName} environment`,
+	};
 }

--- a/webapp/src/routes/__root.tsx
+++ b/webapp/src/routes/__root.tsx
@@ -272,6 +272,7 @@ function HeaderContainer() {
 			sidebarTrigger={isAuthenticated && <SidebarTrigger className="-ml-1" />}
 			version={environment.version}
 			environmentName={environment.deployment.name}
+			pullRequest={environment.deployment.pullRequest}
 			isProduction={environment.deployment.isProduction}
 			isAuthenticated={isAuthenticated}
 			isLoading={isLoading}


### PR DESCRIPTION
## What changed and why

The badge beside the brand logo reads the deployment environment name, so every preview shows the same word: **Preview**. Open two of them and the tabs are indistinguishable, and neither offers a way back to the pull request it came from.

Coolify routes a preview at `pr<id>.<domain>` and passes no pull request variable of its own, so the hostname is the only place the number appears. The client URL already carries that hostname into the runtime config, and a live preview confirms it — so the number is read from there, on the client, and only when the deployment is a preview.

The badge then reads **`Preview · PR #2042`** and links to the pull request. It keeps the pill and its tone dot; `Badge` already renders as an anchor and its `outline` variant already styles `[a]:hover`.

Staging, production and local are untouched: with no pull request the badge resolves exactly as before.

## How to test

```sh
vp run test:webapp        # 1145 + 168 pass
```

`resolveHeaderBadge` gains a case pinning the label, tooltip and link; the existing environment cases assert with `toStrictEqual`, so they also pin that nothing else grows a link. A new `src/environment/index.test.ts` covers the hostname forms and, most importantly, that a deployment which is not a preview gets no pull request however it is named — removing the environment gate fails that case and nothing else. `Header.stories.tsx` gains `PreviewOfAPullRequest`, whose play function finds the link by its visible text and checks its href.

Verified against the live preview of #2042, whose runtime config today carries everything except the number:

```js
window.__ENV__ = { APPLICATION_VERSION: "preview", GIT_BRANCH: "pearl-gazelle",
                   GIT_COMMIT: "57bdaaab2…", DEPLOYED_AT: "2026-09-09T18:34:32Z" }
```

## Release impact

`.changeset/preview-header-names-its-pull-request.md`, patch. No operator action.

## Notes for reviewers

The environment name deliberately stays in the label rather than being left to the dot's colour — that dot is the one part of this pill a colour-blind reader cannot use.

### After adversarial review

Three things changed, all of them defects in the first version:

- **The link carried `aria-label="View pull request #2042"`**, which replaced the visible "Preview · PR #2042" as its accessible name — a name a speech-input user cannot say, and a WCAG 2.5.3 (Label in Name) failure. The story asserted that name, so it entrenched it. The visible text names the link now; the tooltip carries the rest.
- **The number was not gated on the environment**, so any deployment served from a `pr<n>.` host would have shown `Staging · PR #2042`. Now only a preview reads it.
- **It was read from a new `PREVIEW_PR_NUMBER` exported by the webapp entrypoint**, which required `SERVICE_FQDN_WEBAPP` to be present in the container. I could not verify that it is — the one log line that would prove it never fired, and reading a container's environment is off limits — so this took a dependency I could not stand behind, which is the same shape as the bug #2094 fixes. It now reads the client URL, which I did verify on the live preview. The entrypoint is untouched, which also leaves the hostname rule with one home there.

One thing I did **not** change: the preview reports `GIT_COMMIT` as `refs/pull/<n>/merge` (the branch merged into main, injected by Coolify) while the GitHub deployment reports the branch head. Both are defensible answers to different questions, but they disagree with nothing explaining it. Worth a follow-up decision rather than a silent change here.
