### PR TITLE
fix: correct startup lifecycles and preserve CI analysis

### DIFF
--- a/.changeset/audit-link-semantics.md
+++ b/.changeset/audit-link-semantics.md
@@ -1,0 +1,5 @@
+---
+"hephaestus": patch
+---
+
+The instance overview's “View audit log” link now retains native link semantics for keyboard and assistive-technology users.

--- a/.changeset/build-profile-startup.md
+++ b/.changeset/build-profile-startup.md
@@ -1,0 +1,5 @@
+---
+"hephaestus": patch
+---
+
+Building the API contract or container class archive no longer starts server background scheduling or attempts sync-job recovery and signing-key seeding against an unavailable database. Production still validates sealed signing keys and seeds the active key at startup.

--- a/.changeset/component-build-isolation.md
+++ b/.changeset/component-build-isolation.md
@@ -1,0 +1,4 @@
+---
+---
+
+Development tooling only: rebuilding Storybook no longer reloads the application development server, and Storybook no longer searches for nonexistent MDX stories.

--- a/.changeset/session-request-lifetime.md
+++ b/.changeset/session-request-lifetime.md
@@ -1,0 +1,5 @@
+---
+"hephaestus": patch
+---
+
+Opening a page no longer fails when the shared session check is still running as the interface remounts. Signing out still discards pending identity results, and server outages remain visible rather than being treated as a signed-out session.

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -231,7 +231,8 @@ jobs:
             SPRING_DOCKER_COMPOSE_ENABLED=false APPLICATION_HOST_URL=http://localhost:4200 \
             setsid java -jar "$SERVER_JAR" --spring.profiles.active=e2e,playwright > e2e-server.log 2>&1 &
           SERVER_PID=$!
-          timeout 5m bash -c 'until curl --fail --silent http://localhost:8080/actuator/health/liveness >/dev/null; do kill -0 '"${SERVER_PID}"' || exit 1; sleep 2; done'
+          # Liveness precedes ApplicationRunner completion; readiness includes signing-key initialization.
+          timeout 5m bash -c 'until curl --fail --silent http://localhost:8080/actuator/health/readiness >/dev/null; do kill -0 '"${SERVER_PID}"' || exit 1; sleep 2; done'
           curl --fail --silent --show-error -X POST http://localhost:8080/auth/dev-login \
             -H 'content-type: application/json' -d '{"username":"e2e","admin":true}' >/dev/null
           docker compose -f server/compose.yaml exec -T postgres \

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -237,8 +237,9 @@ jobs:
           docker compose -f server/compose.yaml exec -T postgres \
             psql -v ON_ERROR_STOP=1 -U root -d hephaestus < webapp/e2e/seed.sql
           timeout --kill-after=30s 10m vp run --filter webapp test:e2e
+      # A green browser suite can still hide server startup failures. Preserve the raw log too.
       - name: Upload diagnostics
-        if: failure()
+        if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: webapp-e2e-results

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -776,6 +776,15 @@ jobs:
           if-no-files-found: warn
           retention-days: 7
 
+  CodeQL:
+    name: CodeQL
+    uses: ./.github/workflows/codeql.yml
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: read
+      security-events: write
+
   all-ci-passed:
     name: "CI Status Gate"
     timeout-minutes: 10
@@ -783,7 +792,7 @@ jobs:
     permissions:
       actions: read
       statuses: write
-    needs: [detect-changes, gradle-wrapper, workflow-lint, zizmor, Quality, server-package, application-server-image, Build, Security, Test, Changesets, Compose, Docker, Supported-host-smoke, Release-preflight]
+    needs: [detect-changes, gradle-wrapper, workflow-lint, zizmor, CodeQL, Quality, server-package, application-server-image, Build, Security, Test, Changesets, Compose, Docker, Supported-host-smoke, Release-preflight]
     if: always()
     steps:
       - name: Generate workflow timeline
@@ -840,6 +849,7 @@ jobs:
           echo "Package:        ${{ needs.server-package.result }}"
           echo "Server image:   ${{ needs.application-server-image.result }}"
           echo "Build:          ${{ needs.Build.result }}"
+          echo "CodeQL:         ${{ needs.CodeQL.result }}"
           echo "Security:       ${{ needs.Security.result }}"
           echo "Test:           ${{ needs.Test.result }}"
           echo "Changesets:     ${{ needs.Changesets.result }}"
@@ -856,6 +866,13 @@ jobs:
 
           if [[ "${{ contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
             echo "status=cancelled" >> $GITHUB_OUTPUT
+            exit 1
+          fi
+
+          # The queue must retain its ref until analysis and SARIF upload finish.
+          if [[ "${{ needs.CodeQL.result }}" != "success" ]]; then
+            echo "CodeQL did not complete successfully."
+            echo "status=failure" >> $GITHUB_OUTPUT
             exit 1
           fi
 
@@ -887,6 +904,7 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "| Workflow | Status |" >> $GITHUB_STEP_SUMMARY
           echo "|----------|--------|" >> $GITHUB_STEP_SUMMARY
+          echo "| CodeQL | ${{ needs.CodeQL.result }} |" >> $GITHUB_STEP_SUMMARY
 
           result_to_emoji() {
             case "$1" in

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,17 +1,14 @@
 name: CodeQL
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-  merge_group:
+  workflow_call:
   schedule:
     - cron: "15 5 * * 1"
 
 permissions: {}
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: codeql-${{ github.ref }}
   # Preserve analysis for every default-branch commit.
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
@@ -70,13 +67,28 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Set up Java
+        if: matrix.language == 'java-kotlin'
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
+        with:
+          distribution: temurin
+          java-version-file: .java-version
+          cache-jdk: false
+
       - name: Initialize CodeQL
         uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           languages: ${{ matrix.language }}
-          # The repository has no Kotlin, and CodeQL supports build-mode: none for Java without it.
-          build-mode: none
+          # Trace the real Java toolchain, dependencies and generated clients rather than guessing them.
+          build-mode: ${{ matrix.language == 'java-kotlin' && 'manual' || 'none' }}
           config-file: ./.github/codeql/codeql-config.yml
+
+      - name: Compile Java for analysis
+        if: matrix.language == 'java-kotlin'
+        working-directory: server
+        # Extraction observes javac: restored classes and a reused Gradle daemon bypass it.
+        # This produces analysis inputs, never the packaged server that CI tests and ships.
+        run: ./gradlew --no-daemon --no-build-cache --no-configuration-cache clean :application:testClasses
 
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9

--- a/docs/admin/runtime-roles.mdx
+++ b/docs/admin/runtime-roles.mdx
@@ -111,7 +111,8 @@ read `—` in that column.
 Sandbox maintenance follows the worker role in both split-out and single-container deployments.
 Idle mentor sessions and orphaned resources are cleaned periodically without enabling server-wide
 scheduled jobs on the worker. Stalled writes are checked on a separate thread so a slow Docker cleanup
-cannot delay their timeout. API-contract generation and CDS training do not run sandbox maintenance.
+cannot delay their timeout. API-contract generation and CDS training do not run sandbox maintenance, server scheduled jobs or
+startup sync-job recovery.
 
 Only worker containers bind their HTTP and management endpoints to loopback: that is the `worker`
 overlay's doing, and a single-container install running all three roles still serves `/api/**` and

--- a/docs/contributor/ci-cd.mdx
+++ b/docs/contributor/ci-cd.mdx
@@ -67,6 +67,10 @@ published.
 | Actionlint, Zizmor | workflow lint with ShellCheck warnings; Zizmor at medium confidence | — |
 | PR → Validate PR | Conventional Commit title; every commit’s primary author resolves to the pull request author’s GitHub account (including bot accounts); the PR body follows attribution policy | — |
 
+The browser job retains `webapp-e2e-results`, including `e2e-server.log`, for seven days on
+success as well as failure. Inspect server startup and shutdown output even when browser assertions
+pass; a passing suite does not prove that background work started correctly.
+
 The four quality legs call `ci-quality-leg.yml` independently. Job-level conditions omit unchanged
 legs before a runner is allocated; selected legs do not cancel each other on failure. Each runs
 `vp run ci:<leg>`, then pipes `vp run --last-details` through `scripts/report-task-run.ts`: every
@@ -80,7 +84,7 @@ both it and the tooling leg prove the hook dispatcher on a rejected and an accep
 Pull requests targeting `main` merge through GitHub's merge queue after these GitHub
 Actions contexts pass: `CI Status Gate`, `Actionlint`, and `Zizmor`. Required
 workflows run again for the merge group, which includes the current base and queued changes ahead of
-the pull request. Each required context is bound to the GitHub Actions integration rather than
+the pull request. `CI Status Gate` also waits for CodeQL analysis and publication. Each required context is bound to the GitHub Actions integration rather than
 accepting a same-named external status.
 
 A merge group is a diff, so it selects its jobs from the paths it touches —
@@ -222,6 +226,17 @@ because GitHub caps a fork token's `security-events` access at read.
 PR and merge-group diffs select analysis languages, not individual files: each selected language
 scans its configured source tree. Main and scheduled runs select all languages, as do changes to
 the CodeQL workflow or configuration. The language filters live in `.github/workflows/codeql.yml`.
+
+CI calls that reusable workflow, and `CI Status Gate` waits for its successful completion, including
+SARIF upload. A merge group therefore cannot pass the gate and lose its temporary ref while CodeQL
+is still publishing results. The weekly scan also runs directly from the same workflow.
+
+Java uses manual extraction with the JDK pinned in `.java-version` and a clean, uncached
+`:application:testClasses` compilation. This gives CodeQL the real dependencies, generated clients
+and annotation-processed source instead of no-build dependency and JDK guesses. The single-use Gradle
+process runs inside the extractor; neither cached classes nor a pre-existing daemon can bypass it.
+This compilation produces analysis inputs only: the packaged server remains owned by the build-once
+job. Actions and JavaScript/TypeScript retain no-build analysis.
 
 `.github/workflows/codeql.yml` runs CodeQL under advanced setup: only advanced setup reads a
 committed config file, and `.github/codeql/codeql-config.yml` excludes `security/semgrep/**`,

--- a/scripts/ci-contract.test.ts
+++ b/scripts/ci-contract.test.ts
@@ -581,6 +581,8 @@ void describe("CI contract", () => {
 		const e2e = job(build, "webapp-e2e");
 		assert.doesNotMatch(e2e, /needs:/);
 		assert.equal((e2e.match(/actions\/download-artifact@/g) ?? []).length, 1);
+		assert.match(e2e, /name: Upload diagnostics\s+if: always\(\)/);
+		assert.match(e2e, /e2e-server\.log/);
 		const image = job(orchestrator, "application-server-image");
 		assert.match(image, /needs: \[detect-changes, server-package\]/);
 		assert.match(image, /use-buildpacks: true/);
@@ -1485,6 +1487,13 @@ void describe("CI contract", () => {
 		};
 		const passes = { failed: false, outputs: { status: "success" } };
 
+		for (const result of ["skipped", "failure", "cancelled"])
+			assert.equal(
+				(await verdict({ CodeQL: result }, false)).failed,
+				true,
+				`CodeQL ${result} must not release the merge queue ref`,
+			);
+
 		// An ordinary pull request legitimately skips the preflight, and blocking one would block
 		// every pull request in the repository.
 		assert.deepEqual(await verdict({ "Release-preflight": "skipped" }, false), passes);
@@ -2349,7 +2358,7 @@ void test("Semgrep scans PRs, main and merge queues without a privileged trigger
 void test("CodeQL runs advanced setup and excludes the Semgrep fixtures it would otherwise flag", async () => {
 	const source = await readFile(".github/workflows/codeql.yml", "utf8");
 	const workflow = parseDocument(source);
-	for (const trigger of ["pull_request", "push", "merge_group", "schedule"])
+	for (const trigger of ["workflow_call", "schedule"])
 		assert.ok(workflow.hasIn(["on", trigger]), `codeql.yml must run on ${trigger}`);
 	assert.equal(workflow.hasIn(["on", "pull_request_target"]), false);
 	const permissions = workflow.getIn(["jobs", "analyze", "permissions"]);
@@ -2363,7 +2372,33 @@ void test("CodeQL runs advanced setup and excludes the Semgrep fixtures it would
 		for (const match of source.matchAll(new RegExp(`uses: ${action}@([\\w.-]+)`, "g")))
 			assert.match(match[1] ?? "", /^[a-f0-9]{40}$/, `${action} must be pinned by commit`);
 	const init = step(workflow, ["jobs", "analyze"], "github/codeql-action/init");
-	assert.equal(init.get("build-mode"), "none");
+	assert.match(
+		String(init.get("build-mode")),
+		/matrix\.language == 'java-kotlin' && 'manual' \|\| 'none'/,
+	);
+	const java = step(workflow, ["jobs", "analyze"], "actions/setup-java");
+	assert.equal(java.get("java-version-file"), ".java-version");
+	const compile = namedStep(workflow, ["jobs", "analyze"], "Compile Java for analysis");
+	assert.equal(compile.get("if"), "matrix.language == 'java-kotlin'");
+	assert.equal(compile.get("working-directory"), "server");
+	assert.equal(
+		compile.get("run"),
+		"./gradlew --no-daemon --no-build-cache --no-configuration-cache clean :application:testClasses",
+	);
+	const ci = parseDocument(await readFile(".github/workflows/cicd.yml", "utf8"));
+	assert.equal(ci.getIn(["jobs", "CodeQL", "uses"]), "./.github/workflows/codeql.yml");
+	const gate = ci.getIn(["jobs", "all-ci-passed", "needs"]);
+	assert.ok(isSeq(gate));
+	assert.ok(gate.toJSON().includes("CodeQL"));
+	assert.match(
+		String(namedStep(ci, ["jobs", "all-ci-passed"], "Evaluate CI results").get("run")),
+		/needs.CodeQL.result/,
+	);
+	for (const trigger of ["pull_request", "push", "merge_group"])
+		assert.ok(ci.hasIn(["on", trigger]));
+	assert.equal(workflow.hasIn(["on", "pull_request"]), false);
+	assert.equal(workflow.hasIn(["on", "merge_group"]), false);
+	assert.equal(workflow.hasIn(["on", "push"]), false);
 	assert.equal(init.get("config-file"), "./.github/codeql/codeql-config.yml");
 	assert.match(String(init.get("languages")), /^\$\{\{ *matrix\.language *\}\}$/);
 	const analyze = step(workflow, ["jobs", "analyze"], "github/codeql-action/analyze");

--- a/scripts/ci-contract.test.ts
+++ b/scripts/ci-contract.test.ts
@@ -583,6 +583,8 @@ void describe("CI contract", () => {
 		assert.equal((e2e.match(/actions\/download-artifact@/g) ?? []).length, 1);
 		assert.match(e2e, /name: Upload diagnostics\s+if: always\(\)/);
 		assert.match(e2e, /e2e-server\.log/);
+		assert.match(e2e, /http:\/\/localhost:8080\/actuator\/health\/readiness/);
+		assert.doesNotMatch(e2e, /actuator\/health\/liveness/);
 		const image = job(orchestrator, "application-server-image");
 		assert.match(image, /needs: \[detect-changes, server-package\]/);
 		assert.match(image, /use-buildpacks: true/);

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/auth/config/AuthJwtConfig.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/auth/config/AuthJwtConfig.java
@@ -18,6 +18,7 @@ import org.springframework.cache.CacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
 import org.springframework.security.oauth2.server.resource.web.BearerTokenResolver;
 
 /** Wires issuance and verification for ES256 cookie-session JWTs (ADR 0017). */
@@ -82,8 +83,9 @@ public class AuthJwtConfig {
         keyService.assertProdKeysSealed();
     }
 
-    // CDS training exits at context refresh, before runners can perform database writes.
+    // Build profiles load the authentication contract but have no database to seed.
     @Bean
+    @Profile("!specs & !cds-training")
     ApplicationRunner seedKeysOnStartup() {
         return args -> {
             try {

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/auth/stepup/RecentSignInAuthorizationConfig.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/auth/stepup/RecentSignInAuthorizationConfig.java
@@ -11,8 +11,10 @@ import org.jspecify.annotations.Nullable;
 import org.springframework.aop.Advisor;
 import org.springframework.aop.support.annotation.AnnotationMatchingPointcut;
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Role;
 import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.security.authorization.AuthorizationDecision;
 import org.springframework.security.authorization.AuthorizationManager;
@@ -38,6 +40,7 @@ public class RecentSignInAuthorizationConfig {
      * beans up with it.
      */
     @Bean
+    @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
     static Advisor recentSignInAuthorizationAdvisor(ObjectProvider<RecentSignInPolicy> policy) {
         AuthorizationManager<MethodInvocation> manager = (authentication, invocation) -> {
             Authentication current = authentication.get();

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/runtime/ServerSchedulingConfig.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/runtime/ServerSchedulingConfig.java
@@ -16,14 +16,14 @@ import org.springframework.scheduling.annotation.EnableScheduling;
  *
  * <p>{@code matchIfMissing=true} preserves ADR 0005's DX invariant: zero env vars → full monolith
  * boots with scheduling enabled.
- * The {@code specs} profile only introspects the HTTP contract and must not start background work.
+ * Build-only profiles introspect the HTTP contract or train the class archive and must not start background work.
  *
  * <p>Worker-side sandbox maintenance is registered independently by
  * {@code SandboxMaintenanceConfiguration}. Worker-only deployments do not enable this server-wide
  * scheduler; the stalled-write watchdog has its own thread so Docker cleanup cannot delay it.
  */
 @Configuration(proxyBeanMethods = false)
-@Profile("!specs")
+@Profile("!specs & !cds-training")
 @ConditionalOnProperty(name = RuntimeRole.SERVER_PROPERTY, havingValue = "true", matchIfMissing = true)
 @EnableScheduling
 public class ServerSchedulingConfig {}

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/core/sync/SyncJobZombieSweeper.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/core/sync/SyncJobZombieSweeper.java
@@ -6,6 +6,7 @@ import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.annotation.Profile;
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -22,6 +23,7 @@ import org.springframework.stereotype.Component;
  * ever populated on the server role today (the manual REST trigger).
  */
 @Component
+@Profile("!specs & !cds-training")
 @ConditionalOnServerRole
 @WorkspaceAgnostic("Cross-workspace sync-job zombie sweep")
 public class SyncJobZombieSweeper {

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/leaderboard/LeaderboardTaskScheduler.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/leaderboard/LeaderboardTaskScheduler.java
@@ -61,10 +61,8 @@ import org.springframework.transaction.event.TransactionalEventListener;
  */
 @Order(value = Ordered.LOWEST_PRECEDENCE)
 @Component
-// Excluded from `specs` too: that profile boots the full context with an empty H2 and no schema, and
-// scheduleAllWorkspaces() reads `workspace` on ApplicationReadyEvent — an unswallowed boot-time DB read
-// that would fail spec generation with a cryptic "table not found" (see application-specs.yml).
-@Profile("!test & !specs")
+// Build profiles have neither workspace data to schedule nor a server TaskScheduler.
+@Profile("!test & !specs & !cds-training")
 @ConditionalOnProperty(name = RuntimeRole.SERVER_PROPERTY, havingValue = "true", matchIfMissing = true)
 public class LeaderboardTaskScheduler {
 

--- a/server/application/src/main/resources/application-cds-training.yml
+++ b/server/application/src/main/resources/application-cds-training.yml
@@ -18,8 +18,6 @@ spring:
             hibernate:
                 boot:
                     allow_jdbc_metadata_access: false
-                temp:
-                    use_jdbc_metadata_defaults: false
     docker:
         compose:
             enabled: false

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/auth/config/AuthJwtConfigTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/auth/config/AuthJwtConfigTest.java
@@ -12,6 +12,8 @@ import de.tum.cit.aet.hephaestus.core.auth.metrics.AuthMetrics;
 import de.tum.cit.aet.hephaestus.testconfig.BaseUnitTest;
 import java.time.Clock;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.boot.DefaultApplicationArguments;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
@@ -30,10 +32,11 @@ class AuthJwtConfigTest extends BaseUnitTest {
             .withBean(CacheManager.class, ConcurrentMapCacheManager::new)
             .withBean(Clock.class, Clock::systemUTC);
 
-    @Test
-    void shouldNotSeedSigningKeysDuringCdsContextRefresh() {
-        contextRunner.withPropertyValues("spring.profiles.active=cds-training").run(context -> {
-            assertThat(context).hasNotFailed().hasSingleBean(ApplicationRunner.class);
+    @ParameterizedTest
+    @ValueSource(strings = {"specs", "cds-training"})
+    void shouldNotSeedSigningKeysInBuildProfiles(String profile) {
+        contextRunner.withPropertyValues("spring.profiles.active=" + profile).run(context -> {
+            assertThat(context).hasNotFailed().doesNotHaveBean(ApplicationRunner.class);
             verify(keyService, never()).ensureActiveKey();
         });
     }

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/auth/stepup/RecentSignInAuthorizationConfigTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/auth/stepup/RecentSignInAuthorizationConfigTest.java
@@ -1,0 +1,29 @@
+package de.tum.cit.aet.hephaestus.core.auth.stepup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import de.tum.cit.aet.hephaestus.testconfig.BaseUnitTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+class RecentSignInAuthorizationConfigTest extends BaseUnitTest {
+
+    @Test
+    void shouldRegisterInfrastructureAdvisorWithoutInvokingPolicy() {
+        RecentSignInPolicy policy = mock(RecentSignInPolicy.class);
+        new ApplicationContextRunner()
+                .withUserConfiguration(RecentSignInAuthorizationConfig.class)
+                .withBean(RecentSignInPolicy.class, () -> policy)
+                .run(context -> {
+                    assertThat(context).hasNotFailed();
+                    assertThat(context.getBeanFactory()
+                                    .getBeanDefinition("recentSignInAuthorizationAdvisor")
+                                    .getRole())
+                            .isEqualTo(BeanDefinition.ROLE_INFRASTRUCTURE);
+                    verifyNoInteractions(policy);
+                });
+    }
+}

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/runtime/ServerSchedulingConfigTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/runtime/ServerSchedulingConfigTest.java
@@ -4,6 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import de.tum.cit.aet.hephaestus.testconfig.BaseUnitTest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
@@ -35,9 +37,10 @@ class ServerSchedulingConfigTest extends BaseUnitTest {
                         .isEmpty());
     }
 
-    @Test
-    void shouldNotScheduleBackgroundWorkWhileGeneratingTheApiContract() {
-        runner.withPropertyValues("spring.profiles.active=specs")
+    @ParameterizedTest
+    @ValueSource(strings = {"specs", "cds-training"})
+    void shouldNotScheduleBackgroundWorkInBuildProfiles(String profile) {
+        runner.withPropertyValues("spring.profiles.active=" + profile)
                 .run(context -> assertThat(context.getBeansOfType(ScheduledTaskHolder.class).values().stream()
                                 .flatMap(holder -> holder.getScheduledTasks().stream()))
                         .isEmpty());

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/runtime/ServerSchedulingConfigTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/runtime/ServerSchedulingConfigTest.java
@@ -2,6 +2,7 @@ package de.tum.cit.aet.hephaestus.core.runtime;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import de.tum.cit.aet.hephaestus.leaderboard.LeaderboardTaskScheduler;
 import de.tum.cit.aet.hephaestus.testconfig.BaseUnitTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -40,10 +41,14 @@ class ServerSchedulingConfigTest extends BaseUnitTest {
     @ParameterizedTest
     @ValueSource(strings = {"specs", "cds-training"})
     void shouldNotScheduleBackgroundWorkInBuildProfiles(String profile) {
-        runner.withPropertyValues("spring.profiles.active=" + profile)
-                .run(context -> assertThat(context.getBeansOfType(ScheduledTaskHolder.class).values().stream()
-                                .flatMap(holder -> holder.getScheduledTasks().stream()))
-                        .isEmpty());
+        runner.withUserConfiguration(LeaderboardTaskScheduler.class)
+                .withPropertyValues("spring.profiles.active=" + profile)
+                .run(context -> {
+                    assertThat(context).hasNotFailed().doesNotHaveBean(LeaderboardTaskScheduler.class);
+                    assertThat(context.getBeansOfType(ScheduledTaskHolder.class).values().stream()
+                                    .flatMap(holder -> holder.getScheduledTasks().stream()))
+                            .isEmpty();
+                });
     }
 
     static class BackgroundWork {

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/core/sync/SyncJobZombieSweeperTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/core/sync/SyncJobZombieSweeperTest.java
@@ -1,0 +1,40 @@
+package de.tum.cit.aet.hephaestus.integration.core.sync;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import de.tum.cit.aet.hephaestus.testconfig.BaseUnitTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+class SyncJobZombieSweeperTest extends BaseUnitTest {
+    private final ApplicationContextRunner runner =
+            new ApplicationContextRunner().withUserConfiguration(SyncJobZombieSweeper.class);
+
+    @ParameterizedTest
+    @ValueSource(strings = {"specs", "cds-training"})
+    void shouldNotRequireDatabaseServicesInBuildProfiles(String profile) {
+        runner.withPropertyValues("spring.profiles.active=" + profile)
+                .run(context -> assertThat(context).hasNotFailed().doesNotHaveBean(SyncJobZombieSweeper.class));
+    }
+
+    @Test
+    void shouldNotRequireDatabaseServicesWithoutTheServerRole() {
+        runner.withPropertyValues("hephaestus.runtime.server.enabled=false")
+                .run(context -> assertThat(context).hasNotFailed().doesNotHaveBean(SyncJobZombieSweeper.class));
+    }
+
+    @Test
+    void shouldReapAbandonedJobsWhenTheServerIsReady() {
+        var service = mock(SyncJobService.class);
+        runner.withBean(SyncJobService.class, () -> service).run(context -> {
+            assertThat(context).hasNotFailed().hasSingleBean(SyncJobZombieSweeper.class);
+            context.publishEvent(mock(ApplicationReadyEvent.class));
+            verify(service).reapAbandonedJobs();
+        });
+    }
+}

--- a/server/application/src/test/resources/application-test.yml
+++ b/server/application/src/test/resources/application-test.yml
@@ -15,7 +15,6 @@ spring:
         hikari:
             maximum-pool-size: 10
             minimum-idle: 2
-            max-lifetime: 120000 # 2 minutes (shorter for faster cleanup)
             connection-timeout: 5000 # 5 seconds (fail fast)
             idle-timeout: 30000 # 30 seconds (faster cleanup)
             validation-timeout: 3000 # 3 seconds

--- a/webapp/.storybook/main.ts
+++ b/webapp/.storybook/main.ts
@@ -10,7 +10,7 @@ function getAbsolutePath(value: string): string {
 }
 
 const config: StorybookConfig = {
-	stories: ["../src/**/*.mdx", "../src/**/*.stories.@(js|jsx|mjs|ts|tsx)"],
+	stories: ["../src/**/*.stories.@(js|jsx|mjs|ts|tsx)"],
 	addons: [
 		getAbsolutePath("@storybook/addon-docs"),
 		getAbsolutePath("@storybook/addon-onboarding"),

--- a/webapp/src/components/admin/instance/RecentAuthActivityCard.stories.tsx
+++ b/webapp/src/components/admin/instance/RecentAuthActivityCard.stories.tsx
@@ -60,6 +60,10 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
 	play: async ({ canvas }) => {
 		canvas.getByText("Failed sign-in");
+		await expect(canvas.getByRole("link", { name: "View audit log" })).toHaveAttribute(
+			"href",
+			"/admin/audit?tab=signins",
+		);
 	},
 };
 

--- a/webapp/src/components/admin/instance/RecentAuthActivityCard.tsx
+++ b/webapp/src/components/admin/instance/RecentAuthActivityCard.tsx
@@ -11,7 +11,7 @@ import {
 } from "@/components/admin/audit/audit-format";
 import { QueryErrorAlert } from "@/components/common/QueryErrorAlert";
 import { RelativeTime } from "@/components/common/RelativeTime";
-import { Button } from "@/components/ui/button";
+import { buttonVariants } from "@/components/ui/button";
 import {
 	Card,
 	CardAction,
@@ -49,14 +49,14 @@ export function RecentAuthActivityCard({
 				<CardTitle>Recent activity</CardTitle>
 				<CardDescription>Latest authentication and admin events</CardDescription>
 				<CardAction>
-					<Button
-						variant="ghost"
-						size="sm"
-						render={<Link to="/admin/audit" search={{ tab: "signins" }} />}
+					<Link
+						to="/admin/audit"
+						search={{ tab: "signins" }}
+						className={buttonVariants({ variant: "ghost", size: "sm" })}
 					>
 						View audit log
 						<ArrowRight aria-hidden />
-					</Button>
+					</Link>
 				</CardAction>
 			</CardHeader>
 			<CardContent>

--- a/webapp/src/components/admin/integrations/AdminSlackChannelsSettings.test.tsx
+++ b/webapp/src/components/admin/integrations/AdminSlackChannelsSettings.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { describe, expect, it, vi } from "vitest";
 
@@ -77,9 +77,11 @@ describe("AdminSlackChannelsSettings — reversible row actions swallow rejectio
 			fireEvent.click(await screen.findByRole("menuitem", { name: /^pause$/i }));
 
 			await waitFor(() => expect(onUpdateConsent).toHaveBeenCalledTimes(1));
-			// Flush the microtask queue — a genuinely unhandled rejection would have surfaced by now.
-			await new Promise((resolve) => {
-				setTimeout(resolve, 0);
+			// Let unhandled rejections surface on the next event-loop turn while React finishes closing the menu.
+			await act(async () => {
+				await new Promise((resolve) => {
+					setTimeout(resolve, 0);
+				});
 			});
 			expect(onRejection).not.toHaveBeenCalled();
 		} finally {
@@ -97,8 +99,10 @@ describe("AdminSlackChannelsSettings — reversible row actions swallow rejectio
 			fireEvent.click(await screen.findByRole("menuitem", { name: /set up again/i }));
 
 			await waitFor(() => expect(onRegisterChannel).toHaveBeenCalledTimes(1));
-			await new Promise((resolve) => {
-				setTimeout(resolve, 0);
+			await act(async () => {
+				await new Promise((resolve) => {
+					setTimeout(resolve, 0);
+				});
 			});
 			expect(onRejection).not.toHaveBeenCalled();
 		} finally {

--- a/webapp/src/hooks/use-mentor-chat.test.tsx
+++ b/webapp/src/hooks/use-mentor-chat.test.tsx
@@ -1,5 +1,6 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, renderHook, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
 import { type ReactNode, useState } from "react";
 import { afterEach, assert, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -31,6 +32,7 @@ import type { ChatInit } from "ai";
 import { getThreadQueryKey, listThreadsQueryKey } from "@/api/@tanstack/react-query.gen";
 import { useActiveWorkspaceSlug } from "@/hooks/use-active-workspace";
 import type { ChatMessage } from "@/lib/types";
+import { server } from "@/mocks/server";
 
 import { useMentorChat } from "./use-mentor-chat";
 
@@ -181,7 +183,17 @@ describe("useMentorChat", () => {
 
 		chat = installFakeChat();
 
-		global.fetch = vi.fn();
+		server.use(
+			http.get("*/workspaces/:workspaceSlug/mentor/threads", () => HttpResponse.json([])),
+			http.get(
+				"*/workspaces/:workspaceSlug/mentor/threads/:threadId",
+				() => new HttpResponse(null, { status: 404 }),
+			),
+			http.post(
+				"*/workspaces/:workspaceSlug/mentor/threads/:threadId/messages/:messageId/vote",
+				() => HttpResponse.json({}),
+			),
+		);
 	});
 
 	afterEach(() => {
@@ -318,9 +330,13 @@ describe("useMentorChat", () => {
 					isUpvoted: true,
 				}),
 			);
+			await waitFor(() => expect(queryClient.isMutating()).toBe(0));
+			expect(result.current.votes).toContainEqual(
+				expect.objectContaining({ messageId: "msg-123", isUpvoted: true }),
+			);
 		});
 
-		it("records a downvote the same way", () => {
+		it("records a downvote the same way", async () => {
 			const { result } = renderHook(() => useMentorChat({}), {
 				wrapper: createWrapper(queryClient),
 			});
@@ -335,9 +351,13 @@ describe("useMentorChat", () => {
 					isUpvoted: false,
 				}),
 			);
+			await waitFor(() => expect(queryClient.isMutating()).toBe(0));
+			expect(result.current.votes).toContainEqual(
+				expect.objectContaining({ messageId: "msg-456", isUpvoted: false }),
+			);
 		});
 
-		it("keeps one entry per voted message", () => {
+		it("keeps one entry per voted message", async () => {
 			const { result } = renderHook(() => useMentorChat({}), {
 				wrapper: createWrapper(queryClient),
 			});
@@ -349,6 +369,30 @@ describe("useMentorChat", () => {
 			});
 
 			expect(result.current.votes).toHaveLength(3);
+			await waitFor(() => expect(queryClient.isMutating()).toBe(0));
+			expect(result.current.votes).toHaveLength(3);
+		});
+
+		it("rolls back an optimistic vote when the server rejects it", async () => {
+			let respond = (_response: Response) => {};
+			const response = new Promise<Response>((resolve) => {
+				respond = resolve;
+			});
+			server.use(
+				http.post(
+					"*/workspaces/:workspaceSlug/mentor/threads/:threadId/messages/:messageId/vote",
+					() => response,
+				),
+			);
+			const { result } = renderHook(() => useMentorChat({}), {
+				wrapper: createWrapper(queryClient),
+			});
+			act(() => result.current.voteMessage("msg-rejected", true));
+			expect(result.current.votes).toContainEqual(
+				expect.objectContaining({ messageId: "msg-rejected", isUpvoted: true }),
+			);
+			await act(async () => respond(new HttpResponse(null, { status: 500 })));
+			await waitFor(() => expect(result.current.votes).toHaveLength(0));
 		});
 
 		it("should not vote when workspace is not available", () => {
@@ -448,11 +492,15 @@ describe("useMentorChat", () => {
 			const { transport } = chat.lastOptions;
 			assert(transport, "The hook must configure a transport");
 
-			// A fresh Response per call: the transport consumes the body stream, so a shared one
-			// would already be locked by the queries the render kicked off.
-			const fetchMock = vi.mocked(globalThis.fetch);
-			fetchMock.mockImplementation(async () => new Response("data: [DONE]\n\n", { status: 200 }));
-			fetchMock.mockClear();
+			let posted: Request | undefined;
+			server.use(
+				http.post("*/workspaces/:workspaceSlug/mentor/chat", ({ request }) => {
+					posted = request;
+					return new HttpResponse("data: [DONE]\n\n", {
+						headers: { "Content-Type": "text/event-stream" },
+					});
+				}),
+			);
 
 			const latest = createMockMessage("user", "second", "m2");
 			await transport.sendMessages({
@@ -463,15 +511,12 @@ describe("useMentorChat", () => {
 				abortSignal: undefined,
 			});
 
-			// The render also issues the thread GETs, so pick the one write out of the traffic.
-			const posted = fetchMock.mock.calls.find(([, init]) => init?.method === "POST");
 			assert(posted, "The hook sent no message");
-			const [url, init] = posted;
-			expect(url).toBe("http://localhost:8080/workspaces/test-workspace/mentor/chat");
+			expect(posted.url).toBe("http://localhost:8080/workspaces/test-workspace/mentor/chat");
 			// Only the newest message travels; the server rebuilds context from the thread id.
-			expect(init?.body).toBe(JSON.stringify({ id: "thread-1", message: latest }));
-			expect(init?.credentials).toBe("include");
-			expect(new Headers(init?.headers).get("X-XSRF-TOKEN")).toBe("mock-csrf");
+			expect(await posted.text()).toBe(JSON.stringify({ id: "thread-1", message: latest }));
+			expect(posted.credentials).toBe("include");
+			expect(posted.headers.get("X-XSRF-TOKEN")).toBe("mock-csrf");
 		});
 	});
 });

--- a/webapp/src/integrations/auth/guard.test.ts
+++ b/webapp/src/integrations/auth/guard.test.ts
@@ -1,11 +1,11 @@
-import { QueryClient } from "@tanstack/react-query";
+import { QueryClient, QueryObserver } from "@tanstack/react-query";
 import { HttpResponse, http } from "msw";
 import { describe, expect, it, vi } from "vitest";
 
 import { currentUser } from "@/mocks/fixtures/auth";
 import { server } from "@/mocks/server";
 
-import { isAppAdmin, resolveCurrentUser, safeReturnTo } from "./guard";
+import { currentUserQueryOptions, isAppAdmin, resolveCurrentUser, safeReturnTo } from "./guard";
 describe("safeReturnTo", () => {
 	describe("accepts same-origin absolute paths", () => {
 		it.each(["/", "/dashboard", "/w/acme/overview", "/a/b?x=1&y=2", "/path#frag", "/with-dash_x"])(
@@ -115,6 +115,47 @@ describe("resolveCurrentUser", () => {
 		serve(asAppRole("APP_ADMIN"));
 
 		expect(await resolveCurrentUser(client())).toMatchObject({ appRole: "APP_ADMIN" });
+	});
+
+	it("finishes route identity resolution when the last UI observer unmounts", async () => {
+		const queryClient = client();
+		let respond = (_response: Response) => {};
+		const response = new Promise<Response>((resolve) => {
+			respond = resolve;
+		});
+		const requested = vi.fn(() => response);
+		server.use(http.get("*/user", requested));
+		const observer = new QueryObserver(queryClient, currentUserQueryOptions());
+		const unsubscribe = observer.subscribe(vi.fn());
+		const resolved = resolveCurrentUser(queryClient).then(
+			(user) => ({ user }),
+			(error: unknown) => ({ error }),
+		);
+		await vi.waitFor(() => expect(requested).toHaveBeenCalledOnce());
+		unsubscribe();
+		respond(HttpResponse.json(currentUser));
+		expect(await resolved).toStrictEqual({ user: currentUser });
+		queryClient.clear();
+	});
+
+	it("does not restore identity after an explicit session cancellation", async () => {
+		const queryClient = client();
+		let respond = (_response: Response) => {};
+		const response = new Promise<Response>((resolve) => {
+			respond = resolve;
+		});
+		const requested = vi.fn(() => response);
+		server.use(http.get("*/user", requested));
+		const resolved = resolveCurrentUser(queryClient).then(
+			(user) => ({ user }),
+			(error: unknown) => ({ error }),
+		);
+		await vi.waitFor(() => expect(requested).toHaveBeenCalledOnce());
+		await queryClient.cancelQueries({ queryKey: currentUserQueryOptions().queryKey });
+		respond(HttpResponse.json(currentUser));
+		expect(await resolved).toHaveProperty("error");
+		expect(queryClient.getQueryData(currentUserQueryOptions().queryKey)).toBeUndefined();
+		queryClient.clear();
 	});
 
 	it("answers null only when the server confirms the session is unauthenticated", async () => {

--- a/webapp/src/integrations/auth/guard.ts
+++ b/webapp/src/integrations/auth/guard.ts
@@ -15,8 +15,11 @@ export function currentUserQueryOptions() {
 		...getCurrentUserOptions(),
 		retry: false,
 		staleTime: QUERY_STALE_TIME_MS,
-		queryFn: async ({ signal }) => {
-			const { data, error, response } = await getCurrentUser({ signal });
+		// Route guards await this shared request even when AuthProvider has no mounted observer.
+		// Leave its lifetime independent of observer unmounts; explicit query cancellation still
+		// discards the result when the session ends.
+		queryFn: async () => {
+			const { data, error, response } = await getCurrentUser();
 			if (data !== undefined && response?.ok) return data;
 			// The generated client's error body need not contain the actual HTTP status.
 			throw new Error("Could not verify your session.", { cause: response ?? error });

--- a/webapp/src/routes/_authenticated/w/$workspaceSlug/reviews/-route.test.tsx
+++ b/webapp/src/routes/_authenticated/w/$workspaceSlug/reviews/-route.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { HttpResponse, http } from "msw";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -46,10 +46,7 @@ describe("review activity routes", () => {
 
 		// With practices off the surface does not exist here, so the reader ends up on the workspace
 		// home rather than on a page whose only content could be an explanation of its own emptiness.
-		await vi.waitFor(
-			() => expect(router.state.location.pathname).toBe("/w/acme"),
-			ROUTE_RENDER_WAIT,
-		);
+		await waitFor(() => expect(router.state.location.pathname).toBe("/w/acme"), ROUTE_RENDER_WAIT);
 	});
 
 	it("lists recorded work for a member", async () => {
@@ -101,7 +98,7 @@ it("changes the work filter without resetting scroll", async () => {
 	const scroll = vi.spyOn(window, "scrollTo").mockReturnValue(undefined);
 	await userEvent.click(control);
 	await userEvent.click(await screen.findByRole("option", { name: "Issues" }));
-	await vi.waitFor(() => expect(router.state.location.search).toMatchObject({ kind: "scm.issue" }));
+	await waitFor(() => expect(router.state.location.search).toMatchObject({ kind: "scm.issue" }));
 	expect(scroll).not.toHaveBeenCalled();
 	scroll.mockRestore();
 });

--- a/webapp/src/routes/_authenticated/w/$workspaceSlug/user/$username/-practice-group-route.test.tsx
+++ b/webapp/src/routes/_authenticated/w/$workspaceSlug/user/$username/-practice-group-route.test.tsx
@@ -1,4 +1,4 @@
-import { act, screen, within } from "@testing-library/react";
+import { act, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { HttpResponse, http } from "msw";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -119,7 +119,7 @@ describe("practice-group routes", () => {
 			),
 		);
 		const { router } = renderRouteAtWithRouter(path);
-		await vi.waitFor(() => expect(router.state.location.pathname).toBe("/w/acme/user/ada"));
+		await waitFor(() => expect(router.state.location.pathname).toBe("/w/acme/user/ada"));
 		expect(practiceReads).toBe(0);
 	});
 	it("waits for features without redirecting, then loads the enabled surface", async () => {
@@ -129,7 +129,7 @@ describe("practice-group routes", () => {
 		});
 		server.use(http.get("*/workspaces", () => response.then((value) => value.clone())));
 		const { router, queryClient } = renderRouteAtWithRouter(path);
-		await vi.waitFor(() =>
+		await waitFor(() =>
 			expect(queryClient.getQueryState(listWorkspacesQueryKey())?.fetchStatus).toBe("fetching"),
 		);
 		expect(router.state.location.pathname).toBe(path);
@@ -166,13 +166,13 @@ describe("practice-group routes", () => {
 		);
 		const scroll = vi.spyOn(window, "scrollTo").mockReturnValue(undefined);
 		await userEvent.click(filter);
-		await vi.waitFor(() =>
+		await waitFor(() =>
 			expect(router.state.location.search).toMatchObject({ practice: "small-changes" }),
 		);
 		await userEvent.click(
 			screen.getByRole("button", { name: "Clear review-run filter for Keep changes focused" }),
 		);
-		await vi.waitFor(() => expect(router.state.location.search).not.toHaveProperty("practice"));
+		await waitFor(() => expect(router.state.location.search).not.toHaveProperty("practice"));
 		expect(scroll).not.toHaveBeenCalled();
 		scroll.mockRestore();
 	});
@@ -249,7 +249,7 @@ it("refreshes every cached filter of the group after responding to feedback", as
 	});
 	queryClient.setQueryData(filtered, { pages: [{ content: [], hasNext: false }], pageParams: [0] });
 	await userEvent.click(helpful);
-	await vi.waitFor(() => expect(helpful.getAttribute("aria-pressed")).toBe("true"));
+	await waitFor(() => expect(helpful.getAttribute("aria-pressed")).toBe("true"));
 	expect(queryClient.getQueryState(filtered)?.isInvalidated).toBe(true);
 });
 
@@ -265,12 +265,12 @@ it("restores the bookmarked custom timeframe on Back without scrolling on select
 	const scroll = vi.spyOn(window, "scrollTo").mockReturnValue(undefined);
 	await userEvent.click(screen.getByRole("combobox", { name: "Timeframe" }));
 	await userEvent.click(await screen.findByRole("option", { name: "Last week" }));
-	await vi.waitFor(() => expect(router.state.location.search.after).not.toBe(after));
+	await waitFor(() => expect(router.state.location.search.after).not.toBe(after));
 	expect(scroll).not.toHaveBeenCalled();
 	scroll.mockRestore();
 	act(() => router.history.back());
-	await vi.waitFor(() => expect(router.state.location.search).toMatchObject({ after, before }));
-	await vi.waitFor(() =>
+	await waitFor(() => expect(router.state.location.search).toMatchObject({ after, before }));
+	await waitFor(() =>
 		expect(screen.getByRole("combobox", { name: "Timeframe" }).textContent).toContain(
 			"Custom range",
 		),
@@ -279,7 +279,7 @@ it("restores the bookmarked custom timeframe on Back without scrolling on select
 		"Jun 2 – 6",
 	);
 	act(() => router.history.forward());
-	await vi.waitFor(() =>
+	await waitFor(() =>
 		expect(screen.getByRole("combobox", { name: "Timeframe" }).textContent).toContain("Last week"),
 	);
 	expect(screen.queryByRole("button", { name: "Choose custom dates" })).toBeNull();
@@ -309,7 +309,7 @@ it.each([
 		screen.getByRole("heading", { name: "Developer ada" });
 		server.use(http.get(endpoint, () => HttpResponse.json(response)));
 		await userEvent.click(screen.getByRole("button", { name: "Retry" }));
-		await vi.waitFor(() => expect(screen.queryByText("Could not load activity")).toBeNull());
+		await waitFor(() => expect(screen.queryByText("Could not load activity")).toBeNull());
 		screen.getByRole("combobox", { name: "Timeframe" });
 		screen.getByRole("heading", { name: "Developer ada" });
 	},
@@ -338,7 +338,7 @@ it("does not present the previous timeframe's activity as the newly selected ran
 	);
 	await userEvent.click(screen.getByRole("combobox", { name: "Timeframe" }));
 	await userEvent.click(await screen.findByRole("option", { name: "Last week" }));
-	await vi.waitFor(() => expect(activityReads).toBe(1));
+	await waitFor(() => expect(activityReads).toBe(1));
 	expect(screen.queryByRole("heading", { name: "No review activity" })).toBeNull();
 	screen.getByRole("heading", { name: "Developer ada" });
 	screen.getByRole("combobox", { name: "Timeframe" });

--- a/webapp/vite.config.ts
+++ b/webapp/vite.config.ts
@@ -67,9 +67,6 @@ const viteConfig = {
 	build: {
 		sourcemap: "hidden" as const,
 	},
-	optimizeDeps: {
-		exclude: ["storybook-static"],
-	},
 	test: {
 		globals: true,
 		environment: "jsdom",
@@ -88,6 +85,8 @@ const viteConfig = {
 	server: {
 		port: Number.parseInt(process.env.WEBAPP_PORT ?? "", 10) || 4200,
 		strictPort: true,
+		// Storybook writes a separate site inside this root; rebuilding it must not reload the app.
+		watch: { ignored: ["**/storybook-static/**"] },
 		fs: {
 			allow: [resolve(import.meta.dirname, "..")],
 		},


### PR DESCRIPTION
## What changed and why

Build-only startup was performing database work, browser startup could cancel a session check still needed by a route guard, and successful CI runs discarded useful diagnostics. Fix these at their lifecycle boundaries rather than muting their warnings.

- Keep scheduling, sync recovery and signing-key seeding out of specs/CDS profiles; retain production key validation and register the recent-sign-in advisor as infrastructure.
- Let the shared session request survive UI observer remounts while explicit session cancellation still discards its result. Render audit navigation as a native link with the existing button styling.
- Settle asynchronous tests, remove stale Storybook discovery, exclude generated Storybook output from the app watcher, and remove the conflicting test pool-lifetime override.
- Wait for application readiness before E2E login and preserve successful E2E diagnostics. Trace the real Java 21 compilation in CodeQL and make the existing required CI gate await analysis/publication so the merge queue retains its ref until upload finishes.

## How to test

- `vp run format` and `vp run check`: all 39 gates passed.
- `vp run test:webapp`: 1,158 application tests and 168 lint-rule tests passed.
- `vp run test:webapp:stories`: 1,660 Chromium story tests passed.
- From `server/`: `./gradlew :application:test :application:architectureTest :application:integrationTest --tests '*StepUpGateIntegrationTest' --tests '*StartupBudgetIntegrationTest'`: 7,253 unit, 302 architecture and 6 integration tests passed.
- `vp run generate:api:specs`: unchanged wire contract; startup no longer attempts missing-table recovery/key seeding or reports early-advisor wiring.
- Full Java 21 CDS context boot passed with `-Dspring.context.exit=onRefresh`. On an isolated fresh PostgreSQL instance, the first login after readiness returned 204 and authenticated `/user` returned 200/APP_ADMIN at `http://127.0.0.1:56353`; server and database were stopped afterward. The scheduler-consumer and E2E readiness regressions fail before the fixes and pass afterward.
- `vp run docs:build`, Actionlint using the CI severity policy, and Zizmor passed.
- Local CodeQL 2.27.0: all 3,463 handwritten Java files extracted, zero extraction-error/warning results, all 80 default queries completed. Existing context-dependent security results remain visible.
- Browser verification: native link role and keyboard focus at `http://localhost:6006/?path=/story/components-admin-instance-recentauthactivitycard--default`; controlled HTTP 401/503 session responses at `http://localhost:4200/` respectively show the landing page/error state without cancellation errors. Docs homepage checked at `http://localhost:3000/`. All owned servers stopped afterward.

## Release impact

Patch release; no operator action or schema change. Changesets: [build startup](.changeset/build-profile-startup.md), [session startup](.changeset/session-request-lifetime.md), [audit navigation](.changeset/audit-link-semantics.md), and [development build isolation](.changeset/component-build-isolation.md).

## Notes for reviewers

CodeQL now performs a clean compilation for extraction, not a second distributable build; the server JAR tested and shipped still comes from the build-once job. The existing required CI gate now includes CodeQL publication. Its contract tests execute success, skipped, failed and cancelled outcomes. Merge-queue publication and successful E2E artifact retention must also be verified remotely.

No global log suppression, query exclusion or remote security-alert dismissal is introduced. Production sealing, CSRF and cookie security behavior are unchanged.

## Visual evidence

The audit link retains its appearance while gaining native link semantics. Before/after images are attached below.

![Recent activity before: audit navigation is incorrectly exposed as a button](https://github.com/user-attachments/assets/58ecb7e6-1ec9-44a5-bd12-e27fd2c7ce76)

![Recent activity after: unchanged styling with native audit link semantics](https://github.com/user-attachments/assets/d11fd6a6-c2b9-45c4-8189-dbc130398ef3)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed the “View audit log” link so it behaves like a standard link while retaining its appearance.
  - Prevented page-loading failures when session checks overlap with interface remounts.
  - Sign-out now discards pending identity results reliably, while server outages remain visible.

- **Build and Development**
  - API contract and CDS training builds no longer start background jobs or require database startup tasks.
  - Storybook rebuilds no longer reload the application or search for unsupported MDX stories.
  - Added CodeQL analysis to required CI quality checks.
  - CI now preserves end-to-end diagnostics after every browser test run.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
