### PR TITLE
fix(ci): match complete attribution markers in PR descriptions

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -214,8 +214,8 @@ jobs:
           script: |
             const { writeFile } = require("node:fs/promises");
 
-            // Kept equal to `scripts/lib/model-attribution.ts` by
-            // `scripts/model-attribution.test.ts`; this job has no checkout to import it from.
+            // Mirrors `scripts/lib/model-attribution.ts`; this job has no checkout to import it.
+            // `scripts/pull-request-workflows.test.ts` executes this policy against real descriptions.
             const patterns = [
               {
                 name: "a Co-Authored-By trailer naming a model or tool",
@@ -223,7 +223,7 @@ jobs:
                   /^co-authored-by:.*(?:claude|codex|copilot|gpt|openai|anthropic|gemini|cursor|noreply@anthropic\.com)/im,
               },
               { name: "a Claude-Session trailer", pattern: /^claude-session:/im },
-              { name: 'a "Generated with" marker', pattern: /generated with/i },
+              { name: 'a "Generated with" marker', pattern: /\bgenerated with\b/i },
               { name: "a claude.ai/code or session link", pattern: /claude\.ai\/(?:code|session)/i },
             ];
             const findAttribution = (text) =>

--- a/scripts/lib/model-attribution.ts
+++ b/scripts/lib/model-attribution.ts
@@ -7,8 +7,9 @@
  * record who or what worked on a commit, and crediting a tool there is allowed.
  *
  * The workflow step has no checkout (`docs/contributor/ci-cd.mdx` explains why), so it cannot
- * import this module; its inline patterns are hand-kept equal to the ones below, which is what
- * `scripts/model-attribution.test.ts` exists to pin down.
+ * import this module; its inline patterns are hand-kept equal to the ones below.
+ * `scripts/pull-request-workflows.test.ts` exercises that policy; `scripts/model-attribution.test.ts`
+ * exercises this module.
  */
 
 const TOOL_NAMES = [
@@ -40,7 +41,7 @@ export const CLAUDE_SESSION_PATTERN = /^claude-session:/im;
 export const MODEL_ATTRIBUTION_PATTERNS: readonly AttributionPattern[] = [
 	{ name: "a Co-Authored-By trailer naming a model or tool", pattern: COAUTHOR_PATTERN },
 	{ name: "a Claude-Session trailer", pattern: CLAUDE_SESSION_PATTERN },
-	{ name: 'a "Generated with" marker', pattern: /generated with/i },
+	{ name: 'a "Generated with" marker', pattern: /\bgenerated with\b/i },
 	{ name: "a claude.ai/code or session link", pattern: /claude\.ai\/(?:code|session)/i },
 ];
 

--- a/scripts/model-attribution.test.ts
+++ b/scripts/model-attribution.test.ts
@@ -37,3 +37,8 @@ void test("every pattern has a name unique enough to report on its own", () => {
 	const names = MODEL_ATTRIBUTION_PATTERNS.map(({ name }) => name);
 	assert.equal(new Set(names).size, names.length);
 });
+
+void test("does not treat artifact regeneration as attribution", () => {
+	assert.deepEqual(findModelAttribution("Both API artifacts were regenerated with zero diff."), []);
+	assert.deepEqual(findModelAttribution("The client was REGENERATED WITH the updated spec."), []);
+});

--- a/scripts/pull-request-workflows.test.ts
+++ b/scripts/pull-request-workflows.test.ts
@@ -124,6 +124,8 @@ void test("body validation uses the current description rather than a stale reru
 		["A clear description", "Generated with a tool", true],
 		["Generated with a tool", "A clear description", false],
 		[null, "Generated with a tool", true],
+		["Both API artifacts were regenerated with zero diff.", null, true],
+		["The client was REGENERATED WITH the updated spec.", null, true],
 	] as const) {
 		const result = spawnSync(
 			process.execPath,


### PR DESCRIPTION
## What changed and why

The PR description guard matched an attribution marker inside the longer word describing artifact regeneration. Ordinary verification notes could therefore fail metadata validation even when they credited no tool.

Match complete words in both the shared policy and the trusted inline workflow. Add regressions for mixed-case regeneration prose in the module tests and the executable workflow-script tests. Existing attribution rejection and human co-author acceptance remain covered. Correct the test-ownership comments to point to the tests that actually execute each policy.

## How to test

- `node --test scripts/model-attribution.test.ts scripts/pull-request-workflows.test.ts scripts/ci-contract.test.ts`: 82 tests passed.
- Negative control: restoring only the original two matcher expressions makes both affected test files fail. The fixed expressions pass; no mutation is committed.
- `vp run format` and `vp run check`: all 39 quality tasks passed; pre-push runs the same quality gate.
- Smoke test after merge: edit a PR description to describe artifact regeneration and verify metadata validation accepts it. Existing explicit attribution fixtures must still be rejected.

## Release impact

Repository workflow/tooling only. No shipped application code, API, schema, dependency, or release changeset is needed.

## Notes for reviewers

This is a precise matcher correction, not removal of the attribution guard. The workflow keeps reading current PR metadata and never executes code from the PR head. No permissions or trust boundaries change.
