### PR TITLE
ci(security): reuse Gradle dependencies during traced CodeQL builds

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,6 +36,7 @@ jobs:
             java-kotlin:
               - 'server/**'
               - '.java-version'
+              - '.github/actions/setup-caches/**'
               - '.github/codeql/**'
               - '.github/workflows/codeql.yml'
             javascript-typescript:
@@ -67,13 +68,9 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up Java
+      - name: Set up Java build
         if: matrix.language == 'java-kotlin'
-        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
-        with:
-          distribution: temurin
-          java-version-file: .java-version
-          cache-jdk: false
+        uses: ./.github/actions/setup-caches
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9

--- a/docs/contributor/ci-cd.mdx
+++ b/docs/contributor/ci-cd.mdx
@@ -268,12 +268,17 @@ CI calls that reusable workflow, and `CI Status Gate` waits for its successful c
 SARIF upload. A merge group therefore cannot pass the gate and lose its temporary ref while CodeQL
 is still publishing results. The weekly scan also runs directly from the same workflow.
 
-Java uses manual extraction with the JDK pinned in `.java-version` and a clean, uncached
-`:application:testClasses` compilation. This gives CodeQL the real dependencies, generated clients
-and annotation-processed source instead of no-build dependency and JDK guesses. The single-use Gradle
-process runs inside the extractor; neither cached classes nor a pre-existing daemon can bypass it.
-This compilation produces analysis inputs only: the packaged server remains owned by the build-once
-job. Actions and JavaScript/TypeScript retain no-build analysis.
+Java uses manual extraction with the JDK pinned in `.java-version` and a clean
+`:application:testClasses` compilation with build and configuration caches disabled. The shared
+`setup-caches` action restores Gradle dependencies read-only from the default-branch package
+producer through the Gradle action's OS-wide fallback; analysis never publishes a cache. The
+package job is the only writer, and a missing or expired entry falls back to a cold build.
+This gives CodeQL the real dependencies, generated clients and annotation-processed source instead
+of no-build dependency and JDK guesses. The single-use Gradle process runs inside the extractor;
+neither cached classes nor a pre-existing daemon can bypass project compilation. Gradle's own
+generated version-catalog helpers, outside the project source tree, need not be recompiled or
+extracted on a cache hit. This compilation produces analysis inputs only: the packaged server
+remains owned by the build-once job. Actions and JavaScript/TypeScript retain no-build analysis.
 
 `.github/workflows/codeql.yml` runs CodeQL under advanced setup: only advanced setup reads a
 committed config file, and `.github/codeql/codeql-config.yml` excludes `security/semgrep/**`,

--- a/scripts/ci-contract.test.ts
+++ b/scripts/ci-contract.test.ts
@@ -419,6 +419,10 @@ void describe("CI contract", () => {
 	void test("the server package job is the only Gradle cache producer", async () => {
 		const action = parseDocument(await readFile(".github/actions/setup-caches/action.yml", "utf8"));
 		assert.equal(action.getIn(["inputs", "cache-write", "default"]), "false");
+		assert.equal(
+			namedStep(action, ["runs"], "Set up JDK").getIn(["with", "java-version-file"]),
+			".java-version",
+		);
 		const sources = await workflowSources();
 		const writers = [...sources].filter(([, source]) => source.includes('cache-write: "true"'));
 		assert.deepEqual(
@@ -2554,12 +2558,28 @@ void test("CodeQL runs advanced setup and excludes the Semgrep fixtures it would
 		for (const match of source.matchAll(new RegExp(`uses: ${action}@([\\w.-]+)`, "g")))
 			assert.match(match[1] ?? "", /^[a-f0-9]{40}$/, `${action} must be pinned by commit`);
 	const init = step(workflow, ["jobs", "analyze"], "github/codeql-action/init");
+	for (const input of ["debug", "debug-artifact-name", "debug-database-name"]) {
+		assert.equal(
+			init.has(input),
+			false,
+			"full debug databases are temporary evidence, not routine CI artifacts",
+		);
+	}
 	assert.match(
 		String(init.get("build-mode")),
 		/matrix\.language == 'java-kotlin' && 'manual' \|\| 'none'/,
 	);
-	const java = step(workflow, ["jobs", "analyze"], "actions/setup-java");
-	assert.equal(java.get("java-version-file"), ".java-version");
+	const java = namedStep(workflow, ["jobs", "analyze"], "Set up Java build");
+	assert.equal(java.get("uses"), "./.github/actions/setup-caches");
+	assert.equal(java.get("if"), "matrix.language == 'java-kotlin'");
+	assert.equal(java.has("with"), false, "analysis consumes the default read-only Gradle cache");
+	const steps = workflow.getIn(["jobs", "analyze", "steps"]);
+	assert.ok(isSeq(steps));
+	assert.ok(
+		steps.items.indexOf(java) <
+			steps.items.indexOf(namedStep(workflow, ["jobs", "analyze"], "Initialize CodeQL")),
+		"provision dependencies before starting the extractor",
+	);
 	const compile = namedStep(workflow, ["jobs", "analyze"], "Compile Java for analysis");
 	assert.equal(compile.get("if"), "matrix.language == 'java-kotlin'");
 	assert.equal(compile.get("working-directory"), "server");
@@ -2647,6 +2667,9 @@ void test("CodeQL selects languages with native change detection", async () => {
 		);
 	}
 	assert.ok(asArray(filters["java-kotlin"], "Java paths").includes("server/**"));
+	assert.ok(
+		asArray(filters["java-kotlin"], "Java paths").includes(".github/actions/setup-caches/**"),
+	);
 	assert.ok(asArray(filters["javascript-typescript"], "JS paths").includes("pnpm-lock.yaml"));
 });
 


### PR DESCRIPTION
## What changed and why

CodeQL’s manual Java build started Gradle without the dependency cache used by other server jobs. Use the shared read-only Java/Gradle setup before initializing the extractor. Preserve clean compilation, disabled build/configuration caches, and the single-use daemon so application, test, and generated-client compilations remain traced.

Refs #1590 and #1591. The latency budget remains unmet; managed buildless code-quality analysis is distinct and unchanged.

## How to test

- `node --test scripts/ci-contract.test.ts`: 76 tests pass. Negative controls reject enabled build caching and temporary debug publication.
- `vp run format`, `vp run check`, and the contributor documentation build pass.
- The controlled hosted experiment matches all 15,492 project Java source hashes (2,417 main, 1,065 test, 12,010 generated), with no missing or extra project Java files. Only incidental external Gradle catalog helpers differ.
- Both analyses load the same 79 distinct query paths logged by the evaluator and report the same seven security results. The experimental extraction diagnostics report 15,492 successful files and no warnings/errors; the control SARIF omits per-file diagnostics, so no control diagnostic-count equivalence is claimed.
- Both the experiment and final run restored the trusted server-package dependency cache without publishing one. The final debug-off run compiled in 550 seconds versus 611 seconds for the control (61 seconds, about 10%, faster in these single samples); Java/cache setup took 9 seconds and analysis took 270 seconds. The earlier debug-on experiment took 575 seconds. This is an observed improvement, not a median/p90 claim, and the six-minute overall target remains unmet.

## Release impact

CI and contributor documentation only; no shipped-code changeset or operator action.

## Notes for reviewers

Temporary debug inputs are removed and their absence is regression-tested. The debug database artifact was deleted after comparison. No restored-class shortcut, compiler-analysis suppression, query change, or new cache writer is introduced. A missing compatible dependency cache falls back to a normal cold traced build.

Final hosted verification: [CodeQL Java job](https://github.com/hephaestus-build/Hephaestus/actions/runs/34537291020/job/103071800613) succeeded; every current required check is green.
