### PR TITLE
test(server): consume HTTP responses before reusing connections

### DIFF
--- a/server/AGENTS.md
+++ b/server/AGENTS.md
@@ -81,6 +81,12 @@ Name tests `should[ExpectedBehavior]When[Condition]`. Controller-level integrati
 `WebTestClient` + `TestAuthUtils` — the identity comes from the mock JWT **token string**, not from an
 annotation.
 
+**Consume every HTTP response.** A `WebTestClient` status or header assertion does not consume its
+body. If the body is irrelevant to the assertion, finish with `.expectBody(Void.class)` so a large
+response cannot hold a pooled connection indefinitely. Body assertions already consume it; streaming
+tests own their subscription and cancellation explicitly. Use `.returnResult(Void.class)` when only
+response headers or cookies are needed; a non-void `returnResult` leaves the body subscription to you.
+
 **Rows written by earlier tests are already there.** Assert on the row you created, never on a count
 or on "the only" result, and never write cleanup that another test depends on having run.
 

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/AgentsPathDispatchIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/AgentsPathDispatchIntegrationTest.java
@@ -87,6 +87,7 @@ class AgentsPathDispatchIntegrationTest extends AbstractWorkspaceIntegrationTest
                 .bodyValue(Map.of("instanceModelId", 1))
                 .exchange()
                 .expectStatus()
-                .isBadRequest();
+                .isBadRequest()
+                .expectBody(Void.class);
     }
 }

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/backfill/ReviewBackfillControllerIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/backfill/ReviewBackfillControllerIntegrationTest.java
@@ -119,9 +119,9 @@ class ReviewBackfillControllerIntegrationTest extends AbstractWorkspaceIntegrati
     void aCancelledCampaignCannotBeRestarted() {
         Workspace workspace = setupWorkspace("backfill-restart");
         String runId = preflight(workspace);
-        patchStatus(workspace, runId, "CANCELLED").expectStatus().isOk();
+        patchStatus(workspace, runId, "CANCELLED").expectStatus().isOk().expectBody(Void.class);
 
-        patchStatus(workspace, runId, "RUNNING").expectStatus().isEqualTo(409);
+        patchStatus(workspace, runId, "RUNNING").expectStatus().isEqualTo(409).expectBody(Void.class);
     }
 
     /**
@@ -133,7 +133,7 @@ class ReviewBackfillControllerIntegrationTest extends AbstractWorkspaceIntegrati
     void aSecondCampaignIsRefusedWhileOneIsUnderWay() {
         Workspace workspace = setupWorkspace("backfill-second");
         String runId = preflight(workspace);
-        patchStatus(workspace, runId, "RUNNING").expectStatus().isOk();
+        patchStatus(workspace, runId, "RUNNING").expectStatus().isOk().expectBody(Void.class);
 
         webTestClient
                 .post()
@@ -145,7 +145,8 @@ class ReviewBackfillControllerIntegrationTest extends AbstractWorkspaceIntegrati
                 .expectStatus()
                 .isEqualTo(409)
                 .expectHeader()
-                .contentTypeCompatibleWith(MediaType.APPLICATION_PROBLEM_JSON);
+                .contentTypeCompatibleWith(MediaType.APPLICATION_PROBLEM_JSON)
+                .expectBody(Void.class);
     }
 
     /** Told at preflight, so the admin narrows the window instead of discovering the limit later. */
@@ -164,7 +165,8 @@ class ReviewBackfillControllerIntegrationTest extends AbstractWorkspaceIntegrati
                 .expectStatus()
                 .isBadRequest()
                 .expectHeader()
-                .contentTypeCompatibleWith(MediaType.APPLICATION_PROBLEM_JSON);
+                .contentTypeCompatibleWith(MediaType.APPLICATION_PROBLEM_JSON)
+                .expectBody(Void.class);
     }
 
     @Test
@@ -181,7 +183,8 @@ class ReviewBackfillControllerIntegrationTest extends AbstractWorkspaceIntegrati
                         "artifactKind", "chat.conversation_thread", "fromAt", FROM.toString(), "toAt", TO.toString()))
                 .exchange()
                 .expectStatus()
-                .isBadRequest();
+                .isBadRequest()
+                .expectBody(Void.class);
     }
 
     /** A campaign can spend a workspace's whole monthly AI budget, so a plain member cannot start one. */
@@ -199,7 +202,8 @@ class ReviewBackfillControllerIntegrationTest extends AbstractWorkspaceIntegrati
                 .headers(TestAuthUtils.withCurrentUser())
                 .exchange()
                 .expectStatus()
-                .isForbidden();
+                .isForbidden()
+                .expectBody(Void.class);
 
         webTestClient
                 .post()
@@ -209,7 +213,8 @@ class ReviewBackfillControllerIntegrationTest extends AbstractWorkspaceIntegrati
                 .bodyValue(window())
                 .exchange()
                 .expectStatus()
-                .isForbidden();
+                .isForbidden()
+                .expectBody(Void.class);
     }
 
     @Test
@@ -225,7 +230,8 @@ class ReviewBackfillControllerIntegrationTest extends AbstractWorkspaceIntegrati
                 .headers(asAdminAccount())
                 .exchange()
                 .expectStatus()
-                .isNotFound();
+                .isNotFound()
+                .expectBody(Void.class);
     }
 
     private String preflight(Workspace workspace) {

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/backfill/ReviewSweepScheduleControllerIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/backfill/ReviewSweepScheduleControllerIntegrationTest.java
@@ -61,7 +61,8 @@ class ReviewSweepScheduleControllerIntegrationTest extends AbstractWorkspaceInte
                 .bodyValue(body("scm.pull_request", "DAILY", 2))
                 .exchange()
                 .expectStatus()
-                .isForbidden();
+                .isForbidden()
+                .expectBody(Void.class);
     }
 
     /** Membership is not authority to commit the workspace's budget every night. */
@@ -78,7 +79,8 @@ class ReviewSweepScheduleControllerIntegrationTest extends AbstractWorkspaceInte
                 .bodyValue(body("scm.pull_request", "DAILY", 2))
                 .exchange()
                 .expectStatus()
-                .isForbidden();
+                .isForbidden()
+                .expectBody(Void.class);
     }
 
     @Test
@@ -107,26 +109,32 @@ class ReviewSweepScheduleControllerIntegrationTest extends AbstractWorkspaceInte
      */
     @Test
     void refusesAWindowLongerThanTheCadenceAllows() {
-        post(body("scm.pull_request", "DAILY", 5)).expectStatus().isBadRequest();
+        post(body("scm.pull_request", "DAILY", 5)).expectStatus().isBadRequest().expectBody(Void.class);
 
         assertThat(scheduleRepository.findAll()).isEmpty();
     }
 
     @Test
     void refusesAKindNoCampaignCanEnumerate() {
-        post(body("chat.conversation_thread", "DAILY", 1)).expectStatus().isBadRequest();
+        post(body("chat.conversation_thread", "DAILY", 1))
+                .expectStatus()
+                .isBadRequest()
+                .expectBody(Void.class);
     }
 
     @Test
     void refusesASecondScheduleForTheSameKindOfWork() {
-        post(body("scm.pull_request", "DAILY", 2)).expectStatus().isCreated();
+        post(body("scm.pull_request", "DAILY", 2)).expectStatus().isCreated().expectBody(Void.class);
 
-        post(body("scm.pull_request", "WEEKLY", 7)).expectStatus().isEqualTo(409);
+        post(body("scm.pull_request", "WEEKLY", 7))
+                .expectStatus()
+                .isEqualTo(409)
+                .expectBody(Void.class);
     }
 
     @Test
     void anAdminChangesTheTermsAndSwitchesTheSweepOff() {
-        post(body("scm.pull_request", "DAILY", 2)).expectStatus().isCreated();
+        post(body("scm.pull_request", "DAILY", 2)).expectStatus().isCreated().expectBody(Void.class);
         UUID scheduleId = scheduleRepository.findAll().getFirst().getId();
 
         webTestClient
@@ -147,7 +155,7 @@ class ReviewSweepScheduleControllerIntegrationTest extends AbstractWorkspaceInte
 
     @Test
     void anAdminStopsSweeping() {
-        post(body("scm.pull_request", "DAILY", 2)).expectStatus().isCreated();
+        post(body("scm.pull_request", "DAILY", 2)).expectStatus().isCreated().expectBody(Void.class);
         UUID scheduleId = scheduleRepository.findAll().getFirst().getId();
 
         webTestClient
@@ -156,7 +164,8 @@ class ReviewSweepScheduleControllerIntegrationTest extends AbstractWorkspaceInte
                 .headers(asAdminAccount())
                 .exchange()
                 .expectStatus()
-                .isNoContent();
+                .isNoContent()
+                .expectBody(Void.class);
 
         assertThat(scheduleRepository.findAll()).isEmpty();
     }
@@ -169,7 +178,8 @@ class ReviewSweepScheduleControllerIntegrationTest extends AbstractWorkspaceInte
                 .headers(asAdminAccount())
                 .exchange()
                 .expectStatus()
-                .isNotFound();
+                .isNotFound()
+                .expectBody(Void.class);
     }
 
     private WebTestClient.ResponseSpec post(Map<String, Object> body) {

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/catalog/InstanceLlmSettingsControllerIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/catalog/InstanceLlmSettingsControllerIntegrationTest.java
@@ -78,7 +78,8 @@ class InstanceLlmSettingsControllerIntegrationTest extends AbstractWorkspaceInte
                 .bodyValue(new UpdateInstanceLlmSettingsRequestDTO("api.openai.com", false))
                 .exchange()
                 .expectStatus()
-                .isOk();
+                .isOk()
+                .expectBody(Void.class);
 
         InstanceLlmSettingsDTO fetched = webTestClient
                 .put()
@@ -106,6 +107,7 @@ class InstanceLlmSettingsControllerIntegrationTest extends AbstractWorkspaceInte
                 .headers(h -> h.setBearerAuth(MENTOR_TOKEN))
                 .exchange()
                 .expectStatus()
-                .isForbidden();
+                .isForbidden()
+                .expectBody(Void.class);
     }
 }

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/catalog/LlmConnectionAdminControllerIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/catalog/LlmConnectionAdminControllerIntegrationTest.java
@@ -102,7 +102,8 @@ class LlmConnectionAdminControllerIntegrationTest extends AbstractWorkspaceInteg
                 .headers(h -> h.setBearerAuth(ADMIN_TOKEN))
                 .exchange()
                 .expectStatus()
-                .isNoContent();
+                .isNoContent()
+                .expectBody(Void.class);
 
         webTestClient
                 .get()
@@ -110,7 +111,8 @@ class LlmConnectionAdminControllerIntegrationTest extends AbstractWorkspaceInteg
                 .headers(h -> h.setBearerAuth(ADMIN_TOKEN))
                 .exchange()
                 .expectStatus()
-                .isNotFound();
+                .isNotFound()
+                .expectBody(Void.class);
     }
 
     @Test
@@ -153,7 +155,8 @@ class LlmConnectionAdminControllerIntegrationTest extends AbstractWorkspaceInteg
                 .headers(h -> h.setBearerAuth(ADMIN_TOKEN))
                 .exchange()
                 .expectStatus()
-                .isEqualTo(409);
+                .isEqualTo(409)
+                .expectBody(Void.class);
     }
 
     @Test
@@ -164,6 +167,7 @@ class LlmConnectionAdminControllerIntegrationTest extends AbstractWorkspaceInteg
                 .headers(h -> h.setBearerAuth(MENTOR_TOKEN))
                 .exchange()
                 .expectStatus()
-                .isForbidden();
+                .isForbidden()
+                .expectBody(Void.class);
     }
 }

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/catalog/LlmModelAdminControllerIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/catalog/LlmModelAdminControllerIntegrationTest.java
@@ -107,7 +107,8 @@ class LlmModelAdminControllerIntegrationTest extends AbstractWorkspaceIntegratio
                 .headers(h -> h.setBearerAuth(ADMIN_TOKEN))
                 .exchange()
                 .expectStatus()
-                .isNoContent();
+                .isNoContent()
+                .expectBody(Void.class);
 
         webTestClient
                 .get()
@@ -115,7 +116,8 @@ class LlmModelAdminControllerIntegrationTest extends AbstractWorkspaceIntegratio
                 .headers(h -> h.setBearerAuth(ADMIN_TOKEN))
                 .exchange()
                 .expectStatus()
-                .isNotFound();
+                .isNotFound()
+                .expectBody(Void.class);
     }
 
     @Test
@@ -133,7 +135,8 @@ class LlmModelAdminControllerIntegrationTest extends AbstractWorkspaceIntegratio
                 .bodyValue(firstPrice)
                 .exchange()
                 .expectStatus()
-                .isOk();
+                .isOk()
+                .expectBody(Void.class);
 
         var secondPrice = new UpdateLlmModelPriceRequestDTO(
                 PricingMode.PRICED, new BigDecimal("3.00"), new BigDecimal("4.00"), null, null, null);
@@ -253,7 +256,8 @@ class LlmModelAdminControllerIntegrationTest extends AbstractWorkspaceIntegratio
                 .headers(h -> h.setBearerAuth(ADMIN_TOKEN))
                 .exchange()
                 .expectStatus()
-                .isEqualTo(409);
+                .isEqualTo(409)
+                .expectBody(Void.class);
     }
 
     @Test
@@ -298,7 +302,8 @@ class LlmModelAdminControllerIntegrationTest extends AbstractWorkspaceIntegratio
                 .headers(h -> h.setBearerAuth(MENTOR_TOKEN))
                 .exchange()
                 .expectStatus()
-                .isForbidden();
+                .isForbidden()
+                .expectBody(Void.class);
     }
 
     private LlmModel llmModelFromRepository(Long id) {

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/catalog/WorkspaceLlmConnectionControllerIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/catalog/WorkspaceLlmConnectionControllerIntegrationTest.java
@@ -107,7 +107,8 @@ class WorkspaceLlmConnectionControllerIntegrationTest extends AbstractWorkspaceI
                 .headers(TestAuthUtils.withCurrentUser())
                 .exchange()
                 .expectStatus()
-                .isNoContent();
+                .isNoContent()
+                .expectBody(Void.class);
 
         webTestClient
                 .get()
@@ -115,7 +116,8 @@ class WorkspaceLlmConnectionControllerIntegrationTest extends AbstractWorkspaceI
                 .headers(TestAuthUtils.withCurrentUser())
                 .exchange()
                 .expectStatus()
-                .isNotFound();
+                .isNotFound()
+                .expectBody(Void.class);
     }
 
     @Test
@@ -164,7 +166,8 @@ class WorkspaceLlmConnectionControllerIntegrationTest extends AbstractWorkspaceI
                 .headers(TestAuthUtils.withCurrentUser())
                 .exchange()
                 .expectStatus()
-                .isForbidden();
+                .isForbidden()
+                .expectBody(Void.class);
     }
 
     @Test
@@ -184,7 +187,8 @@ class WorkspaceLlmConnectionControllerIntegrationTest extends AbstractWorkspaceI
                 .headers(TestAuthUtils.withCurrentUser())
                 .exchange()
                 .expectStatus()
-                .isNotFound();
+                .isNotFound()
+                .expectBody(Void.class);
     }
 
     @Test
@@ -211,7 +215,8 @@ class WorkspaceLlmConnectionControllerIntegrationTest extends AbstractWorkspaceI
                 .headers(TestAuthUtils.withCurrentUser())
                 .exchange()
                 .expectStatus()
-                .isForbidden();
+                .isForbidden()
+                .expectBody(Void.class);
 
         webTestClient
                 .get()
@@ -219,7 +224,8 @@ class WorkspaceLlmConnectionControllerIntegrationTest extends AbstractWorkspaceI
                 .headers(TestAuthUtils.withCurrentUser())
                 .exchange()
                 .expectStatus()
-                .isOk();
+                .isOk()
+                .expectBody(Void.class);
     }
 
     @Test
@@ -248,6 +254,7 @@ class WorkspaceLlmConnectionControllerIntegrationTest extends AbstractWorkspaceI
                 .bodyValue(request)
                 .exchange()
                 .expectStatus()
-                .isForbidden();
+                .isForbidden()
+                .expectBody(Void.class);
     }
 }

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/catalog/WorkspaceLlmModelControllerIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/catalog/WorkspaceLlmModelControllerIntegrationTest.java
@@ -163,7 +163,8 @@ class WorkspaceLlmModelControllerIntegrationTest extends AbstractWorkspaceIntegr
                 .headers(TestAuthUtils.withCurrentUser())
                 .exchange()
                 .expectStatus()
-                .isNoContent();
+                .isNoContent()
+                .expectBody(Void.class);
 
         webTestClient
                 .get()
@@ -171,7 +172,8 @@ class WorkspaceLlmModelControllerIntegrationTest extends AbstractWorkspaceIntegr
                 .headers(TestAuthUtils.withCurrentUser())
                 .exchange()
                 .expectStatus()
-                .isNotFound();
+                .isNotFound()
+                .expectBody(Void.class);
     }
 
     @Test
@@ -192,7 +194,8 @@ class WorkspaceLlmModelControllerIntegrationTest extends AbstractWorkspaceIntegr
                 .headers(TestAuthUtils.withCurrentUser())
                 .exchange()
                 .expectStatus()
-                .isNotFound();
+                .isNotFound()
+                .expectBody(Void.class);
     }
 
     @Test
@@ -285,7 +288,8 @@ class WorkspaceLlmModelControllerIntegrationTest extends AbstractWorkspaceIntegr
                         null, null, null, null, false, null, null, null, null, null, null))
                 .exchange()
                 .expectStatus()
-                .isOk();
+                .isOk()
+                .expectBody(Void.class);
 
         List<AvailableLlmModelDTO> available = webTestClient
                 .get()
@@ -346,7 +350,8 @@ class WorkspaceLlmModelControllerIntegrationTest extends AbstractWorkspaceIntegr
                 .headers(TestAuthUtils.withCurrentUser())
                 .exchange()
                 .expectStatus()
-                .isForbidden();
+                .isForbidden()
+                .expectBody(Void.class);
 
         webTestClient
                 .get()
@@ -354,7 +359,8 @@ class WorkspaceLlmModelControllerIntegrationTest extends AbstractWorkspaceIntegr
                 .headers(TestAuthUtils.withCurrentUser())
                 .exchange()
                 .expectStatus()
-                .isForbidden();
+                .isForbidden()
+                .expectBody(Void.class);
 
         webTestClient
                 .post()
@@ -366,7 +372,8 @@ class WorkspaceLlmModelControllerIntegrationTest extends AbstractWorkspaceIntegr
                 .bodyValue(Map.of("displayName", "Member Model", "upstreamModelId", "gpt-5"))
                 .exchange()
                 .expectStatus()
-                .isForbidden();
+                .isForbidden()
+                .expectBody(Void.class);
 
         webTestClient
                 .delete()
@@ -374,7 +381,8 @@ class WorkspaceLlmModelControllerIntegrationTest extends AbstractWorkspaceIntegr
                 .headers(TestAuthUtils.withCurrentUser())
                 .exchange()
                 .expectStatus()
-                .isForbidden();
+                .isForbidden()
+                .expectBody(Void.class);
     }
 
     @Test
@@ -395,7 +403,8 @@ class WorkspaceLlmModelControllerIntegrationTest extends AbstractWorkspaceIntegr
                 .headers(TestAuthUtils.withCurrentUser())
                 .exchange()
                 .expectStatus()
-                .isForbidden();
+                .isForbidden()
+                .expectBody(Void.class);
 
         webTestClient
                 .get()
@@ -403,6 +412,7 @@ class WorkspaceLlmModelControllerIntegrationTest extends AbstractWorkspaceIntegr
                 .headers(TestAuthUtils.withCurrentUser())
                 .exchange()
                 .expectStatus()
-                .isOk();
+                .isOk()
+                .expectBody(Void.class);
     }
 }

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/catalog/WorkspaceLlmSettingsControllerIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/catalog/WorkspaceLlmSettingsControllerIntegrationTest.java
@@ -68,7 +68,8 @@ class WorkspaceLlmSettingsControllerIntegrationTest extends AbstractWorkspaceInt
                 .headers(TestAuthUtils.withCurrentUser())
                 .exchange()
                 .expectStatus()
-                .isForbidden();
+                .isForbidden()
+                .expectBody(Void.class);
     }
 
     @Test
@@ -93,7 +94,8 @@ class WorkspaceLlmSettingsControllerIntegrationTest extends AbstractWorkspaceInt
                 .headers(TestAuthUtils.withCurrentUser())
                 .exchange()
                 .expectStatus()
-                .isForbidden();
+                .isForbidden()
+                .expectBody(Void.class);
 
         webTestClient
                 .get()
@@ -101,6 +103,7 @@ class WorkspaceLlmSettingsControllerIntegrationTest extends AbstractWorkspaceInt
                 .headers(TestAuthUtils.withCurrentUser())
                 .exchange()
                 .expectStatus()
-                .isOk();
+                .isOk()
+                .expectBody(Void.class);
     }
 }

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/config/AgentBindingControllerIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/config/AgentBindingControllerIntegrationTest.java
@@ -64,7 +64,8 @@ class AgentBindingControllerIntegrationTest extends AbstractWorkspaceIntegration
                 .bodyValue(Map.of("instanceModelId", model.getId(), "enabled", true))
                 .exchange()
                 .expectStatus()
-                .isOk();
+                .isOk()
+                .expectBody(Void.class);
 
         // A separate request, so the listing loads the binding fresh: the write above cannot have left
         // it hydrated in a session.
@@ -101,7 +102,8 @@ class AgentBindingControllerIntegrationTest extends AbstractWorkspaceIntegration
                 .bodyValue(Map.of("instanceModelId", model.getId(), "enabled", false))
                 .exchange()
                 .expectStatus()
-                .isOk();
+                .isOk()
+                .expectBody(Void.class);
 
         webTestClient
                 .get()
@@ -122,7 +124,8 @@ class AgentBindingControllerIntegrationTest extends AbstractWorkspaceIntegration
                 .headers(TestAuthUtils.withCurrentUser())
                 .exchange()
                 .expectStatus()
-                .isNoContent();
+                .isNoContent()
+                .expectBody(Void.class);
 
         webTestClient
                 .get()
@@ -153,7 +156,8 @@ class AgentBindingControllerIntegrationTest extends AbstractWorkspaceIntegration
                 .bodyValue(Map.of("instanceModelId", model.getId(), "enabled", true))
                 .exchange()
                 .expectStatus()
-                .isBadRequest();
+                .isBadRequest()
+                .expectBody(Void.class);
     }
 
     @Test
@@ -171,7 +175,8 @@ class AgentBindingControllerIntegrationTest extends AbstractWorkspaceIntegration
                 .uri("/workspaces/{slug}/agents", workspace.getWorkspaceSlug())
                 .exchange()
                 .expectStatus()
-                .isUnauthorized();
+                .isUnauthorized()
+                .expectBody(Void.class);
     }
 
     @Test
@@ -196,7 +201,8 @@ class AgentBindingControllerIntegrationTest extends AbstractWorkspaceIntegration
                         true))
                 .exchange()
                 .expectStatus()
-                .isForbidden();
+                .isForbidden()
+                .expectBody(Void.class);
     }
 
     @Test
@@ -213,7 +219,8 @@ class AgentBindingControllerIntegrationTest extends AbstractWorkspaceIntegration
                 .headers(TestAuthUtils.withCurrentUser())
                 .exchange()
                 .expectStatus()
-                .isForbidden();
+                .isForbidden()
+                .expectBody(Void.class);
     }
 
     @Test
@@ -235,7 +242,8 @@ class AgentBindingControllerIntegrationTest extends AbstractWorkspaceIntegration
                 .headers(TestAuthUtils.withCurrentUser())
                 .exchange()
                 .expectStatus()
-                .isForbidden();
+                .isForbidden()
+                .expectBody(Void.class);
 
         webTestClient
                 .get()
@@ -243,6 +251,7 @@ class AgentBindingControllerIntegrationTest extends AbstractWorkspaceIntegration
                 .headers(TestAuthUtils.withCurrentUser())
                 .exchange()
                 .expectStatus()
-                .isOk();
+                .isOk()
+                .expectBody(Void.class);
     }
 }

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobControllerIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobControllerIntegrationTest.java
@@ -154,7 +154,8 @@ class AgentJobControllerIntegrationTest extends AbstractWorkspaceIntegrationTest
                 .headers(TestAuthUtils.withCurrentUser())
                 .exchange()
                 .expectStatus()
-                .isNotFound();
+                .isNotFound()
+                .expectBody(Void.class);
     }
 
     @Test
@@ -174,7 +175,8 @@ class AgentJobControllerIntegrationTest extends AbstractWorkspaceIntegrationTest
                 .headers(TestAuthUtils.withCurrentUser())
                 .exchange()
                 .expectStatus()
-                .isNotFound();
+                .isNotFound()
+                .expectBody(Void.class);
     }
 
     @Test
@@ -255,7 +257,8 @@ class AgentJobControllerIntegrationTest extends AbstractWorkspaceIntegrationTest
                 .headers(TestAuthUtils.withCurrentUser())
                 .exchange()
                 .expectStatus()
-                .isEqualTo(409);
+                .isEqualTo(409)
+                .expectBody(Void.class);
     }
 
     @Test
@@ -269,7 +272,8 @@ class AgentJobControllerIntegrationTest extends AbstractWorkspaceIntegrationTest
                 .headers(TestAuthUtils.withCurrentUser())
                 .exchange()
                 .expectStatus()
-                .isNotFound();
+                .isNotFound()
+                .expectBody(Void.class);
     }
 
     @Test
@@ -289,7 +293,8 @@ class AgentJobControllerIntegrationTest extends AbstractWorkspaceIntegrationTest
                 .headers(TestAuthUtils.withCurrentUser())
                 .exchange()
                 .expectStatus()
-                .isNotFound();
+                .isNotFound()
+                .expectBody(Void.class);
     }
 
     @Test
@@ -328,6 +333,7 @@ class AgentJobControllerIntegrationTest extends AbstractWorkspaceIntegrationTest
                 .uri("/workspaces/{slug}/agents/jobs", workspace.getWorkspaceSlug())
                 .exchange()
                 .expectStatus()
-                .isUnauthorized();
+                .isUnauthorized()
+                .expectBody(Void.class);
     }
 }

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/job/PracticeReviewRequestControllerIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/job/PracticeReviewRequestControllerIntegrationTest.java
@@ -102,7 +102,8 @@ class PracticeReviewRequestControllerIntegrationTest extends AbstractWorkspaceIn
                     .bodyValue(body(ArtifactKinds.PULL_REQUEST.value(), pullRequestId))
                     .exchange()
                     .expectStatus()
-                    .isForbidden();
+                    .isForbidden()
+                    .expectBody(Void.class);
         }
 
         /**
@@ -115,7 +116,8 @@ class PracticeReviewRequestControllerIntegrationTest extends AbstractWorkspaceIn
         void refusesAWorkspaceMemberWhoIsNeitherAuthorNorAssignee() {
             post(ArtifactKinds.PULL_REQUEST.value(), pullRequestId)
                     .expectStatus()
-                    .isForbidden();
+                    .isForbidden()
+                    .expectBody(Void.class);
         }
 
         @Test
@@ -123,7 +125,8 @@ class PracticeReviewRequestControllerIntegrationTest extends AbstractWorkspaceIn
         void admitsTheAuthorOfTheWork() {
             post(ArtifactKinds.PULL_REQUEST.value(), pullRequestId)
                     .expectStatus()
-                    .isOk();
+                    .isOk()
+                    .expectBody(Void.class);
         }
 
         @Test
@@ -133,7 +136,8 @@ class PracticeReviewRequestControllerIntegrationTest extends AbstractWorkspaceIn
 
             post(ArtifactKinds.PULL_REQUEST.value(), pullRequestId)
                     .expectStatus()
-                    .isOk();
+                    .isOk()
+                    .expectBody(Void.class);
         }
     }
 
@@ -169,7 +173,8 @@ class PracticeReviewRequestControllerIntegrationTest extends AbstractWorkspaceIn
         void answersNotFoundForWorkThisWorkspaceDoesNotMonitor() {
             post(ArtifactKinds.PULL_REQUEST.value(), pullRequestId + 9999)
                     .expectStatus()
-                    .isNotFound();
+                    .isNotFound()
+                    .expectBody(Void.class);
         }
 
         /** A chat thread is reviewed on the occasion its source produces; there is nothing to point at. */
@@ -178,13 +183,14 @@ class PracticeReviewRequestControllerIntegrationTest extends AbstractWorkspaceIn
         void refusesAKindThatHasNoFrontDoorHere() {
             post(ArtifactKinds.CONVERSATION_THREAD.value(), pullRequestId)
                     .expectStatus()
-                    .isBadRequest();
+                    .isBadRequest()
+                    .expectBody(Void.class);
         }
 
         @Test
         @WithUser
         void refusesSomethingThatIsNotAnArtifactKindAtAll() {
-            post("NotAKind", pullRequestId).expectStatus().isBadRequest();
+            post("NotAKind", pullRequestId).expectStatus().isBadRequest().expectBody(Void.class);
         }
 
         /**
@@ -285,7 +291,8 @@ class PracticeReviewRequestControllerIntegrationTest extends AbstractWorkspaceIn
 
             post(ArtifactKinds.PULL_REQUEST.value(), pullRequestId)
                     .expectStatus()
-                    .isOk();
+                    .isOk()
+                    .expectBody(Void.class);
 
             org.assertj.core.api.Assertions.assertThat(signalRepository.findForArtifact(
                             workspace.getId(), ArtifactKinds.PULL_REQUEST.value(), pullRequestId))

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/job/PracticeReviewSummaryControllerIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/job/PracticeReviewSummaryControllerIntegrationTest.java
@@ -328,7 +328,8 @@ class PracticeReviewSummaryControllerIntegrationTest extends AbstractWorkspaceIn
                 .headers(TestAuthUtils.withCurrentUser())
                 .exchange()
                 .expectStatus()
-                .isForbidden();
+                .isForbidden()
+                .expectBody(Void.class);
     }
 
     private Practice persistPractice(Workspace targetWorkspace) {

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/mentor/chat/MentorChatControllerAuthIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/mentor/chat/MentorChatControllerAuthIntegrationTest.java
@@ -77,7 +77,8 @@ class MentorChatControllerAuthIntegrationTest extends AbstractWorkspaceIntegrati
                 .bodyValue(validBody())
                 .exchange()
                 .expectStatus()
-                .isForbidden();
+                .isForbidden()
+                .expectBody(Void.class);
     }
 
     @Test
@@ -96,7 +97,8 @@ class MentorChatControllerAuthIntegrationTest extends AbstractWorkspaceIntegrati
                 .bodyValue(validBody())
                 .exchange()
                 .expectStatus()
-                .isForbidden();
+                .isForbidden()
+                .expectBody(Void.class);
     }
 
     @Test
@@ -123,7 +125,8 @@ class MentorChatControllerAuthIntegrationTest extends AbstractWorkspaceIntegrati
                 .expectHeader()
                 .valueEquals("x-vercel-ai-ui-message-stream", "v1")
                 .expectHeader()
-                .valueEquals("Cache-Control", "no-cache");
+                .valueEquals("Cache-Control", "no-cache")
+                .expectBody(Void.class);
 
         assertThat(mentorChatStarter.awaitInvocation()).isTrue();
     }
@@ -147,6 +150,7 @@ class MentorChatControllerAuthIntegrationTest extends AbstractWorkspaceIntegrati
                 .bodyValue(validBody())
                 .exchange()
                 .expectStatus()
-                .isNotFound();
+                .isNotFound()
+                .expectBody(Void.class);
     }
 }

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/usage/LlmUsageAdminControllerIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/usage/LlmUsageAdminControllerIntegrationTest.java
@@ -160,7 +160,8 @@ class LlmUsageAdminControllerIntegrationTest extends AbstractWorkspaceIntegratio
                 .bodyValue(Map.of("monthlyBudgetUsd", "25.00"))
                 .exchange()
                 .expectStatus()
-                .isNoContent();
+                .isNoContent()
+                .expectBody(Void.class);
         assertThat(workspaceRepository.findById(workspace.getId()).orElseThrow().getMonthlyLlmBudgetUsd())
                 .isEqualByComparingTo("25.00");
 
@@ -172,7 +173,8 @@ class LlmUsageAdminControllerIntegrationTest extends AbstractWorkspaceIntegratio
                 .bodyValue(Map.of())
                 .exchange()
                 .expectStatus()
-                .isNoContent();
+                .isNoContent()
+                .expectBody(Void.class);
         assertThat(workspaceRepository.findById(workspace.getId()).orElseThrow().getMonthlyLlmBudgetUsd())
                 .isNull();
     }
@@ -191,7 +193,8 @@ class LlmUsageAdminControllerIntegrationTest extends AbstractWorkspaceIntegratio
                 .bodyValue(Map.of("monthlyBudgetUsd", "25.00"))
                 .exchange()
                 .expectStatus()
-                .isNotFound();
+                .isNotFound()
+                .expectBody(Void.class);
     }
 
     @Test
@@ -206,7 +209,8 @@ class LlmUsageAdminControllerIntegrationTest extends AbstractWorkspaceIntegratio
                 .bodyValue(Map.of("monthlyBudgetUsd", "-1.00"))
                 .exchange()
                 .expectStatus()
-                .isBadRequest();
+                .isBadRequest()
+                .expectBody(Void.class);
     }
 
     /**
@@ -249,7 +253,8 @@ class LlmUsageAdminControllerIntegrationTest extends AbstractWorkspaceIntegratio
                 .headers(h -> h.setBearerAuth(MENTOR_TOKEN))
                 .exchange()
                 .expectStatus()
-                .isForbidden();
+                .isForbidden()
+                .expectBody(Void.class);
     }
 
     @Test
@@ -257,7 +262,13 @@ class LlmUsageAdminControllerIntegrationTest extends AbstractWorkspaceIntegratio
         // 401, not 403: an unauthenticated caller must be told to authenticate. The two are answered
         // by different layers (the entry point vs. @PreAuthorize), so passing the 403 case above says
         // nothing about this one.
-        webTestClient.get().uri("/admin/llm/usage").exchange().expectStatus().isUnauthorized();
+        webTestClient
+                .get()
+                .uri("/admin/llm/usage")
+                .exchange()
+                .expectStatus()
+                .isUnauthorized()
+                .expectBody(Void.class);
     }
 
     @Test
@@ -270,7 +281,8 @@ class LlmUsageAdminControllerIntegrationTest extends AbstractWorkspaceIntegratio
                 .bodyValue(Map.of("monthlyBudgetUsd", 1))
                 .exchange()
                 .expectStatus()
-                .isForbidden();
+                .isForbidden()
+                .expectBody(Void.class);
 
         // 403, not the 401 the anonymous *read* above returns: a state-changing request with no
         // `Authorization: Bearer` header is cookie-shaped, so SecurityConfig#requiresCsrf refuses it
@@ -283,6 +295,7 @@ class LlmUsageAdminControllerIntegrationTest extends AbstractWorkspaceIntegratio
                 .bodyValue(Map.of("monthlyBudgetUsd", 1))
                 .exchange()
                 .expectStatus()
-                .isForbidden();
+                .isForbidden()
+                .expectBody(Void.class);
     }
 }

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/usage/LlmUsageControllerIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/usage/LlmUsageControllerIntegrationTest.java
@@ -363,7 +363,8 @@ class LlmUsageControllerIntegrationTest extends AbstractWorkspaceIntegrationTest
                 .headers(TestAuthUtils.withCurrentUser())
                 .exchange()
                 .expectStatus()
-                .isBadRequest();
+                .isBadRequest()
+                .expectBody(Void.class);
     }
 
     @Test
@@ -409,7 +410,8 @@ class LlmUsageControllerIntegrationTest extends AbstractWorkspaceIntegrationTest
                 .headers(TestAuthUtils.withCurrentUser())
                 .exchange()
                 .expectStatus()
-                .isForbidden();
+                .isForbidden()
+                .expectBody(Void.class);
 
         webTestClient
                 .get()
@@ -417,7 +419,8 @@ class LlmUsageControllerIntegrationTest extends AbstractWorkspaceIntegrationTest
                 .headers(TestAuthUtils.withCurrentUser())
                 .exchange()
                 .expectStatus()
-                .isOk();
+                .isOk()
+                .expectBody(Void.class);
     }
 
     @Test
@@ -433,7 +436,8 @@ class LlmUsageControllerIntegrationTest extends AbstractWorkspaceIntegrationTest
                 .bodyValue(Map.of("monthlyBudgetUsd", "25.00"))
                 .exchange()
                 .expectStatus()
-                .isNoContent();
+                .isNoContent()
+                .expectBody(Void.class);
         assertThat(workspaceRepository.findById(workspace.getId()).orElseThrow().getMonthlyByoLlmBudgetUsd())
                 .isEqualByComparingTo("25.00");
 
@@ -446,7 +450,8 @@ class LlmUsageControllerIntegrationTest extends AbstractWorkspaceIntegrationTest
                 .bodyValue(Map.of())
                 .exchange()
                 .expectStatus()
-                .isNoContent();
+                .isNoContent()
+                .expectBody(Void.class);
         assertThat(workspaceRepository.findById(workspace.getId()).orElseThrow().getMonthlyByoLlmBudgetUsd())
                 .isNull();
     }
@@ -466,7 +471,8 @@ class LlmUsageControllerIntegrationTest extends AbstractWorkspaceIntegrationTest
                 .bodyValue(Map.of("monthlyBudgetUsd", "0.00"))
                 .exchange()
                 .expectStatus()
-                .isNoContent();
+                .isNoContent()
+                .expectBody(Void.class);
 
         Workspace reloaded = workspaceRepository.findById(workspace.getId()).orElseThrow();
         assertThat(reloaded.getMonthlyByoLlmBudgetUsd()).isEqualByComparingTo("0.00");
@@ -486,7 +492,8 @@ class LlmUsageControllerIntegrationTest extends AbstractWorkspaceIntegrationTest
                 .bodyValue(Map.of("monthlyBudgetUsd", "12.50"))
                 .exchange()
                 .expectStatus()
-                .isNoContent();
+                .isNoContent()
+                .expectBody(Void.class);
 
         ConfigAuditEvent row = configAuditEventRepository.findAll().stream()
                 .filter(e -> e.getEntityType() == ConfigAuditEntityType.WORKSPACE_OWN_PROVIDER_LLM_BUDGET)
@@ -511,7 +518,8 @@ class LlmUsageControllerIntegrationTest extends AbstractWorkspaceIntegrationTest
                 .bodyValue(Map.of("monthlyBudgetUsd", cap))
                 .exchange()
                 .expectStatus()
-                .isBadRequest();
+                .isBadRequest()
+                .expectBody(Void.class);
         assertThat(workspaceRepository.findById(workspace.getId()).orElseThrow().getMonthlyByoLlmBudgetUsd())
                 .as(why)
                 .isNull();
@@ -532,7 +540,8 @@ class LlmUsageControllerIntegrationTest extends AbstractWorkspaceIntegrationTest
                 .bodyValue(Map.of("monthlyBudgetUsd", "25.00"))
                 .exchange()
                 .expectStatus()
-                .isUnauthorized();
+                .isUnauthorized()
+                .expectBody(Void.class);
         assertThat(workspaceRepository.findById(workspace.getId()).orElseThrow().getMonthlyByoLlmBudgetUsd())
                 .isNull();
     }
@@ -557,7 +566,8 @@ class LlmUsageControllerIntegrationTest extends AbstractWorkspaceIntegrationTest
                 .bodyValue(Map.of("monthlyBudgetUsd", "25.00"))
                 .exchange()
                 .expectStatus()
-                .isNoContent();
+                .isNoContent()
+                .expectBody(Void.class);
 
         webTestClient
                 .put()
@@ -567,7 +577,8 @@ class LlmUsageControllerIntegrationTest extends AbstractWorkspaceIntegrationTest
                 .bodyValue(Map.of("monthlyBudgetUsd", "999.00"))
                 .exchange()
                 .expectStatus()
-                .isForbidden();
+                .isForbidden()
+                .expectBody(Void.class);
         assertThat(workspaceRepository.findById(workspace.getId()).orElseThrow().getMonthlyLlmBudgetUsd())
                 .isNull();
     }
@@ -634,7 +645,8 @@ class LlmUsageControllerIntegrationTest extends AbstractWorkspaceIntegrationTest
                 .bodyValue(Map.of("monthlyBudgetUsd", "999.00"))
                 .exchange()
                 .expectStatus()
-                .isForbidden();
+                .isForbidden()
+                .expectBody(Void.class);
 
         assertThat(workspaceRepository
                         .findById(otherWorkspace.getId())
@@ -660,7 +672,8 @@ class LlmUsageControllerIntegrationTest extends AbstractWorkspaceIntegrationTest
                 .bodyValue(Map.of("monthlyBudgetUsd", "1.00"))
                 .exchange()
                 .expectStatus()
-                .isForbidden();
+                .isForbidden()
+                .expectBody(Void.class);
 
         assertThat(workspaceRepository.findById(workspace.getId()).orElseThrow().getMonthlyByoLlmBudgetUsd())
                 .isNull();
@@ -681,6 +694,7 @@ class LlmUsageControllerIntegrationTest extends AbstractWorkspaceIntegrationTest
                 .headers(TestAuthUtils.withCurrentUser())
                 .exchange()
                 .expectStatus()
-                .isForbidden();
+                .isForbidden()
+                .expectBody(Void.class);
     }
 }

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/audit/ConfigAuditIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/audit/ConfigAuditIntegrationTest.java
@@ -145,7 +145,8 @@ class ConfigAuditIntegrationTest extends AbstractWorkspaceIntegrationTest {
                 .bodyValue(Map.of("mentorEnabled", true))
                 .exchange()
                 .expectStatus()
-                .isOk();
+                .isOk()
+                .expectBody(Void.class);
 
         ConfigAuditEvent row = configAuditEventRepository.findAll().stream()
                 .filter(e -> e.getEntityType() == ConfigAuditEntityType.WORKSPACE_FEATURES)
@@ -199,7 +200,8 @@ class ConfigAuditIntegrationTest extends AbstractWorkspaceIntegrationTest {
                         "return { hints: ['updated'] };"))
                 .exchange()
                 .expectStatus()
-                .isOk();
+                .isOk()
+                .expectBody(Void.class);
 
         webTestClient
                 .delete()
@@ -207,7 +209,8 @@ class ConfigAuditIntegrationTest extends AbstractWorkspaceIntegrationTest {
                 .headers(TestAuthUtils.withCurrentUser())
                 .exchange()
                 .expectStatus()
-                .isNoContent();
+                .isNoContent()
+                .expectBody(Void.class);
 
         List<ConfigAuditEvent> rows = configAuditEventRepository.findAll().stream()
                 .filter(row -> java.util.Objects.equals(row.getWorkspaceId(), workspace.getId()))
@@ -363,7 +366,8 @@ class ConfigAuditIntegrationTest extends AbstractWorkspaceIntegrationTest {
                 .headers(TestAuthUtils.withCurrentUser())
                 .exchange()
                 .expectStatus()
-                .isUnauthorized();
+                .isUnauthorized()
+                .expectBody(Void.class);
     }
 
     @Test
@@ -375,7 +379,8 @@ class ConfigAuditIntegrationTest extends AbstractWorkspaceIntegrationTest {
                 .headers(TestAuthUtils.withCurrentUser())
                 .exchange()
                 .expectStatus()
-                .isForbidden();
+                .isForbidden()
+                .expectBody(Void.class);
     }
 
     /**
@@ -490,7 +495,8 @@ class ConfigAuditIntegrationTest extends AbstractWorkspaceIntegrationTest {
                 .headers(TestAuthUtils.withCurrentUser())
                 .exchange()
                 .expectStatus()
-                .isBadRequest();
+                .isBadRequest()
+                .expectBody(Void.class);
     }
 
     @Test
@@ -543,7 +549,7 @@ class ConfigAuditIntegrationTest extends AbstractWorkspaceIntegrationTest {
                 .exchange()
                 .expectStatus()
                 .isOk()
-                .returnResult(String.class)
+                .returnResult(Void.class)
                 .getResponseHeaders()
                 .getETag();
         String etag = Objects.requireNonNull(version, "the settings endpoint always answers with an ETag");
@@ -559,7 +565,8 @@ class ConfigAuditIntegrationTest extends AbstractWorkspaceIntegrationTest {
                 .bodyValue(body)
                 .exchange()
                 .expectStatus()
-                .isOk();
+                .isOk()
+                .expectBody(Void.class);
     }
 
     /** Authenticates as one specific account id — the JWT subject the native-auth filters read. */
@@ -623,6 +630,7 @@ class ConfigAuditIntegrationTest extends AbstractWorkspaceIntegrationTest {
                         true))
                 .exchange()
                 .expectStatus()
-                .isCreated();
+                .isCreated()
+                .expectBody(Void.class);
     }
 }

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/auth/CookieAuthenticationIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/auth/CookieAuthenticationIntegrationTest.java
@@ -94,7 +94,13 @@ class CookieAuthenticationIntegrationTest extends RealAuthIntegrationTest {
 
     @Test
     void noCredentialsIsUnauthorized() {
-        webTestClient.get().uri("/user").exchange().expectStatus().isUnauthorized();
+        webTestClient
+                .get()
+                .uri("/user")
+                .exchange()
+                .expectStatus()
+                .isUnauthorized()
+                .expectBody(Void.class);
     }
 
     @Test
@@ -110,7 +116,8 @@ class CookieAuthenticationIntegrationTest extends RealAuthIntegrationTest {
                 .header(HttpHeaders.COOKIE, cookieName + "=" + issued.token())
                 .exchange()
                 .expectStatus()
-                .isOk();
+                .isOk()
+                .expectBody(Void.class);
 
         // Revoke every session for the account (the issuer persisted the issued_jwt row). The
         // @Modifying query needs an active, COMMITTED tx so the server thread's next read sees it.
@@ -125,7 +132,8 @@ class CookieAuthenticationIntegrationTest extends RealAuthIntegrationTest {
                 .header(HttpHeaders.COOKIE, cookieName + "=" + issued.token())
                 .exchange()
                 .expectStatus()
-                .isUnauthorized();
+                .isUnauthorized()
+                .expectBody(Void.class);
     }
 
     @Test
@@ -142,7 +150,8 @@ class CookieAuthenticationIntegrationTest extends RealAuthIntegrationTest {
                 .headers(headers -> headers.setBearerAuth(issued.token()))
                 .exchange()
                 .expectStatus()
-                .isOk();
+                .isOk()
+                .expectBody(Void.class);
     }
 
     @Test
@@ -154,7 +163,8 @@ class CookieAuthenticationIntegrationTest extends RealAuthIntegrationTest {
                 .header(HttpHeaders.COOKIE, cookieName + "=" + issued.token())
                 .exchange()
                 .expectStatus()
-                .isForbidden();
+                .isForbidden()
+                .expectBody(Void.class);
     }
 
     @Test
@@ -167,7 +177,8 @@ class CookieAuthenticationIntegrationTest extends RealAuthIntegrationTest {
                 .headers(headers -> headers.setBearerAuth(issued.token()))
                 .exchange()
                 .expectStatus()
-                .isForbidden();
+                .isForbidden()
+                .expectBody(Void.class);
     }
 
     @Test
@@ -178,7 +189,8 @@ class CookieAuthenticationIntegrationTest extends RealAuthIntegrationTest {
                 .headers(headers -> headers.setBearerAuth("invalid-token"))
                 .exchange()
                 .expectStatus()
-                .isUnauthorized();
+                .isUnauthorized()
+                .expectBody(Void.class);
     }
 
     @Test
@@ -223,7 +235,8 @@ class CookieAuthenticationIntegrationTest extends RealAuthIntegrationTest {
                 .header(HttpHeaders.COOKIE, cookieName + "=" + issued.token())
                 .exchange()
                 .expectStatus()
-                .isUnauthorized();
+                .isUnauthorized()
+                .expectBody(Void.class);
     }
 
     private record IssuedAccount(String token, long accountId) {}

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/auth/CsrfProtectionIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/auth/CsrfProtectionIntegrationTest.java
@@ -40,7 +40,13 @@ class CsrfProtectionIntegrationTest extends BaseIntegrationTest {
         // No Authorization: Bearer header → treated as a cookie-style browser POST, so CSRF applies.
         // No token → 403 from the CSRF filter (before authentication; the SecurityContext has no
         // authentication yet, so AccessDenied resolves to 403, not the entry-point 401).
-        webTestClient.post().uri("/auth/logout").exchange().expectStatus().isForbidden();
+        webTestClient
+                .post()
+                .uri("/auth/logout")
+                .exchange()
+                .expectStatus()
+                .isForbidden()
+                .expectBody(Void.class);
     }
 
     @Test
@@ -55,7 +61,8 @@ class CsrfProtectionIntegrationTest extends BaseIntegrationTest {
                 .headers(TestAuthUtils.withCsrf(token))
                 .exchange()
                 .expectStatus()
-                .isUnauthorized();
+                .isUnauthorized()
+                .expectBody(Void.class);
     }
 
     @Test
@@ -69,6 +76,7 @@ class CsrfProtectionIntegrationTest extends BaseIntegrationTest {
                 .header(XSRF_HEADER, "totally-different-value")
                 .exchange()
                 .expectStatus()
-                .isForbidden();
+                .isForbidden()
+                .expectBody(Void.class);
     }
 }

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/auth/ImpersonationLifecycleIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/auth/ImpersonationLifecycleIntegrationTest.java
@@ -156,7 +156,8 @@ class ImpersonationLifecycleIntegrationTest extends RealAuthIntegrationTest {
                 .headers(h -> h.setBearerAuth(uncappedImpersonation))
                 .exchange()
                 .expectStatus()
-                .isUnauthorized();
+                .isUnauthorized()
+                .expectBody(Void.class);
 
         assertThat(impersonationEndsFor(target)).isEmpty();
     }

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/auth/SessionRefreshLifecycleIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/auth/SessionRefreshLifecycleIntegrationTest.java
@@ -70,15 +70,15 @@ class SessionRefreshLifecycleIntegrationTest extends RealAuthIntegrationTest {
         String csrf = fetchCsrfToken();
 
         for (int cycle = 1; cycle <= 5; cycle++) {
-            getUser(current).expectStatus().isOk();
+            getUser(current).expectStatus().isOk().expectBody(Void.class);
 
             String rotated = refreshAndReadNewCookie(current, csrf);
 
             assertThat(rotated)
                     .as("cycle %d: refresh must mint a NEW token", cycle)
                     .isNotEqualTo(current);
-            getUser(rotated).expectStatus().isOk();
-            getUser(current).expectStatus().isUnauthorized();
+            getUser(rotated).expectStatus().isOk().expectBody(Void.class);
+            getUser(current).expectStatus().isUnauthorized().expectBody(Void.class);
 
             current = rotated;
         }

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/auth/dev/DevLoginDisabledIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/auth/dev/DevLoginDisabledIntegrationTest.java
@@ -29,7 +29,8 @@ class DevLoginDisabledIntegrationTest extends RealAuthIntegrationTest {
                 .expectStatus()
                 .isForbidden()
                 .expectCookie()
-                .doesNotExist("__Host-HEPHAESTUS_AT");
+                .doesNotExist("__Host-HEPHAESTUS_AT")
+                .expectBody(Void.class);
     }
 
     @Test

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/auth/oauth/ImpersonationGuardIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/auth/oauth/ImpersonationGuardIntegrationTest.java
@@ -54,7 +54,8 @@ class ImpersonationGuardIntegrationTest extends BaseIntegrationTest {
                 .headers(headers -> headers.setBearerAuth(TestSecurityConfig.IMPERSONATION_TOKEN))
                 .exchange()
                 .expectStatus()
-                .value(status -> Assertions.assertThat(status).isNotEqualTo(403));
+                .value(status -> Assertions.assertThat(status).isNotEqualTo(403))
+                .expectBody(Void.class);
     }
 
     @Test
@@ -67,6 +68,7 @@ class ImpersonationGuardIntegrationTest extends BaseIntegrationTest {
                 .headers(headers -> headers.setBearerAuth(TestSecurityConfig.IMPERSONATION_TOKEN))
                 .exchange()
                 .expectStatus()
-                .value(status -> Assertions.assertThat(status).isNotEqualTo(403));
+                .value(status -> Assertions.assertThat(status).isNotEqualTo(403))
+                .expectBody(Void.class);
     }
 }

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/auth/stepup/StepUpGateIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/auth/stepup/StepUpGateIntegrationTest.java
@@ -89,7 +89,8 @@ class StepUpGateIntegrationTest extends RealAuthIntegrationTest {
                 .bodyValue(Map.of("appRole", "APP_ADMIN"))
                 .exchange()
                 .expectStatus()
-                .isForbidden();
+                .isForbidden()
+                .expectBody(Void.class);
 
         assertThat(authEventRepository.findByAccountSince(adminId, Instant.now().minus(Duration.ofMinutes(5))))
                 .singleElement()
@@ -133,7 +134,8 @@ class StepUpGateIntegrationTest extends RealAuthIntegrationTest {
                 .bodyValue(Map.of("appRole", "APP_ADMIN"))
                 .exchange()
                 .expectStatus()
-                .isOk();
+                .isOk()
+                .expectBody(Void.class);
 
         assertThat(accountRepository.findById(victimId))
                 .get()
@@ -152,7 +154,8 @@ class StepUpGateIntegrationTest extends RealAuthIntegrationTest {
                 .headers(h -> h.setBearerAuth(tokenFor(admin, staleSignIn())))
                 .exchange()
                 .expectStatus()
-                .isOk();
+                .isOk()
+                .expectBody(Void.class);
     }
 
     private Instant staleSignIn() {

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/auth/web/AccountAdminRoleIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/auth/web/AccountAdminRoleIntegrationTest.java
@@ -64,7 +64,8 @@ class AccountAdminRoleIntegrationTest extends RealAuthIntegrationTest {
                 .bodyValue(Map.of("appRole", "USER"))
                 .exchange()
                 .expectStatus()
-                .isOk();
+                .isOk()
+                .expectBody(Void.class);
 
         assertThat(accountRepository.findById(persistedId(victim.getId())))
                 .get()
@@ -160,7 +161,8 @@ class AccountAdminRoleIntegrationTest extends RealAuthIntegrationTest {
                 .headers(h -> h.setBearerAuth(tokenFor(user)))
                 .exchange()
                 .expectStatus()
-                .isForbidden();
+                .isForbidden()
+                .expectBody(Void.class);
     }
 
     private Callable<Integer> demote(String token, Long targetId, CountDownLatch ready, CountDownLatch go) {

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/auth/web/AccountUnlinkIdentityIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/auth/web/AccountUnlinkIdentityIntegrationTest.java
@@ -70,7 +70,8 @@ class AccountUnlinkIdentityIntegrationTest extends RealAuthIntegrationTest {
                 .headers(h -> h.setBearerAuth(token))
                 .exchange()
                 .expectStatus()
-                .isNoContent();
+                .isNoContent()
+                .expectBody(Void.class);
 
         // Hard delete: the unlinked row is gone (not soft-disabled), the other identity stays active.
         assertThat(identityLinkRepository.findById(persistedId(github.getId()))).isEmpty();
@@ -92,7 +93,8 @@ class AccountUnlinkIdentityIntegrationTest extends RealAuthIntegrationTest {
                 .headers(h -> h.setBearerAuth(token))
                 .exchange()
                 .expectStatus()
-                .isNoContent();
+                .isNoContent()
+                .expectBody(Void.class);
 
         // The row is gone, so the global (provider, subject) uniqueness is freed and the SAME GitHub
         // identity can be linked again — the promise the disconnect dialog makes. A soft-delete
@@ -143,7 +145,8 @@ class AccountUnlinkIdentityIntegrationTest extends RealAuthIntegrationTest {
                 .headers(h -> h.setBearerAuth(myToken))
                 .exchange()
                 .expectStatus()
-                .isNotFound();
+                .isNotFound()
+                .expectBody(Void.class);
 
         assertThat(identityLinkRepository.findActiveByAccountId(persistedId(other.getId())))
                 .extracting(IdentityLink::getId)
@@ -163,7 +166,8 @@ class AccountUnlinkIdentityIntegrationTest extends RealAuthIntegrationTest {
                 .headers(h -> h.setBearerAuth(token))
                 .exchange()
                 .expectStatus()
-                .isNotFound();
+                .isNotFound()
+                .expectBody(Void.class);
     }
 
     @Test

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/auth/web/AuthAuditControllerIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/auth/web/AuthAuditControllerIntegrationTest.java
@@ -55,7 +55,8 @@ class AuthAuditControllerIntegrationTest extends RealAuthIntegrationTest {
                 .headers(h -> h.setBearerAuth(tokenFor(user)))
                 .exchange()
                 .expectStatus()
-                .isForbidden();
+                .isForbidden()
+                .expectBody(Void.class);
     }
 
     @Test
@@ -337,7 +338,8 @@ class AuthAuditControllerIntegrationTest extends RealAuthIntegrationTest {
                 .headers(h -> h.setBearerAuth(tokenFor(user)))
                 .exchange()
                 .expectStatus()
-                .isForbidden();
+                .isForbidden()
+                .expectBody(Void.class);
     }
 
     private void seedFailure(long id, AuthEvent.EventType type, Instant occurredAt, String failureReason) {

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/auth/web/LoginProviderAdminControllerIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/auth/web/LoginProviderAdminControllerIntegrationTest.java
@@ -38,7 +38,8 @@ class LoginProviderAdminControllerIntegrationTest extends AbstractWorkspaceInteg
                 .headers(TestAuthUtils.withCurrentUser())
                 .exchange()
                 .expectStatus()
-                .isForbidden();
+                .isForbidden()
+                .expectBody(Void.class);
     }
 
     @Test
@@ -54,7 +55,8 @@ class LoginProviderAdminControllerIntegrationTest extends AbstractWorkspaceInteg
                 .bodyValue(Map.of("enabled", false))
                 .exchange()
                 .expectStatus()
-                .isForbidden();
+                .isForbidden()
+                .expectBody(Void.class);
 
         webTestClient
                 .delete()
@@ -62,7 +64,8 @@ class LoginProviderAdminControllerIntegrationTest extends AbstractWorkspaceInteg
                 .headers(TestAuthUtils.withCurrentUser())
                 .exchange()
                 .expectStatus()
-                .isForbidden();
+                .isForbidden()
+                .expectBody(Void.class);
     }
 
     @Test
@@ -128,10 +131,12 @@ class LoginProviderAdminControllerIntegrationTest extends AbstractWorkspaceInteg
     void aRefusedUpdateLeavesNoSuccessOnTheTrail() {
         createGitLabProvider("gitlab-taken", "https://gitlab.taken.test")
                 .expectStatus()
-                .isCreated();
+                .isCreated()
+                .expectBody(Void.class);
         createGitLabProvider("gitlab-mover", "https://gitlab.mover.test")
                 .expectStatus()
-                .isCreated();
+                .isCreated()
+                .expectBody(Void.class);
 
         webTestClient
                 .patch()
@@ -141,7 +146,8 @@ class LoginProviderAdminControllerIntegrationTest extends AbstractWorkspaceInteg
                 .bodyValue(Map.of("baseUrl", "https://gitlab.taken.test"))
                 .exchange()
                 .expectStatus()
-                .is4xxClientError();
+                .is4xxClientError()
+                .expectBody(Void.class);
 
         webTestClient
                 .get()

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/auth/web/SecurityHeadersIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/auth/web/SecurityHeadersIntegrationTest.java
@@ -60,6 +60,7 @@ class SecurityHeadersIntegrationTest extends RealAuthIntegrationTest {
                                 not(containsString("http:"))))
                 // A future accidental re-introduction of reportOnly() must fail this test.
                 .expectHeader()
-                .doesNotExist("Content-Security-Policy-Report-Only");
+                .doesNotExist("Content-Security-Policy-Report-Only")
+                .expectBody(Void.class);
     }
 }

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/configuration/ConfigurationReadinessControllerIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/configuration/ConfigurationReadinessControllerIntegrationTest.java
@@ -22,7 +22,8 @@ class ConfigurationReadinessControllerIntegrationTest extends BaseIntegrationTes
                 .headers(TestAuthUtils.withCurrentUser())
                 .exchange()
                 .expectStatus()
-                .isForbidden();
+                .isForbidden()
+                .expectBody(Void.class);
     }
 
     @Test

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/settings/InstanceSettingsAdminControllerIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/settings/InstanceSettingsAdminControllerIntegrationTest.java
@@ -57,7 +57,8 @@ class InstanceSettingsAdminControllerIntegrationTest extends AbstractWorkspaceIn
                 .headers(TestAuthUtils.withCurrentUser())
                 .exchange()
                 .expectStatus()
-                .isForbidden();
+                .isForbidden()
+                .expectBody(Void.class);
 
         webTestClient
                 .patch()
@@ -67,12 +68,19 @@ class InstanceSettingsAdminControllerIntegrationTest extends AbstractWorkspaceIn
                 .bodyValue(Map.of("engaged", true))
                 .exchange()
                 .expectStatus()
-                .isForbidden();
+                .isForbidden()
+                .expectBody(Void.class);
     }
 
     @Test
     void anonymousIsRejected() {
-        webTestClient.get().uri("/admin/settings").exchange().expectStatus().isUnauthorized();
+        webTestClient
+                .get()
+                .uri("/admin/settings")
+                .exchange()
+                .expectStatus()
+                .isUnauthorized()
+                .expectBody(Void.class);
     }
 
     @Test
@@ -113,7 +121,8 @@ class InstanceSettingsAdminControllerIntegrationTest extends AbstractWorkspaceIn
                 .bodyValue(Map.of("engaged", false))
                 .exchange()
                 .expectStatus()
-                .isEqualTo(412);
+                .isEqualTo(412)
+                .expectBody(Void.class);
 
         assertThat(getSettings().silentModeEngaged()).isTrue();
         assertThat(getSettings().etag()).isEqualTo(engaged.etag());
@@ -130,7 +139,8 @@ class InstanceSettingsAdminControllerIntegrationTest extends AbstractWorkspaceIn
                 .bodyValue(Map.of("engaged", false))
                 .exchange()
                 .expectStatus()
-                .isEqualTo(428);
+                .isEqualTo(428)
+                .expectBody(Void.class);
     }
 
     @Test
@@ -189,7 +199,8 @@ class InstanceSettingsAdminControllerIntegrationTest extends AbstractWorkspaceIn
                 .bodyValue(Map.of("reason", "no engaged flag"))
                 .exchange()
                 .expectStatus()
-                .isBadRequest();
+                .isBadRequest()
+                .expectBody(Void.class);
     }
 
     private InstanceSettingsDTO getSettings() {

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/feature/FeatureFlagControllerIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/feature/FeatureFlagControllerIntegrationTest.java
@@ -28,7 +28,8 @@ class FeatureFlagControllerIntegrationTest extends BaseIntegrationTest {
                     .headers(TestAuthUtils.withCurrentUserOrNone())
                     .exchange()
                     .expectStatus()
-                    .isUnauthorized();
+                    .isUnauthorized()
+                    .expectBody(Void.class);
         }
 
         @Test

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/core/sync/api/SyncControllerIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/core/sync/api/SyncControllerIntegrationTest.java
@@ -177,7 +177,8 @@ class SyncControllerIntegrationTest extends AbstractWorkspaceIntegrationTest {
                 .headers(TestAuthUtils.withCurrentUser())
                 .exchange()
                 .expectStatus()
-                .isNotFound();
+                .isNotFound()
+                .expectBody(Void.class);
     }
 
     @Test
@@ -257,7 +258,10 @@ class SyncControllerIntegrationTest extends AbstractWorkspaceIntegrationTest {
         assertThat(runnerStarted.await(5, TimeUnit.SECONDS)).isTrue();
 
         // Different-type request while the reconciliation holds the one-active slot: genuine conflict, not absorb.
-        triggerRequest(adminToken, SyncJobType.BACKFILL).expectStatus().isEqualTo(HttpStatus.CONFLICT);
+        triggerRequest(adminToken, SyncJobType.BACKFILL)
+                .expectStatus()
+                .isEqualTo(HttpStatus.CONFLICT)
+                .expectBody(Void.class);
 
         release.countDown();
         firstCaller.join(5000);
@@ -276,7 +280,8 @@ class SyncControllerIntegrationTest extends AbstractWorkspaceIntegrationTest {
                 .bodyValue("{}")
                 .exchange()
                 .expectStatus()
-                .isBadRequest();
+                .isBadRequest()
+                .expectBody(Void.class);
     }
 
     @Test
@@ -286,7 +291,10 @@ class SyncControllerIntegrationTest extends AbstractWorkspaceIntegrationTest {
         connection.setState(IntegrationState.SUSPENDED);
         connectionRepository.save(connection);
 
-        triggerRequest(TestAuthUtils.getCurrentUserToken()).expectStatus().isEqualTo(HttpStatus.CONFLICT);
+        triggerRequest(TestAuthUtils.getCurrentUserToken())
+                .expectStatus()
+                .isEqualTo(HttpStatus.CONFLICT)
+                .expectBody(Void.class);
     }
 
     @Test
@@ -336,7 +344,8 @@ class SyncControllerIntegrationTest extends AbstractWorkspaceIntegrationTest {
                 .bodyValue("{\"cancelRequested\":true}")
                 .exchange()
                 .expectStatus()
-                .isEqualTo(HttpStatus.ACCEPTED);
+                .isEqualTo(HttpStatus.ACCEPTED)
+                .expectBody(Void.class);
 
         firstCaller.join(5000);
 
@@ -369,7 +378,8 @@ class SyncControllerIntegrationTest extends AbstractWorkspaceIntegrationTest {
                 .bodyValue("{\"cancelRequested\":false}")
                 .exchange()
                 .expectStatus()
-                .isBadRequest();
+                .isBadRequest()
+                .expectBody(Void.class);
     }
 
     @Test
@@ -404,15 +414,19 @@ class SyncControllerIntegrationTest extends AbstractWorkspaceIntegrationTest {
         User member = persistUser("mentor");
         ensureWorkspaceMembership(workspace, member, WorkspaceRole.MEMBER);
 
-        statusRequest().expectStatus().isForbidden();
+        statusRequest().expectStatus().isForbidden().expectBody(Void.class);
         webTestClient
                 .get()
                 .uri("/workspaces/{slug}/connections/catalog", workspace.getWorkspaceSlug())
                 .headers(TestAuthUtils.withCurrentUser())
                 .exchange()
                 .expectStatus()
-                .isForbidden();
-        triggerRequest(TestAuthUtils.getCurrentUserToken()).expectStatus().isForbidden();
+                .isForbidden()
+                .expectBody(Void.class);
+        triggerRequest(TestAuthUtils.getCurrentUserToken())
+                .expectStatus()
+                .isForbidden()
+                .expectBody(Void.class);
     }
 
     @Test
@@ -432,7 +446,8 @@ class SyncControllerIntegrationTest extends AbstractWorkspaceIntegrationTest {
                 .headers(h -> h.setBearerAuth(adminToken))
                 .exchange()
                 .expectStatus()
-                .isNotFound();
+                .isNotFound()
+                .expectBody(Void.class);
 
         webTestClient
                 .get()
@@ -440,7 +455,8 @@ class SyncControllerIntegrationTest extends AbstractWorkspaceIntegrationTest {
                 .headers(h -> h.setBearerAuth(adminToken))
                 .exchange()
                 .expectStatus()
-                .isNotFound();
+                .isNotFound()
+                .expectBody(Void.class);
 
         webTestClient
                 .get()
@@ -448,7 +464,8 @@ class SyncControllerIntegrationTest extends AbstractWorkspaceIntegrationTest {
                 .headers(h -> h.setBearerAuth(adminToken))
                 .exchange()
                 .expectStatus()
-                .isNotFound();
+                .isNotFound()
+                .expectBody(Void.class);
 
         webTestClient
                 .post()
@@ -457,7 +474,8 @@ class SyncControllerIntegrationTest extends AbstractWorkspaceIntegrationTest {
                 .bodyValue(new TriggerSyncJobRequestDTO(SyncJobType.RECONCILIATION))
                 .exchange()
                 .expectStatus()
-                .isNotFound();
+                .isNotFound()
+                .expectBody(Void.class);
 
         webTestClient
                 .patch()
@@ -471,7 +489,8 @@ class SyncControllerIntegrationTest extends AbstractWorkspaceIntegrationTest {
                 .bodyValue("{\"cancelRequested\":true}")
                 .exchange()
                 .expectStatus()
-                .isNotFound();
+                .isNotFound()
+                .expectBody(Void.class);
 
         // The reach must not have mutated the other tenant's job on the way to the 404.
         assertThat(syncJobRepository.findById(otherJob.getId()).orElseThrow().isCancelRequested())
@@ -499,7 +518,8 @@ class SyncControllerIntegrationTest extends AbstractWorkspaceIntegrationTest {
                 .bodyValue("{\"cancelRequested\":true}")
                 .exchange()
                 .expectStatus()
-                .isNotFound();
+                .isNotFound()
+                .expectBody(Void.class);
 
         assertThat(syncJobRepository.findById(otherJob.getId()).orElseThrow().isCancelRequested())
                 .isFalse();

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/outline/collection/OutlineCollectionAdminControllerIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/outline/collection/OutlineCollectionAdminControllerIntegrationTest.java
@@ -121,8 +121,8 @@ class OutlineCollectionAdminControllerIntegrationTest extends AbstractWorkspaceI
         User mentor = persistUser("mentor");
         ensureWorkspaceMembership(workspace, mentor, WorkspaceRole.MEMBER);
 
-        listRequest().expectStatus().isForbidden();
-        registerRequest(COLLECTION_ID).expectStatus().isForbidden();
+        listRequest().expectStatus().isForbidden().expectBody(Void.class);
+        registerRequest(COLLECTION_ID).expectStatus().isForbidden().expectBody(Void.class);
     }
 
     @Test
@@ -132,15 +132,16 @@ class OutlineCollectionAdminControllerIntegrationTest extends AbstractWorkspaceI
         ensureAdminMembership(workspace);
         connectionRepository.deleteById(connectionId);
 
-        listRequest().expectStatus().isNotFound();
-        registerRequest(COLLECTION_ID).expectStatus().isNotFound();
+        listRequest().expectStatus().isNotFound().expectBody(Void.class);
+        registerRequest(COLLECTION_ID).expectStatus().isNotFound().expectBody(Void.class);
         webTestClient
                 .get()
                 .uri("/workspaces/{slug}/outline/collections/{id}", workspace.getWorkspaceSlug(), COLLECTION_ID)
                 .headers(TestAuthUtils.withCurrentUser())
                 .exchange()
                 .expectStatus()
-                .isNotFound();
+                .isNotFound()
+                .expectBody(Void.class);
         // The unified sync-observability endpoints 404 the same way once the connection row is gone.
         webTestClient
                 .get()
@@ -148,7 +149,8 @@ class OutlineCollectionAdminControllerIntegrationTest extends AbstractWorkspaceI
                 .headers(TestAuthUtils.withCurrentUser())
                 .exchange()
                 .expectStatus()
-                .isNotFound();
+                .isNotFound()
+                .expectBody(Void.class);
         webTestClient
                 .post()
                 .uri("/workspaces/{slug}/connections/{id}/sync/jobs", workspace.getWorkspaceSlug(), connectionId)
@@ -157,7 +159,8 @@ class OutlineCollectionAdminControllerIntegrationTest extends AbstractWorkspaceI
                 .bodyValue(new TriggerSyncJobRequestDTO(SyncJobType.RECONCILIATION))
                 .exchange()
                 .expectStatus()
-                .isNotFound();
+                .isNotFound()
+                .expectBody(Void.class);
     }
 
     @Test
@@ -192,7 +195,7 @@ class OutlineCollectionAdminControllerIntegrationTest extends AbstractWorkspaceI
         assertThat(listed.get(0).collectionId()).isEqualTo(COLLECTION_ID);
 
         // Idempotent repeat: same natural key answers 200, not a duplicate row.
-        registerRequest(COLLECTION_ID).expectStatus().isOk();
+        registerRequest(COLLECTION_ID).expectStatus().isOk().expectBody(Void.class);
         assertThat(collectionRepository.findByWorkspaceIdOrderByCreatedAtAsc(workspace.getId()))
                 .hasSize(1);
     }
@@ -226,7 +229,8 @@ class OutlineCollectionAdminControllerIntegrationTest extends AbstractWorkspaceI
                 .headers(TestAuthUtils.withCurrentUser())
                 .exchange()
                 .expectStatus()
-                .isNotFound();
+                .isNotFound()
+                .expectBody(Void.class);
     }
 
     @Test
@@ -284,7 +288,10 @@ class OutlineCollectionAdminControllerIntegrationTest extends AbstractWorkspaceI
         // meant to sync, rather than racing the not-yet-committed transaction.
         assertThat(stored.getSyncStatus()).isEqualTo(SyncStatus.COMPLETE);
 
-        patchState("no-such-collection", MirrorState.PAUSED).expectStatus().isNotFound();
+        patchState("no-such-collection", MirrorState.PAUSED)
+                .expectStatus()
+                .isNotFound()
+                .expectBody(Void.class);
     }
 
     @Test
@@ -302,7 +309,8 @@ class OutlineCollectionAdminControllerIntegrationTest extends AbstractWorkspaceI
                 .headers(TestAuthUtils.withCurrentUser())
                 .exchange()
                 .expectStatus()
-                .isNoContent();
+                .isNoContent()
+                .expectBody(Void.class);
 
         assertThat(collectionRepository.findByWorkspaceIdAndConnectionIdAndCollectionId(
                         workspace.getId(), connectionId, COLLECTION_ID))
@@ -428,7 +436,8 @@ class OutlineCollectionAdminControllerIntegrationTest extends AbstractWorkspaceI
                 .bodyValue(new TriggerSyncJobRequestDTO(SyncJobType.RECONCILIATION))
                 .exchange()
                 .expectStatus()
-                .isAccepted();
+                .isAccepted()
+                .expectBody(Void.class);
     }
 
     private WebTestClient.ResponseSpec syncStatusRequest() {

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/outline/connect/OutlineConnectionAdminControllerIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/outline/connect/OutlineConnectionAdminControllerIntegrationTest.java
@@ -109,7 +109,7 @@ class OutlineConnectionAdminControllerIntegrationTest extends AbstractWorkspaceI
         User mentor = persistUser("mentor");
         ensureWorkspaceMembership(workspace, mentor, WorkspaceRole.MEMBER);
 
-        tokenRequest().expectStatus().isForbidden();
+        tokenRequest().expectStatus().isForbidden().expectBody(Void.class);
     }
 
     @Test
@@ -118,7 +118,7 @@ class OutlineConnectionAdminControllerIntegrationTest extends AbstractWorkspaceI
     void admin_admitted() {
         ensureAdminMembership(workspace);
 
-        tokenRequest().expectStatus().isOk();
+        tokenRequest().expectStatus().isOk().expectBody(Void.class);
     }
 
     // --- helpers ---

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/slack/channel/SlackChannelAdminControllerIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/slack/channel/SlackChannelAdminControllerIntegrationTest.java
@@ -157,7 +157,10 @@ class SlackChannelAdminControllerIntegrationTest extends AbstractWorkspaceIntegr
         ensureWorkspaceMembership(workspace, mentor, WorkspaceRole.MEMBER);
         seedChannel(workspace.getId(), "C1", ConsentState.PENDING, null);
 
-        patchConsent("C1", ConsentState.ACTIVE, null).expectStatus().isForbidden();
+        patchConsent("C1", ConsentState.ACTIVE, null)
+                .expectStatus()
+                .isForbidden()
+                .expectBody(Void.class);
 
         assertThat(monitoredChannelRepository
                         .findByWorkspaceIdAndSlackChannelId(workspace.getId(), "C1")
@@ -174,7 +177,10 @@ class SlackChannelAdminControllerIntegrationTest extends AbstractWorkspaceIntegr
         ensureAdminMembership(workspace);
         seedChannel(workspace.getId(), "C1", ConsentState.PENDING, null);
 
-        patchConsent("C1", ConsentState.PAUSED, null).expectStatus().isEqualTo(409);
+        patchConsent("C1", ConsentState.PAUSED, null)
+                .expectStatus()
+                .isEqualTo(409)
+                .expectBody(Void.class);
 
         assertThat(consentEventRepository.findByWorkspaceIdAndSlackChannelIdOrderByCreatedAtAscIdAsc(
                         workspace.getId(), "C1"))
@@ -196,7 +202,7 @@ class SlackChannelAdminControllerIntegrationTest extends AbstractWorkspaceIntegr
         UUID observationId = conv.observationId();
         UUID feedbackId = conv.feedbackId();
 
-        patchConsent("C1", ConsentState.REVOKED, null).expectStatus().isOk();
+        patchConsent("C1", ConsentState.REVOKED, null).expectStatus().isOk().expectBody(Void.class);
 
         // Channel flipped to REVOKED (row survives as the terminal record) …
         assertThat(currentState("C1")).isEqualTo(ConsentState.REVOKED);
@@ -223,10 +229,11 @@ class SlackChannelAdminControllerIntegrationTest extends AbstractWorkspaceIntegr
         ensureAdminMembership(workspace);
         seedChannel(workspace.getId(), "C1", ConsentState.PENDING, null);
 
-        patchConsent("C1", ConsentState.ACTIVE, "go").expectStatus().isOk();
+        patchConsent("C1", ConsentState.ACTIVE, "go").expectStatus().isOk().expectBody(Void.class);
         patchConsent("C1", ConsentState.PAUSED, "pause for review")
                 .expectStatus()
-                .isOk();
+                .isOk()
+                .expectBody(Void.class);
 
         List<SlackChannelConsentEventDTO> events = webTestClient
                 .get()
@@ -260,7 +267,10 @@ class SlackChannelAdminControllerIntegrationTest extends AbstractWorkspaceIntegr
         seedChannel(other.getId(), "C-OTHER", ConsentState.PENDING, null);
 
         // Reaching the other workspace's channel through THIS workspace's URL resolves to nothing → 404.
-        patchConsent("C-OTHER", ConsentState.ACTIVE, null).expectStatus().isNotFound();
+        patchConsent("C-OTHER", ConsentState.ACTIVE, null)
+                .expectStatus()
+                .isNotFound()
+                .expectBody(Void.class);
 
         webTestClient
                 .get()
@@ -268,7 +278,8 @@ class SlackChannelAdminControllerIntegrationTest extends AbstractWorkspaceIntegr
                 .headers(TestAuthUtils.withCurrentUser())
                 .exchange()
                 .expectStatus()
-                .isNotFound();
+                .isNotFound()
+                .expectBody(Void.class);
 
         // The other workspace's channel is untouched.
         assertThat(monitoredChannelRepository

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/practices/PracticeCatalogControllerIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/practices/PracticeCatalogControllerIntegrationTest.java
@@ -300,7 +300,8 @@ class PracticeCatalogControllerIntegrationTest extends AbstractWorkspaceIntegrat
                     .headers(TestAuthUtils.withCurrentUser())
                     .exchange()
                     .expectStatus()
-                    .isForbidden();
+                    .isForbidden()
+                    .expectBody(Void.class);
         }
 
         @Test
@@ -311,7 +312,8 @@ class PracticeCatalogControllerIntegrationTest extends AbstractWorkspaceIntegrat
                     .uri(BASE_URI, workspace.getWorkspaceSlug())
                     .exchange()
                     .expectStatus()
-                    .isUnauthorized();
+                    .isUnauthorized()
+                    .expectBody(Void.class);
         }
     }
 
@@ -361,7 +363,8 @@ class PracticeCatalogControllerIntegrationTest extends AbstractWorkspaceIntegrat
                     .headers(TestAuthUtils.withCurrentUser())
                     .exchange()
                     .expectStatus()
-                    .isForbidden();
+                    .isForbidden()
+                    .expectBody(Void.class);
         }
 
         @Test
@@ -393,7 +396,8 @@ class PracticeCatalogControllerIntegrationTest extends AbstractWorkspaceIntegrat
                     .uri(BASE_URI + "/{slug}", workspace.getWorkspaceSlug(), "any-slug")
                     .exchange()
                     .expectStatus()
-                    .isUnauthorized();
+                    .isUnauthorized()
+                    .expectBody(Void.class);
         }
     }
 
@@ -562,7 +566,8 @@ class PracticeCatalogControllerIntegrationTest extends AbstractWorkspaceIntegrat
                     .bodyValue(inGroup(validCreateRequest("scoped-practice"), "foreign-group"))
                     .exchange()
                     .expectStatus()
-                    .isNotFound();
+                    .isNotFound()
+                    .expectBody(Void.class);
 
             assertThat(practiceRepository.findByWorkspaceIdAndSlug(workspace.getId(), "scoped-practice"))
                     .isEmpty();
@@ -865,7 +870,8 @@ class PracticeCatalogControllerIntegrationTest extends AbstractWorkspaceIntegrat
                     .bodyValue(request)
                     .exchange()
                     .expectStatus()
-                    .isBadRequest();
+                    .isBadRequest()
+                    .expectBody(Void.class);
         }
 
         @Test
@@ -892,7 +898,8 @@ class PracticeCatalogControllerIntegrationTest extends AbstractWorkspaceIntegrat
                     .bodyValue(request)
                     .exchange()
                     .expectStatus()
-                    .isBadRequest();
+                    .isBadRequest()
+                    .expectBody(Void.class);
         }
 
         @Test
@@ -909,7 +916,8 @@ class PracticeCatalogControllerIntegrationTest extends AbstractWorkspaceIntegrat
                     .bodyValue(validCreateRequest("forbidden-practice"))
                     .exchange()
                     .expectStatus()
-                    .isForbidden();
+                    .isForbidden()
+                    .expectBody(Void.class);
         }
 
         @Test
@@ -922,7 +930,8 @@ class PracticeCatalogControllerIntegrationTest extends AbstractWorkspaceIntegrat
                     .bodyValue(validCreateRequest("anon-practice"))
                     .exchange()
                     .expectStatus()
-                    .isForbidden();
+                    .isForbidden()
+                    .expectBody(Void.class);
         }
     }
 
@@ -1113,7 +1122,8 @@ class PracticeCatalogControllerIntegrationTest extends AbstractWorkspaceIntegrat
                     .bodyValue(request)
                     .exchange()
                     .expectStatus()
-                    .isNotFound();
+                    .isNotFound()
+                    .expectBody(Void.class);
 
             Practice persisted = practiceRepository
                     .findByWorkspaceIdAndSlug(workspace.getId(), "atomic-update")
@@ -1212,7 +1222,8 @@ class PracticeCatalogControllerIntegrationTest extends AbstractWorkspaceIntegrat
                     .bodyValue(request)
                     .exchange()
                     .expectStatus()
-                    .isNotFound();
+                    .isNotFound()
+                    .expectBody(Void.class);
         }
 
         @Test
@@ -1330,7 +1341,8 @@ class PracticeCatalogControllerIntegrationTest extends AbstractWorkspaceIntegrat
                     .bodyValue(request)
                     .exchange()
                     .expectStatus()
-                    .isBadRequest();
+                    .isBadRequest()
+                    .expectBody(Void.class);
         }
 
         @Test
@@ -1350,7 +1362,8 @@ class PracticeCatalogControllerIntegrationTest extends AbstractWorkspaceIntegrat
                     .bodyValue(request)
                     .exchange()
                     .expectStatus()
-                    .isForbidden();
+                    .isForbidden()
+                    .expectBody(Void.class);
         }
 
         @Test
@@ -1366,7 +1379,8 @@ class PracticeCatalogControllerIntegrationTest extends AbstractWorkspaceIntegrat
                     .bodyValue(request)
                     .exchange()
                     .expectStatus()
-                    .isUnauthorized();
+                    .isUnauthorized()
+                    .expectBody(Void.class);
         }
     }
 
@@ -1521,7 +1535,8 @@ class PracticeCatalogControllerIntegrationTest extends AbstractWorkspaceIntegrat
 
             place("protected", new PlacePracticeRequestDTO(null, 0))
                     .expectStatus()
-                    .isForbidden();
+                    .isForbidden()
+                    .expectBody(Void.class);
         }
 
         @Test
@@ -1534,11 +1549,16 @@ class PracticeCatalogControllerIntegrationTest extends AbstractWorkspaceIntegrat
 
             place("alpha", new PlacePracticeRequestDTO("group", 2))
                     .expectStatus()
-                    .isBadRequest();
+                    .isBadRequest()
+                    .expectBody(Void.class);
             place("alpha", new PlacePracticeRequestDTO("missing", 0))
                     .expectStatus()
-                    .isNotFound();
-            place("alpha", "{\"groupSlug\":\"group\"}").expectStatus().isBadRequest();
+                    .isNotFound()
+                    .expectBody(Void.class);
+            place("alpha", "{\"groupSlug\":\"group\"}")
+                    .expectStatus()
+                    .isBadRequest()
+                    .expectBody(Void.class);
 
             List<Practice> persisted = practiceRepository.findByWorkspaceIdAndGroupIdOrderByDisplayOrderAscNameAsc(
                     workspace.getId(), group.getId());
@@ -1623,7 +1643,8 @@ class PracticeCatalogControllerIntegrationTest extends AbstractWorkspaceIntegrat
                     .bodyValue(new UpdatePracticeAutonomyRequestDTO(PracticeAutonomy.AUTOMATIC))
                     .exchange()
                     .expectStatus()
-                    .isBadRequest();
+                    .isBadRequest()
+                    .expectBody(Void.class);
         }
 
         @Test
@@ -1664,7 +1685,8 @@ class PracticeCatalogControllerIntegrationTest extends AbstractWorkspaceIntegrat
                     .bodyValue(new UpdatePracticeAutonomyRequestDTO(PracticeAutonomy.OFF))
                     .exchange()
                     .expectStatus()
-                    .isNotFound();
+                    .isNotFound()
+                    .expectBody(Void.class);
         }
 
         @Test
@@ -1682,7 +1704,8 @@ class PracticeCatalogControllerIntegrationTest extends AbstractWorkspaceIntegrat
                     .bodyValue(new UpdatePracticeAutonomyRequestDTO(PracticeAutonomy.OFF))
                     .exchange()
                     .expectStatus()
-                    .isForbidden();
+                    .isForbidden()
+                    .expectBody(Void.class);
         }
 
         /**
@@ -1737,7 +1760,8 @@ class PracticeCatalogControllerIntegrationTest extends AbstractWorkspaceIntegrat
                     .bodyValue(new UpdatePracticeAutonomyRequestDTO(PracticeAutonomy.OFF))
                     .exchange()
                     .expectStatus()
-                    .isUnauthorized();
+                    .isUnauthorized()
+                    .expectBody(Void.class);
         }
     }
 
@@ -1757,7 +1781,8 @@ class PracticeCatalogControllerIntegrationTest extends AbstractWorkspaceIntegrat
                     .headers(TestAuthUtils.withCurrentUser())
                     .exchange()
                     .expectStatus()
-                    .isNoContent();
+                    .isNoContent()
+                    .expectBody(Void.class);
 
             Optional<Practice> persisted = practiceRepository.findByWorkspaceIdAndSlug(workspace.getId(), "to-delete");
             assertThat(persisted).isEmpty();
@@ -1775,7 +1800,8 @@ class PracticeCatalogControllerIntegrationTest extends AbstractWorkspaceIntegrat
                     .headers(TestAuthUtils.withCurrentUser())
                     .exchange()
                     .expectStatus()
-                    .isNotFound();
+                    .isNotFound()
+                    .expectBody(Void.class);
         }
 
         @Test
@@ -1791,7 +1817,8 @@ class PracticeCatalogControllerIntegrationTest extends AbstractWorkspaceIntegrat
                     .headers(TestAuthUtils.withCurrentUser())
                     .exchange()
                     .expectStatus()
-                    .isForbidden();
+                    .isForbidden()
+                    .expectBody(Void.class);
         }
 
         @Test
@@ -1803,7 +1830,8 @@ class PracticeCatalogControllerIntegrationTest extends AbstractWorkspaceIntegrat
                     .headers(withCsrfForAnonymousWrite())
                     .exchange()
                     .expectStatus()
-                    .isUnauthorized();
+                    .isUnauthorized()
+                    .expectBody(Void.class);
         }
     }
 
@@ -1836,7 +1864,8 @@ class PracticeCatalogControllerIntegrationTest extends AbstractWorkspaceIntegrat
                     .headers(TestAuthUtils.withCurrentUser())
                     .exchange()
                     .expectStatus()
-                    .isOk();
+                    .isOk()
+                    .expectBody(Void.class);
 
             webTestClient
                     .get()
@@ -1844,7 +1873,8 @@ class PracticeCatalogControllerIntegrationTest extends AbstractWorkspaceIntegrat
                     .headers(TestAuthUtils.withCurrentUser())
                     .exchange()
                     .expectStatus()
-                    .isNotFound();
+                    .isNotFound()
+                    .expectBody(Void.class);
         }
 
         @Test
@@ -1897,7 +1927,8 @@ class PracticeCatalogControllerIntegrationTest extends AbstractWorkspaceIntegrat
                     .bodyValue(validCreateRequest("shared-slug"))
                     .exchange()
                     .expectStatus()
-                    .isCreated();
+                    .isCreated()
+                    .expectBody(Void.class);
 
             webTestClient
                     .post()
@@ -1907,7 +1938,8 @@ class PracticeCatalogControllerIntegrationTest extends AbstractWorkspaceIntegrat
                     .bodyValue(validCreateRequest("shared-slug"))
                     .exchange()
                     .expectStatus()
-                    .isCreated();
+                    .isCreated()
+                    .expectBody(Void.class);
         }
 
         @Test
@@ -1940,7 +1972,8 @@ class PracticeCatalogControllerIntegrationTest extends AbstractWorkspaceIntegrat
                     .bodyValue(request)
                     .exchange()
                     .expectStatus()
-                    .isNotFound();
+                    .isNotFound()
+                    .expectBody(Void.class);
         }
     }
 
@@ -1973,7 +2006,8 @@ class PracticeCatalogControllerIntegrationTest extends AbstractWorkspaceIntegrat
                     .bodyValue(validCreateRequest("versioned-practice"))
                     .exchange()
                     .expectStatus()
-                    .isCreated();
+                    .isCreated()
+                    .expectBody(Void.class);
 
             List<PracticeRevision> revisions = revisionsFor("versioned-practice");
             assertThat(revisions).hasSize(1);
@@ -2004,7 +2038,8 @@ class PracticeCatalogControllerIntegrationTest extends AbstractWorkspaceIntegrat
                     .bodyValue(validCreateRequest("evolving-practice"))
                     .exchange()
                     .expectStatus()
-                    .isCreated();
+                    .isCreated()
+                    .expectBody(Void.class);
 
             var request = new UpdatePracticeRequestDTO(
                     null, null, "A revised detection rubric", null, null, null, null, null, null);
@@ -2017,7 +2052,8 @@ class PracticeCatalogControllerIntegrationTest extends AbstractWorkspaceIntegrat
                     .bodyValue(request)
                     .exchange()
                     .expectStatus()
-                    .isOk();
+                    .isOk()
+                    .expectBody(Void.class);
 
             List<PracticeRevision> revisions = revisionsFor("evolving-practice");
             assertThat(revisions).hasSize(2);
@@ -2042,7 +2078,8 @@ class PracticeCatalogControllerIntegrationTest extends AbstractWorkspaceIntegrat
                     .bodyValue(validCreateRequest("stable-practice"))
                     .exchange()
                     .expectStatus()
-                    .isCreated();
+                    .isCreated()
+                    .expectBody(Void.class);
 
             var request =
                     new UpdatePracticeRequestDTO("Renamed Practice", null, null, null, null, null, null, null, null);
@@ -2055,7 +2092,8 @@ class PracticeCatalogControllerIntegrationTest extends AbstractWorkspaceIntegrat
                     .bodyValue(request)
                     .exchange()
                     .expectStatus()
-                    .isOk();
+                    .isOk()
+                    .expectBody(Void.class);
 
             List<PracticeRevision> revisions = revisionsFor("stable-practice");
             assertThat(revisions).hasSize(2);
@@ -2081,7 +2119,8 @@ class PracticeCatalogControllerIntegrationTest extends AbstractWorkspaceIntegrat
                     .bodyValue(validCreateRequest("noop-criteria-practice"))
                     .exchange()
                     .expectStatus()
-                    .isCreated();
+                    .isCreated()
+                    .expectBody(Void.class);
 
             var request = new UpdatePracticeRequestDTO(
                     null, null, "Detect if the PR follows best practices", null, null, null, null, null, null);
@@ -2094,7 +2133,8 @@ class PracticeCatalogControllerIntegrationTest extends AbstractWorkspaceIntegrat
                     .bodyValue(request)
                     .exchange()
                     .expectStatus()
-                    .isOk();
+                    .isOk()
+                    .expectBody(Void.class);
 
             assertThat(revisionsFor("noop-criteria-practice")).hasSize(1);
         }
@@ -2227,7 +2267,8 @@ class PracticeCatalogControllerIntegrationTest extends AbstractWorkspaceIntegrat
                     .bodyValue(request)
                     .exchange()
                     .expectStatus()
-                    .isBadRequest();
+                    .isBadRequest()
+                    .expectBody(Void.class);
 
             assertThat(practiceRepository.findByWorkspaceIdAndSlug(workspace.getId(), "two-minds"))
                     .isEmpty();
@@ -2298,7 +2339,8 @@ class PracticeCatalogControllerIntegrationTest extends AbstractWorkspaceIntegrat
                     .bodyValue(request)
                     .exchange()
                     .expectStatus()
-                    .isCreated();
+                    .isCreated()
+                    .expectBody(Void.class);
 
             String rawJson = webTestClient
                     .get()
@@ -2378,7 +2420,8 @@ class PracticeCatalogControllerIntegrationTest extends AbstractWorkspaceIntegrat
                     .bodyValue(createWithExemplar("guard-assessment", "Flagged GOOD, BAD, or ABSENT by the detector."))
                     .exchange()
                     .expectStatus()
-                    .isBadRequest();
+                    .isBadRequest()
+                    .expectBody(Void.class);
         }
 
         @Test
@@ -2406,7 +2449,8 @@ class PracticeCatalogControllerIntegrationTest extends AbstractWorkspaceIntegrat
                     .bodyValue(dto)
                     .exchange()
                     .expectStatus()
-                    .isBadRequest();
+                    .isBadRequest()
+                    .expectBody(Void.class);
             assertThat(practiceRepository.findByWorkspaceIdAndSlug(workspace.getId(), "guard-why"))
                     .isEmpty();
         }
@@ -2425,7 +2469,8 @@ class PracticeCatalogControllerIntegrationTest extends AbstractWorkspaceIntegrat
                     .bodyValue(createWithExemplar("guard-not-applicable", "Marked NOT_APPLICABLE here."))
                     .exchange()
                     .expectStatus()
-                    .isBadRequest();
+                    .isBadRequest()
+                    .expectBody(Void.class);
         }
 
         @Test
@@ -2446,7 +2491,8 @@ class PracticeCatalogControllerIntegrationTest extends AbstractWorkspaceIntegrat
                     .bodyValue(request)
                     .exchange()
                     .expectStatus()
-                    .isBadRequest();
+                    .isBadRequest()
+                    .expectBody(Void.class);
         }
 
         @Test

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/practices/PracticeGroupControllerIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/practices/PracticeGroupControllerIntegrationTest.java
@@ -140,7 +140,8 @@ class PracticeGroupControllerIntegrationTest extends AbstractWorkspaceIntegratio
                     .uri(BASE_URI, workspace.getWorkspaceSlug())
                     .exchange()
                     .expectStatus()
-                    .isUnauthorized();
+                    .isUnauthorized()
+                    .expectBody(Void.class);
         }
     }
 
@@ -177,7 +178,8 @@ class PracticeGroupControllerIntegrationTest extends AbstractWorkspaceIntegratio
                     .uri(BASE_URI + "/{groupSlug}", workspace.getWorkspaceSlug(), "any-slug")
                     .exchange()
                     .expectStatus()
-                    .isUnauthorized();
+                    .isUnauthorized()
+                    .expectBody(Void.class);
         }
     }
 
@@ -201,7 +203,8 @@ class PracticeGroupControllerIntegrationTest extends AbstractWorkspaceIntegratio
                     .bodyValue(validCreateRequest("forbidden-group"))
                     .exchange()
                     .expectStatus()
-                    .isForbidden();
+                    .isForbidden()
+                    .expectBody(Void.class);
 
             assertThat(groupRepository.existsByWorkspaceIdAndSlug(workspace.getId(), "forbidden-group"))
                     .isFalse();
@@ -219,7 +222,8 @@ class PracticeGroupControllerIntegrationTest extends AbstractWorkspaceIntegratio
                     .bodyValue(validCreateRequest("anon-group"))
                     .exchange()
                     .expectStatus()
-                    .isForbidden();
+                    .isForbidden()
+                    .expectBody(Void.class);
         }
     }
 
@@ -246,7 +250,8 @@ class PracticeGroupControllerIntegrationTest extends AbstractWorkspaceIntegratio
                     .bodyValue(request)
                     .exchange()
                     .expectStatus()
-                    .isForbidden();
+                    .isForbidden()
+                    .expectBody(Void.class);
 
             PracticeGroup persisted = groupRepository
                     .findByWorkspaceIdAndSlug(workspace.getId(), "forbidden-update")
@@ -269,7 +274,8 @@ class PracticeGroupControllerIntegrationTest extends AbstractWorkspaceIntegratio
                     .bodyValue(request)
                     .exchange()
                     .expectStatus()
-                    .isUnauthorized();
+                    .isUnauthorized()
+                    .expectBody(Void.class);
         }
     }
 
@@ -334,7 +340,8 @@ class PracticeGroupControllerIntegrationTest extends AbstractWorkspaceIntegratio
                     .bodyValue(request)
                     .exchange()
                     .expectStatus()
-                    .isForbidden();
+                    .isForbidden()
+                    .expectBody(Void.class);
         }
 
         @Test
@@ -352,7 +359,8 @@ class PracticeGroupControllerIntegrationTest extends AbstractWorkspaceIntegratio
                     .bodyValue(request)
                     .exchange()
                     .expectStatus()
-                    .isUnauthorized();
+                    .isUnauthorized()
+                    .expectBody(Void.class);
         }
     }
 
@@ -377,7 +385,8 @@ class PracticeGroupControllerIntegrationTest extends AbstractWorkspaceIntegratio
                     .bodyValue(validCreateRequest("dup"))
                     .exchange()
                     .expectStatus()
-                    .isEqualTo(409);
+                    .isEqualTo(409)
+                    .expectBody(Void.class);
         }
 
         @Test
@@ -392,7 +401,8 @@ class PracticeGroupControllerIntegrationTest extends AbstractWorkspaceIntegratio
                     .headers(TestAuthUtils.withCurrentUser())
                     .exchange()
                     .expectStatus()
-                    .isNotFound();
+                    .isNotFound()
+                    .expectBody(Void.class);
         }
 
         @Test
@@ -410,7 +420,8 @@ class PracticeGroupControllerIntegrationTest extends AbstractWorkspaceIntegratio
                     .bodyValue(request)
                     .exchange()
                     .expectStatus()
-                    .isNotFound();
+                    .isNotFound()
+                    .expectBody(Void.class);
         }
 
         @Test
@@ -425,7 +436,8 @@ class PracticeGroupControllerIntegrationTest extends AbstractWorkspaceIntegratio
                     .headers(TestAuthUtils.withCurrentUser())
                     .exchange()
                     .expectStatus()
-                    .isNotFound();
+                    .isNotFound()
+                    .expectBody(Void.class);
         }
 
         @Test
@@ -445,7 +457,8 @@ class PracticeGroupControllerIntegrationTest extends AbstractWorkspaceIntegratio
                     .bodyValue(request)
                     .exchange()
                     .expectStatus()
-                    .isBadRequest();
+                    .isBadRequest()
+                    .expectBody(Void.class);
         }
 
         @Test
@@ -465,7 +478,8 @@ class PracticeGroupControllerIntegrationTest extends AbstractWorkspaceIntegratio
                     .bodyValue(request)
                     .exchange()
                     .expectStatus()
-                    .isNotFound();
+                    .isNotFound()
+                    .expectBody(Void.class);
         }
 
         @Test
@@ -490,7 +504,8 @@ class PracticeGroupControllerIntegrationTest extends AbstractWorkspaceIntegratio
                     .headers(TestAuthUtils.withCurrentUser())
                     .exchange()
                     .expectStatus()
-                    .isNotFound();
+                    .isNotFound()
+                    .expectBody(Void.class);
         }
     }
 
@@ -513,7 +528,8 @@ class PracticeGroupControllerIntegrationTest extends AbstractWorkspaceIntegratio
                     .headers(TestAuthUtils.withCurrentUser())
                     .exchange()
                     .expectStatus()
-                    .isForbidden();
+                    .isForbidden()
+                    .expectBody(Void.class);
 
             assertThat(groupRepository.existsByWorkspaceIdAndSlug(workspace.getId(), "forbidden-delete"))
                     .isTrue();
@@ -530,7 +546,8 @@ class PracticeGroupControllerIntegrationTest extends AbstractWorkspaceIntegratio
                     .headers(TestAuthUtils.withCsrf(csrf))
                     .exchange()
                     .expectStatus()
-                    .isUnauthorized();
+                    .isUnauthorized()
+                    .expectBody(Void.class);
         }
     }
 
@@ -732,7 +749,8 @@ class PracticeGroupControllerIntegrationTest extends AbstractWorkspaceIntegratio
                     .bodyValue(new UpdatePracticeAutonomyRequestDTO(PracticeAutonomy.OFF))
                     .exchange()
                     .expectStatus()
-                    .isOk();
+                    .isOk()
+                    .expectBody(Void.class);
 
             assertThat(auditedChangesTo(group)).isEqualTo(auditedBefore + 1);
         }
@@ -751,7 +769,8 @@ class PracticeGroupControllerIntegrationTest extends AbstractWorkspaceIntegratio
                     .bodyValue(new UpdatePracticeAutonomyRequestDTO(PracticeAutonomy.OFF))
                     .exchange()
                     .expectStatus()
-                    .isNotFound();
+                    .isNotFound()
+                    .expectBody(Void.class);
         }
 
         @Test
@@ -769,7 +788,8 @@ class PracticeGroupControllerIntegrationTest extends AbstractWorkspaceIntegratio
                     .bodyValue(new UpdatePracticeAutonomyRequestDTO(PracticeAutonomy.OFF))
                     .exchange()
                     .expectStatus()
-                    .isForbidden();
+                    .isForbidden()
+                    .expectBody(Void.class);
 
             assertThat(storedTierOf("forbidden-autonomy")).isEqualTo(PracticeAutonomy.AUTOMATIC);
         }
@@ -786,7 +806,8 @@ class PracticeGroupControllerIntegrationTest extends AbstractWorkspaceIntegratio
                     .bodyValue(new UpdatePracticeAutonomyRequestDTO(PracticeAutonomy.OFF))
                     .exchange()
                     .expectStatus()
-                    .isUnauthorized();
+                    .isUnauthorized()
+                    .expectBody(Void.class);
         }
     }
 }

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/practices/PracticeGroupStandingIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/practices/PracticeGroupStandingIntegrationTest.java
@@ -903,7 +903,8 @@ class PracticeGroupStandingIntegrationTest extends AbstractWorkspaceIntegrationT
                     .uri(STANDINGS_URI, workspace.getWorkspaceSlug())
                     .exchange()
                     .expectStatus()
-                    .isUnauthorized();
+                    .isUnauthorized()
+                    .expectBody(Void.class);
         }
     }
 }

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/practices/curated/CuratedCatalogAdminControllerIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/practices/curated/CuratedCatalogAdminControllerIntegrationTest.java
@@ -127,7 +127,10 @@ class CuratedCatalogAdminControllerIntegrationTest extends AbstractWorkspaceInte
 
     @Test
     void theShippedDefinitionIsAlwaysThereToCompareAgainstBeforeTakingIt() {
-        putPractice(etagOf(getPractice()), "Our own criteria").expectStatus().isOk();
+        putPractice(etagOf(getPractice()), "Our own criteria")
+                .expectStatus()
+                .isOk()
+                .expectBody(Void.class);
 
         CuratedPracticeDTO edited = getPractice();
 
@@ -161,14 +164,18 @@ class CuratedCatalogAdminControllerIntegrationTest extends AbstractWorkspaceInte
                 .bodyValue(body)
                 .exchange()
                 .expectStatus()
-                .isOk();
+                .isOk()
+                .expectBody(Void.class);
 
         assertThat(getPractice().status().changeKind()).isEqualTo(CatalogChangeKind.WORDING);
     }
 
     @Test
     void usingTheHephaestusVersionRemovesTheStoredEditEntirely() {
-        putPractice(etagOf(getPractice()), "Our own criteria").expectStatus().isOk();
+        putPractice(etagOf(getPractice()), "Our own criteria")
+                .expectStatus()
+                .isOk()
+                .expectBody(Void.class);
         assertThat(overrideRows()).isOne();
 
         webTestClient
@@ -191,7 +198,7 @@ class CuratedCatalogAdminControllerIntegrationTest extends AbstractWorkspaceInte
     @Test
     void savingTheShippedDefinitionStopsOverridingIt() {
         CuratedPracticeDTO original = getPractice();
-        putPractice(etagOf(original), "Our own criteria").expectStatus().isOk();
+        putPractice(etagOf(original), "Our own criteria").expectStatus().isOk().expectBody(Void.class);
         CuratedPracticeDTO edited = getPractice();
         assertThat(edited.shipped()).isNotNull();
 
@@ -220,7 +227,7 @@ class CuratedCatalogAdminControllerIntegrationTest extends AbstractWorkspaceInte
     @Test
     void refusesAnEditBasedOnAVersionSomebodyElseHasMovedOn() {
         String stale = etagOf(getPractice());
-        putPractice(stale, "Our own criteria").expectStatus().isOk();
+        putPractice(stale, "Our own criteria").expectStatus().isOk().expectBody(Void.class);
 
         putPractice(stale, "Someone else's criteria")
                 .expectStatus()
@@ -240,13 +247,17 @@ class CuratedCatalogAdminControllerIntegrationTest extends AbstractWorkspaceInte
                 .bodyValue(definitionOf(getPractice(), "Our own criteria"))
                 .exchange()
                 .expectStatus()
-                .isEqualTo(428);
+                .isEqualTo(428)
+                .expectBody(Void.class);
     }
 
     @Test
     void guardsTheFirstEditOfAnEntryNobodyHasTouched() {
         assertThat(overrideRows()).isZero();
-        putPractice("\"nonsense\"", "Our own criteria").expectStatus().isEqualTo(412);
+        putPractice("\"nonsense\"", "Our own criteria")
+                .expectStatus()
+                .isEqualTo(412)
+                .expectBody(Void.class);
     }
 
     @Test
@@ -263,7 +274,8 @@ class CuratedCatalogAdminControllerIntegrationTest extends AbstractWorkspaceInte
                 .bodyValue(new UpdateCuratedStatusRequestDTO(CuratedStatus.RETIRED))
                 .exchange()
                 .expectStatus()
-                .isOk();
+                .isOk()
+                .expectBody(Void.class);
 
         CuratedCatalogDTO catalog = getCatalog();
         webTestClient
@@ -277,7 +289,8 @@ class CuratedCatalogAdminControllerIntegrationTest extends AbstractWorkspaceInte
                 .bodyValue(new UpdateCuratedStatusRequestDTO(CuratedStatus.RETIRED))
                 .exchange()
                 .expectStatus()
-                .isOk();
+                .isOk()
+                .expectBody(Void.class);
 
         webTestClient
                 .put()
@@ -288,7 +301,8 @@ class CuratedCatalogAdminControllerIntegrationTest extends AbstractWorkspaceInte
                 })
                 .exchange()
                 .expectStatus()
-                .isOk();
+                .isOk()
+                .expectBody(Void.class);
         webTestClient
                 .put()
                 .uri(CATALOG + "/groups/" + GROUP + "/override/acknowledgement")
@@ -298,7 +312,8 @@ class CuratedCatalogAdminControllerIntegrationTest extends AbstractWorkspaceInte
                 })
                 .exchange()
                 .expectStatus()
-                .isOk();
+                .isOk()
+                .expectBody(Void.class);
 
         assertThat(jdbcTemplate.queryForObject(
                         "SELECT count(*) FROM curated_practice_override WHERE slug = ? AND based_on_digest IS NULL",
@@ -550,7 +565,8 @@ class CuratedCatalogAdminControllerIntegrationTest extends AbstractWorkspaceInte
                 .headers(TestAuthUtils.withCurrentUser())
                 .exchange()
                 .expectStatus()
-                .isNotFound();
+                .isNotFound()
+                .expectBody(Void.class);
     }
 
     @Test
@@ -574,7 +590,8 @@ class CuratedCatalogAdminControllerIntegrationTest extends AbstractWorkspaceInte
                 .bodyValue(new PlacePracticeRequestDTO(destinationGroup, 0))
                 .exchange()
                 .expectStatus()
-                .isOk();
+                .isOk()
+                .expectBody(Void.class);
 
         webTestClient
                 .patch()
@@ -587,7 +604,8 @@ class CuratedCatalogAdminControllerIntegrationTest extends AbstractWorkspaceInte
                 .bodyValue(new UpdateCuratedStatusRequestDTO(CuratedStatus.RETIRED))
                 .exchange()
                 .expectStatus()
-                .isEqualTo(412);
+                .isEqualTo(412)
+                .expectBody(Void.class);
     }
 
     @Test
@@ -657,7 +675,8 @@ class CuratedCatalogAdminControllerIntegrationTest extends AbstractWorkspaceInte
                 .bodyValue(new CreateCuratedPracticeRequestDTO(practiceSlug, definitionOf(template, "Saved criteria")))
                 .exchange()
                 .expectStatus()
-                .isCreated();
+                .isCreated()
+                .expectBody(Void.class);
 
         String groupSlug = "removed-group";
         webTestClient
@@ -669,7 +688,8 @@ class CuratedCatalogAdminControllerIntegrationTest extends AbstractWorkspaceInte
                         groupSlug, new CuratedGroupRequestDTO("Removed group", "Saved description", "Folder", "slate")))
                 .exchange()
                 .expectStatus()
-                .isCreated();
+                .isCreated()
+                .expectBody(Void.class);
 
         jdbcTemplate.update(
                 "UPDATE curated_practice_override SET based_on_digest = repeat('a', 64) WHERE slug = ?", practiceSlug);
@@ -690,7 +710,8 @@ class CuratedCatalogAdminControllerIntegrationTest extends AbstractWorkspaceInte
                 })
                 .exchange()
                 .expectStatus()
-                .isEqualTo(412);
+                .isEqualTo(412)
+                .expectBody(Void.class);
 
         webTestClient
                 .put()
@@ -748,7 +769,8 @@ class CuratedCatalogAdminControllerIntegrationTest extends AbstractWorkspaceInte
                         "house-rules", new CuratedGroupRequestDTO("House rules", "Ours alone", "Scale", "amber")))
                 .exchange()
                 .expectStatus()
-                .isCreated();
+                .isCreated()
+                .expectBody(Void.class);
 
         CuratedCatalogDTO afterGroup = getCatalog();
         assertThat(afterGroup.groups())
@@ -780,7 +802,8 @@ class CuratedCatalogAdminControllerIntegrationTest extends AbstractWorkspaceInte
                         new CreateCuratedPracticeRequestDTO("house-practice", definitionOf(template, "House criteria")))
                 .exchange()
                 .expectStatus()
-                .isCreated();
+                .isCreated()
+                .expectBody(Void.class);
 
         List<CuratedPracticeSummaryDTO> afterPractices = getCatalog().practices().stream()
                 .filter(practice -> java.util.Objects.equals(
@@ -840,12 +863,16 @@ class CuratedCatalogAdminControllerIntegrationTest extends AbstractWorkspaceInte
                 .bodyValue(new CreateCuratedPracticeRequestDTO("anything", definitionOf(getPractice(), "Criteria")))
                 .exchange()
                 .expectStatus()
-                .isForbidden();
+                .isForbidden()
+                .expectBody(Void.class);
     }
 
     @Test
     void recordsAnInstanceAuditRowWithoutCopyingTheDefinitionIntoIt() {
-        putPractice(etagOf(getPractice()), "Our own criteria").expectStatus().isOk();
+        putPractice(etagOf(getPractice()), "Our own criteria")
+                .expectStatus()
+                .isOk()
+                .expectBody(Void.class);
 
         var rows = jdbcTemplate.queryForList("""
             SELECT workspace_id, new_value::text AS new_value
@@ -865,7 +892,7 @@ class CuratedCatalogAdminControllerIntegrationTest extends AbstractWorkspaceInte
     @Test
     void auditsSuccessiveGuidanceOnlyEdits() {
         CuratedPracticeDTO original = getPractice();
-        putPractice(etagOf(original), "Our own criteria").expectStatus().isOk();
+        putPractice(etagOf(original), "Our own criteria").expectStatus().isOk().expectBody(Void.class);
 
         CuratedPracticeDTO edited = getPractice();
         CuratedPracticeRequestDTO guidanceEdit = new CuratedPracticeRequestDTO(
@@ -888,7 +915,8 @@ class CuratedCatalogAdminControllerIntegrationTest extends AbstractWorkspaceInte
                 .bodyValue(guidanceEdit)
                 .exchange()
                 .expectStatus()
-                .isOk();
+                .isOk()
+                .expectBody(Void.class);
 
         assertThat(jdbcTemplate.queryForObject(
                         "SELECT count(*) FROM config_audit_event WHERE entity_type = 'CURATED_PRACTICE' AND entity_id = ? AND action = 'UPDATED'",

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/practices/curated/adoption/CatalogAdoptionControllerIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/practices/curated/adoption/CatalogAdoptionControllerIntegrationTest.java
@@ -151,8 +151,8 @@ class CatalogAdoptionControllerIntegrationTest extends AbstractWorkspaceIntegrat
                 .jsonPath("$.title")
                 .isEqualTo("Practice adoption preview changed");
 
-        adopt("W/" + previewEtag()).expectStatus().isEqualTo(412);
-        adopt("malformed").expectStatus().isEqualTo(412);
+        adopt("W/" + previewEtag()).expectStatus().isEqualTo(412).expectBody(Void.class);
+        adopt("malformed").expectStatus().isEqualTo(412).expectBody(Void.class);
     }
 
     @Test
@@ -160,7 +160,7 @@ class CatalogAdoptionControllerIntegrationTest extends AbstractWorkspaceIntegrat
     void shouldAdoptWhenIfMatchUsesStandardWildcard() {
         ensureAdminMembership(workspace);
 
-        adopt("*").expectStatus().isCreated();
+        adopt("*").expectStatus().isCreated().expectBody(Void.class);
     }
 
     @Test
@@ -224,7 +224,7 @@ class CatalogAdoptionControllerIntegrationTest extends AbstractWorkspaceIntegrat
     void shouldReturnConflictWhenPracticeIsAlreadyAdopted() {
         ensureAdminMembership(workspace);
         String etag = previewEtag();
-        adopt(etag).expectStatus().isCreated();
+        adopt(etag).expectStatus().isCreated().expectBody(Void.class);
         var practice = practiceRepository
                 .findByWorkspaceIdAndSlug(workspace.getId(), PRACTICE)
                 .orElseThrow();
@@ -251,7 +251,7 @@ class CatalogAdoptionControllerIntegrationTest extends AbstractWorkspaceIntegrat
     @WithAdminUser
     void shouldAllowAdoptionAgainAfterWorkspacePracticeIsDeleted() {
         ensureAdminMembership(workspace);
-        adopt(previewEtag()).expectStatus().isCreated();
+        adopt(previewEtag()).expectStatus().isCreated().expectBody(Void.class);
 
         webTestClient
                 .delete()
@@ -259,7 +259,8 @@ class CatalogAdoptionControllerIntegrationTest extends AbstractWorkspaceIntegrat
                 .headers(TestAuthUtils.withCurrentUser())
                 .exchange()
                 .expectStatus()
-                .isNoContent();
+                .isNoContent()
+                .expectBody(Void.class);
 
         webTestClient
                 .get()
@@ -272,7 +273,7 @@ class CatalogAdoptionControllerIntegrationTest extends AbstractWorkspaceIntegrat
                 .jsonPath("$[?(@.slug == '" + PRACTICE + "')].availability")
                 .isEqualTo("AVAILABLE");
 
-        adopt(previewEtag()).expectStatus().isCreated();
+        adopt(previewEtag()).expectStatus().isCreated().expectBody(Void.class);
 
         assertThat(practiceRepository.findAllForCatalog(workspace.getId())).hasSize(1);
         assertThat(groupRepository.findByWorkspaceIdAndSlug(workspace.getId(), GROUP))
@@ -327,7 +328,7 @@ class CatalogAdoptionControllerIntegrationTest extends AbstractWorkspaceIntegrat
     void shouldAllowWholeGroupAdoptionAgainAfterGroupAndPracticesAreDeleted() {
         ensureAdminMembership(workspace);
         CatalogGroupAdoptionPreviewDTO firstPreview = previewGroup();
-        adoptGroup(firstPreview.etag()).expectStatus().isOk();
+        adoptGroup(firstPreview.etag()).expectStatus().isOk().expectBody(Void.class);
 
         webTestClient
                 .delete()
@@ -338,7 +339,8 @@ class CatalogAdoptionControllerIntegrationTest extends AbstractWorkspaceIntegrat
                 .headers(TestAuthUtils.withCurrentUser())
                 .exchange()
                 .expectStatus()
-                .isNoContent();
+                .isNoContent()
+                .expectBody(Void.class);
 
         assertThat(groupRepository.findByWorkspaceIdAndSlug(workspace.getId(), GROUP))
                 .isEmpty();
@@ -347,7 +349,7 @@ class CatalogAdoptionControllerIntegrationTest extends AbstractWorkspaceIntegrat
         assertThat(secondPreview.practices())
                 .allMatch(practice -> practice.availability() == CatalogAdoptionAvailability.AVAILABLE);
 
-        adoptGroup(secondPreview.etag()).expectStatus().isOk();
+        adoptGroup(secondPreview.etag()).expectStatus().isOk().expectBody(Void.class);
 
         assertThat(groupRepository.findByWorkspaceIdAndSlug(workspace.getId(), GROUP))
                 .isPresent();
@@ -360,7 +362,7 @@ class CatalogAdoptionControllerIntegrationTest extends AbstractWorkspaceIntegrat
     void shouldRestoreUnassignedCatalogPracticesWhenDeletedGroupIsAdoptedAgain() {
         ensureAdminMembership(workspace);
         CatalogGroupAdoptionPreviewDTO firstPreview = previewGroup();
-        adoptGroup(firstPreview.etag()).expectStatus().isOk();
+        adoptGroup(firstPreview.etag()).expectStatus().isOk().expectBody(Void.class);
 
         webTestClient
                 .delete()
@@ -368,7 +370,8 @@ class CatalogAdoptionControllerIntegrationTest extends AbstractWorkspaceIntegrat
                 .headers(TestAuthUtils.withCurrentUser())
                 .exchange()
                 .expectStatus()
-                .isNoContent();
+                .isNoContent()
+                .expectBody(Void.class);
 
         CatalogGroupAdoptionPreviewDTO restorePreview = previewGroup();
         assertThat(restorePreview.actions())
@@ -441,7 +444,8 @@ class CatalogAdoptionControllerIntegrationTest extends AbstractWorkspaceIntegrat
                 .headers(TestAuthUtils.withCurrentUser())
                 .exchange()
                 .expectStatus()
-                .isForbidden();
+                .isForbidden()
+                .expectBody(Void.class);
 
         webTestClient
                 .get()
@@ -449,7 +453,8 @@ class CatalogAdoptionControllerIntegrationTest extends AbstractWorkspaceIntegrat
                 .headers(TestAuthUtils.withCurrentUser())
                 .exchange()
                 .expectStatus()
-                .isForbidden();
+                .isForbidden()
+                .expectBody(Void.class);
 
         webTestClient
                 .post()
@@ -460,7 +465,8 @@ class CatalogAdoptionControllerIntegrationTest extends AbstractWorkspaceIntegrat
                 })
                 .exchange()
                 .expectStatus()
-                .isForbidden();
+                .isForbidden()
+                .expectBody(Void.class);
     }
 
     private String previewEtag() {
@@ -471,7 +477,7 @@ class CatalogAdoptionControllerIntegrationTest extends AbstractWorkspaceIntegrat
                 .exchange()
                 .expectStatus()
                 .isOk()
-                .returnResult(CatalogPracticePreviewDTO.class)
+                .returnResult(Void.class)
                 .getResponseHeaders()
                 .getETag());
     }

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/practices/feedback/FeedbackResponseControllerIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/practices/feedback/FeedbackResponseControllerIntegrationTest.java
@@ -228,7 +228,8 @@ class FeedbackResponseControllerIntegrationTest extends AbstractWorkspaceIntegra
                     .bodyValue(request)
                     .exchange()
                     .expectStatus()
-                    .isOk();
+                    .isOk()
+                    .expectBody(Void.class);
 
             var resolutions = reactionRepository.findCurrentResolutionByRecurrenceKeys(
                     List.of(RECURRENCE_KEY), adminUser.getId(), workspace.getId());
@@ -251,7 +252,8 @@ class FeedbackResponseControllerIntegrationTest extends AbstractWorkspaceIntegra
                     .bodyValue(request)
                     .exchange()
                     .expectStatus()
-                    .isBadRequest();
+                    .isBadRequest()
+                    .expectBody(Void.class);
         }
 
         @Test
@@ -268,7 +270,8 @@ class FeedbackResponseControllerIntegrationTest extends AbstractWorkspaceIntegra
                     .bodyValue(request1)
                     .exchange()
                     .expectStatus()
-                    .isOk();
+                    .isOk()
+                    .expectBody(Void.class);
 
             webTestClient
                     .put()
@@ -278,7 +281,8 @@ class FeedbackResponseControllerIntegrationTest extends AbstractWorkspaceIntegra
                     .bodyValue(request2)
                     .exchange()
                     .expectStatus()
-                    .isOk();
+                    .isOk()
+                    .expectBody(Void.class);
 
             assertThat(reactionRepository.findAll()).hasSize(2);
         }
@@ -296,7 +300,8 @@ class FeedbackResponseControllerIntegrationTest extends AbstractWorkspaceIntegra
                     .bodyValue(request)
                     .exchange()
                     .expectStatus()
-                    .isNotFound();
+                    .isNotFound()
+                    .expectBody(Void.class);
         }
 
         @Test
@@ -315,7 +320,8 @@ class FeedbackResponseControllerIntegrationTest extends AbstractWorkspaceIntegra
                     .bodyValue(request)
                     .exchange()
                     .expectStatus()
-                    .isNotFound();
+                    .isNotFound()
+                    .expectBody(Void.class);
         }
 
         @Test
@@ -349,7 +355,8 @@ class FeedbackResponseControllerIntegrationTest extends AbstractWorkspaceIntegra
                     .bodyValue(request)
                     .exchange()
                     .expectStatus()
-                    .isNotFound();
+                    .isNotFound()
+                    .expectBody(Void.class);
         }
 
         @Test
@@ -363,7 +370,8 @@ class FeedbackResponseControllerIntegrationTest extends AbstractWorkspaceIntegra
                     .bodyValue(request)
                     .exchange()
                     .expectStatus()
-                    .isForbidden();
+                    .isForbidden()
+                    .expectBody(Void.class);
         }
     }
 
@@ -380,7 +388,8 @@ class FeedbackResponseControllerIntegrationTest extends AbstractWorkspaceIntegra
                     .headers(TestAuthUtils.withCurrentUser())
                     .exchange()
                     .expectStatus()
-                    .isNoContent();
+                    .isNoContent()
+                    .expectBody(Void.class);
         }
 
         @Test
@@ -392,7 +401,8 @@ class FeedbackResponseControllerIntegrationTest extends AbstractWorkspaceIntegra
                     .headers(TestAuthUtils.withCurrentUser())
                     .exchange()
                     .expectStatus()
-                    .isNotFound();
+                    .isNotFound()
+                    .expectBody(Void.class);
         }
 
         @Test
@@ -409,7 +419,8 @@ class FeedbackResponseControllerIntegrationTest extends AbstractWorkspaceIntegra
                     .bodyValue(request1)
                     .exchange()
                     .expectStatus()
-                    .isOk();
+                    .isOk()
+                    .expectBody(Void.class);
 
             webTestClient
                     .put()
@@ -419,7 +430,8 @@ class FeedbackResponseControllerIntegrationTest extends AbstractWorkspaceIntegra
                     .bodyValue(request2)
                     .exchange()
                     .expectStatus()
-                    .isOk();
+                    .isOk()
+                    .expectBody(Void.class);
 
             FeedbackResponseDTO response = webTestClient
                     .get()
@@ -504,7 +516,8 @@ class FeedbackResponseControllerIntegrationTest extends AbstractWorkspaceIntegra
                     .headers(TestAuthUtils.withCurrentUser())
                     .exchange()
                     .expectStatus()
-                    .isNoContent();
+                    .isNoContent()
+                    .expectBody(Void.class);
 
             webTestClient
                     .get()
@@ -512,7 +525,8 @@ class FeedbackResponseControllerIntegrationTest extends AbstractWorkspaceIntegra
                     .headers(TestAuthUtils.withCurrentUser())
                     .exchange()
                     .expectStatus()
-                    .isNoContent();
+                    .isNoContent()
+                    .expectBody(Void.class);
 
             submit(new FeedbackResponseRequestDTO(FeedbackUsefulness.UNHELPFUL, null, null));
             FeedbackResponseDTO response = current();
@@ -531,7 +545,8 @@ class FeedbackResponseControllerIntegrationTest extends AbstractWorkspaceIntegra
                     .bodyValue(request)
                     .exchange()
                     .expectStatus()
-                    .isOk();
+                    .isOk()
+                    .expectBody(Void.class);
         }
 
         private @org.jspecify.annotations.Nullable FeedbackResponseDTO current() {
@@ -563,7 +578,8 @@ class FeedbackResponseControllerIntegrationTest extends AbstractWorkspaceIntegra
                     .bodyValue(new FeedbackResponseRequestDTO(null, FeedbackResolution.ADDRESSED, null))
                     .exchange()
                     .expectStatus()
-                    .isOk();
+                    .isOk()
+                    .expectBody(Void.class);
 
             User owner2 = persistUser("other-ws-owner");
             Workspace otherWorkspace = createWorkspace("other-ws", "Other WS", "other-org", AccountType.ORG, owner2);
@@ -621,7 +637,8 @@ class FeedbackResponseControllerIntegrationTest extends AbstractWorkspaceIntegra
                     .bodyValue(new FeedbackResponseRequestDTO(null, FeedbackResolution.ADDRESSED, null))
                     .exchange()
                     .expectStatus()
-                    .isOk();
+                    .isOk()
+                    .expectBody(Void.class);
 
             webTestClient
                     .put()
@@ -631,7 +648,8 @@ class FeedbackResponseControllerIntegrationTest extends AbstractWorkspaceIntegra
                     .bodyValue(new FeedbackResponseRequestDTO(null, FeedbackResolution.DISPUTED, "Wrong detection"))
                     .exchange()
                     .expectStatus()
-                    .isOk();
+                    .isOk()
+                    .expectBody(Void.class);
 
             FeedbackResolutionCountsDTO response = webTestClient
                     .get()
@@ -676,7 +694,8 @@ class FeedbackResponseControllerIntegrationTest extends AbstractWorkspaceIntegra
                     .bodyValue(new FeedbackResponseRequestDTO(null, FeedbackResolution.ADDRESSED, null))
                     .exchange()
                     .expectStatus()
-                    .isOk();
+                    .isOk()
+                    .expectBody(Void.class);
             webTestClient
                     .put()
                     .uri(FEEDBACK_URI, workspace.getWorkspaceSlug(), secondFeedbackUnit.getId())
@@ -685,7 +704,8 @@ class FeedbackResponseControllerIntegrationTest extends AbstractWorkspaceIntegra
                     .bodyValue(new FeedbackResponseRequestDTO(null, FeedbackResolution.ADDRESSED, null))
                     .exchange()
                     .expectStatus()
-                    .isOk();
+                    .isOk()
+                    .expectBody(Void.class);
 
             FeedbackResolutionCountsDTO response = webTestClient
                     .get()

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/practices/groupdetail/PracticeGroupTrendControllerIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/practices/groupdetail/PracticeGroupTrendControllerIntegrationTest.java
@@ -97,7 +97,8 @@ class PracticeGroupTrendControllerIntegrationTest extends AbstractWorkspaceInteg
                 .headers(TestAuthUtils.withCurrentUser())
                 .exchange()
                 .expectStatus()
-                .isForbidden();
+                .isForbidden()
+                .expectBody(Void.class);
     }
 
     @Test

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/practices/observation/ObservationControllerIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/practices/observation/ObservationControllerIntegrationTest.java
@@ -528,7 +528,8 @@ class ObservationControllerIntegrationTest extends AbstractWorkspaceIntegrationT
                     .headers(TestAuthUtils.withCurrentUser())
                     .exchange()
                     .expectStatus()
-                    .isBadRequest();
+                    .isBadRequest()
+                    .expectBody(Void.class);
         }
 
         @Test
@@ -541,7 +542,8 @@ class ObservationControllerIntegrationTest extends AbstractWorkspaceIntegrationT
                     .headers(TestAuthUtils.withCurrentUser())
                     .exchange()
                     .expectStatus()
-                    .isBadRequest();
+                    .isBadRequest()
+                    .expectBody(Void.class);
         }
 
         @Test
@@ -597,7 +599,8 @@ class ObservationControllerIntegrationTest extends AbstractWorkspaceIntegrationT
                     .uri(BASE_URI, workspace.getWorkspaceSlug())
                     .exchange()
                     .expectStatus()
-                    .isUnauthorized();
+                    .isUnauthorized()
+                    .expectBody(Void.class);
         }
 
         @Test
@@ -802,7 +805,8 @@ class ObservationControllerIntegrationTest extends AbstractWorkspaceIntegrationT
                     .uri(BASE_URI + "/summary", workspace.getWorkspaceSlug())
                     .exchange()
                     .expectStatus()
-                    .isUnauthorized();
+                    .isUnauthorized()
+                    .expectBody(Void.class);
         }
 
         @Test
@@ -896,7 +900,8 @@ class ObservationControllerIntegrationTest extends AbstractWorkspaceIntegrationT
                     .headers(TestAuthUtils.withCurrentUser())
                     .exchange()
                     .expectStatus()
-                    .isNotFound();
+                    .isNotFound()
+                    .expectBody(Void.class);
         }
 
         @Test
@@ -906,7 +911,8 @@ class ObservationControllerIntegrationTest extends AbstractWorkspaceIntegrationT
                     .uri(BASE_URI + "/{findingId}", workspace.getWorkspaceSlug(), UUID.randomUUID())
                     .exchange()
                     .expectStatus()
-                    .isUnauthorized();
+                    .isUnauthorized()
+                    .expectBody(Void.class);
         }
 
         @Test
@@ -918,7 +924,8 @@ class ObservationControllerIntegrationTest extends AbstractWorkspaceIntegrationT
                     .headers(TestAuthUtils.withCurrentUser())
                     .exchange()
                     .expectStatus()
-                    .isNotFound();
+                    .isNotFound()
+                    .expectBody(Void.class);
         }
 
         @Test
@@ -1034,7 +1041,8 @@ class ObservationControllerIntegrationTest extends AbstractWorkspaceIntegrationT
                     .headers(TestAuthUtils.withCurrentUser())
                     .exchange()
                     .expectStatus()
-                    .isNotFound();
+                    .isNotFound()
+                    .expectBody(Void.class);
         }
     }
 
@@ -1125,7 +1133,8 @@ class ObservationControllerIntegrationTest extends AbstractWorkspaceIntegrationT
                     .uri(BASE_URI + "/pull-request/{prId}", workspace.getWorkspaceSlug(), 999L)
                     .exchange()
                     .expectStatus()
-                    .isUnauthorized();
+                    .isUnauthorized()
+                    .expectBody(Void.class);
         }
 
         @Test
@@ -1332,7 +1341,8 @@ class ObservationControllerIntegrationTest extends AbstractWorkspaceIntegrationT
                     .uri("/workspaces/{workspaceSlug}/practices/standings", workspace.getWorkspaceSlug())
                     .exchange()
                     .expectStatus()
-                    .isUnauthorized();
+                    .isUnauthorized()
+                    .expectBody(Void.class);
         }
     }
 }

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/practices/review/PracticeReviewSettingsControllerIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/practices/review/PracticeReviewSettingsControllerIntegrationTest.java
@@ -79,7 +79,8 @@ class PracticeReviewSettingsControllerIntegrationTest extends AbstractWorkspaceI
                 .bodyValue(Map.of("cooldownMinutes", 5000))
                 .exchange()
                 .expectStatus()
-                .isBadRequest();
+                .isBadRequest()
+                .expectBody(Void.class);
     }
 
     @Test
@@ -95,7 +96,8 @@ class PracticeReviewSettingsControllerIntegrationTest extends AbstractWorkspaceI
                 .bodyValue(Map.of("personMode", "SELECTED", "repositories", List.of(), "personUserIds", List.of()))
                 .exchange()
                 .expectStatus()
-                .isBadRequest();
+                .isBadRequest()
+                .expectBody(Void.class);
     }
 
     @Test
@@ -131,7 +133,8 @@ class PracticeReviewSettingsControllerIntegrationTest extends AbstractWorkspaceI
 
         patch(workspace.getWorkspaceSlug(), null, Map.of("deliverToMerged", true))
                 .expectStatus()
-                .isEqualTo(HttpStatus.PRECONDITION_REQUIRED);
+                .isEqualTo(HttpStatus.PRECONDITION_REQUIRED)
+                .expectBody(Void.class);
     }
 
     @Test
@@ -194,7 +197,7 @@ class PracticeReviewSettingsControllerIntegrationTest extends AbstractWorkspaceI
                 .exchange()
                 .expectStatus()
                 .isOk()
-                .returnResult(PracticeReviewSettingsDTO.class)
+                .returnResult(Void.class)
                 .getResponseHeaders()
                 .getETag();
         return java.util.Objects.requireNonNull(version, "the settings endpoint always answers with an ETag");
@@ -229,7 +232,8 @@ class PracticeReviewSettingsControllerIntegrationTest extends AbstractWorkspaceI
                 .headers(TestAuthUtils.withCurrentUser())
                 .exchange()
                 .expectStatus()
-                .isForbidden();
+                .isForbidden()
+                .expectBody(Void.class);
 
         webTestClient
                 .patch()
@@ -239,7 +243,8 @@ class PracticeReviewSettingsControllerIntegrationTest extends AbstractWorkspaceI
                 .bodyValue(Map.of("skipDrafts", false))
                 .exchange()
                 .expectStatus()
-                .isForbidden();
+                .isForbidden()
+                .expectBody(Void.class);
     }
 
     @Test
@@ -262,7 +267,8 @@ class PracticeReviewSettingsControllerIntegrationTest extends AbstractWorkspaceI
                 .bodyValue(Map.of("skipDrafts", false))
                 .exchange()
                 .expectStatus()
-                .isForbidden();
+                .isForbidden()
+                .expectBody(Void.class);
 
         webTestClient
                 .get()
@@ -270,6 +276,7 @@ class PracticeReviewSettingsControllerIntegrationTest extends AbstractWorkspaceI
                 .headers(TestAuthUtils.withCurrentUser())
                 .exchange()
                 .expectStatus()
-                .isOk();
+                .isOk()
+                .expectBody(Void.class);
     }
 }

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/practices/review/autonomy/AutonomyRollupIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/practices/review/autonomy/AutonomyRollupIntegrationTest.java
@@ -252,7 +252,8 @@ class AutonomyRollupIntegrationTest extends AbstractWorkspaceIntegrationTest {
                     .headers(TestAuthUtils.withCurrentUser())
                     .exchange()
                     .expectStatus()
-                    .isForbidden();
+                    .isForbidden()
+                    .expectBody(Void.class);
         }
 
         @Test
@@ -263,7 +264,8 @@ class AutonomyRollupIntegrationTest extends AbstractWorkspaceIntegrationTest {
                     .uri(URI, workspace.getWorkspaceSlug())
                     .exchange()
                     .expectStatus()
-                    .isUnauthorized();
+                    .isUnauthorized()
+                    .expectBody(Void.class);
         }
     }
 

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/practices/reviewoutput/PracticeReviewOutputControllerIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/practices/reviewoutput/PracticeReviewOutputControllerIntegrationTest.java
@@ -294,19 +294,26 @@ class PracticeReviewOutputControllerIntegrationTest extends AbstractWorkspaceInt
                     .uri(OBSERVATIONS, workspace.getWorkspaceSlug())
                     .exchange()
                     .expectStatus()
-                    .isUnauthorized();
+                    .isUnauthorized()
+                    .expectBody(Void.class);
         }
 
         @Test
         @WithUser
         void workspaceMemberCannotReadReviewOutput() {
-            get(OBSERVATIONS, workspace.getWorkspaceSlug()).expectStatus().isForbidden();
+            get(OBSERVATIONS, workspace.getWorkspaceSlug())
+                    .expectStatus()
+                    .isForbidden()
+                    .expectBody(Void.class);
         }
 
         @Test
         @WithMentorUser
         void workspaceAdminWithoutInstanceAuthorityIsAdmitted() {
-            get(OBSERVATIONS, workspace.getWorkspaceSlug()).expectStatus().isOk();
+            get(OBSERVATIONS, workspace.getWorkspaceSlug())
+                    .expectStatus()
+                    .isOk()
+                    .expectBody(Void.class);
         }
     }
 
@@ -351,7 +358,8 @@ class PracticeReviewOutputControllerIntegrationTest extends AbstractWorkspaceInt
 
             get(OBSERVATIONS + "/{id}", workspace.getWorkspaceSlug(), theirs)
                     .expectStatus()
-                    .isNotFound();
+                    .isNotFound()
+                    .expectBody(Void.class);
         }
 
         @Test
@@ -820,7 +828,8 @@ class PracticeReviewOutputControllerIntegrationTest extends AbstractWorkspaceInt
 
             get(FEEDBACK + "/{id}", workspace.getWorkspaceSlug(), theirs.getId())
                     .expectStatus()
-                    .isNotFound();
+                    .isNotFound()
+                    .expectBody(Void.class);
         }
 
         @Test
@@ -963,7 +972,8 @@ class PracticeReviewOutputControllerIntegrationTest extends AbstractWorkspaceInt
 
             get(FEEDBACK + "?artifactId=99", workspace.getWorkspaceSlug())
                     .expectStatus()
-                    .isBadRequest();
+                    .isBadRequest()
+                    .expectBody(Void.class);
         }
 
         @Test

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/practices/trace/ArtifactTraceControllerIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/practices/trace/ArtifactTraceControllerIntegrationTest.java
@@ -108,7 +108,8 @@ class ArtifactTraceControllerIntegrationTest extends AbstractWorkspaceIntegratio
                     .uri(TRACE, workspace.getWorkspaceSlug(), ArtifactKinds.PULL_REQUEST.value(), ARTIFACT_ID)
                     .exchange()
                     .expectStatus()
-                    .isUnauthorized();
+                    .isUnauthorized()
+                    .expectBody(Void.class);
         }
 
         @Test
@@ -146,7 +147,8 @@ class ArtifactTraceControllerIntegrationTest extends AbstractWorkspaceIntegratio
 
             get(TRACE, workspace.getWorkspaceSlug(), ArtifactKinds.PULL_REQUEST.value(), ARTIFACT_ID)
                     .expectStatus()
-                    .isNotFound();
+                    .isNotFound()
+                    .expectBody(Void.class);
         }
 
         @Test
@@ -154,7 +156,8 @@ class ArtifactTraceControllerIntegrationTest extends AbstractWorkspaceIntegratio
         void refusesAnUnknownArtifactKind() {
             get(TRACE, workspace.getWorkspaceSlug(), "NotAKind", ARTIFACT_ID)
                     .expectStatus()
-                    .isBadRequest();
+                    .isBadRequest()
+                    .expectBody(Void.class);
         }
     }
 
@@ -237,7 +240,8 @@ class ArtifactTraceControllerIntegrationTest extends AbstractWorkspaceIntegratio
 
             get(TRACE, workspace.getWorkspaceSlug(), ArtifactKinds.PULL_REQUEST.value(), ARTIFACT_ID)
                     .expectStatus()
-                    .isNotFound();
+                    .isNotFound()
+                    .expectBody(Void.class);
         }
     }
 

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/productfeedback/FeedbackControllerIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/productfeedback/FeedbackControllerIntegrationTest.java
@@ -24,7 +24,8 @@ class FeedbackControllerIntegrationTest extends AbstractWorkspaceIntegrationTest
                 .headers(TestAuthUtils.withCurrentUser())
                 .exchange()
                 .expectStatus()
-                .isOk();
+                .isOk()
+                .expectBody(Void.class);
     }
 
     @Test
@@ -36,7 +37,8 @@ class FeedbackControllerIntegrationTest extends AbstractWorkspaceIntegrationTest
                 .headers(TestAuthUtils.withCurrentUser())
                 .exchange()
                 .expectStatus()
-                .isForbidden();
+                .isForbidden()
+                .expectBody(Void.class);
     }
 
     @Test
@@ -46,7 +48,8 @@ class FeedbackControllerIntegrationTest extends AbstractWorkspaceIntegrationTest
                 .uri("/admin/product-feedback")
                 .exchange()
                 .expectStatus()
-                .isUnauthorized();
+                .isUnauthorized()
+                .expectBody(Void.class);
         String csrf = TestAuthUtils.fetchCsrfToken(webTestClient);
         webTestClient
                 .post()
@@ -54,6 +57,7 @@ class FeedbackControllerIntegrationTest extends AbstractWorkspaceIntegrationTest
                 .headers(TestAuthUtils.withCsrf(csrf))
                 .exchange()
                 .expectStatus()
-                .isUnauthorized();
+                .isUnauthorized()
+                .expectBody(Void.class);
     }
 }

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/testconfig/WebTestClientConnectionReuseTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/testconfig/WebTestClientConnectionReuseTest.java
@@ -1,0 +1,43 @@
+package de.tum.cit.aet.hephaestus.testconfig;
+
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import reactor.core.publisher.Mono;
+import reactor.netty.http.client.HttpClient;
+import reactor.netty.http.server.HttpServer;
+import reactor.netty.resources.ConnectionProvider;
+
+class WebTestClientConnectionReuseTest extends BaseUnitTest {
+
+    @Test
+    void shouldReleaseDiscardedBodiesBeforeTheNextRequest() {
+        // A small response can be buffered completely and hide a missing body subscription.
+        var server = HttpServer.create()
+                .host("127.0.0.1")
+                .port(0)
+                .handle((request, response) -> response.sendString(Mono.just("x".repeat(100_000))))
+                .bindNow();
+        var connections = ConnectionProvider.builder("response-cleanup-test")
+                .maxConnections(1)
+                .pendingAcquireTimeout(Duration.ofSeconds(5))
+                .build();
+        try {
+            var client = WebTestClient.bindToServer(new ReactorClientHttpConnector(HttpClient.create(connections)))
+                    .baseUrl("http://127.0.0.1:" + server.port())
+                    .responseTimeout(Duration.ofSeconds(10))
+                    .build();
+
+            for (int request = 0; request < 2; request++) {
+                client.get().uri("/").exchange().expectStatus().isOk().expectBody(Void.class);
+            }
+        } finally {
+            try {
+                connections.disposeLater().block(Duration.ofSeconds(5));
+            } finally {
+                server.disposeNow();
+            }
+        }
+    }
+}

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/workspace/CrossTenantIsolationIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/workspace/CrossTenantIsolationIntegrationTest.java
@@ -255,8 +255,12 @@ class CrossTenantIsolationIntegrationTest extends AbstractWorkspaceIntegrationTe
         @Test
         @WithMentorUser
         void detailIsScopedToWorkspace() {
-            expectDetailStatus("/practices/{key}", tenantA.practiceSlug()).isOk();
-            expectDetailStatus("/practices/{key}", tenantB.practiceSlug()).isNotFound();
+            expectDetailStatus("/practices/{key}", tenantA.practiceSlug())
+                    .isOk()
+                    .expectBody(Void.class);
+            expectDetailStatus("/practices/{key}", tenantB.practiceSlug())
+                    .isNotFound()
+                    .expectBody(Void.class);
         }
     }
 
@@ -285,9 +289,11 @@ class CrossTenantIsolationIntegrationTest extends AbstractWorkspaceIntegrationTe
         @WithMentorUser
         void detailIsScopedToWorkspace() {
             expectDetailStatus("/practices/observations/{key}", tenantA.observationId())
-                    .isOk();
+                    .isOk()
+                    .expectBody(Void.class);
             expectDetailStatus("/practices/observations/{key}", tenantB.observationId())
-                    .isNotFound();
+                    .isNotFound()
+                    .expectBody(Void.class);
         }
 
         @Test
@@ -348,7 +354,8 @@ class CrossTenantIsolationIntegrationTest extends AbstractWorkspaceIntegrationTe
             expectDetailStatus("/practices/feedback/{key}/response", tenantA.feedbackId())
                     .isNoContent();
             expectDetailStatus("/practices/feedback/{key}/response", tenantB.feedbackId())
-                    .isNotFound();
+                    .isNotFound()
+                    .expectBody(Void.class);
         }
     }
 
@@ -497,8 +504,12 @@ class CrossTenantIsolationIntegrationTest extends AbstractWorkspaceIntegrationTe
         @Test
         @WithMentorUser
         void detailIsScopedToWorkspace() {
-            expectDetailStatus("/mentor/threads/{key}", tenantA.threadId()).isOk();
-            expectDetailStatus("/mentor/threads/{key}", tenantB.threadId()).isNotFound();
+            expectDetailStatus("/mentor/threads/{key}", tenantA.threadId())
+                    .isOk()
+                    .expectBody(Void.class);
+            expectDetailStatus("/mentor/threads/{key}", tenantB.threadId())
+                    .isNotFound()
+                    .expectBody(Void.class);
         }
     }
 
@@ -540,16 +551,21 @@ class CrossTenantIsolationIntegrationTest extends AbstractWorkspaceIntegrationTe
         @Test
         @WithMentorUser
         void shouldReturnNotFoundWhenProfileUserOnlyBelongsToAnotherWorkspace() {
-            expectDetailStatus("/profile/{key}", "mentor").isOk();
-            expectDetailStatus("/profile/{key}", bobOnlyB.getLogin()).isNotFound();
+            expectDetailStatus("/profile/{key}", "mentor").isOk().expectBody(Void.class);
+            expectDetailStatus("/profile/{key}", bobOnlyB.getLogin())
+                    .isNotFound()
+                    .expectBody(Void.class);
         }
 
         @Test
         @WithMentorUser
         void shouldReturnNotFoundWhenActivityUserOnlyBelongsToAnotherWorkspace() {
-            expectDetailStatus("/profile/{key}/activity-monitor", "mentor").isOk();
+            expectDetailStatus("/profile/{key}/activity-monitor", "mentor")
+                    .isOk()
+                    .expectBody(Void.class);
             expectDetailStatus("/profile/{key}/activity-monitor", bobOnlyB.getLogin())
-                    .isNotFound();
+                    .isNotFound()
+                    .expectBody(Void.class);
         }
     }
 
@@ -609,8 +625,8 @@ class CrossTenantIsolationIntegrationTest extends AbstractWorkspaceIntegrationTe
             Team ownTeam = seedTeam("own-team", 900_300L, SHARED_LOGIN, ensureGitHubProvider());
             Team foreignTeam = seedTeam("foreign-team", 900_301L, SHARED_LOGIN, ensureGitLabProvider());
 
-            expectVisibilityWriteStatus(ownTeam.getId()).isOk();
-            expectVisibilityWriteStatus(foreignTeam.getId()).isNotFound();
+            expectVisibilityWriteStatus(ownTeam.getId()).isOk().expectBody(Void.class);
+            expectVisibilityWriteStatus(foreignTeam.getId()).isNotFound().expectBody(Void.class);
         }
     }
 
@@ -627,7 +643,8 @@ class CrossTenantIsolationIntegrationTest extends AbstractWorkspaceIntegrationTe
                     .headers(TestAuthUtils.withCurrentUser())
                     .exchange()
                     .expectStatus()
-                    .isForbidden();
+                    .isForbidden()
+                    .expectBody(Void.class);
         }
 
         @Test
@@ -639,7 +656,8 @@ class CrossTenantIsolationIntegrationTest extends AbstractWorkspaceIntegrationTe
                     .headers(TestAuthUtils.withCurrentUser())
                     .exchange()
                     .expectStatus()
-                    .isForbidden();
+                    .isForbidden()
+                    .expectBody(Void.class);
         }
     }
 

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/workspace/GitLabWorkspaceCreationIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/workspace/GitLabWorkspaceCreationIntegrationTest.java
@@ -350,7 +350,8 @@ class GitLabWorkspaceCreationIntegrationTest extends AbstractWorkspaceIntegratio
                 .bodyValue(gitlabRequest)
                 .exchange()
                 .expectStatus()
-                .isCreated();
+                .isCreated()
+                .expectBody(Void.class);
 
         List<WorkspaceListItemDTO> workspaces = webTestClient
                 .get()

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/workspace/WorkspaceAdminControllerIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/workspace/WorkspaceAdminControllerIntegrationTest.java
@@ -63,6 +63,7 @@ class WorkspaceAdminControllerIntegrationTest extends AbstractWorkspaceIntegrati
                 .headers(h -> h.setBearerAuth(MENTOR_TOKEN))
                 .exchange()
                 .expectStatus()
-                .isForbidden();
+                .isForbidden()
+                .expectBody(Void.class);
     }
 }

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/workspace/WorkspaceContextFilterIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/workspace/WorkspaceContextFilterIntegrationTest.java
@@ -79,7 +79,8 @@ class WorkspaceContextFilterIntegrationTest extends AbstractWorkspaceIntegration
                 .headers(TestAuthUtils.withCurrentUser())
                 .exchange()
                 .expectStatus()
-                .isForbidden();
+                .isForbidden()
+                .expectBody(Void.class);
     }
 
     @Test
@@ -103,7 +104,8 @@ class WorkspaceContextFilterIntegrationTest extends AbstractWorkspaceIntegration
                 .headers(TestAuthUtils.withCurrentUser())
                 .exchange()
                 .expectStatus()
-                .isForbidden();
+                .isForbidden()
+                .expectBody(Void.class);
 
         assertThat(workspaceMembershipRepository.findByWorkspace_IdAndUser_IdIn(
                         workspace.getId(), Set.of(visitor.getId())))
@@ -144,7 +146,8 @@ class WorkspaceContextFilterIntegrationTest extends AbstractWorkspaceIntegration
                 .headers(TestAuthUtils.withCurrentUser())
                 .exchange()
                 .expectStatus()
-                .isNotFound();
+                .isNotFound()
+                .expectBody(Void.class);
     }
 
     @Test
@@ -179,7 +182,8 @@ class WorkspaceContextFilterIntegrationTest extends AbstractWorkspaceIntegration
                 .headers(TestAuthUtils.withCurrentUser())
                 .exchange()
                 .expectStatus()
-                .isNotFound();
+                .isNotFound()
+                .expectBody(Void.class);
     }
 
     @Test
@@ -209,8 +213,20 @@ class WorkspaceContextFilterIntegrationTest extends AbstractWorkspaceIntegration
 
     @Test
     void unauthenticatedWorkspaceListIsUnauthorized() {
-        webTestClient.get().uri("/workspaces").exchange().expectStatus().isUnauthorized();
-        webTestClient.get().uri("/workspaces/").exchange().expectStatus().isUnauthorized();
+        webTestClient
+                .get()
+                .uri("/workspaces")
+                .exchange()
+                .expectStatus()
+                .isUnauthorized()
+                .expectBody(Void.class);
+        webTestClient
+                .get()
+                .uri("/workspaces/")
+                .exchange()
+                .expectStatus()
+                .isUnauthorized()
+                .expectBody(Void.class);
     }
 
     @Test
@@ -245,7 +261,8 @@ class WorkspaceContextFilterIntegrationTest extends AbstractWorkspaceIntegration
                 .uri("/workspaces/{workspaceSlug}/context-echo", workspace.getWorkspaceSlug())
                 .exchange()
                 .expectStatus()
-                .isUnauthorized();
+                .isUnauthorized()
+                .expectBody(Void.class);
     }
 
     @Test
@@ -330,7 +347,8 @@ class WorkspaceContextFilterIntegrationTest extends AbstractWorkspaceIntegration
                 .uri("/workspaces/{workspaceSlug}/context-echo", "secret-space")
                 .exchange()
                 .expectStatus()
-                .isNotFound();
+                .isNotFound()
+                .expectBody(Void.class);
     }
 
     @Test

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/workspace/WorkspaceControllerIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/workspace/WorkspaceControllerIntegrationTest.java
@@ -113,7 +113,8 @@ class WorkspaceControllerIntegrationTest extends AbstractWorkspaceIntegrationTes
                 .bodyValue(request)
                 .exchange()
                 .expectStatus()
-                .isForbidden();
+                .isForbidden()
+                .expectBody(Void.class);
 
         assertThat(workspaceRepository.count()).isZero();
     }
@@ -141,7 +142,8 @@ class WorkspaceControllerIntegrationTest extends AbstractWorkspaceIntegrationTes
                 .bodyValue(request)
                 .exchange()
                 .expectStatus()
-                .isCreated();
+                .isCreated()
+                .expectBody(Void.class);
 
         assertThat(workspaceRepository.count()).isEqualTo(1);
     }
@@ -308,7 +310,8 @@ class WorkspaceControllerIntegrationTest extends AbstractWorkspaceIntegrationTes
                 .headers(TestAuthUtils.withCurrentUser())
                 .exchange()
                 .expectStatus()
-                .isNotFound();
+                .isNotFound()
+                .expectBody(Void.class);
 
         webTestClient
                 .delete()
@@ -319,7 +322,8 @@ class WorkspaceControllerIntegrationTest extends AbstractWorkspaceIntegrationTes
                 .headers(TestAuthUtils.withCurrentUser())
                 .exchange()
                 .expectStatus()
-                .isNoContent();
+                .isNoContent()
+                .expectBody(Void.class);
 
         assertThat(repositoryToMonitorRepository.findById(repository.getId())).isEmpty();
 
@@ -358,7 +362,8 @@ class WorkspaceControllerIntegrationTest extends AbstractWorkspaceIntegrationTes
                 .headers(TestAuthUtils.withCurrentUser())
                 .exchange()
                 .expectStatus()
-                .isOk();
+                .isOk()
+                .expectBody(Void.class);
 
         var membership = workspaceMembershipRepository
                 .findByWorkspace_IdAndUser_Id(workspace.getId(), user.getId())
@@ -408,7 +413,8 @@ class WorkspaceControllerIntegrationTest extends AbstractWorkspaceIntegrationTes
                 .bodyValue(new UpdateWorkspaceNotificationsRequestDTO(true, "core-team", "C12345678"))
                 .exchange()
                 .expectStatus()
-                .isOk();
+                .isOk()
+                .expectBody(Void.class);
 
         Workspace updated = workspaceRepository.findById(workspace.getId()).orElseThrow();
         assertThat(updated.getLeaderboardNotificationEnabled()).isTrue();
@@ -900,7 +906,8 @@ class WorkspaceControllerIntegrationTest extends AbstractWorkspaceIntegrationTes
                 .headers(TestAuthUtils.withCurrentUser())
                 .exchange()
                 .expectStatus()
-                .isNoContent();
+                .isNoContent()
+                .expectBody(Void.class);
 
         Workspace purged = workspaceRepository.findById(workspace.getId()).orElseThrow();
         assertThat(purged.getStatus()).isEqualTo(Workspace.WorkspaceStatus.PURGED);
@@ -989,7 +996,8 @@ class WorkspaceControllerIntegrationTest extends AbstractWorkspaceIntegrationTes
                     .headers(TestAuthUtils.withCurrentUser())
                     .exchange()
                     .expectStatus()
-                    .isNotFound();
+                    .isNotFound()
+                    .expectBody(Void.class);
         }
         for (String suffix : List.of("/recalculate", "/reload")) {
             webTestClient
@@ -1001,7 +1009,8 @@ class WorkspaceControllerIntegrationTest extends AbstractWorkspaceIntegrationTes
                     .headers(TestAuthUtils.withCurrentUser())
                     .exchange()
                     .expectStatus()
-                    .isNotFound();
+                    .isNotFound()
+                    .expectBody(Void.class);
         }
     }
 
@@ -1111,7 +1120,8 @@ class WorkspaceControllerIntegrationTest extends AbstractWorkspaceIntegrationTes
                 .bodyValue(new UpdateWorkspaceFeaturesRequestDTO(true, null, true, true, true, null, null))
                 .exchange()
                 .expectStatus()
-                .isOk();
+                .isOk()
+                .expectBody(Void.class);
 
         // Explicitly disable progression — others should remain true
         WorkspaceDTO afterDisable = webTestClient
@@ -1212,7 +1222,8 @@ class WorkspaceControllerIntegrationTest extends AbstractWorkspaceIntegrationTes
                 .bodyValue(new UpdateWorkspaceFeaturesRequestDTO(true, null, true, true, true, null, null))
                 .exchange()
                 .expectStatus()
-                .isForbidden();
+                .isForbidden()
+                .expectBody(Void.class);
     }
 
     @Test
@@ -1231,7 +1242,8 @@ class WorkspaceControllerIntegrationTest extends AbstractWorkspaceIntegrationTes
                 .bodyValue(new UpdateWorkspaceFeaturesRequestDTO(true, null, true, false, false, null, null))
                 .exchange()
                 .expectStatus()
-                .isOk();
+                .isOk()
+                .expectBody(Void.class);
 
         // Verify list endpoint includes feature flags
         List<WorkspaceListItemDTO> workspaces = webTestClient

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/workspace/WorkspaceMembershipControllerIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/workspace/WorkspaceMembershipControllerIntegrationTest.java
@@ -216,6 +216,7 @@ class WorkspaceMembershipControllerIntegrationTest extends AbstractWorkspaceInte
                 .headers(TestAuthUtils.withCurrentUser())
                 .exchange()
                 .expectStatus()
-                .isForbidden();
+                .isForbidden()
+                .expectBody(Void.class);
     }
 }

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/workspace/WorkspacePurgeIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/workspace/WorkspacePurgeIntegrationTest.java
@@ -499,7 +499,8 @@ class WorkspacePurgeIntegrationTest extends AbstractWorkspaceIntegrationTest {
                 .headers(TestAuthUtils.withCurrentUser())
                 .exchange()
                 .expectStatus()
-                .isNoContent();
+                .isNoContent()
+                .expectBody(Void.class);
 
         Workspace purged = workspaceRepository.findById(workspace.getId()).orElseThrow();
         assertThat(purged.getStatus()).isEqualTo(Workspace.WorkspaceStatus.PURGED);
@@ -528,7 +529,8 @@ class WorkspacePurgeIntegrationTest extends AbstractWorkspaceIntegrationTest {
                 .headers(TestAuthUtils.withCurrentUser())
                 .exchange()
                 .expectStatus()
-                .isForbidden();
+                .isForbidden()
+                .expectBody(Void.class);
 
         Workspace unchanged = workspaceRepository.findById(workspace.getId()).orElseThrow();
         assertThat(unchanged.getStatus()).isEqualTo(Workspace.WorkspaceStatus.ACTIVE);

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/workspace/WorkspaceScopedControllerIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/workspace/WorkspaceScopedControllerIntegrationTest.java
@@ -50,7 +50,8 @@ class WorkspaceScopedControllerIntegrationTest extends AbstractWorkspaceIntegrat
                 .headers(TestAuthUtils.withCurrentUser())
                 .exchange()
                 .expectStatus()
-                .isNotFound();
+                .isNotFound()
+                .expectBody(Void.class);
     }
 
     @Test
@@ -62,6 +63,7 @@ class WorkspaceScopedControllerIntegrationTest extends AbstractWorkspaceIntegrat
                 .headers(TestAuthUtils.withCurrentUser())
                 .exchange()
                 .expectStatus()
-                .isNotFound();
+                .isNotFound()
+                .expectBody(Void.class);
     }
 }

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/workspace/WorkspaceSlugRenameIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/workspace/WorkspaceSlugRenameIntegrationTest.java
@@ -88,7 +88,8 @@ class WorkspaceSlugRenameIntegrationTest extends AbstractWorkspaceIntegrationTes
                     .bodyValue(request)
                     .exchange()
                     .expectStatus()
-                    .isOk();
+                    .isOk()
+                    .expectBody(Void.class);
 
             currentSlug = nextSlug;
         }
@@ -162,7 +163,8 @@ class WorkspaceSlugRenameIntegrationTest extends AbstractWorkspaceIntegrationTes
                 .bodyValue(request)
                 .exchange()
                 .expectStatus()
-                .isEqualTo(HttpStatus.CONFLICT);
+                .isEqualTo(HttpStatus.CONFLICT)
+                .expectBody(Void.class);
     }
 
     @Test

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/workspace/settings/WorkspaceTeamSettingsControllerIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/workspace/settings/WorkspaceTeamSettingsControllerIntegrationTest.java
@@ -146,7 +146,8 @@ class WorkspaceTeamSettingsControllerIntegrationTest extends AbstractWorkspaceIn
                     .uri("/workspaces/{slug}/teams/{teamId}/settings", workspace.getWorkspaceSlug(), team.getId())
                     .exchange()
                     .expectStatus()
-                    .isUnauthorized();
+                    .isUnauthorized()
+                    .expectBody(Void.class);
         }
 
         @Test
@@ -195,7 +196,8 @@ class WorkspaceTeamSettingsControllerIntegrationTest extends AbstractWorkspaceIn
                     .bodyValue(request)
                     .exchange()
                     .expectStatus()
-                    .isForbidden();
+                    .isForbidden()
+                    .expectBody(Void.class);
         }
 
         @Test
@@ -214,7 +216,8 @@ class WorkspaceTeamSettingsControllerIntegrationTest extends AbstractWorkspaceIn
                     .bodyValue(request)
                     .exchange()
                     .expectStatus()
-                    .isNotFound();
+                    .isNotFound()
+                    .expectBody(Void.class);
         }
     }
 
@@ -261,7 +264,8 @@ class WorkspaceTeamSettingsControllerIntegrationTest extends AbstractWorkspaceIn
                             repository.getId())
                     .exchange()
                     .expectStatus()
-                    .isUnauthorized();
+                    .isUnauthorized()
+                    .expectBody(Void.class);
         }
 
         @Test
@@ -319,7 +323,8 @@ class WorkspaceTeamSettingsControllerIntegrationTest extends AbstractWorkspaceIn
                     .bodyValue(request)
                     .exchange()
                     .expectStatus()
-                    .isForbidden();
+                    .isForbidden()
+                    .expectBody(Void.class);
         }
 
         @Test
@@ -342,7 +347,8 @@ class WorkspaceTeamSettingsControllerIntegrationTest extends AbstractWorkspaceIn
                     .bodyValue(request)
                     .exchange()
                     .expectStatus()
-                    .isNotFound();
+                    .isNotFound()
+                    .expectBody(Void.class);
         }
     }
 
@@ -390,7 +396,8 @@ class WorkspaceTeamSettingsControllerIntegrationTest extends AbstractWorkspaceIn
                     .headers(TestAuthUtils.withCurrentUser())
                     .exchange()
                     .expectStatus()
-                    .isCreated();
+                    .isCreated()
+                    .expectBody(Void.class);
 
             // Assert: Verify database state
             var filters = labelFilterRepository.findByWorkspaceIdAndTeamId(workspace.getId(), team.getId());
@@ -416,7 +423,8 @@ class WorkspaceTeamSettingsControllerIntegrationTest extends AbstractWorkspaceIn
                     .headers(TestAuthUtils.withCurrentUser())
                     .exchange()
                     .expectStatus()
-                    .isForbidden();
+                    .isForbidden()
+                    .expectBody(Void.class);
         }
 
         @Test
@@ -435,7 +443,8 @@ class WorkspaceTeamSettingsControllerIntegrationTest extends AbstractWorkspaceIn
                     .headers(TestAuthUtils.withCurrentUser())
                     .exchange()
                     .expectStatus()
-                    .isCreated();
+                    .isCreated()
+                    .expectBody(Void.class);
 
             // Act: Try to add the same filter again
             webTestClient
@@ -448,7 +457,8 @@ class WorkspaceTeamSettingsControllerIntegrationTest extends AbstractWorkspaceIn
                     .headers(TestAuthUtils.withCurrentUser())
                     .exchange()
                     .expectStatus()
-                    .isCreated();
+                    .isCreated()
+                    .expectBody(Void.class);
 
             // Assert: Only one filter exists
             var filters = labelFilterRepository.findByWorkspaceIdAndTeamId(workspace.getId(), team.getId());
@@ -471,7 +481,8 @@ class WorkspaceTeamSettingsControllerIntegrationTest extends AbstractWorkspaceIn
                     .headers(TestAuthUtils.withCurrentUser())
                     .exchange()
                     .expectStatus()
-                    .isCreated();
+                    .isCreated()
+                    .expectBody(Void.class);
 
             // Verify filter exists
             var filtersBefore = labelFilterRepository.findByWorkspaceIdAndTeamId(workspace.getId(), team.getId());
@@ -487,7 +498,8 @@ class WorkspaceTeamSettingsControllerIntegrationTest extends AbstractWorkspaceIn
                     .headers(TestAuthUtils.withCurrentUser())
                     .exchange()
                     .expectStatus()
-                    .isNoContent();
+                    .isNoContent()
+                    .expectBody(Void.class);
 
             // Assert: Verify database state
             var filtersAfter = labelFilterRepository.findByWorkspaceIdAndTeamId(workspace.getId(), team.getId());
@@ -511,7 +523,8 @@ class WorkspaceTeamSettingsControllerIntegrationTest extends AbstractWorkspaceIn
                     .headers(TestAuthUtils.withCurrentUser())
                     .exchange()
                     .expectStatus()
-                    .isNotFound();
+                    .isNotFound()
+                    .expectBody(Void.class);
         }
 
         @Test
@@ -531,7 +544,8 @@ class WorkspaceTeamSettingsControllerIntegrationTest extends AbstractWorkspaceIn
                     .headers(TestAuthUtils.withCurrentUser())
                     .exchange()
                     .expectStatus()
-                    .isCreated();
+                    .isCreated()
+                    .expectBody(Void.class);
 
             webTestClient
                     .post()
@@ -543,7 +557,8 @@ class WorkspaceTeamSettingsControllerIntegrationTest extends AbstractWorkspaceIn
                     .headers(TestAuthUtils.withCurrentUser())
                     .exchange()
                     .expectStatus()
-                    .isCreated();
+                    .isCreated()
+                    .expectBody(Void.class);
 
             List<LabelInfoDTO> result = webTestClient
                     .get()
@@ -584,7 +599,8 @@ class WorkspaceTeamSettingsControllerIntegrationTest extends AbstractWorkspaceIn
                     .bodyValue(new UpdateTeamSettingsRequestDTO(true))
                     .exchange()
                     .expectStatus()
-                    .isOk();
+                    .isOk()
+                    .expectBody(Void.class);
 
             // Assert: Verify the team is hidden when fetching settings
             WorkspaceTeamSettingsDTO result = webTestClient
@@ -620,7 +636,8 @@ class WorkspaceTeamSettingsControllerIntegrationTest extends AbstractWorkspaceIn
                     .bodyValue(new UpdateRepositorySettingsRequestDTO(true))
                     .exchange()
                     .expectStatus()
-                    .isOk();
+                    .isOk()
+                    .expectBody(Void.class);
 
             // Assert: Verify the repository is hidden when fetching settings
             WorkspaceTeamRepositorySettingsDTO result = webTestClient
@@ -656,7 +673,8 @@ class WorkspaceTeamSettingsControllerIntegrationTest extends AbstractWorkspaceIn
                     .bodyValue(new UpdateTeamSettingsRequestDTO(true))
                     .exchange()
                     .expectStatus()
-                    .isOk();
+                    .isOk()
+                    .expectBody(Void.class);
 
             // Act: Unhide the team
             WorkspaceTeamSettingsDTO result = webTestClient


### PR DESCRIPTION
## What changed and why

Status and header assertions in the server integration suite left HTTP response bodies unconsumed. A large response can retain a pooled connection even after its assertion passes; a single-connection reproduction fails on the next request without body consumption.

Finish 409 status/header-only assertions with `expectBody(Void.class)` and use `returnResult(Void.class)` in three header-only helpers. Existing status, header, body and authorization assertions remain intact. Add a focused real-HTTP connection-reuse regression and document response ownership for test authors. No retries, pool tuning or warning suppression.

## How to test

- `vp run format` and `vp run check`.
- `HEPHAESTUS_INTEGRATION_SHARD=application vp run test:server:integration`: 1,010 tests passed.
- `HEPHAESTUS_INTEGRATION_SHARD=providers-and-startup vp run test:server:integration`: 543 tests passed.
- `cd server && ./gradlew :application:test :application:jacocoTestCoverageVerification`: 7,230 tests passed, including the real-HTTP regression. The three final header-helper changes also passed a focused 46-test integration rerun.

## Release impact

Tests and contributor instructions only; no shipped behavior or release note changes.

## Notes for reviewers

The regression uses an ephemeral loopback HTTP server, one pooled connection and a 100 KB response; it disposes both server and provider. Existing integration clients keep their normal configuration. This proves and fixes a resource leak, not a deterministic reproduction of the earlier inactive-channel failure.

Surface review: no integration adapters, runtime roles, wire contract, schema, feedback channels, admin UI or product vocabulary change. Existing workspace-isolation requests and assertions are preserved.
