### PR TITLE
fix(server): make serialization contracts explicit

### DIFF
--- a/.changeset/explicit-serialization-contracts.md
+++ b/.changeset/explicit-serialization-contracts.md
@@ -1,0 +1,5 @@
+---
+"hephaestus": patch
+---
+
+Server builds no longer emit avoidable serialization warnings. Request-local and managed service state remain in-process rather than being silently discarded for serialization.

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/backfill/ReviewBackfillConflictException.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/backfill/ReviewBackfillConflictException.java
@@ -1,7 +1,12 @@
 package de.tum.cit.aet.hephaestus.agent.backfill;
 
+import java.io.Serial;
+
 /** A campaign cannot be started, cancelled or superseded from the state it is in. Maps to 409. */
 public class ReviewBackfillConflictException extends RuntimeException {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     public ReviewBackfillConflictException(String message) {
         super(message);

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/backfill/ReviewSweepScheduleConflictException.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/backfill/ReviewSweepScheduleConflictException.java
@@ -1,5 +1,7 @@
 package de.tum.cit.aet.hephaestus.agent.backfill;
 
+import java.io.Serial;
+
 /**
  * A sweep schedule cannot exist on the terms asked for — this workspace already sweeps that kind of
  * work. Maps to 409.
@@ -9,6 +11,9 @@ package de.tum.cit.aet.hephaestus.agent.backfill;
  * campaign that is running, a schedule conflict on the schedule that already exists.
  */
 public class ReviewSweepScheduleConflictException extends RuntimeException {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     public ReviewSweepScheduleConflictException(String message) {
         super(message);

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/catalog/LlmModelWorkspaceGrant.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/catalog/LlmModelWorkspaceGrant.java
@@ -5,6 +5,7 @@ import jakarta.persistence.Embeddable;
 import jakarta.persistence.EmbeddedId;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
+import java.io.Serial;
 import java.io.Serializable;
 import java.time.Instant;
 import lombok.AllArgsConstructor;
@@ -43,6 +44,9 @@ public class LlmModelWorkspaceGrant {
     @AllArgsConstructor
     @EqualsAndHashCode
     public static class Id implements Serializable {
+
+        @Serial
+        private static final long serialVersionUID = 1L;
 
         @Column(name = "model_id", nullable = false)
         private Long modelId;

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/context/EvidenceCollectionException.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/context/EvidenceCollectionException.java
@@ -1,8 +1,12 @@
 package de.tum.cit.aet.hephaestus.agent.context;
 
+import java.io.Serial;
 import org.jspecify.annotations.Nullable;
 
 public final class EvidenceCollectionException extends RuntimeException {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     public EvidenceCollectionException(String message, @Nullable Throwable cause) {
         super(message, cause);

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/context/InsufficientEvidenceException.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/context/InsufficientEvidenceException.java
@@ -2,9 +2,15 @@ package de.tum.cit.aet.hephaestus.agent.context;
 
 import de.tum.cit.aet.hephaestus.agent.handler.spi.JobPreparationException;
 import de.tum.cit.aet.hephaestus.agent.handler.spi.PreparedJobInputs;
+import java.io.Serial;
 
 public final class InsufficientEvidenceException extends JobPreparationException {
 
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    // The preparation coordinator consumes this evidence in-process; it is never sent via Java serialization.
+    @SuppressWarnings("serial")
     private final PreparedJobInputs preparedInputs;
 
     public InsufficientEvidenceException(String message, PreparedJobInputs preparedInputs) {

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/context/UnreplayableEvidenceException.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/context/UnreplayableEvidenceException.java
@@ -1,5 +1,7 @@
 package de.tum.cit.aet.hephaestus.agent.context;
 
+import java.io.Serial;
+
 /**
  * Review readiness cannot be re-evaluated for a recorded manifest because the source contract it was
  * captured under is no longer shipped.
@@ -10,6 +12,9 @@ package de.tum.cit.aet.hephaestus.agent.context;
  * evidence were malformed.
  */
 public class UnreplayableEvidenceException extends RuntimeException {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     public UnreplayableEvidenceException(String message) {
         super(message);

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/handler/PracticeDetectionResultParser.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/handler/PracticeDetectionResultParser.java
@@ -4,6 +4,7 @@ import de.tum.cit.aet.hephaestus.practices.feedback.FeedbackSuppressionReason;
 import de.tum.cit.aet.hephaestus.practices.model.Assessment;
 import de.tum.cit.aet.hephaestus.practices.model.Presence;
 import de.tum.cit.aet.hephaestus.practices.model.Severity;
+import java.io.Serial;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -273,6 +274,9 @@ public class PracticeDetectionResultParser {
     }
 
     private static class EntryValidationException extends RuntimeException {
+
+        @Serial
+        private static final long serialVersionUID = 1L;
 
         EntryValidationException(String message) {
             super(message);

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/handler/spi/EvidenceQuoteUnverifiedException.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/handler/spi/EvidenceQuoteUnverifiedException.java
@@ -1,5 +1,7 @@
 package de.tum.cit.aet.hephaestus.agent.handler.spi;
 
+import java.io.Serial;
+
 /**
  * An observation quoted evidence that does not appear where it said the evidence was.
  *
@@ -10,6 +12,9 @@ package de.tum.cit.aet.hephaestus.agent.handler.spi;
  * means the run itself cannot be trusted, and stays fatal.
  */
 public class EvidenceQuoteUnverifiedException extends JobDeliveryException {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     public EvidenceQuoteUnverifiedException(String message) {
         super(message);

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/handler/spi/JobDeliveryException.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/handler/spi/JobDeliveryException.java
@@ -1,5 +1,7 @@
 package de.tum.cit.aet.hephaestus.agent.handler.spi;
 
+import java.io.Serial;
+
 /**
  * Thrown when a {@link JobTypeHandler} fails to deliver results for a completed job.
  *
@@ -8,6 +10,9 @@ package de.tum.cit.aet.hephaestus.agent.handler.spi;
  * (e.g. stream operations, functional interfaces).
  */
 public class JobDeliveryException extends RuntimeException {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     public JobDeliveryException(String message) {
         super(message);

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/handler/spi/JobDeliverySuppressedException.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/handler/spi/JobDeliverySuppressedException.java
@@ -1,6 +1,11 @@
 package de.tum.cit.aet.hephaestus.agent.handler.spi;
 
+import java.io.Serial;
+
 public final class JobDeliverySuppressedException extends JobDeliveryException {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     public JobDeliverySuppressedException(String message, Throwable cause) {
         super(message, cause);

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/handler/spi/JobPreparationException.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/handler/spi/JobPreparationException.java
@@ -1,5 +1,7 @@
 package de.tum.cit.aet.hephaestus.agent.handler.spi;
 
+import java.io.Serial;
+
 /**
  * Thrown when a {@link JobTypeHandler} fails to prepare context for a job.
  *
@@ -8,6 +10,9 @@ package de.tum.cit.aet.hephaestus.agent.handler.spi;
  * (e.g. stream operations, functional interfaces).
  */
 public class JobPreparationException extends RuntimeException {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     public JobPreparationException(String message) {
         super(message);

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/handler/spi/ObservationsRefusedException.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/handler/spi/ObservationsRefusedException.java
@@ -1,5 +1,7 @@
 package de.tum.cit.aet.hephaestus.agent.handler.spi;
 
+import java.io.Serial;
+
 /**
  * A review whose observations the server will not record: the run finished, and what it submitted
  * does not support a claim about anyone's work. This is a decision the review stage took, not a
@@ -10,6 +12,9 @@ package de.tum.cit.aet.hephaestus.agent.handler.spi;
  * message, which names one job.
  */
 public class ObservationsRefusedException extends JobDeliveryException {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private final String reasonCode;
     private final String reason;

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobExecutor.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobExecutor.java
@@ -44,6 +44,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import jakarta.annotation.PreDestroy;
 import java.io.IOException;
+import java.io.Serial;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.HashMap;
@@ -1376,6 +1377,9 @@ public class AgentJobExecutor {
     }
 
     private static final class TerminalPersistenceException extends RuntimeException {
+
+        @Serial
+        private static final long serialVersionUID = 1L;
 
         private TerminalPersistenceException(Throwable cause) {
             super("Could not durably persist terminal job result and usage", cause);

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/proxy/JobTokenAuthentication.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/proxy/JobTokenAuthentication.java
@@ -1,5 +1,6 @@
 package de.tum.cit.aet.hephaestus.agent.proxy;
 
+import java.io.Serial;
 import java.util.List;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
 
@@ -9,6 +10,11 @@ import org.springframework.security.authentication.AbstractAuthenticationToken;
  */
 class JobTokenAuthentication extends AbstractAuthenticationToken {
 
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    // Proxy authentication is stateless request-local routing, never an HTTP session or serialized token.
+    @SuppressWarnings("serial")
     private final ProxyRouting routing;
 
     JobTokenAuthentication(ProxyRouting routing) {

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/sandbox/spi/InteractiveSandboxException.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/sandbox/spi/InteractiveSandboxException.java
@@ -1,7 +1,12 @@
 package de.tum.cit.aet.hephaestus.agent.sandbox.spi;
 
+import java.io.Serial;
+
 /** Unchecked exception for interactive-sandbox infrastructure failures. */
 public class InteractiveSandboxException extends RuntimeException {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     public InteractiveSandboxException(String message) {
         super(message);

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/sandbox/spi/SandboxCancelledException.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/sandbox/spi/SandboxCancelledException.java
@@ -1,7 +1,12 @@
 package de.tum.cit.aet.hephaestus.agent.sandbox.spi;
 
+import java.io.Serial;
+
 /** Thrown when a sandbox execution is cancelled before completion. */
 public class SandboxCancelledException extends SandboxException {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     public SandboxCancelledException(String message) {
         super(message);

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/sandbox/spi/SandboxException.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/sandbox/spi/SandboxException.java
@@ -1,5 +1,7 @@
 package de.tum.cit.aet.hephaestus.agent.sandbox.spi;
 
+import java.io.Serial;
+
 /**
  * Unchecked exception for sandbox infrastructure failures.
  *
@@ -7,6 +9,9 @@ package de.tum.cit.aet.hephaestus.agent.sandbox.spi;
  * SandboxManager} do not depend on Docker-specific types.
  */
 public class SandboxException extends RuntimeException {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     public SandboxException(String message) {
         super(message);

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/sandbox/spi/SandboxInfrastructureException.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/sandbox/spi/SandboxInfrastructureException.java
@@ -1,5 +1,7 @@
 package de.tum.cit.aet.hephaestus.agent.sandbox.spi;
 
+import java.io.Serial;
+
 /**
  * A {@link SandboxException} whose cause is PROVABLY transient infrastructure — a Docker daemon call
  * or sandbox I/O that failed, timed out, or was interrupted. This subtype is what makes a failed job
@@ -8,6 +10,9 @@ package de.tum.cit.aet.hephaestus.agent.sandbox.spi;
  * {@link SandboxException}.
  */
 public class SandboxInfrastructureException extends SandboxException {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     public SandboxInfrastructureException(String message) {
         super(message);

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/audit/spi/ConfigAuditUnavailableException.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/audit/spi/ConfigAuditUnavailableException.java
@@ -1,5 +1,7 @@
 package de.tum.cit.aet.hephaestus.core.audit.spi;
 
+import java.io.Serial;
+
 /**
  * The audit trail could not record a change, so the change must not commit.
  *
@@ -8,6 +10,9 @@ package de.tum.cit.aet.hephaestus.core.audit.spi;
  * quietly at the observability layer.
  */
 public class ConfigAuditUnavailableException extends RuntimeException {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     public ConfigAuditUnavailableException(String message) {
         super(message);

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/auth/audit/AuthEvent.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/auth/audit/AuthEvent.java
@@ -7,6 +7,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Table;
+import java.io.Serial;
 import java.io.Serializable;
 import java.time.Instant;
 import lombok.AllArgsConstructor;
@@ -182,6 +183,9 @@ public class AuthEvent {
     @AllArgsConstructor
     @EqualsAndHashCode
     public static class Id implements Serializable {
+
+        @Serial
+        private static final long serialVersionUID = 1L;
 
         @Column(name = "id", nullable = false)
         private Long id;

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/auth/domain/AccountFeature.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/auth/domain/AccountFeature.java
@@ -5,6 +5,7 @@ import jakarta.persistence.Embeddable;
 import jakarta.persistence.EmbeddedId;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
+import java.io.Serial;
 import java.io.Serializable;
 import java.time.Instant;
 import lombok.AllArgsConstructor;
@@ -49,6 +50,9 @@ public class AccountFeature {
     @AllArgsConstructor
     @EqualsAndHashCode
     public static class Id implements Serializable {
+
+        @Serial
+        private static final long serialVersionUID = 1L;
 
         @Column(name = "account_id", nullable = false)
         private Long accountId;

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/auth/oauth/AccountLinkConflictException.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/auth/oauth/AccountLinkConflictException.java
@@ -1,7 +1,12 @@
 package de.tum.cit.aet.hephaestus.core.auth.oauth;
 
+import java.io.Serial;
+
 /** Raised when a link-mode OAuth identity already belongs to another account. */
 public class AccountLinkConflictException extends RuntimeException {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     public AccountLinkConflictException(String registrationId, String subject, Long accountId) {
         super("auth.link: identity (provider=" + registrationId

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/auth/oauth/LinkOnlyProviderLoginException.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/auth/oauth/LinkOnlyProviderLoginException.java
@@ -1,7 +1,12 @@
 package de.tum.cit.aet.hephaestus.core.auth.oauth;
 
+import java.io.Serial;
+
 /** Raised when a secondary identity provider is used as a primary sign-in method. */
 public class LinkOnlyProviderLoginException extends RuntimeException {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     public LinkOnlyProviderLoginException(String registrationId) {
         super("provider requires authenticated account linking: " + registrationId);

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/auth/stepup/StepUpRequiredException.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/auth/stepup/StepUpRequiredException.java
@@ -1,5 +1,6 @@
 package de.tum.cit.aet.hephaestus.core.auth.stepup;
 
+import java.io.Serial;
 import java.time.Duration;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
@@ -15,6 +16,10 @@ import org.springframework.web.ErrorResponseException;
  * {@code code} and {@code maxAgeSeconds} carry what the header would have.
  */
 public class StepUpRequiredException extends ErrorResponseException {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
     public static final String CODE = "step_up_required";
 
     public StepUpRequiredException(Duration maxAge) {

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/runtime/hub/auth/WorkerJwtInvalidException.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/runtime/hub/auth/WorkerJwtInvalidException.java
@@ -1,11 +1,16 @@
 package de.tum.cit.aet.hephaestus.core.runtime.hub.auth;
 
+import java.io.Serial;
+
 /**
  * Thrown by {@link WorkerJwtVerifier} on any failure. The detail message is for log-side
  * diagnosis only — the handshake interceptor maps every variant to a single 401 to avoid
  * attack-surface enumeration. {@link #getReasonTag()} carries the metric-friendly reason.
  */
 public class WorkerJwtInvalidException extends RuntimeException {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private final String reasonTag;
 

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/runtime/worker/protocol/FrameCodec.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/runtime/worker/protocol/FrameCodec.java
@@ -1,5 +1,6 @@
 package de.tum.cit.aet.hephaestus.core.runtime.worker.protocol;
 
+import java.io.Serial;
 import tools.jackson.core.JacksonException;
 import tools.jackson.databind.ObjectMapper;
 
@@ -47,6 +48,9 @@ public final class FrameCodec {
     }
 
     public static final class FrameCodecException extends RuntimeException {
+
+        @Serial
+        private static final long serialVersionUID = 1L;
 
         public FrameCodecException(String message) {
             super(message);

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/security/EncryptionException.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/security/EncryptionException.java
@@ -1,9 +1,14 @@
 package de.tum.cit.aet.hephaestus.core.security;
 
+import java.io.Serial;
+
 /**
  * Exception thrown when encryption or decryption of sensitive data fails.
  */
 public class EncryptionException extends RuntimeException {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     public EncryptionException(String message) {
         super(message);

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/security/MissingCredentialKeyException.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/security/MissingCredentialKeyException.java
@@ -1,11 +1,16 @@
 package de.tum.cit.aet.hephaestus.core.security;
 
+import java.io.Serial;
+
 /**
  * Exception thrown when the key a stored credential was encrypted under is not configured on this
  * instance. Separated from a decryption failure because it is a property of the configuration, not
  * of the row: correcting the configuration makes the same ciphertext readable again.
  */
 public class MissingCredentialKeyException extends EncryptionException {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     public MissingCredentialKeyException(String message) {
         super(message);

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/settings/InstanceSettingsPreconditionRequiredException.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/settings/InstanceSettingsPreconditionRequiredException.java
@@ -1,6 +1,11 @@
 package de.tum.cit.aet.hephaestus.core.settings;
 
+import java.io.Serial;
+
 final class InstanceSettingsPreconditionRequiredException extends RuntimeException {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     InstanceSettingsPreconditionRequiredException() {
         super("If-Match must contain the current instance settings ETag when releasing Silent Mode");

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/settings/StaleInstanceSettingsException.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/settings/StaleInstanceSettingsException.java
@@ -1,8 +1,12 @@
 package de.tum.cit.aet.hephaestus.core.settings;
 
+import java.io.Serial;
 import org.jspecify.annotations.Nullable;
 
 final class StaleInstanceSettingsException extends RuntimeException {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     StaleInstanceSettingsException() {
         this(null);

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/tenancy/TenancyViolationException.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/tenancy/TenancyViolationException.java
@@ -1,5 +1,6 @@
 package de.tum.cit.aet.hephaestus.core.tenancy;
 
+import java.io.Serial;
 import java.util.Set;
 
 /**
@@ -13,6 +14,11 @@ import java.util.Set;
  */
 public final class TenancyViolationException extends RuntimeException {
 
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    // Set.copyOf produces a serializable immutable set when its String elements are serializable.
+    @SuppressWarnings("serial")
     private final Set<String> unguardedTables;
 
     public TenancyViolationException(Set<String> unguardedTables) {

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/tenancy/WorkspaceStatementInspector.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/tenancy/WorkspaceStatementInspector.java
@@ -4,6 +4,7 @@ import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import de.tum.cit.aet.hephaestus.core.LoggingUtils;
 import io.micrometer.core.instrument.Counter;
+import java.io.Serial;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
@@ -39,7 +40,13 @@ import org.slf4j.LoggerFactory;
  * <p>Wired via Spring Boot's {@code HibernatePropertiesCustomizer} in
  * {@link TenancyConfiguration}.
  */
+// Hibernate requires Serializable, but this Spring-managed inspector is recreated with each session factory.
+// Its metric registry, reporter and cache must not be serialized or restored as detached service state.
+@SuppressWarnings("serial")
 public class WorkspaceStatementInspector implements StatementInspector {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private static final Logger log = LoggerFactory.getLogger(WorkspaceStatementInspector.class);
 

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/core/connection/ConnectionModeConflictException.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/core/connection/ConnectionModeConflictException.java
@@ -1,10 +1,15 @@
 package de.tum.cit.aet.hephaestus.integration.core.connection;
 
+import java.io.Serial;
+
 /**
  * A write that the connection's current mode cannot take, such as a bearer token for a GitHub App
  * installation, which runs on its installation and stores no token. A state conflict, answered as one.
  */
 public class ConnectionModeConflictException extends RuntimeException {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     public ConnectionModeConflictException(String message) {
         super(message);

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/core/connection/CredentialUnreadableException.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/core/connection/CredentialUnreadableException.java
@@ -1,6 +1,7 @@
 package de.tum.cit.aet.hephaestus.integration.core.connection;
 
 import de.tum.cit.aet.hephaestus.integration.core.spi.IntegrationKind;
+import java.io.Serial;
 import java.util.Locale;
 
 /**
@@ -10,6 +11,9 @@ import java.util.Locale;
  * that needs the plaintext gets this answer.
  */
 public class CredentialUnreadableException extends RuntimeException {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private final long connectionId;
     private final IntegrationKind kind;

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/core/egress/OutboundEgressSuppressedException.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/core/egress/OutboundEgressSuppressedException.java
@@ -1,8 +1,12 @@
 package de.tum.cit.aet.hephaestus.integration.core.egress;
 
 import de.tum.cit.aet.hephaestus.integration.core.spi.FeedbackDeliveryException;
+import java.io.Serial;
 
 public class OutboundEgressSuppressedException extends FeedbackDeliveryException {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     public OutboundEgressSuppressedException(String operation) {
         super("Instance Silent Mode suppressed outbound operation: " + operation);

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/core/spi/FeedbackDeliveryException.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/core/spi/FeedbackDeliveryException.java
@@ -1,5 +1,7 @@
 package de.tum.cit.aet.hephaestus.integration.core.spi;
 
+import java.io.Serial;
+
 /**
  * Thrown by {@link SummaryChannel}, {@link InlineFeedbackChannel}, and
  * {@link ApprovalChannel} implementations when posting fails irrecoverably.
@@ -12,6 +14,9 @@ package de.tum.cit.aet.hephaestus.integration.core.spi;
  * signatures without forcing a {@code throws} declaration.
  */
 public class FeedbackDeliveryException extends RuntimeException {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     public FeedbackDeliveryException(String message) {
         super(message);

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/core/sync/SyncJobConflictException.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/core/sync/SyncJobConflictException.java
@@ -18,6 +18,9 @@ public class SyncJobConflictException extends RuntimeException {
     @Serial
     private static final long serialVersionUID = 1L;
 
+    // The caught conflict returns its managed entity to the same request; it never crosses a Java serialization
+    // boundary.
+    @SuppressWarnings("serial")
     private final SyncJob activeJob;
 
     public SyncJobConflictException(SyncJob activeJob) {

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/core/webhook/JetStreamPublisher.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/core/webhook/JetStreamPublisher.java
@@ -11,6 +11,7 @@ import io.nats.client.PublishOptions;
 import io.nats.client.api.PublishAck;
 import io.nats.client.impl.Headers;
 import java.io.IOException;
+import java.io.Serial;
 import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
@@ -124,6 +125,9 @@ public class JetStreamPublisher {
     }
 
     public static class PublishFailedException extends RuntimeException {
+
+        @Serial
+        private static final long serialVersionUID = 1L;
 
         public PublishFailedException(String message, Throwable cause) {
             super(message, cause);

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/outline/client/OutlineApiException.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/outline/client/OutlineApiException.java
@@ -1,5 +1,6 @@
 package de.tum.cit.aet.hephaestus.integration.outline.client;
 
+import java.io.Serial;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -12,6 +13,9 @@ import org.jspecify.annotations.Nullable;
  * {@code outlineRestApiRetry} decorator retries the former with backoff and gives up on the latter.
  */
 public class OutlineApiException extends RuntimeException {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private final boolean retryable;
 

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/outline/client/OutlineRateLimitedException.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/outline/client/OutlineRateLimitedException.java
@@ -1,5 +1,6 @@
 package de.tum.cit.aet.hephaestus.integration.outline.client;
 
+import java.io.Serial;
 import java.time.Duration;
 import org.jspecify.annotations.Nullable;
 
@@ -13,6 +14,9 @@ import org.jspecify.annotations.Nullable;
  * {@code outlineRestApiRetry} decorator honors this hint as its backoff interval.
  */
 public class OutlineRateLimitedException extends OutlineApiException {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private final @Nullable Duration retryAfter;
 

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/outline/collection/UnknownOutlineCollectionException.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/outline/collection/UnknownOutlineCollectionException.java
@@ -1,5 +1,7 @@
 package de.tum.cit.aet.hephaestus.integration.outline.collection;
 
+import java.io.Serial;
+
 /**
  * Raised when a registration names a collection id that the live {@code collections.list} does not
  * contain — a typo, a deleted collection, or one the token cannot see. Mapped to
@@ -7,6 +9,9 @@ package de.tum.cit.aet.hephaestus.integration.outline.collection;
  * well-formed, but the referenced collection does not exist in Outline.
  */
 public class UnknownOutlineCollectionException extends RuntimeException {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     public UnknownOutlineCollectionException(String collectionId) {
         super("Collection \"" + collectionId + "\" was not found in Outline");

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/domain/common/exception/CircuitBreakerOpenException.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/domain/common/exception/CircuitBreakerOpenException.java
@@ -1,5 +1,7 @@
 package de.tum.cit.aet.hephaestus.integration.scm.domain.common.exception;
 
+import java.io.Serial;
+
 /**
  * Exception thrown when a GitHub API call is rejected because the circuit breaker is open.
  * <p>
@@ -14,6 +16,9 @@ package de.tum.cit.aet.hephaestus.integration.scm.domain.common.exception;
  * </ul>
  */
 public class CircuitBreakerOpenException extends RuntimeException {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     public CircuitBreakerOpenException(String message) {
         super(message);

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/domain/common/exception/InstallationNotFoundException.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/domain/common/exception/InstallationNotFoundException.java
@@ -1,5 +1,7 @@
 package de.tum.cit.aet.hephaestus.integration.scm.domain.common.exception;
 
+import java.io.Serial;
+
 /**
  * Exception thrown when a GitHub App installation is no longer accessible.
  * This typically occurs when:
@@ -13,6 +15,9 @@ package de.tum.cit.aet.hephaestus.integration.scm.domain.common.exception;
  * by retrying. The caller should abort the operation and clean up any cached state.
  */
 public class InstallationNotFoundException extends RuntimeException {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private final long installationId;
 

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/domain/common/exception/ParentEntityNotFoundException.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/domain/common/exception/ParentEntityNotFoundException.java
@@ -1,5 +1,7 @@
 package de.tum.cit.aet.hephaestus.integration.scm.domain.common.exception;
 
+import java.io.Serial;
+
 /**
  * Exception thrown when a parent entity required for processing is not found.
  * <p>
@@ -18,6 +20,9 @@ package de.tum.cit.aet.hephaestus.integration.scm.domain.common.exception;
  * to handle event ordering issues that occur in distributed systems.
  */
 public class ParentEntityNotFoundException extends RuntimeException {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     public ParentEntityNotFoundException(String message) {
         super(message);

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/domain/common/exception/PayloadParsingException.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/domain/common/exception/PayloadParsingException.java
@@ -1,5 +1,7 @@
 package de.tum.cit.aet.hephaestus.integration.scm.domain.common.exception;
 
+import java.io.Serial;
+
 /**
  * Exception thrown when parsing a webhook payload fails.
  * <p>
@@ -11,6 +13,9 @@ package de.tum.cit.aet.hephaestus.integration.scm.domain.common.exception;
  * </ul>
  */
 public class PayloadParsingException extends RuntimeException {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     public PayloadParsingException(String message, Throwable cause) {
         super(message, cause);

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/domain/common/exception/RepositoryNotFoundOnGitProviderException.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/domain/common/exception/RepositoryNotFoundOnGitProviderException.java
@@ -1,5 +1,7 @@
 package de.tum.cit.aet.hephaestus.integration.scm.domain.common.exception;
 
+import java.io.Serial;
+
 /**
  * The git provider <em>definitively</em> responded that a repository does not exist —
  * distinct from a transient failure ({@code Optional.empty()}). Only callers taking
@@ -7,6 +9,9 @@ package de.tum.cit.aet.hephaestus.integration.scm.domain.common.exception;
  * to this; transient-tolerant callers stay on the Optional path.
  */
 public class RepositoryNotFoundOnGitProviderException extends RuntimeException {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private final String nameWithOwner;
 

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/domain/organization/OrganizationMembershipId.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/domain/organization/OrganizationMembershipId.java
@@ -1,5 +1,6 @@
 package de.tum.cit.aet.hephaestus.integration.scm.domain.organization;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Objects;
 import lombok.NoArgsConstructor;
@@ -7,6 +8,9 @@ import org.jspecify.annotations.Nullable;
 
 @NoArgsConstructor
 public class OrganizationMembershipId implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private @Nullable Long organizationId;
     private @Nullable Long userId;

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/domain/repository/collaborator/RepositoryCollaborator.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/domain/repository/collaborator/RepositoryCollaborator.java
@@ -12,6 +12,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.MapsId;
 import jakarta.persistence.Table;
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Locale;
 import lombok.AllArgsConstructor;
@@ -93,6 +94,9 @@ public class RepositoryCollaborator {
     @AllArgsConstructor
     @EqualsAndHashCode
     public static class Id implements Serializable {
+
+        @Serial
+        private static final long serialVersionUID = 1L;
 
         @Column(name = "repository_id", nullable = false)
         private Long repositoryId;

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/domain/team/membership/TeamMembership.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/domain/team/membership/TeamMembership.java
@@ -13,6 +13,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.MapsId;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
+import java.io.Serial;
 import java.io.Serializable;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
@@ -109,6 +110,9 @@ public class TeamMembership implements Persistable<TeamMembership.Id> {
     @AllArgsConstructor
     @EqualsAndHashCode
     public static class Id implements Serializable {
+
+        @Serial
+        private static final long serialVersionUID = 1L;
 
         @Nullable
         private Long teamId;

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/domain/team/permission/TeamRepositoryPermission.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/domain/team/permission/TeamRepositoryPermission.java
@@ -13,6 +13,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.MapsId;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
+import java.io.Serial;
 import java.io.Serializable;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
@@ -115,6 +116,9 @@ public class TeamRepositoryPermission implements Persistable<TeamRepositoryPermi
     @AllArgsConstructor
     @EqualsAndHashCode
     public static class Id implements Serializable {
+
+        @Serial
+        private static final long serialVersionUID = 1L;
 
         @Nullable
         private Long teamId;

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/github/graphql/GitHubGraphQlConfig.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/github/graphql/GitHubGraphQlConfig.java
@@ -29,6 +29,7 @@ import de.tum.cit.aet.hephaestus.integration.scm.github.metrics.GithubMetrics;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.netty.resolver.DefaultAddressResolverGroup;
+import java.io.Serial;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -341,6 +342,9 @@ public class GitHubGraphQlConfig {
 
     private static class RetryableException extends RuntimeException {
 
+        @Serial
+        private static final long serialVersionUID = 1L;
+
         private final int statusCode;
 
         RetryableException(int statusCode) {
@@ -355,6 +359,9 @@ public class GitHubGraphQlConfig {
 
     public static class GitHubGraphQlException extends RuntimeException {
 
+        @Serial
+        private static final long serialVersionUID = 1L;
+
         private final int statusCode;
 
         public GitHubGraphQlException(String message, int statusCode) {
@@ -368,6 +375,9 @@ public class GitHubGraphQlConfig {
     }
 
     public static class TransportException extends RuntimeException {
+
+        @Serial
+        private static final long serialVersionUID = 1L;
 
         public TransportException(String message, Throwable cause) {
             super(message, cause);

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/github/sync/backfill/GitHubHistoricalBackfillService.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/github/sync/backfill/GitHubHistoricalBackfillService.java
@@ -41,6 +41,7 @@ import de.tum.cit.aet.hephaestus.integration.scm.github.pullrequest.dto.PullRequ
 import de.tum.cit.aet.hephaestus.integration.scm.github.pullrequestreview.GitHubPullRequestReviewProcessor;
 import de.tum.cit.aet.hephaestus.integration.scm.github.pullrequestreview.GitHubPullRequestReviewSyncService;
 import de.tum.cit.aet.hephaestus.integration.scm.github.pullrequestreviewcomment.GitHubPullRequestReviewCommentSyncService;
+import java.io.Serial;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -1619,6 +1620,9 @@ public class GitHubHistoricalBackfillService {
      * transport-level retries, so the caller should apply repository-level cooldown.
      */
     static class BackfillTransientException extends RuntimeException {
+
+        @Serial
+        private static final long serialVersionUID = 1L;
 
         BackfillTransientException(String message, @Nullable Throwable cause) {
             super(message, cause);

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/github/sync/exception/SyncInterruptedException.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/github/sync/exception/SyncInterruptedException.java
@@ -1,5 +1,7 @@
 package de.tum.cit.aet.hephaestus.integration.scm.github.sync.exception;
 
+import java.io.Serial;
+
 /**
  * Exception thrown when a sync operation is interrupted.
  * <p>
@@ -11,6 +13,9 @@ package de.tum.cit.aet.hephaestus.integration.scm.github.sync.exception;
  * </ul>
  */
 public class SyncInterruptedException extends RuntimeException {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     public SyncInterruptedException(String message, Throwable cause) {
         super(message, cause);

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/github/sync/exception/SyncRetriesExhaustedException.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/github/sync/exception/SyncRetriesExhaustedException.java
@@ -1,5 +1,7 @@
 package de.tum.cit.aet.hephaestus.integration.scm.github.sync.exception;
 
+import java.io.Serial;
+
 /**
  * Exception thrown when all retry attempts for a sync operation have been exhausted.
  * <p>
@@ -7,6 +9,9 @@ package de.tum.cit.aet.hephaestus.integration.scm.github.sync.exception;
  * retry attempts during data synchronization.
  */
 public class SyncRetriesExhaustedException extends RuntimeException {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     public SyncRetriesExhaustedException(String message, Throwable cause) {
         super(message, cause);

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/gitlab/common/graphql/GitLabGraphQlConfig.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/gitlab/common/graphql/GitLabGraphQlConfig.java
@@ -14,6 +14,7 @@ import de.tum.cit.aet.hephaestus.integration.scm.common.ScmTransportErrors;
 import de.tum.cit.aet.hephaestus.integration.scm.gitlab.common.GitLabGraphQlClientProvider;
 import de.tum.cit.aet.hephaestus.integration.scm.gitlab.common.GitLabRateLimitTracker;
 import io.netty.resolver.DefaultAddressResolverGroup;
+import java.io.Serial;
 import java.time.Duration;
 import java.util.List;
 import java.util.Objects;
@@ -259,6 +260,9 @@ public class GitLabGraphQlConfig {
      */
     private static class RetryableStatusException extends RuntimeException {
 
+        @Serial
+        private static final long serialVersionUID = 1L;
+
         private final int statusCode;
 
         RetryableStatusException(int statusCode) {
@@ -276,6 +280,9 @@ public class GitLabGraphQlConfig {
      */
     private static class GitLabGraphQlRetryExhaustedException extends RuntimeException {
 
+        @Serial
+        private static final long serialVersionUID = 1L;
+
         GitLabGraphQlRetryExhaustedException(String message) {
             super(message);
         }
@@ -285,6 +292,9 @@ public class GitLabGraphQlConfig {
      * Thrown when GitLab GraphQL requests fail after exhausting transport-level retries.
      */
     private static class GitLabTransportRetryExhaustedException extends RuntimeException {
+
+        @Serial
+        private static final long serialVersionUID = 1L;
 
         GitLabTransportRetryExhaustedException(String message, Throwable cause) {
             super(message, cause);

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/gitlab/feedback/GitlabInlineFeedbackChannel.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/gitlab/feedback/GitlabInlineFeedbackChannel.java
@@ -15,6 +15,7 @@ import de.tum.cit.aet.hephaestus.integration.scm.gitlab.common.GitLabGraphQlClie
 import de.tum.cit.aet.hephaestus.integration.scm.gitlab.common.graphql.GitLabPageInfo;
 import de.tum.cit.aet.hephaestus.integration.scm.gitlab.feedback.GitlabMrResolver.MrCoordinates;
 import de.tum.cit.aet.hephaestus.integration.scm.gitlab.feedback.GitlabMrResolver.MrInfo;
+import java.io.Serial;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -504,6 +505,9 @@ public class GitlabInlineFeedbackChannel implements InlineFeedbackChannel {
 
     /** Signals the per-finding loop to stop and fail the rest of the batch on a rate-limit hit. */
     private static final class RateLimitHit extends RuntimeException {
+
+        @Serial
+        private static final long serialVersionUID = 1L;
 
         private RateLimitHit(Throwable cause) {
             super(cause);

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/slack/channel/SlackChannelConsentViolationException.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/slack/channel/SlackChannelConsentViolationException.java
@@ -1,11 +1,16 @@
 package de.tum.cit.aet.hephaestus.integration.slack.channel;
 
+import java.io.Serial;
+
 /**
  * Signals that a requested Slack channel consent transition violates the state machine — e.g. pausing a channel
  * that was never activated. Mapped by {@code SlackChannelControllerAdvice} to a {@code 409 Conflict}
  * {@code ProblemDetail}.
  */
 public class SlackChannelConsentViolationException extends RuntimeException {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     public SlackChannelConsentViolationException(String message) {
         super(message);

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/slack/connect/SlackOAuthException.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/slack/connect/SlackOAuthException.java
@@ -1,6 +1,11 @@
 package de.tum.cit.aet.hephaestus.integration.slack.connect;
 
+import java.io.Serial;
+
 public class SlackOAuthException extends RuntimeException {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     public SlackOAuthException(String message) {
         super(message);

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/slack/domain/SlackParticipantConsent.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/slack/domain/SlackParticipantConsent.java
@@ -4,6 +4,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.IdClass;
 import jakarta.persistence.Table;
+import java.io.Serial;
 import java.io.Serializable;
 import java.time.Instant;
 import java.util.Objects;
@@ -73,6 +74,9 @@ public class SlackParticipantConsent {
     @Setter
     @NoArgsConstructor
     public static class Id implements Serializable {
+
+        @Serial
+        private static final long serialVersionUID = 1L;
 
         private @Nullable Long workspaceId;
         private @Nullable String slackUserId;

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/slack/messaging/SlackSendException.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/slack/messaging/SlackSendException.java
@@ -1,7 +1,12 @@
 package de.tum.cit.aet.hephaestus.integration.slack.messaging;
 
+import java.io.Serial;
+
 /** Raised by {@link SlackMessageService#sendForWorkspace}; carries the Slack error code. */
 public class SlackSendException extends RuntimeException {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     /** Sentinel for {@link #retryAfterMillis}: this failure is not a rate-limit (HTTP 429). */
     public static final long NOT_RATE_LIMITED = -1L;

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/practices/curated/CuratedCatalogConflictException.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/practices/curated/CuratedCatalogConflictException.java
@@ -1,6 +1,11 @@
 package de.tum.cit.aet.hephaestus.practices.curated;
 
+import java.io.Serial;
+
 public class CuratedCatalogConflictException extends RuntimeException {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     public CuratedCatalogConflictException(String message) {
         super(message);

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/practices/curated/CuratedPreconditionRequiredException.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/practices/curated/CuratedPreconditionRequiredException.java
@@ -1,6 +1,11 @@
 package de.tum.cit.aet.hephaestus.practices.curated;
 
+import java.io.Serial;
+
 public class CuratedPreconditionRequiredException extends RuntimeException {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     public CuratedPreconditionRequiredException() {
         super("If-Match must contain the current catalog entry ETag");

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/practices/curated/StaleCuratedEntryException.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/practices/curated/StaleCuratedEntryException.java
@@ -1,6 +1,11 @@
 package de.tum.cit.aet.hephaestus.practices.curated;
 
+import java.io.Serial;
+
 public class StaleCuratedEntryException extends RuntimeException {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     public StaleCuratedEntryException(String subject) {
         super(subject + " changed since it was loaded.");

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/practices/curated/adoption/CatalogAdoptionPreconditionRequiredException.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/practices/curated/adoption/CatalogAdoptionPreconditionRequiredException.java
@@ -1,6 +1,11 @@
 package de.tum.cit.aet.hephaestus.practices.curated.adoption;
 
+import java.io.Serial;
+
 public class CatalogAdoptionPreconditionRequiredException extends RuntimeException {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     public CatalogAdoptionPreconditionRequiredException() {
         super("If-Match must contain the adoption preview ETag.");

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/practices/curated/adoption/StaleCatalogAdoptionPlanException.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/practices/curated/adoption/StaleCatalogAdoptionPlanException.java
@@ -1,6 +1,11 @@
 package de.tum.cit.aet.hephaestus.practices.curated.adoption;
 
+import java.io.Serial;
+
 public class StaleCatalogAdoptionPlanException extends RuntimeException {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     public StaleCatalogAdoptionPlanException() {
         super("The practice or its workspace adoption outcome changed. Review the current definition before adopting.");

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/practices/feedback/FeedbackObservation.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/practices/feedback/FeedbackObservation.java
@@ -15,6 +15,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.MapsId;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.UUID;
 import lombok.EqualsAndHashCode;
@@ -125,6 +126,9 @@ public class FeedbackObservation {
     @NoArgsConstructor
     @EqualsAndHashCode
     public static class Id implements Serializable {
+
+        @Serial
+        private static final long serialVersionUID = 1L;
 
         @Column(name = "feedback_id", columnDefinition = "UUID")
         private UUID feedbackId;

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/practices/review/InvalidReviewCoverageException.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/practices/review/InvalidReviewCoverageException.java
@@ -1,6 +1,11 @@
 package de.tum.cit.aet.hephaestus.practices.review;
 
+import java.io.Serial;
+
 public class InvalidReviewCoverageException extends RuntimeException {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     InvalidReviewCoverageException(String message) {
         super(message);

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/practices/review/PracticeReviewPreconditionRequiredException.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/practices/review/PracticeReviewPreconditionRequiredException.java
@@ -1,6 +1,11 @@
 package de.tum.cit.aet.hephaestus.practices.review;
 
+import java.io.Serial;
+
 public class PracticeReviewPreconditionRequiredException extends RuntimeException {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     PracticeReviewPreconditionRequiredException() {
         super("If-Match must contain the current practice-review settings ETag");

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/practices/review/StalePracticeReviewSettingsException.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/practices/review/StalePracticeReviewSettingsException.java
@@ -1,6 +1,11 @@
 package de.tum.cit.aet.hephaestus.practices.review;
 
+import java.io.Serial;
+
 public class StalePracticeReviewSettingsException extends RuntimeException {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     StalePracticeReviewSettingsException() {
         super("Practice-review settings changed after they were loaded");

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/workspace/WorkspaceMembership.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/workspace/WorkspaceMembership.java
@@ -2,6 +2,7 @@ package de.tum.cit.aet.hephaestus.workspace;
 
 import de.tum.cit.aet.hephaestus.integration.scm.domain.user.User;
 import jakarta.persistence.*;
+import java.io.Serial;
 import java.io.Serializable;
 import java.time.Instant;
 import java.util.Locale;
@@ -117,6 +118,9 @@ public class WorkspaceMembership {
     @EqualsAndHashCode
     @ToString
     public static class Id implements Serializable {
+
+        @Serial
+        private static final long serialVersionUID = 1L;
 
         @Nullable
         private Long workspaceId;

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/workspace/exception/RepositoryAlreadyMonitoredException.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/workspace/exception/RepositoryAlreadyMonitoredException.java
@@ -1,6 +1,11 @@
 package de.tum.cit.aet.hephaestus.workspace.exception;
 
+import java.io.Serial;
+
 public class RepositoryAlreadyMonitoredException extends RuntimeException {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     public RepositoryAlreadyMonitoredException(String nameWithOwner) {
         super("Repository with name '" + nameWithOwner + "' is already monitored");

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/workspace/exception/WorkspaceLifecycleViolationException.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/workspace/exception/WorkspaceLifecycleViolationException.java
@@ -1,10 +1,15 @@
 package de.tum.cit.aet.hephaestus.workspace.exception;
 
+import java.io.Serial;
+
 /**
  * Signals that a requested lifecycle transition violates workspace invariants
  * (e.g., attempting to resume or suspend a purged workspace).
  */
 public class WorkspaceLifecycleViolationException extends RuntimeException {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     public WorkspaceLifecycleViolationException(String message) {
         super(message);

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/workspace/settings/PracticeReviewPersonTarget.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/workspace/settings/PracticeReviewPersonTarget.java
@@ -5,6 +5,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.IdClass;
 import jakarta.persistence.Table;
+import java.io.Serial;
 import java.io.Serializable;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
@@ -38,6 +39,9 @@ public class PracticeReviewPersonTarget {
     @AllArgsConstructor
     @EqualsAndHashCode
     public static class Key implements Serializable {
+
+        @Serial
+        private static final long serialVersionUID = 1L;
 
         @Nullable
         private Long workspaceId;

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/workspace/settings/PracticeReviewRepositoryTarget.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/workspace/settings/PracticeReviewRepositoryTarget.java
@@ -5,6 +5,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.IdClass;
 import jakarta.persistence.Table;
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.List;
 import lombok.AllArgsConstructor;
@@ -46,6 +47,9 @@ public class PracticeReviewRepositoryTarget {
     @AllArgsConstructor
     @EqualsAndHashCode
     public static class Key implements Serializable {
+
+        @Serial
+        private static final long serialVersionUID = 1L;
 
         @Nullable
         private Long workspaceId;

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/workspace/settings/WorkspaceTeamLabelFilter.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/workspace/settings/WorkspaceTeamLabelFilter.java
@@ -13,6 +13,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.MapsId;
 import jakarta.persistence.Table;
+import java.io.Serial;
 import java.io.Serializable;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
@@ -117,6 +118,9 @@ public class WorkspaceTeamLabelFilter {
     @EqualsAndHashCode
     @ToString
     public static class Id implements Serializable {
+
+        @Serial
+        private static final long serialVersionUID = 1L;
 
         @Column(name = "workspace_id")
         private Long workspaceId;

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/workspace/settings/WorkspaceTeamRepositorySettings.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/workspace/settings/WorkspaceTeamRepositorySettings.java
@@ -13,6 +13,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.MapsId;
 import jakarta.persistence.Table;
+import java.io.Serial;
 import java.io.Serializable;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
@@ -127,6 +128,9 @@ public class WorkspaceTeamRepositorySettings {
     @EqualsAndHashCode
     @ToString
     public static class Id implements Serializable {
+
+        @Serial
+        private static final long serialVersionUID = 1L;
 
         @Column(name = "workspace_id")
         private Long workspaceId;

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/workspace/settings/WorkspaceTeamSettings.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/workspace/settings/WorkspaceTeamSettings.java
@@ -12,6 +12,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.MapsId;
 import jakarta.persistence.Table;
+import java.io.Serial;
 import java.io.Serializable;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
@@ -107,6 +108,9 @@ public class WorkspaceTeamSettings {
     @EqualsAndHashCode
     @ToString
     public static class Id implements Serializable {
+
+        @Serial
+        private static final long serialVersionUID = 1L;
 
         @Column(name = "workspace_id")
         private Long workspaceId;

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/workspace/spi/WorkspacePurgeBlockedException.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/workspace/spi/WorkspacePurgeBlockedException.java
@@ -1,6 +1,11 @@
 package de.tum.cit.aet.hephaestus.workspace.spi;
 
+import java.io.Serial;
+
 public class WorkspacePurgeBlockedException extends RuntimeException {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     public WorkspacePurgeBlockedException(String message) {
         super(message);


### PR DESCRIPTION
## What changed and why

Explicit Java serialization contracts were missing from exception and composite-key classes, filling server compilation with avoidable warnings. Declare their stream versions and narrowly document the fields that are deliberately request-local or managed service state. No field is made transient and no compiler warning category is disabled.

This is the serialization-only part of #2112, separated to stay within the review service's file limit. The remaining compiler and runtime changes are not included.

## How to test

- `vp run format` and `vp run check`.
- `vp run test:server:unit`.
- Inspect the diff: only serialization declarations and narrowly scoped in-process state documentation change; persistence mappings, HTTP contracts and exception behavior are unchanged.

## Release impact

Patch changeset: `.changeset/explicit-serialization-contracts.md`. No operator action or database migration.

## Notes for reviewers

The other compiler diagnostics on the base branch remain visible and are addressed separately. This change neither claims those warnings are fixed nor suppresses them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Reduced avoidable serialization warnings during server builds.
  - Preserved request-local, managed-service, and in-process state instead of treating it as serializable data.
  - Improved serialization compatibility and metadata for server-side errors and persisted identifier types.
- **Chores**
  - Added a patch release changeset for the `hephaestus` package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->