### PR TITLE
ci(security): pin the scanner behind the TruffleHog action

### DIFF
--- a/.github/workflows/ci-security-scan.yml
+++ b/.github/workflows/ci-security-scan.yml
@@ -138,6 +138,9 @@ jobs:
         continue-on-error: true
         uses: trufflesecurity/trufflehog@363923b901c911a9164f50b6c423f47c15372b1c # v3.97.4
         with:
+          # The action pins the wrapper, not its scanner: the version input otherwise uses latest.
+          image: ghcr.io/trufflesecurity/trufflehog
+          version: 3.97.4@sha256:562bc231afa9de3d04de44cfe624252b08207de1fc3cebc5e7ed92bed7f279e4
           path: ./
           base: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before || '' }}
           head: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.sha }}

--- a/docs/contributor/ci-cd.mdx
+++ b/docs/contributor/ci-cd.mdx
@@ -205,6 +205,16 @@ The first Trivy pass is the code-scanning feed: SARIF output reports every sever
 and it keeps Trivy's secret scanner,
 which covers the whole tree where TruffleHog covers a pull request's own commits.
 
+TruffleHog has two independent pins in `ci-security-scan.yml`: the action commit selects its
+wrapper, while the supported `image` and `version` inputs select the scanner container by tag and
+digest. The wrapper otherwise defaults to a mutable scanner tag even when its action is pinned.
+Renovate tracks the wrapper through its GitHub Actions manager and the scanner through a Docker
+custom manager; their versions need not move together. When reviewing a wrapper update, verify its
+[`image` and `version` input contract](https://github.com/trufflesecurity/trufflehog/blob/363923b901c911a9164f50b6c423f47c15372b1c/action.yml):
+the resulting Docker reference must retain the digest, and scanner failure must still fail the step.
+The event's immutable base/head commit range, verified-secret policy, and scan-error failure policy
+apply to either update.
+
 Renovate groups routine Gradle updates as server dependencies and webapp development updates
 separately. Webapp production dependencies remain separate unless Renovate identifies a package
 family that must move together.

--- a/renovate.json
+++ b/renovate.json
@@ -253,6 +253,15 @@
 				"SEMGREP_IMAGE: (?<depName>semgrep/semgrep):(?<currentValue>[0-9.]+)@(?<currentDigest>sha256:[a-f0-9]{64})"
 			],
 			"datasourceTemplate": "docker"
+		},
+		{
+			"description": "Track the TruffleHog scanner image",
+			"customType": "regex",
+			"managerFilePatterns": ["/^\\.github/workflows/ci-security-scan\\.yml$/"],
+			"matchStrings": [
+				"image: (?<depName>ghcr.io/trufflesecurity/trufflehog)\\s+version: (?<currentValue>[0-9.]+)@(?<currentDigest>sha256:[a-f0-9]{64})"
+			],
+			"datasourceTemplate": "docker"
 		}
 	],
 	"vulnerabilityAlerts": {

--- a/scripts/ci-contract.test.ts
+++ b/scripts/ci-contract.test.ts
@@ -1869,6 +1869,8 @@ void describe("CI contract", () => {
 		const scanPath = ["jobs", "security-scan"];
 		assert.equal(workflow.getIn([...scanPath, "env", "TRIVY_INCLUDE_DEV_DEPS"]), "true");
 		const secretScan = stepInputs(namedStep(workflow, scanPath, "Secret detection"));
+		assert.equal(secretScan.get("image"), "ghcr.io/trufflesecurity/trufflehog");
+		assert.match(String(secretScan.get("version")), /^\d+\.\d+\.\d+@sha256:[a-f0-9]{64}$/);
 		assert.equal(
 			secretScan.get("base"),
 			`\${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before || '' }}`,
@@ -1878,6 +1880,7 @@ void describe("CI contract", () => {
 			`\${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.sha }}`,
 		);
 		assert.ok(String(secretScan.get("extra_args")).split(" ").includes("--fail-on-scan-errors"));
+		assert.ok(String(secretScan.get("extra_args")).split(" ").includes("--only-verified"));
 		const report = stepInputs(namedStep(workflow, scanPath, "Trivy dependency scan"));
 		assert.equal(report.get("format"), "sarif");
 		assert.ok(

--- a/scripts/renovate-config.test.ts
+++ b/scripts/renovate-config.test.ts
@@ -217,6 +217,7 @@ void test("every custom manager reads every file it claims to read", async () =>
 		],
 		["Track release image tags and digests", ["security/release-images.json"]],
 		["Track the isolated Semgrep scanner image", [".github/workflows/semgrep.yml"]],
+		["Track the TruffleHog scanner image", [".github/workflows/ci-security-scan.yml"]],
 	]);
 	assert.ok(Array.isArray(config.customManagers));
 	assert.ok(config.customManagers.every(isRecord));


### PR DESCRIPTION
## What changed and why

Pin the scanner container that the TruffleHog action actually runs. A pinned action commit alone still used the wrapper's mutable default scanner version.

Use the upstream-supported image and version inputs with an immutable multi-platform digest. Renovate owns this Docker pin separately from the action wrapper, and existing workflow/update contracts reject losing the digest. Scan ranges, verified-secret detection and scan-error failure behavior are unchanged.

Closes #1986.

## How to test

- `node --test scripts/ci-contract.test.ts scripts/renovate-config.test.ts`: all 86 tests passed.
- Replacing the scanner version with `latest` fails both the workflow and Renovate contracts; restoring the pin passes.
- Executed the exact pinned upstream wrapper with a recording Docker stub and real Git base/head commits: it invoked the full tag-plus-digest reference, retained every required scan flag and propagated scanner exit 183. Omitting the version reproduced the former mutable default.
- Verified the registry tag and multi-platform index digest against the publisher.
- `vp run format` and `vp run check` passed.

## Release impact

CI-only scanner identity fix; no shipped application change or operator action. No changeset or visual evidence is applicable.
