### PR TITLE
ci(deps): cache pnpm's verified lockfile verdict

### DIFF
--- a/.github/actions/setup-toolchain/action.yml
+++ b/.github/actions/setup-toolchain/action.yml
@@ -1,5 +1,5 @@
 name: "Setup toolchain"
-description: "The Node.js version package.json pins and, for a frozen install, its pnpm and Vite+ pins with the pnpm executable and the pnpm store cached; install is none or frozen."
+description: "The Node.js version package.json pins and, for a frozen install, its pnpm and Vite+ pins with the executable, package store and native lockfile-verification verdict cached; install is none or frozen."
 inputs:
   install:
     description: "none: the Node.js runtime alone, for dependency-free Node scripts or shell; frozen: pnpm and Vite+ as well, then pnpm install --frozen-lockfile --ignore-scripts. No lifecycle script runs in CI, so pnpm-workspace.yaml#allowBuilds is exercised only by a contributor's install."
@@ -102,7 +102,45 @@ runs:
         node-manager: false
         cache: false
         run-install: false
+    # setup-node caches package bytes, not pnpm's content-and-policy-validated verification record.
+    # Without the latter, even a fully warm store repeats registry metadata checks on every runner.
+    - name: Locate pnpm verification cache
+      id: pnpm-verification-path
+      if: inputs.install == 'frozen'
+      shell: bash
+      run: |
+        cache_dir="$(pnpm cache path)"
+        echo "path=$(node -p 'require("node:path").join(process.argv[1], "lockfile-verified.jsonl")' "$cache_dir")" >> "$GITHUB_OUTPUT"
+    - name: Restore pnpm verification cache
+      id: pnpm-verification-cache
+      if: inputs.install == 'frozen'
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ${{ steps.pnpm-verification-path.outputs.path }}
+        key: pnpm-verification-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.pnpm.outputs.version }}-${{ hashFiles('pnpm-lock.yaml', 'pnpm-workspace.yaml', '.npmrc') }}
     # pnpm/setup cannot pass --ignore-scripts, so the install is its own step.
-    - if: inputs.install == 'frozen'
+    - name: Install dependencies
+      id: pnpm-install
+      if: inputs.install == 'frozen'
       shell: bash
       run: pnpm install --frozen-lockfile --ignore-scripts
+    - name: Verify pnpm verification cache
+      if: inputs.install == 'frozen'
+      shell: bash
+      env:
+        PNPM_VERIFICATION_CACHE: ${{ steps.pnpm-verification-path.outputs.path }}
+      run: |
+        node -e 'if (!require("node:fs").statSync(process.argv[1]).isFile()) process.exit(1)' "$PNPM_VERIFICATION_CACHE"
+        echo "Verified native cache file: $PNPM_VERIFICATION_CACHE"
+    # Only a successful default-branch push install publishes a reusable policy verdict.
+    # pnpm itself checks the lockfile content and policy again before accepting a restored record.
+    - name: Save pnpm verification cache
+      if: >-
+        inputs.install == 'frozen' && steps.pnpm-install.outcome == 'success' &&
+        steps.pnpm-verification-cache.outputs.cache-hit != 'true' &&
+        github.event_name == 'push' &&
+        github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+      uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ${{ steps.pnpm-verification-path.outputs.path }}
+        key: pnpm-verification-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.pnpm.outputs.version }}-${{ hashFiles('pnpm-lock.yaml', 'pnpm-workspace.yaml', '.npmrc') }}

--- a/docs/contributor/ci-cd.mdx
+++ b/docs/contributor/ci-cd.mdx
@@ -521,6 +521,18 @@ Other jobs are read-only consumers: the Gradle action prefers an older same-job 
 producer cache, so consumers must not publish snapshots that become stale between their main-branch runs.
 The pnpm executable cache also saves only from `main`. The JDK is pinned once, in `.java-version`.
 
+The package store and pnpm's lockfile-verification cache are separate. `setup-toolchain` also restores
+`lockfile-verified.jsonl` from the directory reported by `pnpm cache path`; without it, a warm store
+still needs registry metadata for release-age and resolution checks. Only successful default-branch
+push installs publish this record, keyed by platform, pnpm
+version, lockfile, workspace policy and any repository `.npmrc`. pnpm's [native verification cache](https://github.com/pnpm/pnpm/blob/v12.3.4/pnpm/crates/lockfile-verification/src/cache.rs)
+validates the content and policy before reusing a verdict. The frozen install still runs with scripts
+disabled and package integrity checks intact; a miss performs normal verification, not an offline
+fallback. The action verifies the native cache file exists on each runner, including Windows; a
+changed upstream cache contract must be reviewed rather than silently losing reuse. Registry
+metadata itself is not cached by this action. A dependency update is cold under its new key; only
+later runs with the same inputs can reuse the default branch's verdict.
+
 Java quality verdicts are not stored in the Vite task cache: Gradle owns their task inputs and outputs.
 GraphQL generation opts into Gradle's build cache using the plugin's declared inputs and outputs.
 Its optional timestamped `@Generated` class marker is disabled so unchanged schemas produce identical

--- a/scripts/ci-contract.test.ts
+++ b/scripts/ci-contract.test.ts
@@ -2354,6 +2354,94 @@ void test("proves the toolchain on Windows and from a clean clone", async () => 
 	assert.doesNotMatch(prePushHook, /^\s*vp run check\s*$/m);
 });
 
+void test("pnpm reuses only trusted native verification verdicts and still runs a frozen install", async () => {
+	const action = parseDocument(
+		await readFile(".github/actions/setup-toolchain/action.yml", "utf8"),
+	);
+	const actionPath = ["runs"];
+	const locate = namedStep(action, actionPath, "Locate pnpm verification cache");
+	const restore = namedStep(action, actionPath, "Restore pnpm verification cache");
+	const install = namedStep(action, actionPath, "Install dependencies");
+	const proof = namedStep(action, actionPath, "Verify pnpm verification cache");
+	const save = namedStep(action, actionPath, "Save pnpm verification cache");
+	const steps = action.getIn(["runs", "steps"]);
+	assert.ok(isSeq(steps));
+	assert.ok(steps.items.indexOf(locate) < steps.items.indexOf(restore));
+	assert.ok(steps.items.indexOf(restore) < steps.items.indexOf(install));
+	assert.ok(steps.items.indexOf(install) < steps.items.indexOf(proof));
+	assert.ok(steps.items.indexOf(proof) < steps.items.indexOf(save));
+	for (const declaration of [locate, restore, install, proof])
+		assert.equal(declaration.get("if"), "inputs.install == 'frozen'");
+	assert.equal(install.get("run"), "pnpm install --frozen-lockfile --ignore-scripts");
+	assert.match(String(locate.get("run")), /\$\(pnpm cache path\)/);
+	assert.match(
+		String(locate.get("run")),
+		/require\("node:path"\)\.join\(process\.argv\[1\], "lockfile-verified\.jsonl"\)/,
+	);
+	assert.equal(
+		proof.getIn(["env", "PNPM_VERIFICATION_CACHE"]),
+		`\${{ steps.pnpm-verification-path.outputs.path }}`,
+	);
+	assert.match(String(proof.get("run")), /statSync\(process\.argv\[1\]\)\.isFile\(\)/);
+	assert.match(String(restore.get("uses")), /^actions\/cache\/restore@/);
+	assert.match(String(save.get("uses")), /^actions\/cache\/save@/);
+	const restored = stepInputs(restore);
+	assert.deepEqual(stepInputs(save).toJSON(), restored.toJSON());
+	assert.equal(restored.get("path"), `\${{ steps.pnpm-verification-path.outputs.path }}`);
+	assert.equal(restored.has("restore-keys"), false);
+	assert.equal(
+		restored.get("key"),
+		`pnpm-verification-v1-\${{ runner.os }}-\${{ runner.arch }}-\${{ steps.pnpm.outputs.version }}-\${{ hashFiles('pnpm-lock.yaml', 'pnpm-workspace.yaml', '.npmrc') }}`,
+	);
+	const parsed = new Parser(
+		new Lexer(String(save.get("if"))).lex().tokens,
+		["inputs", "steps", "github"],
+		[],
+	).parse();
+	for (const [event, ref, branch, outcome, hit, mode, expected] of [
+		["push", "refs/heads/main", "main", "success", "false", "frozen", true],
+		["push", "refs/heads/trunk", "trunk", "success", "false", "frozen", true],
+		["push", "refs/heads/topic", "main", "success", "false", "frozen", false],
+		["schedule", "refs/heads/main", "main", "success", "false", "frozen", false],
+		["workflow_dispatch", "refs/heads/main", "main", "success", "false", "frozen", false],
+		["pull_request", "refs/pull/1/merge", "main", "success", "false", "frozen", false],
+		["pull_request_target", "refs/heads/main", "main", "success", "false", "frozen", false],
+		["workflow_run", "refs/heads/main", "main", "success", "false", "frozen", false],
+		[
+			"merge_group",
+			"refs/heads/gh-readonly-queue/main/pr-1",
+			"main",
+			"success",
+			"false",
+			"frozen",
+			false,
+		],
+		["workflow_dispatch", "refs/heads/topic", "main", "success", "false", "frozen", false],
+		["push", "refs/heads/main", "main", "failure", "false", "frozen", false],
+		["push", "refs/heads/main", "main", "skipped", "false", "frozen", false],
+		["push", "refs/heads/main", "main", "success", "true", "frozen", false],
+		["push", "refs/heads/main", "main", "success", "false", "none", false],
+	] as const) {
+		const context: unknown = JSON.parse(
+			JSON.stringify({
+				inputs: { install: mode },
+				steps: {
+					"pnpm-install": { outcome },
+					"pnpm-verification-cache": { outputs: { "cache-hit": hit } },
+				},
+				github: { ref, event_name: event, event: { repository: { default_branch: branch } } },
+			}),
+			data.reviver,
+		);
+		assert.ok(context instanceof data.Dictionary);
+		assert.equal(
+			new Evaluator(parsed, context).evaluate().coerceString(),
+			String(expected),
+			`${event} ${ref} ${outcome} ${hit} ${mode}`,
+		);
+	}
+});
+
 void test(
 	"quality dispatch selects one task and rejects an unknown leg",
 	{ skip: !bashRunsRunnerSteps() },


### PR DESCRIPTION
## What changed and why

A warm pnpm package store was still making registry metadata requests because CI discarded pnpm's separate native lockfile-verification record. Restore that one record rather than changing release-age policy, bypassing validation or caching a large metadata mirror that still requires conditional network requests.

Only a successful default-branch push can publish the record. Its exact cache key includes runner platform, pnpm version, lockfile, workspace policy and any repository `.npmrc`; no prefix fallback is permitted. pnpm validates the lockfile content and policy before reusing the verdict. A changed lockfile therefore gets no verdict from a different lockfile, while unchanged inputs can reuse main's result. This relies on trusted cache provenance, not on treating the unsigned record as self-authenticating.

The existing frozen, script-disabled install still runs. A separate native-file check makes the cache-path contract observable on Windows as well as Linux.

## How to test

- `node --test scripts/ci-contract.test.ts scripts/ci-cache-policy.test.ts`: 78 tests passed. The actual publication expression rejects non-default-branch pushes, pull requests, privileged event aliases, failed/skipped installs, cache hits and runtime-only setup.
- Two isolated Linux checkouts reused all 2,027 packages from the same store, with no tarball downloads. Cold verification checked 2,331 entries in 4,992 ms (5.371 s installation); restoring only the native record in a different checkout gave a cached verdict and a 0.797 s installation.
- Tightening the release-age policy re-ran verification and failed with the expected policy violation. Altering an active package's integrity invalidated the cached verdict and failed the tarball-integrity check.
- Executed the action's cache-location and native-file proof against the pinned pnpm and Node runtimes on Linux.
- `vp run format`, `vp run check`, and `vp run docs:build` passed; format/check passed again after rebasing onto current main.
- PR CI must prove the Windows path and file contract. A warm Windows timing requires a successful main producer and a later same-input follower; the Linux measurements are not a Windows CI speedup claim.

## Release impact

CI-only cache reuse; no application behavior or release-policy change. A dependency update is intentionally cold under its new key. No changeset or visual evidence is applicable.
