### PR TITLE
fix(ci): clean up startup defaults and test resource shutdown

### DIFF
--- a/.changeset/safe-mentor-cleanup-default.md
+++ b/.changeset/safe-mentor-cleanup-default.md
@@ -1,0 +1,5 @@
+---
+"hephaestus": patch
+---
+
+Startup now derives the abandoned mentor-turn cleanup window from the maximum allowed turn duration instead of reporting the built-in default as unsafe. Explicitly configured windows still cannot interrupt a turn that is allowed to run.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -341,6 +341,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Smoke-test the blessed install
+        shell: bash
         env:
           ARCHITECTURE: ${{ matrix.architecture }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/admin/buildpacks-cds-decision.md
+++ b/docs/admin/buildpacks-cds-decision.md
@@ -35,7 +35,7 @@ Much longer CI builds, loss of JIT peak throughput on Hibernate workloads, no JF
 ## Builder pinning
 
 `server/application/project.toml` pins `builder-noble-java-tiny` and the `health-checker` buildpack
-by sha256 digest; `.github/workflows/ci-build.yml` pins `ubuntu-noble-run-tiny` the same way, because
+by sha256 digest; `.github/workflows/cicd.yml` pins `ubuntu-noble-run-tiny` the same way, because
 the project descriptor has no run-image key. Renovate tracks each image's `latest` tag and opens the
 digest bump.
 
@@ -52,7 +52,7 @@ type is added, so no JVM is spawned per probe.
 
 ## Rollback
 
-Re-add a `Dockerfile` for `server/application` and switch the `application-server-image` job in `.github/workflows/ci-build.yml` from `use-buildpacks: true` to `docker-file`. The Dockerfile path builds from the checkout, not from the packaged JAR, so the build-once guarantee lapses until that path also downloads `application-artifact`. Coolify re-deploys the prior image SHA. Detection: Sentry release-tagged error spike, or Prometheus alert on `application_ready_time_seconds > 15` for three consecutive deploys.
+Re-add a `Dockerfile` for `server/application` and switch the `application-server-image` job in `.github/workflows/cicd.yml` from `use-buildpacks: true` to `docker-file`. The Dockerfile path builds from the checkout, not from the packaged JAR, so the build-once guarantee lapses until that path also downloads `application-artifact`. Coolify re-deploys the prior image SHA. Detection: Sentry release-tagged error spike, or Prometheus alert on `application_ready_time_seconds > 15` for three consecutive deploys.
 
 ## Operational checklist
 

--- a/docs/decisions/0026-per-purpose-agent-bindings-and-llm-governance.md
+++ b/docs/decisions/0026-per-purpose-agent-bindings-and-llm-governance.md
@@ -150,8 +150,8 @@ gate never kills a call already streaming; it acts only pre-forward.
   the in-flight term. That execution is bounded only by the ledger term.
 - **A crashed worker's mentor turn, until the reaper runs.** Its spend is on the `chat_message` row but
   not yet in the ledger, so the gate lets the workspace keep spending against headroom that is already
-  gone. `MentorInFlightReaper` bills the calls the proxy recorded once its window elapses (default
-  `PT70M`, floored at 70 minutes). That is reaper latency, not a lost charge.
+  gone. `MentorInFlightReaper` bills the calls the proxy recorded once its window elapses (defaulting to
+  the maximum configurable turn timeout plus ten minutes, which also floors explicit overrides). That is reaper latency, not a lost charge.
 
 ## Consequences
 

--- a/server/AGENTS.md
+++ b/server/AGENTS.md
@@ -166,5 +166,5 @@ envelope to JetStream, all gated on `RuntimeRole.WEBHOOK_PROPERTY`. Configuratio
 
 Paketo Cloud Native Buildpacks with Application CDS; no `Dockerfile`. From `server/`:
 `./gradlew :application:bootJar`, then
-`pack build hephaestus/application-server --path application/build/libs/hephaestus-application-*.jar --descriptor application/project.toml --run-image <the run image pinned in .github/workflows/ci-build.yml>`.
+`pack build hephaestus/application-server --path application/build/libs/hephaestus-application-*.jar --descriptor application/project.toml --run-image <the run image pinned in .github/workflows/cicd.yml>`.
 Pinning and rationale: `docs/admin/buildpacks-cds-decision.md`.

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/mentor/chat/MentorInFlightReaper.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/mentor/chat/MentorInFlightReaper.java
@@ -12,6 +12,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -51,7 +52,7 @@ public class MentorInFlightReaper {
             ChatMessageRepository chatMessageRepository,
             MentorInFlightAccounting accounting,
             MeterRegistry meterRegistry,
-            @Value("${hephaestus.mentor.in-flight-reaper.window:PT70M}") Duration window) {
+            @Value("${hephaestus.mentor.in-flight-reaper.window:#{null}}") @Nullable Duration window) {
         this.chatMessageRepository = chatMessageRepository;
         this.accounting = accounting;
         this.meterRegistry = meterRegistry;
@@ -93,7 +94,10 @@ public class MentorInFlightReaper {
                     failed);
     }
 
-    private static Duration safeWindow(Duration configuredWindow) {
+    private static Duration safeWindow(@Nullable Duration configuredWindow) {
+        if (configuredWindow == null) {
+            return MINIMUM_SAFE_WINDOW;
+        }
         if (configuredWindow.compareTo(MINIMUM_SAFE_WINDOW) < 0) {
             log.warn(
                     "Mentor in-flight reaper window {} is unsafe for configured turns; using {}",

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/mentor/chat/MentorInFlightReaperTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/mentor/chat/MentorInFlightReaperTest.java
@@ -23,6 +23,7 @@ import java.util.UUID;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.dao.OptimisticLockingFailureException;
 
 class MentorInFlightReaperTest extends BaseUnitTest {
@@ -116,8 +117,30 @@ class MentorInFlightReaperTest extends BaseUnitTest {
                 .isGreaterThan(longestPossibleTurn);
     }
 
+    @Test
+    void shouldDeriveTheDefaultWindowWhenNoPropertyIsConfigured() {
+        new ApplicationContextRunner()
+                .withBean(ChatMessageRepository.class, () -> chatMessageRepository)
+                .withBean(MentorInFlightAccounting.class, () -> mock(MentorInFlightAccounting.class))
+                .withBean(io.micrometer.core.instrument.MeterRegistry.class, () -> meterRegistry)
+                .withBean(MentorInFlightReaper.class)
+                .run(context -> assertThat(
+                                context.getBean(MentorInFlightReaper.class).window())
+                        .isEqualTo(Duration.ofSeconds(AgentBindingLimits.MAX_TIMEOUT_SECONDS)
+                                .plusMinutes(10)));
+    }
+
+    @Test
+    void shouldPreserveALongerConfiguredWindow() {
+        Duration configured = Duration.ofDays(1);
+        MentorInFlightReaper reaper = new MentorInFlightReaper(
+                chatMessageRepository, mock(MentorInFlightAccounting.class), meterRegistry, configured);
+
+        assertThat(reaper.window()).isEqualTo(configured);
+    }
+
     private MentorInFlightReaper reaperWith(MentorInFlightAccounting accounting) {
-        return new MentorInFlightReaper(chatMessageRepository, accounting, meterRegistry, Duration.ofMinutes(70));
+        return new MentorInFlightReaper(chatMessageRepository, accounting, meterRegistry, null);
     }
 
     private static ChatMessage messageWithId() {

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/testconfig/NatsTestContainer.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/testconfig/NatsTestContainer.java
@@ -31,7 +31,8 @@ public final class NatsTestContainer {
         return "nats://" + c.getHost() + ":" + c.getMappedPort(CLIENT_PORT);
     }
 
-    @SuppressWarnings("resource") // Closed by the JVM shutdown hook.
+    // Ryuk stops this singleton after JVM exit, keeping it available while Spring closes cached contexts.
+    @SuppressWarnings("resource")
     private static GenericContainer<?> createContainer() {
         GenericContainer<?> newContainer = new GenericContainer<>(IMAGE)
                 .withCommand("-js")
@@ -44,11 +45,6 @@ public final class NatsTestContainer {
                 newContainer.getHost(),
                 newContainer.getMappedPort(CLIENT_PORT));
 
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-            if (newContainer.isRunning()) {
-                newContainer.stop();
-            }
-        }));
         return newContainer;
     }
 }

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/testconfig/PostgreSQLTestContainer.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/testconfig/PostgreSQLTestContainer.java
@@ -117,7 +117,8 @@ public final class PostgreSQLTestContainer {
 
     public record TestDatabase(String jdbcUrl, String username, String password) {}
 
-    @SuppressWarnings("resource") // Closed by the JVM shutdown hook.
+    // Ryuk stops this singleton after JVM exit, keeping it available while Spring closes cached contexts.
+    @SuppressWarnings("resource")
     private static PostgreSQLContainer<?> createContainer() {
         PostgreSQLContainer<?> newContainer = new PostgreSQLContainer<>(DockerImageName.parse(new ImageFromDockerfile()
                                 .withDockerfile(
@@ -139,12 +140,6 @@ public final class PostgreSQLTestContainer {
                 newContainer.getJdbcUrl(),
                 newContainer.getUsername(),
                 newContainer.getDatabaseName());
-
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-            if (newContainer.isRunning()) {
-                newContainer.stop();
-            }
-        }));
 
         return newContainer;
     }

--- a/webapp/src/routes/-chrome-route.test.tsx
+++ b/webapp/src/routes/-chrome-route.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { HttpResponse, http } from "msw";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import type { AdminWorkspaceView } from "@/api/types.gen";
 import { workspaceListItem } from "@/mocks/fixtures/workspaces";
 import { server } from "@/mocks/server";
 import { ROUTE_RENDER_WAIT, renderRouteAt } from "@/test/router-harness";
@@ -17,6 +18,7 @@ vi.setConfig({ testTimeout: 30_000 });
 describe("app chrome on a route with no workspace in the URL", () => {
 	beforeEach(() => {
 		server.use(
+			http.get("*/admin/workspaces", () => HttpResponse.json<AdminWorkspaceView[]>([])),
 			http.get("*/workspaces", () =>
 				HttpResponse.json([workspaceListItem("acme", { displayName: "Acme" })]),
 			),

--- a/webapp/src/test/setup-msw.ts
+++ b/webapp/src/test/setup-msw.ts
@@ -46,6 +46,10 @@ if (typeof window !== "undefined" && typeof window.matchMedia !== "function") {
 	});
 }
 
+// jsdom exposes scrollTo but throws when the router restores scroll after navigation.
+// Layout and scrolling are covered in browser tests, not this DOM-only environment.
+window.scrollTo = () => {};
+
 // jsdom has no scrollIntoView either; Base UI calls it to keep the highlighted option in view.
 if (typeof Element.prototype.scrollIntoView !== "function") {
 	Element.prototype.scrollIntoView = () => {};


### PR DESCRIPTION
## What changed and why

A job-log audit exposed a test shutdown race and a built-in mentor cleanup default that warns on every startup.

- Let Testcontainers own the shared PostgreSQL and NATS containers. Their independent JVM hooks could stop services before Spring closed cached contexts, causing Hikari closed-connection warnings and scheduled-task errors during teardown. Ryuk keeps them alive until the test JVM exits, then removes them.
- Derive the default abandoned mentor-turn cleanup window from the existing maximum turn duration plus its safety allowance. Explicit unsafe overrides still warn and clamp; longer overrides remain unchanged.
- Give the admin-workspace route fixture its actual response contract and stub jsdom's unimplemented `scrollTo`, rather than suppressing warning output.
- Declare the release smoke step's existing Bash shell explicitly so workflow analysis can resolve the matrix runner. Correct documentation references to the image job's current workflow and the derived cleanup window.

## How to test

- `vp run format` and `vp run check`.
- `HEPHAESTUS_INTEGRATION_SHARD=providers-and-startup vp run test:server:integration` and `HEPHAESTUS_INTEGRATION_SHARD=application vp run test:server:integration`: 543 and 1,010 tests passed. Both shutdown logs are clean of the previous Hikari/scheduler teardown errors, and the provider run's PostgreSQL and NATS containers were removed by Ryuk after JVM exit.
- `vp run test:server:unit`: unit baseline and coverage passed, including default binding, unsafe override, and longer-window tests.
- `vp run test:webapp`: full webapp and lint-rule suites.

## Release impact

The patch changeset explains the corrected default cleanup configuration. No operator action. The effective safe cleanup duration is unchanged; omitted configuration no longer triggers an unsafe-override warning.

## Notes for reviewers

Testcontainers' [documented singleton lifecycle](https://java.testcontainers.org/test_framework_integration/manual_lifecycle_control/#singleton-containers) owns cleanup. No retries, pool tuning, log filtering, dependencies or custom shutdown coordinator.

Surface review: the reaper remains server-role-only and provider-independent; no wire contract, schema, workspace authorization, feedback-channel or reverse-state change. The fixture is specifically the instance-admin workspace contract; no shipped UI change. Operator and architecture documentation are updated. Security configuration is untouched.
