### PR TITLE
fix(server): schedule sandbox maintenance on worker runtimes

### DIFF
--- a/.changeset/worker-sandbox-maintenance.md
+++ b/.changeset/worker-sandbox-maintenance.md
@@ -1,0 +1,5 @@
+---
+"hephaestus": patch
+---
+
+Worker-only deployments now reclaim idle mentor sessions and orphaned sandbox resources periodically. Stalled writes to a mentor runtime are now interrupted by the configured timeout, even while Docker cleanup is waiting for a response. Generating the API contract no longer runs sandbox cleanup against the local Docker daemon.

--- a/docs/admin/runtime-roles.mdx
+++ b/docs/admin/runtime-roles.mdx
@@ -108,6 +108,11 @@ sandbox gateway on the same port and needs the same firewall treatment as a spli
 webhook role turns the worker role off, so it opens no gateway — the three `sandbox.gateway` rows
 read `—` in that column.
 
+Sandbox maintenance follows the worker role in both split-out and single-container deployments.
+Idle mentor sessions and orphaned resources are cleaned periodically without enabling server-wide
+scheduled jobs on the worker. Stalled writes are checked on a separate thread so a slow Docker cleanup
+cannot delay their timeout. API-contract generation and CDS training do not run sandbox maintenance.
+
 Only worker containers bind their HTTP and management endpoints to loopback: that is the `worker`
 overlay's doing, and a single-container install running all three roles still serves `/api/**` and
 the management endpoints on `SERVER_PORT`. On that topology the gateway is a second, narrower door

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/SandboxMaintenanceConfiguration.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/SandboxMaintenanceConfiguration.java
@@ -1,0 +1,61 @@
+package de.tum.cit.aet.hephaestus.agent.sandbox.docker;
+
+import com.github.dockerjava.api.DockerClient;
+import de.tum.cit.aet.hephaestus.agent.sandbox.InteractiveSandboxProperties;
+import de.tum.cit.aet.hephaestus.agent.sandbox.SandboxProperties;
+import de.tum.cit.aet.hephaestus.agent.sandbox.docker.interactive.InteractiveSandboxRegistry;
+import de.tum.cit.aet.hephaestus.agent.sandbox.docker.interactive.StdinWriteWatchdog;
+import de.tum.cit.aet.hephaestus.core.runtime.RuntimeRole;
+import java.time.Duration;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.scheduling.config.FixedDelayTask;
+import org.springframework.scheduling.config.ScheduledTaskRegistrar;
+
+/** Worker-owned maintenance without enabling server-wide {@code @Scheduled} methods. */
+@Configuration(proxyBeanMethods = false)
+@Profile("!specs & !cds-training")
+@ConditionalOnClass(DockerClient.class)
+@ConditionalOnProperty(name = RuntimeRole.WORKER_PROPERTY, havingValue = "true", matchIfMissing = true)
+public class SandboxMaintenanceConfiguration {
+
+    @Bean
+    ScheduledTaskRegistrar sandboxWatchdogTasks(StdinWriteWatchdog watchdog) {
+        var tasks = new ScheduledTaskRegistrar();
+        // Docker reconciliation can block on RPCs; stalled-write protection needs its own thread.
+        tasks.addFixedDelayTask(new FixedDelayTask(watchdog::tick, Duration.ofMillis(100), Duration.ZERO));
+        return tasks;
+    }
+
+    @Bean
+    ScheduledTaskRegistrar sandboxMaintenanceTasks(
+            SandboxReconciler reconciler,
+            InteractiveSandboxRegistry sessions,
+            SandboxProperties sandboxProperties,
+            InteractiveSandboxProperties mentorProperties,
+            @Value("${hephaestus.sandbox.reconciliation-initial-delay-seconds:10}") long initialDelaySeconds) {
+        var tasks = new ScheduledTaskRegistrar();
+        tasks.addFixedDelayTask(new FixedDelayTask(
+                reconciler::periodicReconciliation,
+                Duration.ofSeconds(sandboxProperties.reconciliationIntervalSeconds()),
+                Duration.ofSeconds(initialDelaySeconds)));
+        tasks.addFixedDelayTask(new FixedDelayTask(
+                sessions::reap, Duration.ofSeconds(mentorProperties.reapIntervalSeconds()), Duration.ZERO));
+        return tasks;
+    }
+
+    @Bean
+    ApplicationListener<ApplicationReadyEvent> sandboxStartupMaintenance(
+            SandboxReconciler reconciler, InteractiveSandboxRegistry sessions) {
+        return event -> {
+            reconciler.onStartup();
+            sessions.onStartup();
+        };
+    }
+}

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/SandboxReconciler.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/SandboxReconciler.java
@@ -15,15 +15,12 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
-import org.springframework.context.event.EventListener;
-import org.springframework.scheduling.annotation.Scheduled;
 
 /**
  * Detects and cleans up orphaned sandbox resources.
@@ -33,7 +30,7 @@ import org.springframework.scheduling.annotation.Scheduled;
  * <ol>
  *   <li><b>Startup</b> ({@link ApplicationReadyEvent}): resources left by a previous worker process
  *       are cleaned immediately.
- *   <li><b>Periodic</b> ({@link Scheduled}): orphaned containers and networks are cleaned up on a
+ *   <li><b>Periodic</b> (worker maintenance scheduler): orphaned containers and networks are cleaned up on a
  *       configurable interval.
  * </ol>
  *
@@ -91,7 +88,6 @@ public class SandboxReconciler {
     }
 
     /** On startup, clean only resources on this worker's Docker daemon. */
-    @EventListener(ApplicationReadyEvent.class)
     public void onStartup() {
         MDC.put(MDC_RECONCILER_TYPE, "startup");
         try {
@@ -137,10 +133,6 @@ public class SandboxReconciler {
     }
 
     /** Periodic sweep: clean up orphaned Docker resources. */
-    @Scheduled(
-            initialDelayString = "${hephaestus.sandbox.reconciliation-initial-delay-seconds:10}",
-            fixedDelayString = "${hephaestus.sandbox.reconciliation-interval-seconds:60}",
-            timeUnit = TimeUnit.SECONDS)
     public void periodicReconciliation() {
         MDC.put(MDC_RECONCILER_TYPE, "periodic");
         try {

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/interactive/DockerAttachedSandboxAdapter.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/interactive/DockerAttachedSandboxAdapter.java
@@ -322,7 +322,7 @@ public final class DockerAttachedSandboxAdapter implements AttachedSandbox, Stdi
         try {
             closeExecutor.execute(() -> runClose(graceTimeout));
         } catch (RejectedExecutionException ree) {
-            // Executor shut down (e.g. by a @Scheduled tick during Spring destruction).
+            // Executor shut down (e.g. by a maintenance tick during Spring destruction).
             log.warn("closeExecutor rejected runClose for sessionId={} — running inline", sessionId);
             runClose(graceTimeout);
         }

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/interactive/InteractiveSandboxRegistry.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/interactive/InteractiveSandboxRegistry.java
@@ -24,13 +24,10 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.boot.context.event.ApplicationReadyEvent;
-import org.springframework.context.event.EventListener;
-import org.springframework.scheduling.annotation.Scheduled;
 
 /**
  * In-memory registry of live sessions keyed by {@code (userId, workspaceId)}. Owns capacity caps,
- * idle reaper, watchdog tick, and post-restart orphan sweep.
+ * idle reaper and post-restart orphan sweep.
  */
 @WorkspaceAgnostic("Interactive sandbox registry keys by user+workspace, not by workspace-iteration semantics")
 public class InteractiveSandboxRegistry {
@@ -145,11 +142,9 @@ public class InteractiveSandboxRegistry {
         });
     }
 
-    @Scheduled(fixedDelayString = "${hephaestus.mentor.reap-interval-seconds:30}", timeUnit = TimeUnit.SECONDS)
     public void reap() {
         if (shuttingDown) {
-            // During @PreDestroy the scheduler can still fire; closeExecutor may already be down
-            // and we'd run runClose inline on the scheduler thread, stalling the watchdog.
+            // During @PreDestroy a maintenance sweep may already be in progress.
             return;
         }
         Duration ttl = Duration.ofSeconds(properties.idleTtlSeconds());
@@ -162,15 +157,13 @@ public class InteractiveSandboxRegistry {
                         "Reaping idle sandbox: sessionId={}, idleFor={}s",
                         sandbox.identity().sessionId(),
                         sandbox.idleFor().toSeconds());
-                // Fire and forget: the reaper shares Spring's single-thread scheduler with the
-                // watchdog, so blocking here would stall it.
+                // Fire and forget so one closing session does not delay the remaining idle sessions.
                 sandbox.terminate(EvictionReason.IDLE);
             }
         }
     }
 
     /** After a restart the in-memory registry is gone; any {@code KIND=interactive} container is orphan. */
-    @EventListener(ApplicationReadyEvent.class)
     public void onStartup() {
         try {
             List<DockerOperations.ContainerInfo> managed = containerManager.listManagedContainers();

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/interactive/StdinWriteWatchdog.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/interactive/StdinWriteWatchdog.java
@@ -7,7 +7,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Shared timestamp inspector that enforces {@code hephaestus.mentor.stdin-write-timeout-ms}
- * across active sessions. {@link #tick()} runs on a {@code @Scheduled} cadence; each tick is
+ * across active sessions. {@link #tick()} runs on a dedicated worker maintenance scheduler; each tick is
  * O(N) timestamp reads with no blocking.
  */
 public final class StdinWriteWatchdog {

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/runtime/ServerSchedulingConfig.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/runtime/ServerSchedulingConfig.java
@@ -18,10 +18,9 @@ import org.springframework.scheduling.annotation.EnableScheduling;
  * boots with scheduling enabled.
  * The {@code specs} profile only introspects the HTTP contract and must not start background work.
  *
- * <p>Worker-side scheduled tasks (sandbox reconciler tick, interactive sandbox reaper, stdin
- * watchdog) are owned by the worker role: their hosting beans are wired only when
- * {@code DockerSandboxConfiguration} loads, which is itself gated by
- * {@code RuntimeRole.WORKER_PROPERTY}. No additional gating is needed there.
+ * <p>Worker-side sandbox maintenance is registered independently by
+ * {@code SandboxMaintenanceConfiguration}. Worker-only deployments do not enable this server-wide
+ * scheduler; the stalled-write watchdog has its own thread so Docker cleanup cannot delay it.
  */
 @Configuration(proxyBeanMethods = false)
 @Profile("!specs")

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/SandboxMaintenanceConfigurationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/SandboxMaintenanceConfigurationTest.java
@@ -1,0 +1,183 @@
+package de.tum.cit.aet.hephaestus.agent.sandbox.docker;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import de.tum.cit.aet.hephaestus.agent.job.AgentJobRepository;
+import de.tum.cit.aet.hephaestus.agent.metrics.AgentMetrics;
+import de.tum.cit.aet.hephaestus.agent.sandbox.InteractiveSandboxProperties;
+import de.tum.cit.aet.hephaestus.agent.sandbox.SandboxProperties;
+import de.tum.cit.aet.hephaestus.agent.sandbox.docker.interactive.InteractiveSandboxMetrics;
+import de.tum.cit.aet.hephaestus.agent.sandbox.docker.interactive.InteractiveSandboxRegistry;
+import de.tum.cit.aet.hephaestus.agent.sandbox.docker.interactive.StdinWriteWatchdog;
+import de.tum.cit.aet.hephaestus.core.runtime.ServerSchedulingConfig;
+import de.tum.cit.aet.hephaestus.testconfig.BaseUnitTest;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Clock;
+import java.time.Duration;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.config.ScheduledTaskHolder;
+import org.springframework.scheduling.config.ScheduledTaskRegistrar;
+
+class SandboxMaintenanceConfigurationTest extends BaseUnitTest {
+
+    private final AgentJobRepository jobs = mock(AgentJobRepository.class);
+    private final SandboxContainerManager containers = mock(SandboxContainerManager.class);
+    private final SandboxNetworkManager networks = mock(SandboxNetworkManager.class);
+    private final SimpleMeterRegistry meters = new SimpleMeterRegistry();
+    private final StdinWriteWatchdog watchdog = new StdinWriteWatchdog();
+
+    private final ApplicationContextRunner runner = new ApplicationContextRunner()
+            .withUserConfiguration(
+                    SandboxMaintenanceConfiguration.class, PropertiesConfiguration.class, ServerSchedulingConfig.class)
+            .withBean(StdinWriteWatchdog.class, () -> watchdog)
+            .withBean(
+                    SandboxReconciler.class,
+                    () -> new SandboxReconciler(jobs, containers, networks, meters, Clock.systemUTC()))
+            .withBean(
+                    InteractiveSandboxRegistry.class,
+                    () -> new InteractiveSandboxRegistry(
+                            new InteractiveSandboxProperties(300, 1, 1, 512, 5000, 64, 64, 30, 3, 50, 1048576),
+                            containers,
+                            new InteractiveSandboxMetrics(meters),
+                            watchdog,
+                            meters));
+
+    @AfterEach
+    void closeMeters() {
+        meters.close();
+    }
+
+    @Test
+    void shouldReconcileAtStartupWithoutWaitingForThePeriodicSweep() {
+        runner.withPropertyValues("hephaestus.sandbox.reconciliation-initial-delay-seconds=86400")
+                .run(context -> {
+                    context.publishEvent(new ApplicationReadyEvent(
+                            new SpringApplication(),
+                            new String[0],
+                            context.getSourceApplicationContext(),
+                            Duration.ZERO));
+                    assertThat(meters.get(AgentMetrics.SANDBOX_RECONCILER_SWEEPS)
+                                    .tag("outcome", "completed")
+                                    .counter()
+                                    .count())
+                            .isEqualTo(1);
+                });
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void shouldInterruptStalledWritesWithOrWithoutTheServerRole(boolean serverEnabled) {
+        var interrupted = new AtomicBoolean();
+        watchdog.register(UUID.randomUUID(), stalledTarget(interrupted));
+        runner.withPropertyValues("hephaestus.runtime.server.enabled=" + serverEnabled)
+                .run(context -> {
+                    assertThat(context).hasNotFailed();
+                    assertThat(context.getBeansOfType(ScheduledTaskHolder.class).values().stream()
+                                    .flatMap(holder -> holder.getScheduledTasks().stream()))
+                            .hasSize(3);
+                    await().atMost(Duration.ofSeconds(3)).untilTrue(interrupted);
+                });
+    }
+
+    @Test
+    void shouldReconcileOrphansOnAWorkerWithoutServerScheduling() {
+        runner.withPropertyValues(
+                        "hephaestus.runtime.server.enabled=false",
+                        "hephaestus.sandbox.reconciliation-initial-delay-seconds=0")
+                .run(context -> {
+                    assertThat(context).hasNotFailed();
+                    await().atMost(Duration.ofSeconds(3))
+                            .untilAsserted(() -> assertThat(meters.get(AgentMetrics.SANDBOX_RECONCILER_SWEEPS)
+                                            .tag("outcome", "completed")
+                                            .counter()
+                                            .count())
+                                    .isPositive());
+                });
+    }
+
+    @Test
+    void shouldKeepTheWatchdogRunningWhileDockerReconciliationBlocks() {
+        var entered = new CountDownLatch(1);
+        var release = new CountDownLatch(1);
+        when(containers.listManagedContainers()).thenAnswer(invocation -> {
+            entered.countDown();
+            release.await();
+            return java.util.List.of();
+        });
+        runner.withPropertyValues("hephaestus.sandbox.reconciliation-initial-delay-seconds=0")
+                .run(context -> {
+                    try {
+                        assertThat(entered.await(3, TimeUnit.SECONDS)).isTrue();
+                        var interrupted = new AtomicBoolean();
+                        watchdog.register(UUID.randomUUID(), stalledTarget(interrupted));
+                        await().atMost(Duration.ofSeconds(3)).untilTrue(interrupted);
+                    } finally {
+                        release.countDown();
+                    }
+                });
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"specs", "cds-training"})
+    void shouldNotAccessDockerOrTheDatabaseInBuildOnlyProfiles(String profile) {
+        runner.withPropertyValues("spring.profiles.active=" + profile).run(context -> {
+            assertThat(context).hasNotFailed().doesNotHaveBean(ScheduledTaskRegistrar.class);
+            context.publishEvent(new ApplicationReadyEvent(
+                    new SpringApplication(), new String[0], context.getSourceApplicationContext(), Duration.ZERO));
+            verifyNoInteractions(jobs, containers, networks);
+        });
+    }
+
+    @Test
+    void shouldNotScheduleMaintenanceWithoutTheWorkerRole() {
+        runner.withPropertyValues("hephaestus.runtime.worker.enabled=false").run(context -> {
+            assertThat(context).hasNotFailed().doesNotHaveBean(ScheduledTaskRegistrar.class);
+            verifyNoInteractions(jobs, containers, networks);
+        });
+    }
+
+    @Test
+    void shouldCancelMaintenanceWhenTheContextCloses() {
+        var tasks = new java.util.ArrayList<org.springframework.scheduling.config.ScheduledTask>();
+        runner.run(context -> context.getBeansOfType(ScheduledTaskRegistrar.class)
+                .values()
+                .forEach(registrar -> tasks.addAll(registrar.getScheduledTasks())));
+        assertThat(tasks)
+                .hasSize(3)
+                .allSatisfy(task -> assertThat(task.nextExecution()).isNull());
+    }
+
+    private static StdinWriteWatchdog.StallTarget stalledTarget(AtomicBoolean interrupted) {
+        return new StdinWriteWatchdog.StallTarget() {
+            @Override
+            public boolean writeStalled(long nowNanos) {
+                return !interrupted.get();
+            }
+
+            @Override
+            public void onWriteTimeout() {
+                interrupted.set(true);
+            }
+        };
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    @EnableConfigurationProperties({SandboxProperties.class, InteractiveSandboxProperties.class})
+    static class PropertiesConfiguration {}
+}

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/interactive/SandboxIdleMaintenanceTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/interactive/SandboxIdleMaintenanceTest.java
@@ -1,0 +1,69 @@
+package de.tum.cit.aet.hephaestus.agent.sandbox.docker.interactive;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import de.tum.cit.aet.hephaestus.agent.sandbox.InteractiveSandboxProperties;
+import de.tum.cit.aet.hephaestus.agent.sandbox.SandboxProperties;
+import de.tum.cit.aet.hephaestus.agent.sandbox.docker.SandboxContainerManager;
+import de.tum.cit.aet.hephaestus.agent.sandbox.docker.SandboxMaintenanceConfiguration;
+import de.tum.cit.aet.hephaestus.agent.sandbox.docker.SandboxReconciler;
+import de.tum.cit.aet.hephaestus.agent.sandbox.spi.AttachedSandboxState;
+import de.tum.cit.aet.hephaestus.agent.sandbox.spi.EvictionReason;
+import de.tum.cit.aet.hephaestus.agent.sandbox.spi.SandboxIdentity;
+import de.tum.cit.aet.hephaestus.testconfig.BaseUnitTest;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Duration;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+class SandboxIdleMaintenanceTest extends BaseUnitTest {
+
+    @Test
+    void shouldEvictOnlyIdleSessionsOnAWorkerWithoutServerScheduling() {
+        var properties = new InteractiveSandboxProperties(300, 1, 1, 512, 5000, 64, 64, 30, 3, 50, 1048576);
+        var watchdog = new StdinWriteWatchdog();
+        var meters = new SimpleMeterRegistry();
+        var registry = new InteractiveSandboxRegistry(
+                properties,
+                mock(SandboxContainerManager.class),
+                new InteractiveSandboxMetrics(meters),
+                watchdog,
+                meters);
+        var idle = session("idle-user", Duration.ofMinutes(6));
+        var active = session("active-user", Duration.ZERO);
+
+        new ApplicationContextRunner()
+                .withUserConfiguration(SandboxMaintenanceConfiguration.class)
+                .withPropertyValues("hephaestus.runtime.server.enabled=false")
+                .withBean(InteractiveSandboxProperties.class, () -> properties)
+                .withBean(SandboxProperties.class, () -> new SandboxProperties(5, 10, 60, 1073741824L, 500000, null))
+                .withBean(StdinWriteWatchdog.class, () -> watchdog)
+                .withBean(InteractiveSandboxRegistry.class, () -> registry)
+                .withBean(SandboxReconciler.class, () -> mock(SandboxReconciler.class))
+                .run(context -> {
+                    assertThat(context).hasNotFailed();
+                    assertThat(registry.tryRegister(idle))
+                            .isEqualTo(InteractiveSandboxRegistry.RegistrationOutcome.REGISTERED);
+                    assertThat(registry.tryRegister(active))
+                            .isEqualTo(InteractiveSandboxRegistry.RegistrationOutcome.REGISTERED);
+                    await().atMost(Duration.ofSeconds(3))
+                            .untilAsserted(() -> verify(idle).terminate(EvictionReason.IDLE));
+                    verify(active, never()).terminate(EvictionReason.IDLE);
+                });
+        meters.close();
+    }
+
+    private static DockerAttachedSandboxAdapter session(String userId, Duration idleFor) {
+        var session = mock(DockerAttachedSandboxAdapter.class);
+        when(session.identity()).thenReturn(new SandboxIdentity(UUID.randomUUID(), userId, "workspace"));
+        when(session.state()).thenReturn(AttachedSandboxState.ATTACHED);
+        when(session.idleFor()).thenReturn(idleFor);
+        return session;
+    }
+}


### PR DESCRIPTION
## What changed and why

The job-log audit exposed two dormant worker safety mechanisms: the stalled-stdin watchdog had no production caller, and worker-only deployments never scheduled sandbox reconciliation or idle-session eviction because application scheduling is server-role-only. API generation also invoked the interactive orphan sweep against the local Docker daemon.

Register worker maintenance with Spring's native scheduled-task lifecycle, independently of server-wide scheduling. A dedicated watchdog task cannot be starved by blocking Docker reconciliation. Maintenance is absent in API-generation and CDS-training profiles; startup cleanup now shares that same worker/profile boundary. Remove the old annotations so a monolith never schedules duplicate sweeps.

## How to test

- `vp run format` and `vp run check`.
- `vp run test:server:unit`: 7,242 tests passed; `vp run test:server:architecture`: 302 tests passed.
- Both integration shards: `HEPHAESTUS_INTEGRATION_SHARD=application vp run test:server:integration` and `HEPHAESTUS_INTEGRATION_SHARD=providers-and-startup vp run test:server:integration`.
- The new context tests exercise server+worker, worker-only, worker-disabled, `specs`, and `cds-training` configurations. They prove stalled-write interruption, startup and periodic reconciliation, idle-only eviction, watchdog progress while Docker is blocked, no duplicate schedules, no build-profile Docker/database access, and cancellation on context close.
- `vp run generate:api:specs` regenerated the specification without a contract diff. The isolated scrape used port 34109; its application and management connectors were stopped afterward.

## Release impact

A patch changeset explains restored worker cleanup and stalled-write protection. Existing timeout and sweep-interval settings retain their meanings; no operator action or new configuration is required.

## Notes for reviewers

No global scheduling is enabled on workers: that would also activate server-only jobs whose beans intentionally exist on other roles. Spring owns the task executors and cancellation; there is no custom polling loop or retry policy. The watchdog is isolated because Docker RPCs can block, not as speculative performance tuning.

Surface review: applies to both monolith and split worker runtimes, independent of GitHub/GitLab/Slack/Outline adapters. No schema, authorization, wire contract, feedback-channel, admin UI or vocabulary change. Disabled roles and build-only profiles are covered as reverse states. Runtime documentation is updated.
