### PR TITLE
test(scripts): reach the repository's CLI without PATH

### DIFF
--- a/scripts/enable-hooks.test.ts
+++ b/scripts/enable-hooks.test.ts
@@ -6,7 +6,7 @@ import { join, resolve } from "node:path";
 import { after, test } from "node:test";
 
 import { environmentForGitFixture } from "./lib/git-environment.ts";
-import { CAPTURE_LIMIT_BYTES } from "./lib/process.ts";
+import { CAPTURE_LIMIT_BYTES, repositoryCli } from "./lib/process.ts";
 
 const REPO_ROOT = resolve(import.meta.dirname, "..");
 const SCRIPT = join(REPO_ROOT, "scripts", "enable-hooks.ts");
@@ -66,7 +66,11 @@ void test("an install enables the dispatcher and is idempotent", () => {
 void test("an install preserves disabled hooks until explicitly re-enabled", () => {
 	const { repository, git } = clone();
 	const run = (...args: string[]) => {
-		const result = spawnSync("vp", args, { cwd: repository, encoding: "utf8", env: hookFreeEnv() });
+		const result = spawnSync(process.execPath, [repositoryCli(), ...args], {
+			cwd: repository,
+			encoding: "utf8",
+			env: hookFreeEnv(),
+		});
 		assert.equal(result.status, 0, `${result.stdout}${result.stderr}`);
 	};
 	run("hooks", "enable");

--- a/scripts/enable-hooks.ts
+++ b/scripts/enable-hooks.ts
@@ -1,7 +1,7 @@
 /** Configure the Vite+ dispatcher during install without changing local hook preferences. */
 import { execFileSync, spawnSync } from "node:child_process";
 
-import { CAPTURE_LIMIT_BYTES } from "./lib/process.ts";
+import { CAPTURE_LIMIT_BYTES, repositoryCli } from "./lib/process.ts";
 
 const HOOKS_DIR = ".vite-hooks";
 
@@ -33,9 +33,11 @@ function git(...args: string[]): string {
 
 // An image build or a source tarball has no work tree, and no hooks to enable.
 if (git("rev-parse", "--is-inside-work-tree") === "true") {
-	const enabled = spawnSync("vp", ["config", "--no-agent", "--hooks-dir", HOOKS_DIR], {
-		stdio: "inherit",
-	});
+	const enabled = spawnSync(
+		process.execPath,
+		[repositoryCli(), "config", "--no-agent", "--hooks-dir", HOOKS_DIR],
+		{ stdio: "inherit" },
+	);
 	process.exitCode = enabled.status ?? 1;
 
 	// Signing remains a warning so a checkout without a key can still build.

--- a/scripts/lib/process.ts
+++ b/scripts/lib/process.ts
@@ -1,4 +1,5 @@
 import { execFile, spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
@@ -68,4 +69,16 @@ export async function output(
 		maxBuffer: CAPTURE_LIMIT_BYTES,
 	});
 	return stdout;
+}
+
+/**
+ * This repository's CLI, as an argument for `process.execPath`.
+ *
+ * Resolved as a module rather than looked up on PATH: it is a dependency of this repository, so it
+ * is on PATH only for what the package manager starts, and process creation without a shell finds
+ * neither the extensionless script nor the `.cmd` shim a bin directory holds on Windows. Throws
+ * when the dependency is absent, which is the one case a caller can act on.
+ */
+export function repositoryCli(): string {
+	return fileURLToPath(import.meta.resolve("vite-plus/bin"));
 }


### PR DESCRIPTION
## What changed and why

`scripts/enable-hooks.test.ts` answered for **how the suite was started**, not for what the code does:

| Invocation | Before |
|---|---|
| `vp run test:tooling` | 7 pass |
| `node --test scripts/enable-hooks.test.ts` | **6 fail** |

It was never intermittent. The install spawns `vp`, which is a dependency of this repository, so it is on PATH only for what the package manager starts. A bare shell has no such entry, `spawnSync` failed with `ENOENT`, and the test reported that as the install being broken.

**PATH no longer decides the outcome.** The CLI is resolved as a module and run with the current node:

```ts
spawnSync(process.execPath, [repositoryCli(), "config", …])
```

That fixes it for the test *and* for anyone who runs the script from an ordinary shell — which is the case the first version of this change did not cover, because it only taught the test fixture to find the binary.

**Windows gets the same treatment for free.** Process creation without a shell searches for executables, and a bin directory holds an extensionless script plus a `.cmd` shim — neither of which that search finds. CI passes today only because its setup installs a native launcher, so a green Windows gate would not have proved the test self-sufficient. Resolving the module sidesteps the lookup entirely.

The resolution has **one home** in `scripts/lib/process.ts`: the script and the test drive the same CLI and would otherwise each carry their own idea of where it is.

## How to test

The point is that the verdict no longer depends on the caller, with no PATH assistance anywhere:

```sh
node --test scripts/enable-hooks.test.ts                          # 7 pass (was 6 failures)
PATH="$(dirname "$(command -v node)"):/usr/bin:/bin" \
  node --test scripts/enable-hooks.test.ts                        # 7 pass
vp run test:tooling                                               # 697 pass
```

`node <resolved bin> --version` and `vp --version` print the same thing, so the resolved entry is the one the shim runs.

## Release impact

No changeset: a test and a repository script, not shipped code.

## Notes for reviewers

The earlier version of this PR prepended `node_modules/.bin` to the fixture's PATH. Adversarial review was right that this fixed the symptom for the test while leaving the script itself dependent on a lookup that does not work on Windows without a launcher — so the fix moved into the script, and the fixture went back to plain `environmentForGitFixture`. Its git isolation is untouched and doing its job; the signing warning it produces is expected and is only a warning.

`repositoryCli()` throws when the dependency is absent. That is the one case a caller can act on, and a checkout with no work tree returns before reaching it, so a source archive still skips cleanly.