### PR TITLE
test(server): initialize scheduler locks in integration fixtures

### DIFF
--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/interactive/SandboxIdleMaintenanceTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/interactive/SandboxIdleMaintenanceTest.java
@@ -2,6 +2,7 @@ package de.tum.cit.aet.hephaestus.agent.sandbox.docker.interactive;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -52,8 +53,10 @@ class SandboxIdleMaintenanceTest extends BaseUnitTest {
                             .isEqualTo(InteractiveSandboxRegistry.RegistrationOutcome.REGISTERED);
                     assertThat(registry.tryRegister(active))
                             .isEqualTo(InteractiveSandboxRegistry.RegistrationOutcome.REGISTERED);
-                    await().atMost(Duration.ofSeconds(3))
-                            .untilAsserted(() -> verify(idle).terminate(EvictionReason.IDLE));
+                    await().atMost(Duration.ofSeconds(3)).untilAsserted(() -> {
+                        verify(idle, atLeastOnce()).terminate(EvictionReason.IDLE);
+                        verify(active, atLeastOnce()).idleFor();
+                    });
                     verify(active, never()).terminate(EvictionReason.IDLE);
                 });
         meters.close();

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/runtime/SchedulerLockFixtureIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/runtime/SchedulerLockFixtureIntegrationTest.java
@@ -1,0 +1,48 @@
+package de.tum.cit.aet.hephaestus.core.runtime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import de.tum.cit.aet.hephaestus.testconfig.BaseIntegrationTest;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.UUID;
+import net.javacrumbs.shedlock.core.LockConfiguration;
+import net.javacrumbs.shedlock.core.LockProvider;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+class SchedulerLockFixtureIntegrationTest extends BaseIntegrationTest {
+
+    @Autowired
+    private LockProvider locks;
+
+    @Autowired
+    private JdbcTemplate jdbc;
+
+    @Test
+    void shouldPreserveSchedulerLocksWhileCleaningApplicationData() {
+        String name = "fixture-" + UUID.randomUUID();
+        var configuration = new LockConfiguration(Instant.now(), name, Duration.ofMinutes(1), Duration.ZERO);
+        var first = locks.lock(configuration).orElseThrow();
+        try {
+            try {
+                databaseTestUtils.cleanDatabase();
+                assertThat(locks.lock(configuration)).isEmpty();
+                assertThat(jdbc.queryForObject("SELECT count(*) FROM shedlock WHERE name = ?", Integer.class, name))
+                        .isEqualTo(1);
+            } finally {
+                first.unlock();
+            }
+
+            var next = locks.lock(configuration).orElseThrow();
+            try {
+                assertThat(locks.lock(configuration)).isEmpty();
+            } finally {
+                next.unlock();
+            }
+        } finally {
+            jdbc.update("DELETE FROM shedlock WHERE name = ?", name);
+        }
+    }
+}

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/schema/ProductionSchemaContractIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/schema/ProductionSchemaContractIntegrationTest.java
@@ -26,12 +26,16 @@ import de.tum.cit.aet.hephaestus.testconfig.TestCacheConfiguration;
 import de.tum.cit.aet.hephaestus.workspace.AccountType;
 import de.tum.cit.aet.hephaestus.workspace.Workspace;
 import de.tum.cit.aet.hephaestus.workspace.WorkspaceRepository;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.stream.Stream;
+import net.javacrumbs.shedlock.core.LockConfiguration;
+import net.javacrumbs.shedlock.core.LockProvider;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
@@ -93,6 +97,9 @@ class ProductionSchemaContractIntegrationTest {
     private JdbcTemplate jdbcTemplate;
 
     @Autowired
+    private LockProvider locks;
+
+    @Autowired
     private SlackConversationProjector slackConversationProjector;
 
     @Autowired
@@ -112,6 +119,24 @@ class ProductionSchemaContractIntegrationTest {
 
     @Autowired
     private IdentityProviderRepository identityProviderRepository;
+
+    @Test
+    void shouldAcquireAndReleaseSchedulerLocksAgainstTheMigratedSchema() {
+        String name = "schema-" + UUID.randomUUID();
+        var configuration = new LockConfiguration(Instant.now(), name, Duration.ofMinutes(1), Duration.ZERO);
+        var first = locks.lock(configuration).orElseThrow();
+        try {
+            try {
+                assertThat(locks.lock(configuration)).isEmpty();
+            } finally {
+                first.unlock();
+            }
+            var next = locks.lock(configuration).orElseThrow();
+            next.unlock();
+        } finally {
+            jdbcTemplate.update("DELETE FROM shedlock WHERE name = ?", name);
+        }
+    }
 
     @Test
     void observationForeignKeysPreserveTenantAndProvenance() {

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/testconfig/DatabaseTestUtils.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/testconfig/DatabaseTestUtils.java
@@ -21,7 +21,8 @@ import org.springframework.transaction.support.TransactionTemplate;
 @Component
 public class DatabaseTestUtils {
 
-    private static final Set<String> IGNORED_TABLES = Set.of("databasechangelog", "databasechangeloglock");
+    // ShedLock caches known lock rows; truncating them can strand acquisition until the context restarts.
+    private static final Set<String> IGNORED_TABLES = Set.of("databasechangelog", "databasechangeloglock", "shedlock");
     private static final Set<String> RETRYABLE_SQL_STATES = Set.of("40P01", "40001", "55P03");
     private static final int MAX_ATTEMPTS = 5;
     private static final long RETRY_DELAY_MS = 100;

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/testconfig/TestSchedulerSchemaConfiguration.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/testconfig/TestSchedulerSchemaConfiguration.java
@@ -1,0 +1,28 @@
+package de.tum.cit.aet.hephaestus.testconfig;
+
+import javax.sql.DataSource;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.jdbc.datasource.init.DataSourceInitializer;
+import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator;
+
+/** Supplies the non-JPA lock table without hiding missing tables in migrated-schema tests. */
+@Configuration(proxyBeanMethods = false)
+@Profile("test")
+@ConditionalOnProperty(name = "spring.liquibase.enabled", havingValue = "false")
+public class TestSchedulerSchemaConfiguration {
+
+    @Bean
+    @DependsOn("entityManagerFactory")
+    DataSourceInitializer schedulerLockSchema(DataSource dataSource) {
+        var initializer = new DataSourceInitializer();
+        initializer.setDataSource(dataSource);
+        initializer.setDatabasePopulator(
+                new ResourceDatabasePopulator(new ClassPathResource("db/test-scheduler-schema.sql")));
+        return initializer;
+    }
+}

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/testconfig/TestSchedulerSchemaConfigurationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/testconfig/TestSchedulerSchemaConfigurationTest.java
@@ -1,0 +1,29 @@
+package de.tum.cit.aet.hephaestus.testconfig;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.jdbc.datasource.init.DataSourceInitializer;
+
+class TestSchedulerSchemaConfigurationTest extends BaseUnitTest {
+
+    @Test
+    void shouldLeaveMigratedSchemasEntirelyToLiquibase() {
+        new ApplicationContextRunner()
+                .withUserConfiguration(TestSchedulerSchemaConfiguration.class)
+                .withPropertyValues("spring.profiles.active=test", "spring.liquibase.enabled=true")
+                .run(context -> assertThat(context).hasNotFailed().doesNotHaveBean(DataSourceInitializer.class));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"prod", "specs", "cds-training"})
+    void shouldNeverInitializeTheFixtureOutsideTheTestProfile(String profile) {
+        new ApplicationContextRunner()
+                .withUserConfiguration(TestSchedulerSchemaConfiguration.class)
+                .withPropertyValues("spring.profiles.active=" + profile, "spring.liquibase.enabled=false")
+                .run(context -> assertThat(context).hasNotFailed().doesNotHaveBean(DataSourceInitializer.class));
+    }
+}

--- a/server/application/src/test/resources/db/test-scheduler-schema.sql
+++ b/server/application/src/test/resources/db/test-scheduler-schema.sql
@@ -1,0 +1,9 @@
+-- Hibernate cannot create ShedLock's table because it has no JPA entity.
+-- Migrated-schema tests use Liquibase instead of this fixture.
+CREATE TABLE IF NOT EXISTS shedlock (
+    name VARCHAR(64) NOT NULL,
+    lock_until TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+    locked_at TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+    locked_by VARCHAR(255) NOT NULL,
+    CONSTRAINT pk_shedlock PRIMARY KEY (name)
+);


### PR DESCRIPTION
## What changed and why

A successful CI run still logged scheduled-task failures because Hibernate-only integration databases had no `shedlock` table. Scheduler locking lives outside JPA, so `ddl-auto=create` cannot supply it. A focused integration test reproduced the exact missing-table failure before this change.

Initialize the vendor lock-table fixture after JPA initialization, only for the `test` profile with Liquibase explicitly disabled. Preserve lock rows during ordinary application-data cleanup: ShedLock caches which rows exist, so truncating them can prevent subsequent acquisition. Migrated-schema tests remain owned entirely by Liquibase.

The merge-queue run also exposed an asynchronous assertion race in the recently merged sandbox maintenance test: idle eviction could be observed before the active session was inspected. Wait for both observable results before closing the context, retaining strict Mockito validation and avoiding sleeps or lenient stubs.

## How to test

- `vp run format` and `vp run check`.
- `cd server && ./gradlew :application:integrationTest --tests '*SchedulerLockFixtureIntegrationTest'`: proves acquisition, exclusion, preservation through application cleanup, release and reacquisition. This test failed with `relation "shedlock" does not exist` before the fix and passed afterward.
- `cd server && ./gradlew :application:databaseTest --tests '*ProductionSchemaContractIntegrationTest'`: verifies the real lock provider also works against the production migrations (30 tests passed).
- `vp run test:server:unit`: full unit baseline and coverage (7,246 tests passed on the combined tree), including guards proving that the fixture cannot initialize migrated or non-test profiles.
- Run both integration shards using `HEPHAESTUS_INTEGRATION_SHARD=application` and `HEPHAESTUS_INTEGRATION_SHARD=providers-and-startup` with `vp run test:server:integration`.

## Release impact

Test infrastructure and coverage only. No production migration, schema, application behavior or release note changes.

## Notes for reviewers

No scheduled jobs are disabled, no lock provider is mocked in integration tests, and no SQL errors are suppressed. Spring owns initialization and its dependency on the entity-manager factory. The Liquibase guard prevents this fixture from repairing a broken production migration during validation.

Surface review: this is a global scheduler-coordination table, not workspace data. The real migrated schema and the Hibernate-only test schema are both exercised; no integration adapter, runtime-role behavior, wire contract, feedback channel or UI changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved scheduler lock records during database cleanup, helping prevent duplicate scheduled-task execution in affected environments.
  * Improved handling and verification of idle sandbox session maintenance.

* **Tests**
  * Added coverage for scheduler lock acquisition, release, and persistence across database cleanup.
  * Added validation for scheduler schemas with and without database migrations.
  * Added test fixtures to support reliable scheduler lock integration testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->