### PR TITLE
chore: stop naming a private instance in the tree

### DIFF
--- a/.changeset/preview-oauth-callback-guidance.md
+++ b/.changeset/preview-oauth-callback-guidance.md
@@ -1,0 +1,4 @@
+---
+---
+
+No user-facing effect: this corrects a comment in `docker/preview/.env.example`, which documents how the project's own preview deployments register an OAuth callback, and removes a hostname that test fixtures and a test script named. Neither reaches a released instance.

--- a/docker/preview/.env.example
+++ b/docker/preview/.env.example
@@ -21,9 +21,12 @@ HEPHAESTUS_AUTH_BOOTSTRAP_ADMINS=
 # Optional. Overrides the application server's direct-memory ceiling.
 #APP_MAX_DIRECT_MEMORY=128M
 
-# Optional preview-only GitHub OAuth app. Its callback has to cover this application's API hosts,
-# shaped pr<id>.api.<preview zone> — the preview builds its redirect_uri from the host it is served
-# on. Leave these blank to reach the preview as a bootstrap admin instead.
+# Optional preview-only GitHub OAuth app. Register its callback as
+# https://<preview zone>/api/login/oauth2/code/github with wildcard matching enabled: GitHub then
+# accepts any subdomain of that host, which is every pr<id>.<preview zone> and nothing outside the
+# zone. Staging's app does not cover these hosts — a preview is a sibling of staging, not a
+# subdomain of it — and its credentials do not belong in a container running unreviewed code.
+# Leave these blank to reach the preview as a bootstrap admin instead.
 GH_OAUTH_CLIENT_ID=
 GH_OAUTH_CLIENT_SECRET=
 

--- a/scripts/jean-public-test.ts
+++ b/scripts/jean-public-test.ts
@@ -4,11 +4,13 @@ import { access, open, readFile, readlink, rm, writeFile } from "node:fs/promise
 import { dirname, join } from "node:path";
 import { Client } from "pg";
 
-import { positivePort, readEnvFile } from "./lib/env.ts";
+import { isHostname, positivePort, readEnvFile, requiredEnv } from "./lib/env.ts";
 import { output, run, succeeds } from "./lib/process.ts";
 
 const root = join(import.meta.dirname, "..");
-const host = process.env.HEPHAESTUS_PUBLIC_TEST_HOST ?? "hephaestus-test.felixdietrich.com";
+// No default: the host this runs against is an operator's own instance, and naming one here would
+// publish it. The run says which host it needs and stops.
+const host = requiredEnv(process.env, "HEPHAESTUS_PUBLIC_TEST_HOST");
 if (!isHostname(host)) throw new Error("HEPHAESTUS_PUBLIC_TEST_HOST must be a DNS hostname");
 const origin = `https://${host}`;
 const appPort = positivePort(
@@ -30,13 +32,6 @@ const traefikFile =
 const logFile = process.env.HEPHAESTUS_PUBLIC_TEST_SERVER_LOG ?? "/tmp/heph-public-server.log";
 const pidFile = process.env.HEPHAESTUS_PUBLIC_TEST_PID_FILE ?? "/tmp/heph-public-server.pid";
 const nginxFile = process.env.HEPHAESTUS_PUBLIC_TEST_NGINX_CONF ?? "/tmp/heph-local-nginx.conf";
-
-export function isHostname(value: string): boolean {
-	return (
-		value.length <= 253 &&
-		value.split(".").every((label) => /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?$/.test(label))
-	);
-}
 
 async function request(path: string, init?: RequestInit): Promise<Response> {
 	return fetch(`${origin}${path}`, {

--- a/scripts/lib/env.ts
+++ b/scripts/lib/env.ts
@@ -44,3 +44,14 @@ export function requiredPositiveInteger(environment: NodeJS.ProcessEnv, name: st
 	}
 	return value;
 }
+
+/**
+ * Whether a value is a DNS hostname. Env-supplied hosts reach shell and proxy configuration, so a
+ * value that is not one is rejected before it is interpolated anywhere.
+ */
+export function isHostname(value: string): boolean {
+	return (
+		value.length <= 253 &&
+		value.split(".").every((label) => /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?$/.test(label))
+	);
+}

--- a/scripts/tooling-orchestration.test.ts
+++ b/scripts/tooling-orchestration.test.ts
@@ -8,9 +8,8 @@ import { describe, test } from "node:test";
 import { duplicatePorts } from "./check-ports.ts";
 import { withDisposableDatabase } from "./db-utils.ts";
 import { loadConfig } from "./e2e-setup.ts";
-import { isHostname } from "./jean-public-test.ts";
 import { updateEnv } from "./jean-setup.ts";
-import { positivePort, readEnvFile } from "./lib/env.ts";
+import { isHostname, positivePort, readEnvFile } from "./lib/env.ts";
 
 await describe("environment parsing", async () => {
 	await test("parses data without evaluating shell syntax", async () => {

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/outline/client/OutlineApiFixtureDeserializationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/outline/client/OutlineApiFixtureDeserializationTest.java
@@ -138,7 +138,7 @@ class OutlineApiFixtureDeserializationTest {
         assertThat(subscription.getEnabled()).isTrue();
         assertThat(subscription.getEvents()).contains("documents.update", "collections.delete");
         // The secret itself is redacted in the committed fixture — the model field still maps.
-        assertThat(subscription.getUrl()).isEqualTo("https://hephaestus-test.felixdietrich.com/webhooks/outline");
+        assertThat(subscription.getUrl()).isEqualTo("https://hephaestus.example.com/webhooks/outline");
     }
 
     private static OutlineDocumentModel findById(List<OutlineDocumentModel> data, String id) {

--- a/server/application/src/test/resources/outline-api/webhookSubscriptions.list.json
+++ b/server/application/src/test/resources/outline-api/webhookSubscriptions.list.json
@@ -9,7 +9,7 @@
     {
       "id": "451e2dc4-010e-44e7-8052-8537a3927ba8",
       "name": "Hephaestus documentation sync",
-      "url": "https://hephaestus-test.felixdietrich.com/webhooks/outline",
+      "url": "https://hephaestus.example.com/webhooks/outline",
       "secret": "REDACTED_TEST_FIXTURE_SECRET_0000000000000000000000000000",
       "events": [
         "documents.create",

--- a/webapp/src/components/admin/login-providers/LoginProviderFormDialog.test.tsx
+++ b/webapp/src/components/admin/login-providers/LoginProviderFormDialog.test.tsx
@@ -13,7 +13,7 @@ const slackProvider: LoginProviderView = {
 	scopes: "openid profile email",
 	enabled: true,
 	seededFromEnv: true,
-	redirectUri: "https://hephaestus-test.felixdietrich.com/api/login/oauth2/code/slack",
+	redirectUri: "https://hephaestus.example.com/api/login/oauth2/code/slack",
 	createdAt: new Date("2026-05-02T00:00:00Z"),
 	updatedAt: new Date("2026-05-02T00:00:00Z"),
 };
@@ -26,7 +26,7 @@ const outlineProvider: LoginProviderView = {
 	scopes: "read",
 	enabled: true,
 	seededFromEnv: false,
-	redirectUri: "https://hephaestus-test.felixdietrich.com/api/login/oauth2/code/outline-acme",
+	redirectUri: "https://hephaestus.example.com/api/login/oauth2/code/outline-acme",
 	createdAt: new Date("2026-07-02T00:00:00Z"),
 	updatedAt: new Date("2026-07-02T00:00:00Z"),
 };


### PR DESCRIPTION
## What changed and why

A test script defaulted to a real hostname and fixtures recorded it, so the tree published where someone runs Hephaestus. Nothing in this repository needs to know that.

`scripts/jean-public-test.ts` now **requires** `HEPHAESTUS_PUBLIC_TEST_HOST` instead of defaulting to a host. Whoever runs it names one of their own instances, and the run stops with that message when they do not — no instance is named in the tree, and no default silently points a verification run at somebody else's deployment.

The fixtures use `hephaestus.example.com`, the placeholder the rest of the suite already uses 12 times over, which is what recorded data should have carried in the first place.

Also here, because it was stale in the same area: the preview OAuth guidance in `docker/preview/.env.example` still described the callback as covering the API's own hostnames, which stopped being true when the API moved onto the app's origin in #2107. It now names the one callback that covers a preview zone — the zone host with wildcard matching, which GitHub extends to any subdomain of it — and says why staging's app is not that callback: a preview is a sibling of staging rather than a subdomain, and staging's credentials do not belong in a container running unreviewed code.

## How to test

```sh
vp run test:webapp                                    # 1158 + 168 pass
cd server && ./gradlew :application:test --tests '*OutlineApiFixtureDeserializationTest*'
```

`OutlineApiFixtureDeserializationTest` asserts the recorded webhook URL exactly, so the fixture and the assertion move together; the Java suite passes.

Nothing in the tree names a Hephaestus deployment now, other than the public documentation site and changelog history:

```sh
git grep -nE "hephaestus\.build|felixdietrich" -- . | grep -v docs/db/archive
```

## Release impact

Empty changeset. The only file the shipped-code rule counts is `docker/preview/.env.example` — a comment about how this project's own previews register an OAuth callback. Nothing here reaches a released instance, so a release note would be inventing an effect that does not exist.

## Notes for reviewers

One reference to `felixdietrich` stays on purpose:

```
docs/db/archive/v0.77.4/changelog/1762377811570_changelog.xml:
  <changeSet author="felixdietrich" …>
```

That is a person's name, not a domain, and it sits in an archived released migration — never edited, renamed or deleted.

Unrelated, found while landing this: `scripts/enable-hooks.test.ts` fails locally — 6 failures on this branch and the identical 6 on clean `main`, so it predates this change and is not caused by it. It passes in CI, which makes it the same shape as the macOS temp-directory bug fixed in #2087: a test that only fails on a developer's machine, where it blocks every `vp run check`. Worth its own fix.