### PR TITLE
fix(ci): show every story and page in preview comments

### DIFF
--- a/.github/workflows/cd-docs-teardown.yml
+++ b/.github/workflows/cd-docs-teardown.yml
@@ -33,19 +33,11 @@ jobs:
         run: ./node_modules/.bin/surge teardown "$STORYBOOK_PREVIEW_URL" --token "$SURGE_TOKEN"
         continue-on-error: true
 
-      - name: Update PR comment
-        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
+      - name: Retire preview comments and their continuation parts
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
-          header: docs-preview
-          message: |
-            ## 📚 Documentation Preview
-
-            ~~Preview has been removed~~ (PR closed)
-      - name: Update Storybook PR comment
-        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
-        with:
-          header: storybook-preview
-          message: |
-            ## 🧩 Storybook Preview
-
-            ~~Preview has been removed~~ (PR closed)
+          script: |
+            const { publishPreviewComments } = await import(`${process.env.GITHUB_WORKSPACE}/scripts/publish-preview-comments.ts`);
+            for (const kind of ["docs", "storybook"]) {
+              await publishPreviewComments({ github, context, kind });
+            }

--- a/.github/workflows/cd-docs.yml
+++ b/.github/workflows/cd-docs.yml
@@ -11,6 +11,8 @@ on:
     paths:
       - "docs/**"
       - "scripts/render-preview-comment.ts"
+      - "scripts/publish-preview-comments.ts"
+      - "scripts/lib/preview-comment.ts"
       - "scripts/lib/json.ts"
       - "scripts/lib/process.ts"
       - ".github/workflows/cd-docs.yml"
@@ -55,7 +57,7 @@ jobs:
         run: >-
           node scripts/render-preview-comment.ts docs docs/.docusaurus
           "https://$PREVIEW_URL"
-          ${{ github.event.pull_request.base.sha }} docs-preview-comment.md
+          ${{ github.event.pull_request.base.sha }} docs-preview-comment.json
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: docs-build-preview
@@ -64,7 +66,7 @@ jobs:
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: docs-preview-comment
-          path: docs-preview-comment.md
+          path: docs-preview-comment.json
           retention-days: 1
 
   build-production:
@@ -126,10 +128,13 @@ jobs:
         env:
           SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
         run: ./node_modules/.bin/surge ./docs-build "$PREVIEW_URL" --token "$SURGE_TOKEN"
-      - uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          PREVIEW_COMMENT_PATH: preview-comment/docs-preview-comment.json
         with:
-          header: docs-preview
-          path: preview-comment/docs-preview-comment.md
+          script: |
+            const { publishPreviewComments } = await import(`${process.env.GITHUB_WORKSPACE}/scripts/publish-preview-comments.ts`);
+            await publishPreviewComments({ github, context, kind: "docs", path: process.env.PREVIEW_COMMENT_PATH });
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           TARGET_URL: https://${{ env.PREVIEW_URL }}

--- a/.github/workflows/ci-quality-gates.yml
+++ b/.github/workflows/ci-quality-gates.yml
@@ -195,13 +195,16 @@ jobs:
         run: >-
           node scripts/render-preview-comment.ts storybook webapp/storybook-static
           "https://$PREVIEW_URL"
-          ${{ github.event.pull_request.base.sha }} "$RUNNER_TEMP/storybook-preview.md"
+          ${{ github.event.pull_request.base.sha }} "$RUNNER_TEMP/storybook-preview.json"
       - name: Publish Storybook preview links
         if: steps.storybook_preview.outcome == 'success'
-        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          PREVIEW_COMMENT_PATH: ${{ runner.temp }}/storybook-preview.json
         with:
-          header: storybook-preview
-          path: ${{ runner.temp }}/storybook-preview.md
+          script: |
+            const { publishPreviewComments } = await import(`${process.env.GITHUB_WORKSPACE}/scripts/publish-preview-comments.ts`);
+            await publishPreviewComments({ github, context, kind: "storybook", path: process.env.PREVIEW_COMMENT_PATH });
       - name: Create Storybook status check
         if: >-
           success() && ((github.event_name == 'pull_request' && steps.storybook_preview.outcome == 'success') ||

--- a/docs/contributor/ci-cd.mdx
+++ b/docs/contributor/ci-cd.mdx
@@ -797,6 +797,32 @@ Extend the pipeline at the ownership boundary that changed; do not copy an exist
 
 `scripts/ci-contract.test.ts` owns the workflow invariants; extend it when the service introduces one.
 
+## Static preview comments
+
+Storybook and documentation previews list every published story or page from changed source files,
+using the built Storybook index and Docusaurus metadata rather than guessing routes. The lists are
+not a dependency-impact report: changing a component without changing its story file does not add
+that component's stories. Unpublished or deleted entries cannot link to a preview page.
+
+Stories are grouped by their full Storybook component title (including its sidebar path), and pages
+by their source directory. Each group shows its count and all its links, with no collapsed sections
+or item cap. Headings and wrapping link paragraphs keep the paths readable without repeating them
+for every variant or introducing a wide table.
+
+`scripts/render-preview-comment.ts` writes a JSON array of complete Markdown comments. The shared
+renderer keeps whole links together and repeats the group heading when a group spans comments.
+Large lists continue in numbered comments below GitHub's 65,536-character limit; every part retains
+the preview link, total count, checked-out commit and build logs. An individual link too large to fit
+fails explicitly rather than dropping content.
+
+`scripts/publish-preview-comments.ts` uses the GitHub SDK provided by `actions/github-script` to
+update the preview's existing bot comments in place. It validates the entire artifact before
+writing, paginates existing comments, skips unchanged bodies, and deletes surplus parts only after
+publishing every current part. GitHub does not offer atomic multi-comment updates; a failed run
+fails the publication step and a retry converges without duplicate comments. Teardown replaces the
+main comment and deletes continuation parts for both previews. A delayed publisher that observes a
+closed pull request also retires its comments instead of restoring live links.
+
 ## Chromatic visual coverage
 
 The Stories job reports visual coverage separately from interaction tests and the

--- a/scripts/ci-contract.test.ts
+++ b/scripts/ci-contract.test.ts
@@ -733,7 +733,10 @@ void describe("CI contract", () => {
 		assert.match(storybook, /surge \.\/webapp\/storybook-static/);
 		assert.match(storybook, /render-preview-comment\.ts storybook webapp\/storybook-static/);
 		assert.match(storybook, /github\.event\.pull_request\.base\.sha/);
-		assert.match(storybook, /path: \$\{\{ runner\.temp \}\}\/storybook-preview\.md/);
+		assert.match(
+			storybook,
+			/PREVIEW_COMMENT_PATH: \$\{\{ runner\.temp \}\}\/storybook-preview\.json/,
+		);
 		assert.match(storybook, /name: Create Storybook status check\s+if: >-\s+success\(\)/);
 	});
 
@@ -748,7 +751,32 @@ void describe("CI contract", () => {
 		assert.match(buildPreview, /fetch-depth: 0/);
 		assert.match(buildPreview, /render-preview-comment\.ts docs docs\/\.docusaurus/);
 		assert.match(buildPreview, /github\.event\.pull_request\.base\.sha/);
-		assert.match(job(docs, "preview"), /path: preview-comment\/docs-preview-comment\.md/);
+		assert.match(
+			job(docs, "preview"),
+			/PREVIEW_COMMENT_PATH: preview-comment\/docs-preview-comment\.json/,
+		);
+	});
+
+	void test("shares a continuation-aware publisher across both previews and teardown", async () => {
+		for (const [file, kind] of [
+			["ci-quality-gates.yml", "storybook"],
+			["cd-docs.yml", "docs"],
+		]) {
+			const source = await readFile(`.github/workflows/${file}`, "utf8");
+			assert.match(source, /scripts\/publish-preview-comments\.ts/);
+			assert.ok(source.includes(`kind: "${kind}", path: process.env.PREVIEW_COMMENT_PATH`));
+		}
+		const docs = parseDocument(await readFile(".github/workflows/cd-docs.yml", "utf8"));
+		for (const dependency of [
+			"scripts/publish-preview-comments.ts",
+			"scripts/lib/preview-comment.ts",
+		]) {
+			assert.ok(String(docs.getIn(["on", "pull_request", "paths"])).includes(dependency));
+		}
+		const teardown = await readFile(".github/workflows/cd-docs-teardown.yml", "utf8");
+		assert.match(teardown, /scripts\/publish-preview-comments\.ts/);
+		assert.match(teardown, /for \(const kind of \["docs", "storybook"\]\)/);
+		assert.match(teardown, /publishPreviewComments\(\{ github, context, kind \}\)/);
 	});
 
 	void test("routes tooling-only changes away from server infrastructure", async () => {

--- a/scripts/lib/preview-comment.ts
+++ b/scripts/lib/preview-comment.ts
@@ -1,0 +1,71 @@
+/** GitHub issue comments are limited to 65,536 characters, including the publisher's marker. */
+export const PREVIEW_COMMENT_LIMIT = 60_000;
+
+export interface PreviewLink {
+	group: string;
+	title: string;
+	url: string;
+}
+
+export function markdown(value: string): string {
+	return value
+		.replaceAll(/\s/g, " ")
+		.replaceAll("&", "&amp;")
+		.replaceAll(/[\\`*_[\]~|#!]/g, "\\$&")
+		.replaceAll("<", "&lt;")
+		.replaceAll(">", "&gt;");
+}
+
+export function compareLinks(left: PreviewLink, right: PreviewLink): number {
+	// Code-point order is stable across runner locales and metadata traversal order.
+	for (const key of ["group", "title", "url"] as const) {
+		if (left[key] < right[key]) return -1;
+		if (left[key] > right[key]) return 1;
+	}
+	return 0;
+}
+
+/** Pack whole links, repeating the group heading when a group spans comments. Never truncate. */
+export function renderPreviewComments(
+	introduction: string,
+	links: readonly PreviewLink[],
+	emptyMessage: string,
+	footer: string,
+): string[] {
+	const pages: string[] = [];
+	// Reserve room for the part indicator before packing; the footer appears on every part.
+	const budget = PREVIEW_COMMENT_LIMIT - introduction.length - footer.length - 100;
+	let page = "";
+	for (const [group, entries] of Map.groupBy(links.toSorted(compareLinks), (link) => link.group)) {
+		const heading = `#### ${markdown(group)} (${entries.length})\n\n`;
+		let block = heading;
+		for (const entry of entries) {
+			const link = `[${markdown(entry.title)}](<${entry.url.replaceAll("&", "&amp;")}>)`;
+			const separator = block === heading ? "" : " ·\n";
+			if (heading.length + link.length > budget) {
+				throw new Error(`A preview link in ${group} exceeds GitHub's comment limit.`);
+			}
+			if (page.length + block.length + separator.length + link.length > budget) {
+				if (block !== heading) page += block;
+				if (page) pages.push(page.trimEnd());
+				page = "";
+				block = heading + link;
+			} else {
+				block += separator + link;
+			}
+		}
+		page += `${block}\n\n`;
+	}
+	if (page || pages.length === 0) pages.push(page.trimEnd() || emptyMessage);
+	return pages.map((body, index) => {
+		const part =
+			pages.length > 1
+				? `\n\n**Part ${index + 1} of ${pages.length}** — all parts are listed in this pull request.`
+				: "";
+		const rendered = `${introduction}${part}\n\n${body}${footer ? `\n\n${footer}` : ""}\n`;
+		if (rendered.length > PREVIEW_COMMENT_LIMIT) {
+			throw new Error("Preview comment exceeds GitHub's comment limit.");
+		}
+		return rendered;
+	});
+}

--- a/scripts/publish-preview-comments.test.ts
+++ b/scripts/publish-preview-comments.test.ts
@@ -1,0 +1,160 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import { test, type TestContext } from "node:test";
+
+import { PREVIEW_COMMENT_LIMIT } from "./lib/preview-comment.ts";
+import { publishPreviewComments } from "./publish-preview-comments.ts";
+
+const marker = (part = 1, kind = "storybook") =>
+	`<!-- Sticky Pull Request Comment${kind}-preview${part > 1 ? `-part-${part}` : ""} -->`;
+const comment = (id: number, part = 1, kind = "storybook", login = "github-actions[bot]") => ({
+	id,
+	body: `Old body\n${marker(part, kind)}`,
+	user: { login },
+});
+
+async function fixture(t: TestContext, comments = [comment(1)]) {
+	const directory = await mkdtemp(resolve(tmpdir(), "publish-preview-"));
+	t.after(() => rm(directory, { recursive: true, force: true }));
+	const path = resolve(directory, "comments.json");
+	const requests: { operation: string; params: Record<string, unknown> }[] = [];
+	let nextId = 100;
+	let state = "open";
+	let failAt = Number.POSITIVE_INFINITY;
+	const github = {
+		paginate: async <T>(
+			method: (params: Record<string, unknown>) => Promise<{ data: T[] }>,
+			params: Record<string, unknown>,
+		) => (await method(params)).data,
+		rest: {
+			pulls: { get: () => Promise.resolve({ data: { state } }) },
+			issues: {
+				listComments: () => Promise.resolve({ data: comments }),
+				createComment: (params: Record<string, unknown>) => {
+					requests.push({ operation: "create", params });
+					if (requests.length === failAt) throw new Error("API unavailable");
+					comments.push({
+						id: nextId++,
+						body: String(params.body),
+						user: { login: "github-actions[bot]" },
+					});
+					return Promise.resolve({ data: {} });
+				},
+				updateComment: (params: Record<string, unknown>) => {
+					requests.push({ operation: "update", params });
+					if (requests.length === failAt) throw new Error("API unavailable");
+					const previous = comments.find((entry) => entry.id === params.comment_id);
+					assert.ok(previous);
+					previous.body = String(params.body);
+					return Promise.resolve({ data: {} });
+				},
+				deleteComment: (params: Record<string, unknown>) => {
+					requests.push({ operation: "delete", params });
+					const index = comments.findIndex((entry) => entry.id === params.comment_id);
+					assert.ok(index >= 0);
+					comments.splice(index, 1);
+					return Promise.resolve({ data: {} });
+				},
+			},
+		},
+	};
+	const context = { repo: { owner: "example", repo: "project" }, issue: { number: 7 } };
+	const publish = (teardown = false) =>
+		publishPreviewComments({ github, context, kind: "storybook", ...(!teardown && { path }) });
+	return {
+		comments,
+		requests,
+		publish,
+		write: (value: unknown) => writeFile(path, JSON.stringify(value)),
+		close: () => {
+			state = "closed";
+		},
+		fail: (after = 1) => {
+			failAt = requests.length + after;
+		},
+	};
+}
+
+void test("creates all parts in reading order, then updates in place without repeat posts", async (t) => {
+	const f = await fixture(t, []);
+	await f.write(["First", "Second", "Third"]);
+	await f.publish();
+	assert.deepEqual(
+		f.comments.map((entry) => entry.body),
+		[`First\n${marker()}`, `Second\n${marker(2)}`, `Third\n${marker(3)}`],
+	);
+	f.requests.length = 0;
+	await f.publish();
+	assert.equal(f.requests.length, 0);
+	await f.write(["Updated", "Second", "Third"]);
+	await f.publish();
+	assert.deepEqual(
+		f.requests.map((request) => request.operation),
+		["update"],
+	);
+	assert.equal(f.comments[0]?.id, 100);
+});
+
+void test("shrinking replaces the existing sticky comment and removes only owned stale parts", async (t) => {
+	const untouched = [
+		comment(5, 2, "docs"),
+		comment(6, 2, "storybook", "human"),
+		{ ...comment(7), body: `Quoted ${marker(2)}\nNot a marker` },
+	];
+	const f = await fixture(t, [comment(1), comment(2, 2), comment(3, 12), comment(4), ...untouched]);
+	await f.write(["Current"]);
+	await f.publish();
+	assert.deepEqual(f.comments, [{ ...comment(1), body: `Current\n${marker()}` }, ...untouched]);
+	assert.deepEqual(
+		f.requests.map((request) => request.operation),
+		["update", "delete", "delete", "delete"],
+	);
+});
+
+void test("teardown removes continuation comments, including a delayed build after closure", async (t) => {
+	for (const delayedBuild of [false, true]) {
+		const f = await fixture(t, [comment(1), comment(2, 2)]);
+		await f.write(["Live preview", "More live links"]);
+		f.close();
+		await f.publish(!delayedBuild);
+		assert.equal(f.comments.length, 1);
+		assert.match(f.comments[0]?.body ?? "", /Preview has been removed/);
+		assert.doesNotMatch(f.comments[0]?.body ?? "", /Live preview|live links/);
+	}
+});
+
+void test("validates the entire artifact before changing any comments", async (t) => {
+	const f = await fixture(t);
+	for (const value of [{}, [], ["Valid", 3], [""], ["x".repeat(PREVIEW_COMMENT_LIMIT + 1)]]) {
+		await f.write(value);
+		await assert.rejects(f.publish());
+		assert.equal(f.requests.length, 0);
+	}
+});
+
+void test("an API failure propagates and never deletes still-needed previous parts", async (t) => {
+	const f = await fixture(t, [comment(1), comment(2, 2)]);
+	await f.write(["New"]);
+	f.fail();
+	await assert.rejects(f.publish(), /API unavailable/);
+	assert.equal(f.comments.length, 2);
+	assert.deepEqual(
+		f.requests.map((request) => request.operation),
+		["update"],
+	);
+});
+
+void test("retrying a partially created list converges without duplicate parts", async (t) => {
+	const f = await fixture(t, []);
+	await f.write(["First", "Second", "Third"]);
+	f.fail(2);
+	await assert.rejects(f.publish(), /API unavailable/);
+	assert.equal(f.comments.length, 1);
+	await f.publish();
+	assert.deepEqual(
+		f.comments.map((entry) => entry.body),
+		[`First\n${marker()}`, `Second\n${marker(2)}`, `Third\n${marker(3)}`],
+	);
+});

--- a/scripts/publish-preview-comments.ts
+++ b/scripts/publish-preview-comments.ts
@@ -1,0 +1,88 @@
+import { asStringArray, readJsonFile } from "./lib/json.ts";
+import { PREVIEW_COMMENT_LIMIT } from "./lib/preview-comment.ts";
+
+type ApiMethod<T> = (params: Record<string, unknown>) => Promise<{ data: T }>;
+interface Comment {
+	id: number;
+	body?: string | null;
+	user: { login: string } | null;
+}
+
+interface GitHubApi {
+	paginate: <T>(method: ApiMethod<T[]>, params: Record<string, unknown>) => Promise<T[]>;
+	rest: {
+		issues: {
+			listComments: ApiMethod<Comment[]>;
+			createComment: ApiMethod<unknown>;
+			updateComment: ApiMethod<unknown>;
+			deleteComment: ApiMethod<unknown>;
+		};
+		pulls: { get: ApiMethod<{ state: string }> };
+	};
+}
+
+/** One owner for publication, shrinking lists and teardown of both static previews. */
+export async function publishPreviewComments({
+	github,
+	context,
+	kind,
+	path,
+}: {
+	github: GitHubApi;
+	context: {
+		repo: { owner: string; repo: string };
+		issue: { number: number };
+	};
+	kind: "docs" | "storybook";
+	/** Omit on teardown: replace the main comment and remove every continuation. */
+	path?: string;
+}): Promise<void> {
+	const title = kind === "docs" ? "📚 Documentation preview" : "🧩 Storybook preview";
+	const removed = [`## ${title}\n\n~~Preview has been removed~~ (PR closed)\n`];
+	let bodies = path ? asStringArray(await readJsonFile(path), "Preview comments") : removed;
+	if (
+		!bodies.length ||
+		bodies.some((body) => !body.trim() || body.length > PREVIEW_COMMENT_LIMIT)
+	) {
+		throw new Error("Preview comments must be nonempty and fit GitHub's comment limit.");
+	}
+	const { repo, issue } = context;
+	if (path) {
+		const pull = await github.rest.pulls.get({ ...repo, pull_number: issue.number });
+		if (pull.data.state === "closed") bodies = removed;
+	}
+	const comments = await github.paginate(github.rest.issues.listComments, {
+		...repo,
+		issue_number: issue.number,
+		per_page: 100,
+	});
+	const marker = (index: number) =>
+		`<!-- Sticky Pull Request Comment${kind}-preview${index ? `-part-${index + 1}` : ""} -->`;
+	const owned = comments.filter(
+		(comment) =>
+			comment.user?.login === "github-actions[bot]" &&
+			new RegExp(
+				`<!-- Sticky Pull Request Comment${kind}-preview(?:-part-(?:[2-9]|[1-9]\\d+))? -->$`,
+			).test(comment.body?.trimEnd() ?? ""),
+	);
+	const retained = new Set<number>();
+	// Create in reading order and update in place; retries converge after a partial API failure.
+	for (const [index, content] of bodies.entries()) {
+		const body = `${content}\n${marker(index)}`;
+		const previous = owned.find((comment) => comment.body?.trimEnd().endsWith(marker(index)));
+		if (previous) {
+			retained.add(previous.id);
+			if (previous.body !== body) {
+				await github.rest.issues.updateComment({ ...repo, comment_id: previous.id, body });
+			}
+		} else {
+			await github.rest.issues.createComment({ ...repo, issue_number: issue.number, body });
+		}
+	}
+	// Delete only this publisher's stale parts, and only after all current parts were published.
+	for (const comment of owned) {
+		if (!retained.has(comment.id)) {
+			await github.rest.issues.deleteComment({ ...repo, comment_id: comment.id });
+		}
+	}
+}

--- a/scripts/render-preview-comment.test.ts
+++ b/scripts/render-preview-comment.test.ts
@@ -1,11 +1,20 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, resolve } from "node:path";
-import { test } from "node:test";
+import { after, test } from "node:test";
+
+import { fromMarkdown } from "mdast-util-from-markdown";
 
 import { environmentForGitFixture } from "./lib/git-environment.ts";
+import { asStringArray, parseJson } from "./lib/json.ts";
+import { PREVIEW_COMMENT_LIMIT, renderPreviewComments } from "./lib/preview-comment.ts";
+
+const roots: string[] = [];
+after(async () => {
+	await Promise.all(roots.map((root) => rm(root, { recursive: true, force: true })));
+});
 
 const script = resolve("scripts/render-preview-comment.ts");
 
@@ -17,8 +26,9 @@ function git(root: string, ...arguments_: string[]): string {
 	}).trim();
 }
 
-async function repository(changedFile: string): Promise<{ base: string; root: string }> {
+async function repository(...changedFiles: string[]): Promise<{ base: string; root: string }> {
 	const root = await mkdtemp(resolve(tmpdir(), "preview-comment-"));
+	roots.push(root);
 	git(root, "init", "--quiet");
 	git(root, "config", "user.email", "test@example.invalid");
 	git(root, "config", "user.name", "Test");
@@ -26,8 +36,10 @@ async function repository(changedFile: string): Promise<{ base: string; root: st
 	git(root, "add", ".");
 	git(root, "commit", "--quiet", "-m", "seed");
 	const base = git(root, "rev-parse", "HEAD");
-	await mkdir(dirname(resolve(root, changedFile)), { recursive: true });
-	await writeFile(resolve(root, changedFile), "changed");
+	for (const changedFile of changedFiles) {
+		await mkdir(dirname(resolve(root, changedFile)), { recursive: true });
+		await writeFile(resolve(root, changedFile), "changed");
+	}
 	git(root, "add", ".");
 	git(root, "commit", "--quiet", "-m", "change");
 	return { base, root };
@@ -39,17 +51,24 @@ async function render(
 	kind: string,
 	directory: string,
 ): Promise<string> {
-	execFileSync("node", [script, kind, directory, "https://preview.example/", base, "comment.md"], {
-		cwd: root,
-		stdio: "pipe",
-		env: environmentForGitFixture({
-			GITHUB_SERVER_URL: "https://github.com",
-			GITHUB_REPOSITORY: "example/project",
-			GITHUB_RUN_ID: "123",
-			GITHUB_SHA: "not-the-checked-out-commit",
-		}),
-	});
-	return readFile(resolve(root, "comment.md"), "utf8");
+	execFileSync(
+		"node",
+		[script, kind, directory, "https://preview.example/", base, "comments.json"],
+		{
+			cwd: root,
+			stdio: "pipe",
+			env: environmentForGitFixture({
+				GITHUB_SERVER_URL: "https://github.com",
+				GITHUB_REPOSITORY: "example/project",
+				GITHUB_RUN_ID: "123",
+				GITHUB_SHA: "not-the-checked-out-commit",
+			}),
+		},
+	);
+	return asStringArray(
+		parseJson(await readFile(resolve(root, "comments.json"), "utf8")),
+		"comments",
+	).join("\n");
 }
 
 void test("links only stories from changed files to their canvases", async () => {
@@ -88,7 +107,8 @@ void test("links only stories from changed files to their canvases", async () =>
 	);
 	const comment = await render(root, base, "storybook", "build");
 	assert.match(comment, /Stories in changed files/);
-	assert.ok(comment.includes("UI/Button — Primary \\[default\\]"));
+	assert.ok(comment.includes("#### UI/Button (2)"));
+	assert.ok(comment.includes("[Primary \\[default\\]]"));
 	assert.match(comment, /\?path=\/story\/button--primary/);
 	assert.doesNotMatch(comment, /button--docs/);
 	assert.doesNotMatch(comment, /other--unchanged/);
@@ -106,14 +126,14 @@ void test("links only stories from changed files to their canvases", async () =>
 	assert.doesNotMatch(comment, /not-the-checked-out-commit/);
 });
 
-void test("limits long story lists", async () => {
+void test("shows all 106 stories without truncation or disclosure controls", async () => {
 	const { base, root } = await repository("webapp/src/Button.stories.tsx");
 	await mkdir(resolve(root, "build"));
 	await writeFile(
 		resolve(root, "build/index.json"),
 		JSON.stringify({
 			entries: Object.fromEntries(
-				Array.from({ length: 28 }, (_, index) => [
+				Array.from({ length: 106 }, (_, index) => [
 					`button--${index}`,
 					{
 						importPath: "./src/Button.stories.tsx",
@@ -126,8 +146,12 @@ void test("limits long story lists", async () => {
 		}),
 	);
 	const comment = await render(root, base, "storybook", "build");
-	assert.match(comment, /Stories in changed files \(25 of 28\)/);
-	assert.match(comment, /3 more are available in the full preview/);
+	assert.match(comment, /Stories in changed files \(106\)/);
+	assert.match(comment, /#### Button \(106\)/);
+	for (let index = 0; index < 106; index++) {
+		assert.equal(comment.split(`?path=/story/button--${index}>`).length - 1, 1);
+	}
+	assert.doesNotMatch(comment, /more are available|<details|<summary|25 of/);
 });
 
 void test("does not claim files are unchanged when they have no published stories", async () => {
@@ -206,4 +230,120 @@ void test("does not claim docs are unchanged when a changed page is unpublished"
 	await mkdir(resolve(root, "metadata"));
 	const comment = await render(root, base, "docs", "metadata");
 	assert.match(comment, /Changed pages\n\nNo published pages found in changed files\./);
+});
+
+void test("groups every changed documentation page by source directory, not its custom route", async () => {
+	const sources = Array.from(
+		{ length: 35 },
+		(_, index) => `docs/${index % 2 ? "user" : "contributor/deep"}/page-${index}.mdx`,
+	);
+	const { base, root } = await repository(...sources);
+	await mkdir(resolve(root, "metadata"));
+	await Promise.all(
+		sources.map((source, index) =>
+			writeFile(
+				resolve(root, `metadata/${index}.json`),
+				JSON.stringify({
+					source: source.replace(/^docs\//, "@site/"),
+					title: `Page ${index}`,
+					permalink: `/custom/${index}`,
+				}),
+			),
+		),
+	);
+	const comment = await render(root, base, "docs", "metadata");
+	assert.match(comment, /Changed pages \(35\)/);
+	assert.match(comment, /#### docs\/contributor\/deep \(18\)/);
+	assert.match(comment, /#### docs\/user \(17\)/);
+	for (let index = 0; index < sources.length; index++) {
+		assert.equal(comment.split(`https://preview.example/custom/${index}>`).length - 1, 1);
+	}
+});
+
+void test("uses stable, disambiguated groups with complete headings and atomic links across oversized comments", () => {
+	const links = Array.from({ length: 1200 }, (_, index) => ({
+		group: index < 1000 ? "components/admin/Button" : "components/workspace/Button",
+		title: `Story ${index} — 日本語 🧩`,
+		url: `https://preview.example/?path=/story/button--${index}`,
+	}));
+	const renderParts = (entries: typeof links) =>
+		renderPreviewComments(
+			"## Storybook preview\n\n### Stories in changed files (1200)",
+			entries,
+			"Empty",
+			"Build provenance",
+		);
+	const comments = renderParts(links);
+	assert.ok(comments.length > 1);
+	assert.deepEqual(renderParts(links.toReversed()), comments);
+	for (const [index, comment] of comments.entries()) {
+		assert.ok(comment.length <= PREVIEW_COMMENT_LIMIT);
+		assert.ok(comment.includes(`Part ${index + 1} of ${comments.length}`));
+		assert.match(comment, /#### components\/(admin|workspace)\/Button \(\d+\)/);
+		assert.ok(comment.endsWith("Build provenance\n"));
+		assert.doesNotMatch(comment, /<details|<summary/);
+	}
+	const combined = comments.join("\n");
+	for (const { url } of links) assert.equal(combined.split(`](<${url}>)`).length - 1, 1);
+});
+
+void test("renders metadata as literal text rather than Markdown or HTML", () => {
+	const [comment] = renderPreviewComments(
+		"Preview",
+		[
+			{
+				group: "UI/*Button* #1\n<script>",
+				title: "[label](https://evil.example) ![image] `code` ~~strike~~ _em_ | &lt;tag&gt;",
+				url: "https://preview.example/",
+			},
+		],
+		"Empty",
+		"",
+	);
+	assert.ok(comment?.includes("#### UI/\\*Button\\* \\#1 &lt;script&gt;"));
+	assert.ok(comment?.includes("\\`code\\` \\~\\~strike\\~\\~ \\_em\\_ \\| &amp;lt;tag&amp;gt;"));
+	assert.doesNotMatch(comment ?? "", /<script>|!\[image\]/);
+});
+
+void test("refuses an indivisible oversized link rather than silently dropping it", () => {
+	assert.throws(
+		() =>
+			renderPreviewComments(
+				"Preview",
+				[
+					{
+						group: "Button",
+						title: "x".repeat(PREVIEW_COMMENT_LIMIT),
+						url: "https://preview.example/",
+					},
+				],
+				"Empty",
+				"",
+			),
+		/exceeds GitHub's comment limit/,
+	);
+});
+
+void test("Markdown parsing preserves literal labels and entity-like URL segments", () => {
+	const title = "[label](https://evil.example) `code` *em* <img> &copy;";
+	const url = "https://preview.example/a&copy;?x=1&y=2";
+	const [body] = renderPreviewComments(
+		"## Preview",
+		[{ group: "UI/Button", title, url }],
+		"Empty",
+		"",
+	);
+	assert.ok(body);
+	const paragraphs = fromMarkdown(body).children.filter((node) => node.type === "paragraph");
+	const links = paragraphs.flatMap((paragraph) =>
+		paragraph.children.filter((node) => node.type === "link"),
+	);
+	assert.equal(links.length, 1);
+	const link = links[0];
+	assert.ok(link);
+	assert.equal(link.url, url);
+	assert.deepEqual(
+		link.children.map((node) => (node.type === "text" ? node.value : node.type)),
+		[title],
+	);
 });

--- a/scripts/render-preview-comment.test.ts
+++ b/scripts/render-preview-comment.test.ts
@@ -288,12 +288,14 @@ void test("uses stable, disambiguated groups with complete headings and atomic l
 });
 
 void test("renders metadata as literal text rather than Markdown or HTML", () => {
+	const group = "UI/*Button* #1\n<script><SCRIPT><ScRiPt>";
+	const title = "[label](https://evil.example) ![image] `code` ~~strike~~ _em_ | &lt;tag&gt;";
 	const [comment] = renderPreviewComments(
 		"Preview",
 		[
 			{
-				group: "UI/*Button* #1\n<script>",
-				title: "[label](https://evil.example) ![image] `code` ~~strike~~ _em_ | &lt;tag&gt;",
+				group,
+				title,
 				url: "https://preview.example/",
 			},
 		],
@@ -302,7 +304,30 @@ void test("renders metadata as literal text rather than Markdown or HTML", () =>
 	);
 	assert.ok(comment?.includes("#### UI/\\*Button\\* \\#1 &lt;script&gt;"));
 	assert.ok(comment?.includes("\\`code\\` \\~\\~strike\\~\\~ \\_em\\_ \\| &amp;lt;tag&amp;gt;"));
-	assert.doesNotMatch(comment ?? "", /<script>|!\[image\]/);
+	assert.ok(comment);
+	const nodes = fromMarkdown(comment).children;
+	assert.deepEqual(
+		nodes.map((node) => node.type),
+		["paragraph", "heading", "paragraph"],
+	);
+	const heading = nodes.find((node) => node.type === "heading");
+	assert.ok(heading);
+	assert.deepEqual(
+		heading.children.map((node) => (node.type === "text" ? node.value : node.type)),
+		[`${group.replaceAll("\n", " ")} (1)`],
+	);
+	const paragraph = nodes.at(-1);
+	assert.ok(paragraph?.type === "paragraph");
+	assert.deepEqual(
+		paragraph.children.map((node) => node.type),
+		["link"],
+	);
+	const link = paragraph.children[0];
+	assert.ok(link?.type === "link");
+	assert.deepEqual(
+		link.children.map((node) => (node.type === "text" ? node.value : node.type)),
+		[title],
+	);
 });
 
 void test("refuses an indivisible oversized link rather than silently dropping it", () => {

--- a/scripts/render-preview-comment.ts
+++ b/scripts/render-preview-comment.ts
@@ -1,8 +1,9 @@
 import { execFileSync } from "node:child_process";
 import { readdir, writeFile } from "node:fs/promises";
-import { resolve } from "node:path";
+import { posix, resolve } from "node:path";
 
 import { asRecord, asString, isRecord, readJsonFile } from "./lib/json.ts";
+import { compareLinks, renderPreviewComments, type PreviewLink } from "./lib/preview-comment.ts";
 import { CAPTURE_LIMIT_BYTES } from "./lib/process.ts";
 
 function argument(index: number): string {
@@ -20,7 +21,6 @@ const artifactDirectory = argument(3);
 const previewUrl = argument(4);
 const baseSha = argument(5);
 const output = argument(6);
-const MAX_LINKS = 25;
 
 const changedFiles = new Set(
 	execFileSync("git", ["diff", "--name-only", "--diff-filter=ACMRT", "-z", `${baseSha}...HEAD`], {
@@ -33,19 +33,8 @@ const changedFiles = new Set(
 
 const baseUrl = new URL(previewUrl);
 
-function markdown(value: string): string {
-	return value
-		.replaceAll("\r", " ")
-		.replaceAll("\n", " ")
-		.replaceAll("\\", "\\\\")
-		.replaceAll("[", "\\[")
-		.replaceAll("]", "\\]")
-		.replaceAll("<", "&lt;")
-		.replaceAll(">", "&gt;");
-}
-
-async function renderDocs(): Promise<string> {
-	const links = new Map<string, string>();
+async function renderDocs(): Promise<string[]> {
+	const links = new Map<string, PreviewLink>();
 	for (const file of await readdir(artifactDirectory, { recursive: true })) {
 		if (!file.endsWith(".json")) continue;
 		const metadata = await readJsonFile(resolve(artifactDirectory, file));
@@ -61,27 +50,31 @@ async function renderDocs(): Promise<string> {
 		if (changedFiles.has(source)) {
 			const url = new URL(permalink, baseUrl);
 			const existing = links.get(url.href);
-			if (url.origin === baseUrl.origin && (existing === undefined || title < existing)) {
-				links.set(url.href, title);
+			const link = { group: posix.dirname(source), title, url: url.href };
+			if (
+				url.origin === baseUrl.origin &&
+				(existing === undefined || compareLinks(link, existing) < 0)
+			) {
+				links.set(url.href, link);
 			}
 		}
 	}
 	return comment(
 		"📚 Documentation preview",
 		"Open full documentation preview",
-		[...links].map(([url, title]) => ({ title, url })).toSorted(compareLinks),
+		[...links.values()],
 		"Changed pages",
 		"No published pages found in changed files.",
 	);
 }
 
-async function renderStorybook(): Promise<string> {
+async function renderStorybook(): Promise<string[]> {
 	const index = asRecord(
 		await readJsonFile(resolve(artifactDirectory, "index.json")),
 		"Storybook index",
 	);
-	const links = Object.entries(asRecord(index.entries, "Storybook index.entries"))
-		.flatMap(([id, value]) => {
+	const links = Object.entries(asRecord(index.entries, "Storybook index.entries")).flatMap(
+		([id, value]) => {
 			const entry = asRecord(value, `Storybook entry ${id}`);
 			if (entry.type !== "story") return [];
 			const importPath = asString(entry.importPath, `Storybook entry ${id}.importPath`);
@@ -90,12 +83,13 @@ async function renderStorybook(): Promise<string> {
 			if (!changedFiles.has(`webapp/${importPath.replace(/^\.\//, "")}`)) return [];
 			return [
 				{
-					title: `${title} — ${name}`,
+					group: title,
+					title: name,
 					url: new URL(`?path=/story/${encodeURIComponent(id)}`, baseUrl).href,
 				},
 			];
-		})
-		.toSorted(compareLinks);
+		},
+	);
 	return comment(
 		"🧩 Storybook preview",
 		"Open full Storybook preview",
@@ -105,30 +99,16 @@ async function renderStorybook(): Promise<string> {
 	);
 }
 
-function compareLinks(left: { title: string; url: string }, right: { title: string; url: string }) {
-	return left.title.localeCompare(right.title) || left.url.localeCompare(right.url);
-}
-
 function comment(
 	heading: string,
 	previewLabel: string,
-	links: readonly { title: string; url: string }[],
+	links: readonly PreviewLink[],
 	linksHeading: string,
 	emptyMessage: string,
-): string {
-	const sections = [`## ${heading}`, `[${previewLabel}](<${baseUrl.href}>)`];
-	if (links.length === 0) {
-		sections.push(`### ${linksHeading}\n\n${emptyMessage}`);
-	} else {
-		const count = links.length > MAX_LINKS ? ` (${MAX_LINKS} of ${links.length})` : "";
-		const list = links
-			.slice(0, MAX_LINKS)
-			.map(({ title, url }) => `- [${markdown(title)}](<${url}>)`);
-		if (links.length > MAX_LINKS) {
-			list.push("", `${links.length - MAX_LINKS} more are available in the full preview.`);
-		}
-		sections.push(`### ${linksHeading}${count}\n\n${list.join("\n")}`);
-	}
+): string[] {
+	const count = links.length ? ` (${links.length})` : "";
+	const introduction = `## ${heading}\n\n[${previewLabel}](<${baseUrl.href}>)\n\n### ${linksHeading}${count}`;
+	let footer = "";
 	const { GITHUB_SERVER_URL, GITHUB_REPOSITORY, GITHUB_RUN_ID } = process.env;
 	if (GITHUB_SERVER_URL && GITHUB_REPOSITORY && GITHUB_RUN_ID) {
 		const sha = execFileSync("git", ["rev-parse", "HEAD"], {
@@ -136,14 +116,12 @@ function comment(
 			maxBuffer: CAPTURE_LIMIT_BYTES,
 		}).trim();
 		const repositoryUrl = `${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}`;
-		sections.push(
-			`Built from [\`${sha.slice(0, 7)}\`](<${repositoryUrl}/commit/${sha}>) · [Build logs](<${repositoryUrl}/actions/runs/${GITHUB_RUN_ID}>). Updates after successful preview builds.`,
-		);
+		footer = `Built from [\`${sha.slice(0, 7)}\`](<${repositoryUrl}/commit/${sha}>) · [Build logs](<${repositoryUrl}/actions/runs/${GITHUB_RUN_ID}>). Updates after successful preview builds.`;
 	}
-	return `${sections.join("\n\n")}\n`;
+	return renderPreviewComments(introduction, links, emptyMessage, footer);
 }
 
 const rendered =
 	kind === "docs" ? await renderDocs() : kind === "storybook" ? await renderStorybook() : undefined;
 if (!rendered) throw new Error(`Unknown preview kind: ${kind}`);
-await writeFile(output, rendered);
+await writeFile(output, `${JSON.stringify(rendered)}\n`);


### PR DESCRIPTION
## What changed and why

Preview comments currently stop after 25 links. In [the reported Storybook preview](https://github.com/hephaestus-build/Hephaestus/pull/2109#issuecomment-5618218599), that leaves 81 of 106 stories out of the comment and makes reviewers search the preview themselves.

This change keeps every matching link visible while making the comments easier to scan:

- Group stories by their full component/sidebar path and documentation pages by source directory.
- Show group counts and short, wrapping links instead of repeating the component path for every story. Nothing is collapsed or truncated.
- Continue oversized lists in numbered comments, repeating the group context and build provenance. Update comments in place and remove surplus parts when the list shrinks or the preview is retired.

Both preview workflows use the same renderer and publisher. The publisher uses the GitHub SDK already supplied by `actions/github-script`; no dependency is added.

## How to test

Verified locally:

- `vp run format` and `vp run check`.
- `node --test scripts/render-preview-comment.test.ts scripts/publish-preview-comments.test.ts scripts/ci-contract.test.ts` — 93 tests pass, including the 106-story regression, 1,200-link pagination, documentation grouping, escaping, retries, shrinking lists, and teardown.
- `vp run verification:docs-build`.
- GitHub's Markdown API (`https://api.github.com/markdown`) renders the 106-story fixture with all 106 story links, three component headings, and no disclosure controls or injected markup.

Manual workflow check: on a pull request that changes story or documentation source files, confirm that the preview comments show all published entries under the appropriate groups and open the correct canvases/pages. On closure, confirm that the main comment is retired and any continuation comments are removed.

## Release impact

No changeset or operator action is required. This changes pull-request automation and contributor documentation, not a shipped application artifact. No API, schema, runtime-role, or integration behavior changes.

## Notes for reviewers

- Start with `scripts/lib/preview-comment.ts` for grouping and size-aware rendering, then `scripts/publish-preview-comments.ts` for comment ownership, updates, and cleanup.
- The scope remains **published entries from directly changed story/page files**, as established in #1841. This is not transitive component-impact analysis.
- Removing the item cap also requires handling GitHub's comment-size limit. The previous action does not split oversized comments ([upstream issue](https://github.com/marocchino/sticky-pull-request-comment/issues/1395)). Each generated part stays below that limit; an individual link too large to fit fails explicitly instead of disappearing.
- GitHub does not provide atomic multi-comment updates. Publication errors fail the step; retries converge without duplicating parts, and obsolete parts are deleted only after all current parts have been published.

## Visual evidence

Three-link layout example using existing ModelPicker stories. This illustrates the grouping; the automated 106-story regression verifies that the complete list is retained.

### Before

- [components/admin/ai/ModelPicker — Default](<https://hephaestus-build-storybook-pr-2119.surge.sh/?path=/story/components-admin-ai-modelpicker--default>)
- [components/admin/ai/ModelPicker — Invalid](<https://hephaestus-build-storybook-pr-2119.surge.sh/?path=/story/components-admin-ai-modelpicker--invalid>)
- [components/admin/ai/ModelPicker — No Models Yet](<https://hephaestus-build-storybook-pr-2119.surge.sh/?path=/story/components-admin-ai-modelpicker--no-models-yet>)

### After

#### components/admin/ai/ModelPicker (3)

[Default](<https://hephaestus-build-storybook-pr-2119.surge.sh/?path=/story/components-admin-ai-modelpicker--default>) ·
[Invalid](<https://hephaestus-build-storybook-pr-2119.surge.sh/?path=/story/components-admin-ai-modelpicker--invalid>) ·
[No Models Yet](<https://hephaestus-build-storybook-pr-2119.surge.sh/?path=/story/components-admin-ai-modelpicker--no-models-yet>)

The live [documentation comment](https://github.com/hephaestus-build/Hephaestus/pull/2119#issuecomment-5625268030) also demonstrates directory grouping. The [Storybook comment](https://github.com/hephaestus-build/Hephaestus/pull/2119#issuecomment-5625296592) correctly shows the empty state on this tooling-only change.
