### PR TITLE
docs(security): explain Scorecard's Gradle inventory mismatch

### DIFF
--- a/docs/contributor/ci-cd.mdx
+++ b/docs/contributor/ci-cd.mdx
@@ -276,7 +276,7 @@ advanced → Disable CodeQL**, not something a workflow file can do.
 ### Scorecard baseline
 
 `security/scorecard-baseline.json` owns the minimum every enforced Scorecard check must hold, the
-four exclusions with their reasons, and what each enforced check is scored over. Checks are compared
+exclusions with their reasons, and what each enforced check is scored over. Checks are compared
 one at a time, so an improvement cannot offset a regression, and a check the baseline does not name
 is not enforced. Lowering a minimum also edits the map in `scripts/check-scorecard.test.ts`, so the
 change is visible in the pull request that makes it.
@@ -307,6 +307,53 @@ It is a workflow of its own because
 [OpenSSF restricts the publishing job](https://github.com/ossf/scorecard-action#workflow-restrictions)
 to allowlisted actions. Reproduce it with `node scripts/check-scorecard.ts`, or
 `node --test scripts/check-scorecard.test.ts` without network access.
+
+#### Gradle dependency inventory and the Vulnerabilities exclusion
+
+Scorecard's `Vulnerabilities` check does not read the dependency graph submitted to GitHub or
+Dependabot's alerts. The [pinned action's dependencies](https://github.com/ossf/scorecard-action/blob/2d1146689b8cda280b9bc96326124645441f03bc/go.mod)
+select Scorecard 5.5.0 and OSV Scanner 2.3.2. [Scorecard's OSV client](https://github.com/ossf/scorecard/blob/v5.5.0/clients/osv.go)
+scans the checkout recursively and queries its Git commit. The
+[Gradle verification-metadata extractor](https://github.com/google/osv-scalibr/blob/cf20290d7624/extractor/filesystem/language/java/gradleverificationmetadataxml/gradleverificationmetadataxml.go)
+turns every component's group, name and version in `server/gradle/verification-metadata.xml` into a
+package, ignoring its artifact entries and whether Gradle selected that version.
+
+That file is a checksum allowlist, not a resolved dependency graph. Gradle can need an older
+version's POM or module descriptor while selecting a patched JAR; metadata generation also retains
+previously trusted artifacts. For example, resolution reads Jackson 2.15.3 module descriptors and
+the Commons Lang 3.16.0 POM even though the lockfile selects patched versions: their verification
+entries contain only `.module` or `.pom` artifacts, not JARs. Removing their checksums to quiet OSV
+would break fresh dependency verification, not fix a dependency. Pruning obsolete JAR hashes alone
+would still leave these descriptor-only entries in OSV's inventory.
+
+Reproduce the distinction for the Gradle sources from the repository root with the
+[OSV Scanner release used by the action](https://github.com/google/osv-scanner/releases/tag/v2.3.2):
+
+```sh
+osv-scanner scan source --format json --all-packages \
+  --lockfile server/application/gradle.lockfile \
+  --lockfile server/generated-clients/gradle.lockfile \
+  --lockfile server/gradle/verification-metadata.xml
+```
+
+Each result names its `source.path`, package coordinates and version, and any advisory's affected
+ranges. `--all-packages` also includes the patched lockfile entries, so compare the same package
+across sources rather than treating every reported version as selected. Exit 1 means vulnerabilities
+were reported; an extraction or network error is not a clean assessment. The advisories investigated
+in [#2078](https://github.com/hephaestus-build/Hephaestus/issues/2078) all came from verification
+metadata, not either resolved lockfile. The script classpath is separate: those lockfiles do not
+cover the GraphQL and OpenAPI build plugins. `server/build.gradle.kts` forces their GraphQL Java and
+Handlebars dependencies to patched versions; check `./server/gradlew -p server buildEnvironment`
+when diagnosing those packages rather than inferring their absence from an application lockfile.
+Re-run the checks when the action or dependencies change; the recorded observation is not an
+exemption for a new advisory against a resolved package.
+
+This inventory limitation justifies excluding the Scorecard `Vulnerabilities` check, not relaxing
+other gates. The baseline records that reason; its other exclusions have separate policy reasons.
+The [dependency vulnerability gate](#security-and-supply-chain-controls) and release image policy remain
+enforced. Restore the check when its input distinguishes verified descriptors and historical hashes
+from selected dependencies; do not alter dependency submission or disable checksum verification to
+change its score.
 
 ## Environments
 

--- a/security/scorecard-baseline.json
+++ b/security/scorecard-baseline.json
@@ -72,7 +72,7 @@
 			"name": "Vulnerabilities",
 			"score": 10,
 			"scoredOver": "configuration",
-			"reason": "Advisories open against the dependencies the checkout resolves. Excluded below: what it reports is not what this checkout resolves."
+			"reason": "Advisories against the inventory OSV extracts from the checkout, including Gradle verification metadata rather than only resolved dependencies."
 		},
 		{
 			"name": "Signed-Releases",
@@ -104,7 +104,7 @@
 		}
 	],
 	"excluded": {
-		"Vulnerabilities": "Reports fourteen advisories against version ranges this tree resolves outside of \u2014 jackson-core 2.21.5, jackson-databind 2.21.5, graphql-java 25.0, pmd-core 7.27.0, commons-lang3 3.20.0, bcprov-lts8on 2.73.11, handlebars 4.5.2 \u2014 while Dependabot reports none. The list did not change when #2075 forced two of them to patched versions, so it does not track what this repository resolves. Enforcing it would report a regression that does not exist. Tracked in #2078.",
+		"Vulnerabilities": "OSV inventories every Gradle verification-metadata component, including unselected versions and descriptor-only entries. This is a checksum allowlist, not the resolved graph. Source and reproduction: https://docs.hephaestus.build/contributor/ci-cd#gradle-dependency-inventory-and-the-vulnerabilities-exclusion ; upstream extractor: https://github.com/google/osv-scalibr/blob/cf20290d7624/extractor/filesystem/language/java/gradleverificationmetadataxml/gradleverificationmetadataxml.go . Only this Scorecard check is excluded; dependency and release vulnerability gates remain enforced. Tracked in https://github.com/hephaestus-build/Hephaestus/issues/2078.",
 		"Contributors": "Organization diversity is not a repository engineering control.",
 		"CII-Best-Practices": "An OpenSSF badge is a separate adoption decision.",
 		"Fuzzing": "Fuzzing adoption is a separate policy decision.",


### PR DESCRIPTION
## What changed and why

Trace Scorecard's fourteen Gradle advisories to the inventory it actually scans. The pinned Scorecard action embeds OSV Scanner, which treats every Gradle verification-metadata component as a package — including descriptor-only and historical entries that are not selected dependencies. It does not consume this repository's GitHub dependency-graph submission.

Replace the existing exclusion's speculative explanation with pinned upstream source, and document a command that attributes advisories to each Gradle source. Explain the separate plugin script classpath and why deleting required descriptor checksums would break fresh verification. No additional exclusion, score change, scanner bypass or dependency-submission change is introduced.

Closes #2078.

## How to test

- Reproduced with the action's OSV Scanner 2.3.2: all fourteen unique advisories came from verification metadata; neither application nor generated-client lockfile had a reported advisory. The documented JSON command includes package versions, source paths and affected ranges.
- A fresh strict Gradle build downloaded the older descriptor-only entries while selecting patched JARs. `./server/gradlew -p server buildEnvironment` separately confirmed the plugin's GraphQL Java and Handlebars dependencies resolve to their forced patched versions.
- `node --test scripts/check-scorecard.test.ts`: all 17 tests passed, including independent negative tests for every enforced minimum.
- `vp run format`, `vp run check`, and `vp run docs:build` passed on the final tree.

## Release impact

Documentation and existing policy-reason text only. All enforced minimums, classifications, exclusion keys, dependency vulnerability gates and release policies remain unchanged. No changeset or visual evidence is applicable.
