### PR TITLE
fix(release): send the CSRF token from the upgrade test

### DIFF
--- a/scripts/release-upgrade-test.ts
+++ b/scripts/release-upgrade-test.ts
@@ -97,7 +97,28 @@ async function waitUntilReady(name: string, port: number): Promise<void> {
 	throw new Error(`${name} did not become ready within 180 seconds`);
 }
 
-async function login(port: number, username: string): Promise<string> {
+/**
+ * One signed-in caller. A request that changes something sends the CSRF token twice — as a cookie
+ * and as the header it is compared against — so the two travel together rather than as a cookie a
+ * caller can pair and forget. `SecurityConfig` owns when that is required.
+ */
+interface Session {
+	/** The `Cookie` header: authentication and CSRF cookies together. */
+	readonly cookie: string;
+	/** Headers a state-changing request must add on top of `cookie`. */
+	readonly writeHeaders: Readonly<Record<string, string>>;
+}
+
+function cookieNamed(response: Response, suffix: string): string | undefined {
+	// The `__Host-` prefix is present or absent with `hephaestus.auth.cookie-secure`, so match the
+	// suffix rather than the whole name.
+	return response.headers
+		.getSetCookie()
+		.find((value) => value.slice(0, value.indexOf("=")).endsWith(suffix))
+		?.split(";", 1)[0];
+}
+
+async function login(port: number, username: string): Promise<Session> {
 	const response = await fetchWithTimeout(`http://127.0.0.1:${port}/auth/dev-login`, {
 		method: "POST",
 		headers: { "content-type": "application/json" },
@@ -109,17 +130,29 @@ async function login(port: number, username: string): Promise<string> {
 	});
 	if (response.status !== 204)
 		throw new Error(`Dev login returned ${response.status}: ${await response.text()}`);
-	const cookie = response.headers
-		.getSetCookie()
-		.find((value) => value.slice(0, value.indexOf("=")).endsWith("HEPHAESTUS_AT"))
-		?.split(";", 1)[0];
-	if (!cookie) throw new Error("Dev login did not return an authentication cookie");
-	return cookie;
+	const authCookie = cookieNamed(response, "HEPHAESTUS_AT");
+	if (!authCookie) throw new Error("Dev login did not return an authentication cookie");
+	// Fetch a CSRF cookie for the signed-in caller before any write. Dev login is not asked for one,
+	// so it returns none to pair with.
+	const probe = await fetchWithTimeout(`http://127.0.0.1:${port}/user`, {
+		headers: { cookie: authCookie },
+	});
+	if (!probe.ok) throw new Error(`Reading the signed-in user returned ${probe.status}`);
+	// This test drives two releases in turn, and the previous one may predate CSRF enforcement: it
+	// issues no token and requires none. Sending the header anyway would be meaningless, and
+	// demanding one here would fail the upgrade path rather than test it. A candidate that requires
+	// a token still fails loudly — as a 403 on the first request that changes something.
+	const csrfCookie = cookieNamed(probe, "XSRF-TOKEN");
+	if (!csrfCookie) return { cookie: authCookie, writeHeaders: {} };
+	return {
+		cookie: `${authCookie}; ${csrfCookie}`,
+		writeHeaders: { "x-xsrf-token": csrfCookie.slice(csrfCookie.indexOf("=") + 1) },
+	};
 }
 
-async function completeTransparencyNotice(port: number, cookie: string): Promise<void> {
+async function completeTransparencyNotice(port: number, session: Session): Promise<void> {
 	const status = await fetchWithTimeout(`http://127.0.0.1:${port}/user/consent`, {
-		headers: { cookie },
+		headers: { cookie: session.cookie },
 	});
 	if (!status.ok)
 		throw new Error(`Consent status returned ${status.status}: ${await status.text()}`);
@@ -134,7 +167,11 @@ async function completeTransparencyNotice(port: number, cookie: string): Promise
 	if ("completed" in statusBody && statusBody.completed === true) return;
 	const completed = await fetchWithTimeout(`http://127.0.0.1:${port}/user/consent`, {
 		method: "PUT",
-		headers: { "content-type": "application/json", cookie },
+		headers: {
+			"content-type": "application/json",
+			cookie: session.cookie,
+			...session.writeHeaders,
+		},
 		body: JSON.stringify({
 			noticeVersion: statusBody.noticeVersion,
 			termsAccepted: true,
@@ -147,8 +184,10 @@ async function completeTransparencyNotice(port: number, cookie: string): Promise
 		);
 }
 
-async function assertCoreReads(port: number, cookie: string): Promise<void> {
-	const user = await fetchWithTimeout(`http://127.0.0.1:${port}/user`, { headers: { cookie } });
+async function assertCoreReads(port: number, session: Session): Promise<void> {
+	const user = await fetchWithTimeout(`http://127.0.0.1:${port}/user`, {
+		headers: { cookie: session.cookie },
+	});
 	if (!user.ok) throw new Error(`Core read /user returned ${user.status}: ${await user.text()}`);
 	const userBody: unknown = await user.json();
 	if (
@@ -168,7 +207,7 @@ async function assertCoreReads(port: number, cookie: string): Promise<void> {
 	if (!Array.isArray(providerBody) || providerBody.length === 0)
 		throw new Error("Core read /identity-providers returned no providers");
 	const workspaces = await fetchWithTimeout(`http://127.0.0.1:${port}/workspaces`, {
-		headers: { cookie },
+		headers: { cookie: session.cookie },
 	});
 	if (!workspaces.ok)
 		throw new Error(
@@ -188,10 +227,14 @@ async function assertCoreReads(port: number, cookie: string): Promise<void> {
 		throw new Error("Core read /workspaces did not return the seeded workspace");
 }
 
-async function seedWorkspace(port: number, cookie: string, workspaceSlug: string): Promise<void> {
+async function seedWorkspace(port: number, session: Session, workspaceSlug: string): Promise<void> {
 	const response = await fetchWithTimeout(`http://127.0.0.1:${port}/workspaces`, {
 		method: "POST",
-		headers: { "content-type": "application/json", cookie },
+		headers: {
+			"content-type": "application/json",
+			cookie: session.cookie,
+			...session.writeHeaders,
+		},
 		body: JSON.stringify({
 			workspaceSlug,
 			displayName: "Upgrade Fixture",
@@ -205,10 +248,10 @@ async function seedWorkspace(port: number, cookie: string, workspaceSlug: string
 		throw new Error(`Workspace seed returned ${response.status}: ${await response.text()}`);
 }
 
-async function adoptCatalogPractice(port: number, cookie: string): Promise<void> {
+async function adoptCatalogPractice(port: number, session: Session): Promise<void> {
 	const catalog = `http://127.0.0.1:${port}/workspaces/${ADOPTION_WORKSPACE_SLUG}/practice-catalog/adoption`;
 	const offered = await fetchWithTimeout(catalog, {
-		headers: { cookie },
+		headers: { cookie: session.cookie },
 	});
 	if (!offered.ok)
 		throw new Error(`Adoptable practices returned ${offered.status}: ${await offered.text()}`);
@@ -236,7 +279,7 @@ async function adoptCatalogPractice(port: number, cookie: string): Promise<void>
 
 	const url = `${catalog}/${encodeURIComponent(practice.slug)}`;
 	const preview = await fetchWithTimeout(url, {
-		headers: { cookie },
+		headers: { cookie: session.cookie },
 	});
 	if (!preview.ok)
 		throw new Error(`Adoption preview returned ${preview.status}: ${await preview.text()}`);
@@ -244,7 +287,7 @@ async function adoptCatalogPractice(port: number, cookie: string): Promise<void>
 	if (!validator) throw new Error("Adoption preview returned no ETag to send as If-Match");
 	const adopted = await fetchWithTimeout(url, {
 		method: "POST",
-		headers: { cookie, "if-match": validator },
+		headers: { cookie: session.cookie, "if-match": validator, ...session.writeHeaders },
 	});
 	if (adopted.status !== 201)
 		throw new Error(
@@ -433,12 +476,12 @@ try {
 
 	let port = startApplication(application, previousImage);
 	await waitUntilReady(application, port);
-	const previousCookie = await login(port, "alice");
-	await completeTransparencyNotice(port, previousCookie);
+	const previousSession = await login(port, "alice");
+	await completeTransparencyNotice(port, previousSession);
 	await login(port, "root");
 	linkWorkspaceIdentity();
-	await seedWorkspace(port, previousCookie, WORKSPACE_SLUG);
-	await assertCoreReads(port, previousCookie);
+	await seedWorkspace(port, previousSession, WORKSPACE_SLUG);
+	await assertCoreReads(port, previousSession);
 	const seededData = dataFingerprint();
 	for (const kind of ["account", "identity", "user", "workspace", "membership", "connection"]) {
 		if (!seededData.includes(`${kind}|`))
@@ -466,15 +509,15 @@ try {
 		throw new Error(
 			`Liquibase history shrank during upgrade: before=${previousChanges}, after=${candidateChanges}`,
 		);
-	const candidateCookie = await login(port, "alice");
-	await completeTransparencyNotice(port, candidateCookie);
-	await assertCoreReads(port, candidateCookie);
+	const candidateSession = await login(port, "alice");
+	await completeTransparencyNotice(port, candidateSession);
+	await assertCoreReads(port, candidateSession);
 
-	await seedWorkspace(port, candidateCookie, ADOPTION_WORKSPACE_SLUG);
+	await seedWorkspace(port, candidateSession, ADOPTION_WORKSPACE_SLUG);
 	const practicesBeforeAdoption = workspacePracticeCount(ADOPTION_WORKSPACE_SLUG);
 	if (practicesBeforeAdoption !== 0)
 		throw new Error(`New workspace unexpectedly started with ${practicesBeforeAdoption} practices`);
-	await adoptCatalogPractice(port, candidateCookie);
+	await adoptCatalogPractice(port, candidateSession);
 	const practicesAfterAdoption = workspacePracticeCount(ADOPTION_WORKSPACE_SLUG);
 	if (practicesAfterAdoption !== 1)
 		throw new Error(`Adoption created ${practicesAfterAdoption} practices instead of one`);


### PR DESCRIPTION
## What changed and why

The v0.79.0 release stopped at the seeded-upgrade gate, and `publish-release` was skipped:

```
Error: Workspace seed returned 403: {"status":403,"error":"Forbidden","path":"/workspaces"}
    at seedWorkspace (scripts/release-upgrade-test.ts:205)
```

The gate signs in through `/auth/dev-login`, which `requiresCsrf` exempts and which therefore issues no CSRF token. It keeps only the authentication cookie and then makes three cookie-authenticated requests that change something — `PUT /user/consent`, `POST /workspaces`, and the catalog adoption `POST`. Since #2047 those require the double-submit token, so all three are refused.

This is the same root cause as #2098, in the release harness rather than the browser: a state-changing request with a session cookie and no `X-XSRF-TOKEN`.

The fix reads the token from the first read after signing in and sends it the way the server compares it — as a cookie *and* as the header. Both halves now live in one `Session` value, so a caller cannot send the cookie and forget the header.

## How to test

```sh
vp run typecheck:scripts
```

The behaviour itself is proven against a live server: `POST /auth/logout` with only the session cookie answers `403`, and the same request carrying the cookie's raw value in `X-XSRF-TOKEN` answers `401` — accepted, and refused only for want of a session. That is the exact shape this change now sends.

The gate itself re-runs on the next release attempt, which is the only environment that has both images.

## Release impact

No changeset: release tooling, not shipped code. **This unblocks v0.79.0**, whose contents are already merged — the version bump landed as `e7123a96f` and only the publish step remains.

## Notes for reviewers

The subtlety worth checking is the two-release span. This gate boots the **previous** release and then the candidate against the same database, and v0.78.0 predates #2047 — it issues no CSRF cookie and requires none. An absent token therefore has to mean "this server needs none" rather than being an error, or the fix would break the upgrade path from the other side. A candidate that does require one still fails loudly, as a 403 on its first write, so tolerating absence hides nothing.

Cookie names are matched by suffix, as the existing code already does for the auth cookie, because the `__Host-` prefix appears and disappears with `hephaestus.auth.cookie-secure`.

### After adversarial review

It confirmed the correctness question that would have sunk this: `server/application/gradle.lockfile` pins Spring Security **7.1.1**, whose `spa()` installs `SpaCsrfTokenRequestHandler` — a non-blank header selects the **plain** resolver, so the raw cookie value is the right thing to send, exactly as the live `403 → 401` observation showed. It also checked every other caller: `scripts/e2e-setup.ts` uses bearer headers without cookies, `ci-build.yml` calls exempt dev-login, and the browser lifecycle spec already sends CSRF headers (its headerless logout deliberately expects 403). This script was the only gap.

One comment overstated a framework guarantee — dev-login being exempt from validation does not mean Spring skips token handling — so it now states the local contract and leaves server policy to `SecurityConfig`.

### One operational step this needs

The failed attempt created a **draft `v0.79.0` targeting `e7123a96f`**, because `tag-images` runs before the upgrade gate. `scripts/plan-release.ts` refuses to re-cut a version whose draft targets another commit:

```
draft v0.79.0 targets e7123a96f, not <sha>; delete the draft to re-cut v0.79.0 here
```

So the stale draft has to be deleted before the CI/CD run that follows this merge completes, or the re-cut refuses and costs another cycle.
