### PR TITLE
fix(webapp): send the CSRF token, so signing out works

### DIFF
--- a/.changeset/sign-out-works-again.md
+++ b/.changeset/sign-out-works-again.md
@@ -1,0 +1,5 @@
+---
+"hephaestus": patch
+---
+
+Signing out works again. The browser could not find the CSRF token the server requires, so the server rejected the request and the app reported that it could not confirm the sign-out. Other actions that change something were rejected the same way. Instances that never set `XSRF_COOKIE_NAME`, which is every instance following the shipped configuration, were affected.

--- a/webapp/src/environment/index.test.ts
+++ b/webapp/src/environment/index.test.ts
@@ -3,10 +3,14 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 /**
  * The module reads `window.__ENV__` once, at import, so each case loads it afresh.
  */
-async function deploymentFor(runtime: Window["__ENV__"]) {
+async function environmentFor(runtime: Window["__ENV__"]) {
 	vi.resetModules();
 	window.__ENV__ = runtime;
-	return (await import("./index")).default.deployment;
+	return (await import("./index")).default;
+}
+
+async function deploymentFor(runtime: Window["__ENV__"]) {
+	return (await environmentFor(runtime)).deployment;
 }
 
 afterEach(() => {
@@ -48,5 +52,27 @@ describe("preview pull request", () => {
 		});
 
 		expect(deployment.pullRequest).toBeUndefined();
+	});
+});
+
+describe("CSRF cookie name", () => {
+	it("falls back to the secure cookie the server sets when the deployment leaves it unset", async () => {
+		// The entrypoint writes every key of RuntimeEnvVars into window.__ENV__ whether the container
+		// has it or not, so an unset variable arrives as "", which the `??` default cannot rescue.
+		const environment = await environmentFor({
+			SENTRY_ENVIRONMENT: "production",
+			XSRF_COOKIE_NAME: "",
+		});
+
+		expect(environment.xsrfCookieName).toBe("__Host-XSRF-TOKEN");
+	});
+
+	it("keeps a name the deployment does set, which local http E2E needs without the __Host- prefix", async () => {
+		const environment = await environmentFor({
+			SENTRY_ENVIRONMENT: "local",
+			XSRF_COOKIE_NAME: "XSRF-TOKEN",
+		});
+
+		expect(environment.xsrfCookieName).toBe("XSRF-TOKEN");
 	});
 });

--- a/webapp/src/environment/index.ts
+++ b/webapp/src/environment/index.ts
@@ -28,12 +28,22 @@ interface RuntimeEnvVars {
 	DEPLOYED_AT?: string;
 }
 
+/**
+ * The name the server gives the CSRF double-submit cookie when `hephaestus.auth.cookie-secure` is
+ * on, which the `prod` profile requires of itself and every deployment runs under. A blank name
+ * matches no cookie, so it is a variable that was never set rather than a choice — unlike
+ * `SENTRY_DSN`, where blank deliberately turns reporting off. The entrypoint writes every key of
+ * `RuntimeEnvVars` into `window.__ENV__` whether the container has it or not, so an unset variable
+ * arrives as `""`, which no default beside it can rescue.
+ */
+const SECURE_XSRF_COOKIE_NAME = "__Host-XSRF-TOKEN";
+
 // Dev defaults (used when window.__ENV__ is not set)
 const defaults: RuntimeEnvVars = {
 	APPLICATION_VERSION: "DEV",
 	APPLICATION_CLIENT_URL: "http://localhost:4200",
 	APPLICATION_SERVER_URL: "http://localhost:8080",
-	XSRF_COOKIE_NAME: "__Host-XSRF-TOKEN",
+	XSRF_COOKIE_NAME: SECURE_XSRF_COOKIE_NAME,
 	SENTRY_ENVIRONMENT: "local",
 	SENTRY_DSN: "https://289f1f62feeb4f70a8878dc0101825cd@sentry.ase.in.tum.de/3",
 	LEGAL_PROFILE: "",
@@ -86,7 +96,7 @@ const environment = {
 	// CSRF double-submit cookie name. `__Host-`-prefixed in production; dropped for local http E2E
 	// (the browser rejects `__Host-` cookies over http://localhost) — must match the server's
 	// hephaestus.auth.cookie-secure setting.
-	xsrfCookieName: env("XSRF_COOKIE_NAME"),
+	xsrfCookieName: env("XSRF_COOKIE_NAME") || SECURE_XSRF_COOKIE_NAME,
 
 	buildInfo: {
 		branch: env("GIT_BRANCH"),


### PR DESCRIPTION
## What changed and why

Signing out fails on **every** deployment — production, staging and every preview — with *"Could not confirm sign-out. Please try again."* So does every other state-changing request: the server answers `403` because the browser sends no `X-XSRF-TOKEN`.

The webapp reads the double-submit token from a cookie whose name comes from `XSRF_COOKIE_NAME`. No compose file sets it, and `webapp/docker/entrypoint.sh` writes **every** key of `RuntimeEnvVars` into `window.__ENV__` whether the container has it or not. So it arrives as `""` — present, and therefore never replaced by the `??` default sitting right beside it. The client then looks for a cookie literally named `""` while the server sets `__Host-XSRF-TOKEN`.

Measured on all three, server-issued cookie vs. what the client reads:

| | `XSRF_COOKIE_NAME` in `window.__ENV__` | `POST /auth/logout` without header | with header |
|---|---|---|---|
| preview `pr2042` | `""` | **403** | 401 |
| staging | `""` | **403** | — |
| production | `""` | **403** | — |

Confirmed in the shipped production bundle, which computes the name the same way:

```js
function i(){let t=r(e.xsrfCookieName);return t?{"X-XSRF-TOKEN":t}:{}}
```

`#2047` is where this became live: it introduced `csrf.spa()` and the `requiresCsrf` matcher, which demands the header on every non-safe method for cookie-authenticated requests. It set `XSRF_COOKIE_NAME` nowhere, and the client-side gap had been latent since `#1400` made the name configurable.

A blank cookie name can never match a cookie, so it is a variable that was not set rather than a choice — fall back to the name the server uses. `SENTRY_DSN` is exactly why this is not applied to every variable at once: there, blank deliberately turns reporting off, and a blanket `||` would send preview and staging errors to the production Sentry.

## How to test

```sh
vp run test:webapp     # 1155 + 168 pass
```

`src/environment/index.test.ts` gains the deployed shape — `XSRF_COOKIE_NAME: ""` must resolve to `__Host-XSRF-TOKEN` — and a case keeping an explicitly configured name, which local http E2E needs without the `__Host-` prefix. Reverting the one-line fix fails the first and nothing else.

Against a preview once this ships, the check is the table above: `POST /auth/logout` should stop returning 403 from the browser.

## Release impact

`.changeset/sign-out-works-again.md`, patch. **Worth releasing promptly** — sign-out is broken for every user on production today.

## Notes for reviewers

The existing CSRF unit tests (`auth-client.test.ts`) passed throughout and still do. They pass because `window.__ENV__` is undefined under vitest, so the default applies — the one condition no deployment has. That is the same shape as the bug in #2094: a test exercising a default that production never sees.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed sign-out and other actions that modify data when the CSRF cookie name is left at its documented default.
  - Requests now correctly recognize the secure default CSRF cookie configuration.
- **Tests**
  - Added coverage for default and explicitly configured CSRF cookie names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### After adversarial review

Two things it established that the description above did not:

**This fixes production and staging, but not previews.** Production and staging serve the API on the same origin as the app (`hephaestus.build` + `/api`), so the frontend can read the cookie once it knows the name. A preview does not: the app is at `pr<n>.<domain>` and the API at `pr<n>.api.<domain>`, and the `__Host-` prefix forbids a `Domain` attribute, so the cookie is host-only to the API and the app's JavaScript can never read it through `document.cookie`. Correcting the name cannot reach it. That is a separate, pre-existing defect in the preview topology and should not hold this up.

**Users must reload the page after rollout.** An already-open tab keeps the old bundle and will keep failing; a normal reload is enough, and clearing cookies is not needed.

It also checked the fallback against the only environment that uses the insecure cookie name: `application-e2e.yml` sets `cookie-secure: false`, and `webapp/e2e/fixtures.ts` pairs it with an explicit `XSRF_COOKIE_NAME: "XSRF-TOKEN"`, which `||` preserves. `SecurityConfig` refuses `cookie-secure: false` under the `prod` profile, so no deployment can reach the fallback with the wrong name.
