### PR TITLE
fix(server): enforce production keys and separate artifact bootstrap

### DIFF
--- a/.changeset/build-security-bootstrap.md
+++ b/.changeset/build-security-bootstrap.md
@@ -1,0 +1,5 @@
+---
+"hephaestus": patch
+---
+
+Production profile groups now reject missing encryption keys just like the production profile itself. System-key validation is consistent for encrypted fields and JWT signing keys, including non-ASCII key lengths. Build-only profiles no longer supply placeholder secrets or run container-image bootstrap, and cannot be combined with production profiles.

--- a/docs/admin/buildpacks-cds-decision.md
+++ b/docs/admin/buildpacks-cds-decision.md
@@ -18,7 +18,9 @@ prebuilt archive instead; Liquibase's share of startup is unaffected.
 
 `builder-noble-java-tiny` applies the Spring Boot buildpack. With `BP_JVM_CDS_ENABLED=true` the launcher runs once at build time (the "CDS training run") to load the bean-graph classes, archives them to `/workspace/application.jsa`, and bakes `-XX:SharedArchiveFile=/workspace/application.jsa` into the launcher. At runtime the JVM mmaps the archive instead of class-loading from JARs.
 
-The training run boots under the `cds-training` profile (`application-cds-training.yml`), which disables Liquibase + JDBC-metadata probing and pins the Hibernate dialect so context refresh succeeds without a reachable Postgres. Coolify's runtime `SPRING_PROFILES_ACTIVE=prod` overrides the buildpack-baked default (Paketo writes `env.launch/<KEY>.default`, which yields to the runtime env).
+The training run boots under the `cds-training` profile (`application-cds-training.yml`), which disables Liquibase + JDBC-metadata probing and identifies PostgreSQL without opening a connection so context refresh succeeds without a reachable Postgres. Coolify's runtime `SPRING_PROFILES_ACTIVE=prod` overrides the buildpack-baked default (Paketo writes `env.launch/<KEY>.default`, which yields to the runtime env).
+
+The [build-only profile boundary](./runtime-roles.mdx#build-only-profiles) keeps runtime bootstrap out of training and rejects a production/build-profile combination. Authentication types remain available for class loading without configured deployment secrets.
 
 The run image is used unmodified; the server needs no `git` binary (`GitDiffOperations` uses JGit).
 

--- a/docs/admin/runtime-roles.mdx
+++ b/docs/admin/runtime-roles.mdx
@@ -58,6 +58,18 @@ Each role ships with a Spring profile YAML that flips the other two flags off an
 
 To deploy a worker pod set `SPRING_PROFILES_ACTIVE=prod,worker` and point `HEPHAESTUS_HUB_URL` at the app pod's WSS endpoint. See `docker/compose.app.yaml` for a working compose template.
 
+## Build-only profiles
+
+`specs` and `cds-training` generate artifacts; they are not deployment modes. They load the
+application contract without runtime bootstrap, container-image validation or image pulls. They
+supply no shared placeholder secrets. If an authentication component needs a key to initialize,
+the build uses the existing non-production ephemeral-key behavior, without a runtime warning.
+
+Never combine either profile with `prod`, including through the `worker-node` or `webhook-server`
+profile groups. Startup rejects that combination even when production secrets are configured.
+Production encryption requirements apply to Spring's expanded profiles, so selecting a production
+profile group requires the same keys as selecting `prod` directly.
+
 ## Configuration cheatsheet
 
 Each cell is the value a pod boots with when the operator sets **no** env var for it — the profile

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/sandbox/AgentImagePinGuard.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/sandbox/AgentImagePinGuard.java
@@ -4,9 +4,11 @@ import de.tum.cit.aet.hephaestus.agent.runtime.AgentImageProperties;
 import java.util.Objects;
 import java.util.regex.Pattern;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 @Component
+@Profile("!specs & !cds-training")
 @ConditionalOnProperty(prefix = "hephaestus.agent.image", name = "require-digest", havingValue = "true")
 public class AgentImagePinGuard {
 

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/sandbox/AgentImageReferenceGuard.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/sandbox/AgentImageReferenceGuard.java
@@ -6,12 +6,13 @@ import java.util.regex.Pattern;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 /**
  * Refuses agent image references that cannot name a build matching this server.
  *
- * <p>Unconditional, unlike {@link AgentImagePinGuard}: a digest is a production requirement, but a
+ * <p>Applies in every runtime profile, unlike {@link AgentImagePinGuard}: a digest is a production requirement, but a
  * <em>channel tag</em> — one that moves from build to build rather than naming one — is wrong in
  * every environment. It comes in two spellings, a name and a partial version, and both move. The
  * server stages its runners into whatever this resolves to, so an unmatched image is a runtime
@@ -25,6 +26,7 @@ import org.springframework.stereotype.Component;
  * all. Both reach the daemon rather than this guard unless the tag is read out and judged.
  */
 @Component
+@Profile("!specs & !cds-training")
 public class AgentImageReferenceGuard {
 
     private static final Logger log = LoggerFactory.getLogger(AgentImageReferenceGuard.class);

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/AgentImagePullBootstrapper.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/AgentImagePullBootstrapper.java
@@ -17,10 +17,10 @@ import org.springframework.stereotype.Component;
  * Pre-pulls the agent container image on startup. Part of the worker capability (the Docker
  * sandbox), so it shares the worker-role gate with {@code DockerSandboxConfiguration} — present
  * in the monolith ({@code matchIfMissing=true}), absent on non-worker pods.
- * API contract introspection does not run containers and must not contact the Docker registry.
+ * Artifact generation does not run containers and must not contact the Docker registry.
  */
 @Component
-@Profile("!specs")
+@Profile("!specs & !cds-training")
 @ConditionalOnProperty(name = RuntimeRole.WORKER_PROPERTY, havingValue = "true", matchIfMissing = true)
 public class AgentImagePullBootstrapper {
 

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/auth/config/AuthSecurityConfig.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/auth/config/AuthSecurityConfig.java
@@ -14,14 +14,16 @@ import de.tum.cit.aet.hephaestus.core.runtime.ConditionalOnServerRole;
 import de.tum.cit.aet.hephaestus.core.security.SecurityHeaders;
 import java.security.SecureRandom;
 import java.util.Base64;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.core.env.Environment;
-import org.springframework.core.env.Profiles;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
@@ -75,18 +77,19 @@ public class AuthSecurityConfig {
     }
 
     @Bean
-    public CookieOAuth2AuthorizationRequestRepository cookieAuthorizationRequestRepository(
-            AuthProperties properties, Environment environment) {
-        return new CookieOAuth2AuthorizationRequestRepository(resolveStateCookieKey(properties, isProd(environment)));
+    public SecretKey authStateCookieKey(AuthProperties properties, Environment environment) {
+        return new SecretKeySpec(resolveStateCookieKey(properties, environment), "AES");
     }
 
     @Bean
-    public AuthIntentCookie authIntentCookie(AuthProperties properties, Environment environment) {
-        return new AuthIntentCookie(resolveStateCookieKey(properties, isProd(environment)));
+    public CookieOAuth2AuthorizationRequestRepository cookieAuthorizationRequestRepository(
+            @Qualifier("authStateCookieKey") SecretKey key) {
+        return new CookieOAuth2AuthorizationRequestRepository(key.getEncoded());
     }
 
-    private static boolean isProd(Environment environment) {
-        return environment.acceptsProfiles(Profiles.of("prod"));
+    @Bean
+    public AuthIntentCookie authIntentCookie(@Qualifier("authStateCookieKey") SecretKey key) {
+        return new AuthIntentCookie(key.getEncoded());
     }
 
     /**
@@ -202,7 +205,7 @@ public class AuthSecurityConfig {
      * <p>In the {@code prod} profile a blank key is fatal (fail-closed) — an ephemeral key silently
      * invalidates every in-flight login on each pod restart and differs per replica.
      */
-    static byte[] resolveStateCookieKey(AuthProperties properties, boolean prodProfile) {
+    static byte[] resolveStateCookieKey(AuthProperties properties, Environment environment) {
         if (!properties.stateCookieKey().isBlank()) {
             byte[] decoded = Base64.getDecoder().decode(properties.stateCookieKey());
             if (decoded.length != 32) {
@@ -212,14 +215,18 @@ public class AuthSecurityConfig {
             }
             return decoded;
         }
-        if (prodProfile) {
+        if (environment.matchesProfiles("prod")) {
             throw new IllegalStateException("hephaestus.auth.state-cookie-key is required in production (fail-closed). "
                     + "Set it to a base64-encoded 32-byte (256-bit AES) value.");
         }
         byte[] ephemeral = new byte[32];
         new SecureRandom().nextBytes(ephemeral);
-        log.warn("auth: hephaestus.auth.state-cookie-key is unset — generated ephemeral 256-bit key for this boot. "
-                + "In-flight logins will not survive a restart. Set the env var for stable behaviour.");
+        if (environment.matchesProfiles("specs", "cds-training")) {
+            log.debug("Created an ephemeral state-cookie key for artifact generation");
+        } else {
+            log.warn("auth: hephaestus.auth.state-cookie-key is unset — generated ephemeral 256-bit key for this boot. "
+                    + "In-flight logins will not survive a restart. Set the env var for stable behaviour.");
+        }
         return ephemeral;
     }
 }

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/auth/jwt/JwtSigningKeySealer.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/auth/jwt/JwtSigningKeySealer.java
@@ -2,24 +2,19 @@ package de.tum.cit.aet.hephaestus.core.auth.jwt;
 
 import de.tum.cit.aet.hephaestus.core.runtime.ConditionalOnServerRole;
 import de.tum.cit.aet.hephaestus.core.security.EncryptionException;
-import de.tum.cit.aet.hephaestus.core.security.SecurityProperties;
+import de.tum.cit.aet.hephaestus.core.security.SystemEncryptionKey;
 import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
 import javax.crypto.Cipher;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.GCMParameterSpec;
-import javax.crypto.spec.SecretKeySpec;
 import org.jspecify.annotations.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 /**
  * Seals the {@code jwt_signing_key.private_key_pem} column at rest with AES-256-GCM,
- * reusing the system master key bound via {@link SecurityProperties#encryptionKey()} —
- * the same key {@code CredentialBundleConverter} already requires in prod.
+ * reusing the system master key validated by {@link SystemEncryptionKey}. Credential bundles
+ * have their own separately configured encryption keys.
  *
  * <h2>Why system-scoped (not tenant-scoped) AAD</h2>
  * Signing keys are system-wide, not per-workspace. The GCM AAD is a single fixed,
@@ -36,16 +31,14 @@ import org.springframework.stereotype.Component;
  * </pre>
  *
  * <h2>Enablement / fail-fast</h2>
- * Mirrors {@code CredentialBundleConverter}: enabled iff a valid 32-char key is present.
+ * Enabled iff a valid 32-byte system key is present.
  * In the {@code prod} profile a missing key throws (prod requires it); in dev/CI/test an
  * absent key disables sealing so a local boot still works (writing raw {@code v0-unsealed}
- * rows). A non-32-char key is always rejected.
+ * rows). A key that is not 32 UTF-8 bytes is always rejected.
  */
 @ConditionalOnServerRole
 @Component
 public class JwtSigningKeySealer {
-
-    private static final Logger log = LoggerFactory.getLogger(JwtSigningKeySealer.class);
 
     /** Tag stamped on {@code jwt_signing_key.encryption_key_id} for blobs sealed by this class. */
     public static final String KEY_ID = "aesgcm-system-v1";
@@ -70,39 +63,9 @@ public class JwtSigningKeySealer {
     private final @Nullable SecretKey secretKey;
     private final boolean enabled;
 
-    /**
-     * Spring-wired constructor. The key is bound via {@link SecurityProperties}; the active
-     * profile string comes through {@code @Value} so the prod fail-fast check is identical to
-     * {@code CredentialBundleConverter}.
-     */
-    @Autowired
-    public JwtSigningKeySealer(
-            SecurityProperties securityProperties, @Value("${spring.profiles.active:}") String activeProfiles) {
-        this(securityProperties.encryptionKey(), activeProfiles);
-    }
-
-    /**
-     * Canonical constructor (also the unit-test seam): builds the cipher key from raw inputs.
-     * Missing key fails fast in prod, disables elsewhere; a non-32-char key is rejected.
-     */
-    public JwtSigningKeySealer(@Nullable String encryptionKey, @Nullable String activeProfiles) {
-        if (encryptionKey == null || encryptionKey.isBlank()) {
-            if (activeProfiles != null && activeProfiles.contains("prod")) {
-                throw new IllegalStateException("Encryption key is required in production to seal JWT signing keys! "
-                        + "Set hephaestus.security.encryption-key");
-            }
-            log.warn("Skipped JWT signing-key sealing: reason=missing_key, "
-                    + "action=set_hephaestus_security_encryption_key_in_production");
-            this.secretKey = null;
-            this.enabled = false;
-        } else if (encryptionKey.length() != 32) {
-            throw new IllegalArgumentException(
-                    "Encryption key must be exactly 32 characters (256 bits). Got: " + encryptionKey.length());
-        } else {
-            this.secretKey = new SecretKeySpec(encryptionKey.getBytes(StandardCharsets.UTF_8), "AES");
-            this.enabled = true;
-            log.info("Enabled JWT signing-key sealing at rest (AES-256-GCM, system-scoped AAD)");
-        }
+    public JwtSigningKeySealer(SystemEncryptionKey systemEncryptionKey) {
+        this.secretKey = systemEncryptionKey.key();
+        this.enabled = secretKey != null;
     }
 
     /** Whether sealing is operational (a valid key is configured). */

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/runtime/BuildProfileGuard.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/runtime/BuildProfileGuard.java
@@ -1,0 +1,15 @@
+package de.tum.cit.aet.hephaestus.core.runtime;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+/** Artifact profiles disable runtime responsibilities and must never overlay production. */
+@Component
+@Profile("prod & (specs | cds-training)")
+public final class BuildProfileGuard {
+
+    public BuildProfileGuard() {
+        throw new IllegalStateException(
+                "The specs and cds-training profiles are build-only and cannot be combined with production.");
+    }
+}

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/security/EncryptedStringConverter.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/security/EncryptedStringConverter.java
@@ -8,12 +8,10 @@ import java.util.Base64;
 import javax.crypto.Cipher;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.GCMParameterSpec;
-import javax.crypto.spec.SecretKeySpec;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 /**
@@ -22,7 +20,7 @@ import org.springframework.stereotype.Component;
  * Apply via {@code @Convert(converter = EncryptedStringConverter.class)}.
  *
  * <p>Configuration: set {@code hephaestus.security.encryption-key} to a
- * 32-character (256-bit) secret key.
+ * 32-byte (256-bit) secret key.
  */
 @Component
 @Converter
@@ -50,59 +48,11 @@ public class EncryptedStringConverter implements AttributeConverter<String, Stri
         log.debug("Instantiated EncryptedStringConverter: enabled=false, reason=no_spring_context");
     }
 
-    /**
-     * Spring-wired constructor. The key is bound via {@link SecurityProperties}; the active
-     * profile string still comes through {@code @Value} so the prod fail-fast check is identical.
-     */
+    /** The Spring-wired path shares key validation; standalone schema tooling uses the no-arg path. */
     @Autowired
-    public EncryptedStringConverter(
-            SecurityProperties securityProperties, @Value("${spring.profiles.active:}") String activeProfiles) {
-        this(securityProperties.encryptionKey(), activeProfiles);
-    }
-
-    /**
-     * Canonical constructor (also the unit-test seam): builds the cipher key directly from the
-     * raw inputs. Missing key fails fast in prod, warns elsewhere; a key that is not 32 bytes is
-     * rejected.
-     */
-    public EncryptedStringConverter(@Nullable String encryptionKey, @Nullable String activeProfiles) {
-        if (encryptionKey == null || encryptionKey.isBlank()) {
-            if (activeProfiles != null && activeProfiles.contains("prod")) {
-                throw new IllegalStateException(
-                        "Encryption key is required in production! Set hephaestus.security.encryption-key");
-            }
-            log.warn("Skipped encryption configuration: reason=missing_key, "
-                    + "action=set_hephaestus_security_encryption_key_in_production");
-            this.secretKey = null;
-            this.enabled = false;
-        } else {
-            // Validate the actual AES key length in BYTES (not chars): a 32-char key with multibyte
-            // characters is >32 UTF-8 bytes and would otherwise construct fine here and only throw
-            // InvalidKeyException on the first encrypt. Fail fast at startup instead.
-            byte[] keyBytes = encryptionKey.getBytes(StandardCharsets.UTF_8);
-            if (keyBytes.length != 32) {
-                // Report BOTH counts. "32 bytes" alone sends an operator who pasted a 32-character
-                // passphrase with an umlaut in it looking for a 34-character key; "32 characters"
-                // alone is a lie for exactly that operator. Never echo the key itself.
-                int characters = encryptionKey.length();
-                String howToFix = keyBytes.length == characters
-                        ? "For ASCII, bytes and characters are the same, so that is 32 characters: "
-                        : "This key contains non-ASCII characters, and those cost more than one byte each. "
-                                + "Use ASCII only, exactly 32 characters: ";
-                throw new IllegalArgumentException(
-                        "hephaestus.security.encryption-key (HEPHAESTUS_SECURITY_ENCRYPTION_KEY) must be a "
-                                + "32-byte AES-256 key. Got "
-                                + keyBytes.length
-                                + " bytes from "
-                                + characters
-                                + " characters. "
-                                + howToFix
-                                + "openssl rand -base64 24 | cut -c1-32");
-            }
-            this.secretKey = new SecretKeySpec(keyBytes, "AES");
-            this.enabled = true;
-            log.info("Enabled encryption for sensitive database fields");
-        }
+    public EncryptedStringConverter(SystemEncryptionKey systemEncryptionKey) {
+        this.secretKey = systemEncryptionKey.key();
+        this.enabled = secretKey != null;
     }
 
     @Override

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/security/SystemEncryptionKey.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/security/SystemEncryptionKey.java
@@ -1,0 +1,69 @@
+package de.tum.cit.aet.hephaestus.core.security;
+
+import java.nio.charset.StandardCharsets;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Component;
+
+/**
+ * Validates the system encryption key once for both Spring and Hibernate-owned consumers.
+ * Credential bundles use their separate, versioned key configuration.
+ */
+@Component
+public final class SystemEncryptionKey {
+
+    private static final Logger log = LoggerFactory.getLogger(SystemEncryptionKey.class);
+
+    private final @Nullable SecretKey key;
+
+    public SystemEncryptionKey(SecurityProperties properties, Environment environment) {
+        String encryptionKey = properties.encryptionKey();
+        if (encryptionKey == null || encryptionKey.isBlank()) {
+            if (environment.matchesProfiles("prod")) {
+                throw new IllegalStateException(
+                        "Encryption key is required in production! Set hephaestus.security.encryption-key");
+            }
+            if (environment.matchesProfiles("specs", "cds-training")) {
+                log.debug("System encryption is unavailable during artifact generation: reason=missing_key");
+            } else {
+                log.warn("Skipped encryption configuration: reason=missing_key, "
+                        + "action=set_hephaestus_security_encryption_key_in_production");
+            }
+            this.key = null;
+        } else {
+            // Validate the actual AES key length in BYTES (not chars): a 32-char key with multibyte
+            // characters is >32 UTF-8 bytes and would otherwise construct fine here and only throw
+            // InvalidKeyException on the first encrypt. Fail fast at startup instead.
+            byte[] keyBytes = encryptionKey.getBytes(StandardCharsets.UTF_8);
+            if (keyBytes.length != 32) {
+                // Report BOTH counts. "32 bytes" alone sends an operator who pasted a 32-character
+                // passphrase with an umlaut in it looking for a 34-character key; "32 characters"
+                // alone is a lie for exactly that operator. Never echo the key itself.
+                int characters = encryptionKey.length();
+                String howToFix = keyBytes.length == characters
+                        ? "For ASCII, bytes and characters are the same, so that is 32 characters: "
+                        : "This key contains non-ASCII characters, and those cost more than one byte each. "
+                                + "Use ASCII only, exactly 32 characters: ";
+                throw new IllegalArgumentException(
+                        "hephaestus.security.encryption-key (HEPHAESTUS_SECURITY_ENCRYPTION_KEY) must be a "
+                                + "32-byte AES-256 key. Got "
+                                + keyBytes.length
+                                + " bytes from "
+                                + characters
+                                + " characters. "
+                                + howToFix
+                                + "openssl rand -base64 24 | cut -c1-32");
+            }
+            this.key = new SecretKeySpec(keyBytes, "AES");
+            log.info("Enabled system encryption for sensitive data at rest");
+        }
+    }
+
+    public @Nullable SecretKey key() {
+        return key;
+    }
+}

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/core/connection/CredentialBundleConverter.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/core/connection/CredentialBundleConverter.java
@@ -16,7 +16,7 @@ import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.json.JsonMapper;
@@ -44,20 +44,18 @@ public class CredentialBundleConverter {
 
     @Autowired
     public CredentialBundleConverter(
-            SecurityProperties properties,
-            @Value("${spring.profiles.active:}") String activeProfiles,
-            ObjectMapper objectMapper) {
+            SecurityProperties properties, Environment environment, ObjectMapper objectMapper) {
         this(
                 properties.credentialEncryptionKey(),
                 properties.credentialEncryptionKeyVersion(),
                 properties.priorCredentialEncryptionKey(),
                 properties.priorCredentialEncryptionKeyVersion(),
-                activeProfiles,
+                environment.matchesProfiles("prod"),
                 objectMapper);
     }
 
-    public CredentialBundleConverter(@Nullable String encryptionKey, @Nullable String activeProfiles) {
-        this(encryptionKey, 1, null, null, activeProfiles, testObjectMapper());
+    public CredentialBundleConverter(@Nullable String encryptionKey, boolean production) {
+        this(encryptionKey, 1, null, null, production, testObjectMapper());
     }
 
     public CredentialBundleConverter(
@@ -65,13 +63,13 @@ public class CredentialBundleConverter {
             int activeKeyVersion,
             @Nullable String priorCredentialEncryptionKey,
             @Nullable Integer priorKeyVersion,
-            @Nullable String activeProfiles) {
+            boolean production) {
         this(
                 encryptionKey,
                 activeKeyVersion,
                 priorCredentialEncryptionKey,
                 priorKeyVersion,
-                activeProfiles,
+                production,
                 testObjectMapper());
     }
 
@@ -80,7 +78,7 @@ public class CredentialBundleConverter {
             int activeKeyVersion,
             @Nullable String priorCredentialEncryptionKey,
             @Nullable Integer priorKeyVersion,
-            @Nullable String activeProfiles,
+            boolean production,
             ObjectMapper objectMapper) {
         if (activeKeyVersion < 1) throw new IllegalArgumentException("Active key version must be positive");
         if ((priorCredentialEncryptionKey == null) != (priorKeyVersion == null)) {
@@ -93,7 +91,7 @@ public class CredentialBundleConverter {
         this.priorKeyVersion = priorKeyVersion;
         this.objectMapper = objectMapper;
         if (encryptionKey == null || encryptionKey.isBlank()) {
-            if (activeProfiles != null && activeProfiles.contains("prod")) {
+            if (production) {
                 throw new IllegalStateException(
                         "Credential encryption key is required in production! Set hephaestus.security.credential-encryption-key");
             }

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/core/oauth/state/HmacOAuthStateService.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/integration/core/oauth/state/HmacOAuthStateService.java
@@ -102,9 +102,14 @@ public class HmacOAuthStateService implements OAuthStateService {
             throw new IllegalStateException(
                     "Set hephaestus.integration.oauth-state.secret (or hephaestus.webhook.secret) — required for OAuth state HMAC in production.");
         }
-        log.warn("No hephaestus.integration.oauth-state.secret / hephaestus.webhook.secret configured; "
-                + "generating an EPHEMERAL dev-only OAuth-state secret. State tokens won't survive a restart "
-                + "and webhook HMAC will not match any vendor secret — set the secret for real integration testing.");
+        if (environment.matchesProfiles("specs", "cds-training")) {
+            log.debug("Created an ephemeral OAuth-state secret for artifact generation");
+        } else {
+            log.warn(
+                    "No hephaestus.integration.oauth-state.secret / hephaestus.webhook.secret configured; "
+                            + "generating an EPHEMERAL dev-only OAuth-state secret. State tokens won't survive a restart "
+                            + "and webhook HMAC will not match any vendor secret — set the secret for real integration testing.");
+        }
         byte[] ephemeral = new byte[32];
         RANDOM.nextBytes(ephemeral);
         return Base64.getUrlEncoder().withoutPadding().encodeToString(ephemeral);

--- a/server/application/src/main/resources/application-cds-training.yml
+++ b/server/application/src/main/resources/application-cds-training.yml
@@ -21,21 +21,11 @@ spring:
         compose:
             enabled: false
 
-# Quiet the property validators that would otherwise fail under empty env vars during the build.
-# All knobs here gate features that the runtime profile (Coolify SPRING_PROFILES_ACTIVE=prod)
-# overrides; the placeholders only exist to let context refresh reach spring.context.exit=onRefresh.
+# Artifact generation loads the runtime contract, not deployment bootstrap or integrations.
 hephaestus:
     sync:
         nats:
             enabled: false
-            server: nats://cds-training-placeholder:4222
     workspace:
         init-default: false
         init-gitlab-default: false
-    # OAuth-state HMAC + webhook secret — required at boot by HmacOAuthStateService.
-    # Placeholders only; runtime SPRING_PROFILES_ACTIVE=prod provides the real values.
-    integration:
-        oauth-state:
-            secret: cds-training-placeholder-not-secret
-    webhook:
-        secret: cds-training-placeholder-not-secret

--- a/server/application/src/main/resources/application-specs.yml
+++ b/server/application/src/main/resources/application-specs.yml
@@ -31,17 +31,13 @@ hephaestus:
             outline:
                 client-id: ""
                 client-secret: ""
-    # OpenAPI generation boots the full Spring context; HmacOAuthStateService fails fast
-    # without a webhook/oauth-state secret. Use a deterministic placeholder for the spec run.
-    webhook:
-        secret: "specs-only-placeholder-secret-do-not-use-in-prod"
     # Enable Slack/Outline admin endpoints so they surface in the generated client. The vendor
     # clients themselves aren't called during the spec run — just the controllers are loaded.
     integration:
         slack:
             enabled: true
-            client-id: "specs-only-placeholder-client-id"
-            client-secret: "specs-only-placeholder-client-secret"
+            client-id: ""
+            client-secret: ""
         outline:
             enabled: true
     runtime:

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/sandbox/AgentImageReferenceGuardTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/sandbox/AgentImageReferenceGuardTest.java
@@ -11,9 +11,23 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider;
 
 class AgentImageReferenceGuardTest extends BaseUnitTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {"specs", "cds-training"})
+    void shouldNotRequireRuntimeImagesDuringArtifactGeneration(String profile) {
+        // An inherited digest policy is runtime configuration; an artifact build uses no agent image.
+        new ApplicationContextRunner()
+                .withPropertyValues("spring.profiles.active=" + profile, "hephaestus.agent.image.require-digest=true")
+                .withUserConfiguration(AgentImageReferenceGuard.class, AgentImagePinGuard.class)
+                .run(context -> assertThat(context)
+                        .hasNotFailed()
+                        .doesNotHaveBean(AgentImageReferenceGuard.class)
+                        .doesNotHaveBean(AgentImagePinGuard.class));
+    }
 
     private static AgentImageReferenceGuard guardFor(String reference) {
         return new AgentImageReferenceGuard(new AgentImageProperties(reference, ImagePullPolicy.IF_NOT_PRESENT));

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/AgentImagePullBootstrapperTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/AgentImagePullBootstrapperTest.java
@@ -38,8 +38,8 @@ class AgentImagePullBootstrapperTest extends BaseUnitTest {
     }
 
     @ParameterizedTest
-    @CsvSource({"default,true,true", "specs,true,false", "default,false,false"})
-    void shouldOnlyBootstrapImagesForWorkersOutsideSpecGeneration(
+    @CsvSource({"default,true,true", "specs,true,false", "cds-training,true,false", "default,false,false"})
+    void shouldOnlyBootstrapImagesForWorkersOutsideArtifactGeneration(
             String profile, boolean workerEnabled, boolean expected) {
         new ApplicationContextRunner()
                 .withPropertyValues(

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/auth/config/AuthSecurityConfigTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/auth/config/AuthSecurityConfigTest.java
@@ -9,6 +9,12 @@ import de.tum.cit.aet.hephaestus.core.auth.AuthProperties;
 import de.tum.cit.aet.hephaestus.testconfig.BaseUnitTest;
 import java.util.Base64;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+import org.springframework.mock.env.MockEnvironment;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
@@ -23,7 +29,14 @@ import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequ
  * on every restart and differ per replica), while dev/CI tolerate it with a generated key. Mirrors
  * {@code JwtSigningKeySealer}'s prod fail-fast. Fails if either guard is removed.
  */
+@ExtendWith(OutputCaptureExtension.class)
 class AuthSecurityConfigTest extends BaseUnitTest {
+
+    private static MockEnvironment environment(String... profiles) {
+        var environment = new MockEnvironment();
+        environment.setActiveProfiles(profiles);
+        return environment;
+    }
 
     private static AuthProperties propsWithKey(String key) {
         AuthProperties properties = mock(AuthProperties.class);
@@ -35,30 +48,43 @@ class AuthSecurityConfigTest extends BaseUnitTest {
         return Base64.getEncoder().encodeToString(new byte[bytes]);
     }
 
+    @ParameterizedTest
+    @ValueSource(strings = {"specs", "cds-training"})
+    void shouldCreateEphemeralArtifactKeysWithoutRuntimeWarnings(String profile, CapturedOutput output) {
+        byte[] first = AuthSecurityConfig.resolveStateCookieKey(propsWithKey(""), environment(profile));
+        byte[] second = AuthSecurityConfig.resolveStateCookieKey(propsWithKey(""), environment(profile));
+        assertThat(first).hasSize(32).isNotEqualTo(second);
+        assertThat(output.getAll()).doesNotContain("WARN");
+        assertThatThrownBy(
+                        () -> AuthSecurityConfig.resolveStateCookieKey(propsWithKey(""), environment(profile, "prod")))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
     @Test
     void blankKeyInProdFailsClosed() {
-        assertThatThrownBy(() -> AuthSecurityConfig.resolveStateCookieKey(propsWithKey(""), true))
+        assertThatThrownBy(() -> AuthSecurityConfig.resolveStateCookieKey(propsWithKey(""), environment("prod")))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("required in production");
     }
 
     @Test
     void blankKeyOutsideProdGeneratesEphemeral32ByteKey() {
-        byte[] key = AuthSecurityConfig.resolveStateCookieKey(propsWithKey(""), false);
+        byte[] key = AuthSecurityConfig.resolveStateCookieKey(propsWithKey(""), environment("dev"));
 
         assertThat(key).hasSize(32);
     }
 
     @Test
     void configuredKeyIsDecodedAndUsedEvenInProd() {
-        byte[] key = AuthSecurityConfig.resolveStateCookieKey(propsWithKey(base64Key(32)), true);
+        byte[] key = AuthSecurityConfig.resolveStateCookieKey(propsWithKey(base64Key(32)), environment("prod"));
 
         assertThat(key).hasSize(32);
     }
 
     @Test
     void configuredKeyOfWrongLengthIsRejected() {
-        assertThatThrownBy(() -> AuthSecurityConfig.resolveStateCookieKey(propsWithKey(base64Key(16)), false))
+        assertThatThrownBy(
+                        () -> AuthSecurityConfig.resolveStateCookieKey(propsWithKey(base64Key(16)), environment("dev")))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("32 bytes");
     }

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/auth/jwt/JwtSigningKeySealerTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/auth/jwt/JwtSigningKeySealerTest.java
@@ -1,5 +1,6 @@
 package de.tum.cit.aet.hephaestus.core.auth.jwt;
 
+import static de.tum.cit.aet.hephaestus.testconfig.TestSystemEncryptionKeys.systemKey;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -20,7 +21,7 @@ class JwtSigningKeySealerTest extends BaseUnitTest {
     private static final String KEY = "0123456789abcdef0123456789abcdef"; // exactly 32 chars
 
     private JwtSigningKeySealer enabledSealer() {
-        return new JwtSigningKeySealer(KEY, "dev");
+        return new JwtSigningKeySealer(systemKey(KEY, "dev"));
     }
 
     @Test
@@ -122,7 +123,7 @@ class JwtSigningKeySealerTest extends BaseUnitTest {
 
     @Test
     void disabled_whenNoKeyInNonProd() {
-        JwtSigningKeySealer sealer = new JwtSigningKeySealer((String) null, "dev");
+        JwtSigningKeySealer sealer = new JwtSigningKeySealer(systemKey(null, "dev"));
 
         assertThat(sealer.isEnabled()).isFalse();
         assertThatThrownBy(() -> sealer.seal(new byte[] {1}))
@@ -133,21 +134,7 @@ class JwtSigningKeySealerTest extends BaseUnitTest {
 
     @Test
     void disabled_whenBlankKeyInNonProd() {
-        assertThat(new JwtSigningKeySealer("   ", "").isEnabled()).isFalse();
-    }
-
-    @Test
-    void prod_missingKey_failsFast() {
-        assertThatThrownBy(() -> new JwtSigningKeySealer((String) null, "prod"))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining("required in production");
-    }
-
-    @Test
-    void rejectsNon32CharKey() {
-        assertThatThrownBy(() -> new JwtSigningKeySealer("too-short", "dev"))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("32 characters");
+        assertThat(new JwtSigningKeySealer(systemKey("   ")).isEnabled()).isFalse();
     }
 
     @Test

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/auth/jwt/JwtSigningKeyServiceSealingTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/auth/jwt/JwtSigningKeyServiceSealingTest.java
@@ -1,5 +1,6 @@
 package de.tum.cit.aet.hephaestus.core.auth.jwt;
 
+import static de.tum.cit.aet.hephaestus.testconfig.TestSystemEncryptionKeys.systemKey;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.inOrder;
@@ -40,7 +41,7 @@ class JwtSigningKeyServiceSealingTest extends BaseUnitTest {
 
     @Test
     void generatedSealedKey_roundTripsThroughDbLoad() {
-        JwtSigningKeySealer sealer = new JwtSigningKeySealer(KEY, "dev");
+        JwtSigningKeySealer sealer = new JwtSigningKeySealer(systemKey(KEY, "dev"));
         assertThat(sealer.isEnabled()).isTrue();
 
         JwtSigningKeyRepository repo = mock(JwtSigningKeyRepository.class);
@@ -74,7 +75,7 @@ class JwtSigningKeyServiceSealingTest extends BaseUnitTest {
 
     @Test
     void disabledSealer_storesUnsealedAndStillLoads() {
-        JwtSigningKeySealer sealer = new JwtSigningKeySealer((String) null, "dev"); // disabled
+        JwtSigningKeySealer sealer = new JwtSigningKeySealer(systemKey(null, "dev")); // disabled
         assertThat(sealer.isEnabled()).isFalse();
 
         JwtSigningKeyRepository repo = mock(JwtSigningKeyRepository.class);
@@ -97,7 +98,7 @@ class JwtSigningKeyServiceSealingTest extends BaseUnitTest {
         // A legacy v0-unsealed row must fail closed at both the startup assertion and the signing path.
         // ensureActiveKey() is intentionally NOT the guard here: it runs inside AuthJwtConfig's
         // swallowing @PostConstruct, so making it the guard would be inert — the exact bug this pins.
-        JwtSigningKeySealer sealer = new JwtSigningKeySealer(KEY, "prod");
+        JwtSigningKeySealer sealer = new JwtSigningKeySealer(systemKey(KEY, "prod"));
         JwtSigningKeyRepository repo = mock(JwtSigningKeyRepository.class);
 
         JwtSigningKey legacy = new JwtSigningKey();
@@ -124,7 +125,7 @@ class JwtSigningKeyServiceSealingTest extends BaseUnitTest {
         // insert outside the lock or drop the re-check (the load-bearing step countByActiveTrue's
         // Javadoc calls out). Postgres owns the cross-pod semantics of pg_advisory_xact_lock; this pins
         // OUR sequence around it.
-        JwtSigningKeySealer sealer = new JwtSigningKeySealer(KEY, "dev");
+        JwtSigningKeySealer sealer = new JwtSigningKeySealer(systemKey(KEY, "dev"));
         JwtSigningKeyRepository repo = mock(JwtSigningKeyRepository.class);
         when(repo.countByActiveTrue()).thenReturn(0L); // empty before AND after the lock
         when(repo.save(any())).thenAnswer(inv -> inv.getArgument(0));
@@ -143,7 +144,7 @@ class JwtSigningKeyServiceSealingTest extends BaseUnitTest {
         // Two pods race past the unlocked fast path (both see 0). The loser blocks on the advisory lock;
         // by the time it acquires it, the winner has committed a key. The post-lock re-check must see
         // that key and SKIP the insert — otherwise the cluster mints two active signing identities.
-        JwtSigningKeySealer sealer = new JwtSigningKeySealer(KEY, "dev");
+        JwtSigningKeySealer sealer = new JwtSigningKeySealer(systemKey(KEY, "dev"));
         JwtSigningKeyRepository repo = mock(JwtSigningKeyRepository.class);
         // 0 at the fast path, then 1 after acquiring the lock (the winner inserted while we waited).
         when(repo.countByActiveTrue()).thenReturn(0L).thenReturn(1L);
@@ -158,7 +159,7 @@ class JwtSigningKeyServiceSealingTest extends BaseUnitTest {
     void warmBoot_skipsTheAdvisoryLockEntirely() {
         // The overwhelmingly common path: a key already exists, so the cheap unlocked read short-circuits
         // and the bootstrap lock is never taken (it would needlessly serialize every warm boot).
-        JwtSigningKeySealer sealer = new JwtSigningKeySealer(KEY, "dev");
+        JwtSigningKeySealer sealer = new JwtSigningKeySealer(systemKey(KEY, "dev"));
         JwtSigningKeyRepository repo = mock(JwtSigningKeyRepository.class);
         when(repo.countByActiveTrue()).thenReturn(1L);
 
@@ -170,7 +171,7 @@ class JwtSigningKeyServiceSealingTest extends BaseUnitTest {
 
     @Test
     void prod_emptyTable_bootstrapsSealedKey() {
-        JwtSigningKeySealer sealer = new JwtSigningKeySealer(KEY, "prod");
+        JwtSigningKeySealer sealer = new JwtSigningKeySealer(systemKey(KEY, "prod"));
         JwtSigningKeyRepository repo = mock(JwtSigningKeyRepository.class);
         when(repo.countByActiveTrue()).thenReturn(0L);
         ArgumentCaptor<JwtSigningKey> saved = ArgumentCaptor.forClass(JwtSigningKey.class);

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/runtime/BuildProfileGuardTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/runtime/BuildProfileGuardTest.java
@@ -1,0 +1,54 @@
+package de.tum.cit.aet.hephaestus.core.runtime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import de.tum.cit.aet.hephaestus.testconfig.BaseUnitTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider;
+import org.springframework.mock.env.MockEnvironment;
+
+class BuildProfileGuardTest extends BaseUnitTest {
+
+    private final ApplicationContextRunner runner = new ApplicationContextRunner()
+            .withInitializer(new ConfigDataApplicationContextInitializer())
+            .withPropertyValues("spring.config.import=")
+            .withUserConfiguration(BuildProfileGuard.class);
+
+    @Test
+    void shouldBeDiscoveredByTheApplicationComponentScan() {
+        var environment = new MockEnvironment();
+        environment.setActiveProfiles("prod", "specs");
+        var scanner = new ClassPathScanningCandidateComponentProvider(true, environment);
+        assertThat(scanner.findCandidateComponents(BuildProfileGuard.class.getPackageName()))
+                .extracting(BeanDefinition::getBeanClassName)
+                .contains(BuildProfileGuard.class.getName());
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                "prod,specs", "prod,cds-training",
+                "worker-node,specs", "worker-node,cds-training",
+                "webhook-server,specs", "webhook-server,cds-training"
+            })
+    void shouldRejectProductionBuildProfileCombinationsEvenThroughGroups(String profiles) {
+        runner.withPropertyValues("spring.profiles.active=" + profiles).run(context -> {
+            assertThat(context).hasFailed();
+            assertThat(context.getStartupFailure())
+                    .hasRootCauseMessage(
+                            "The specs and cds-training profiles are build-only and cannot be combined with production.");
+        });
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"prod", "worker-node", "webhook-server", "specs", "cds-training", "test"})
+    void shouldAllowRuntimeAndArtifactProfilesSeparately(String profile) {
+        runner.withPropertyValues("spring.profiles.active=" + profile)
+                .run(context -> assertThat(context).hasNotFailed());
+    }
+}

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/runtime/BuildProfileSecretsTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/runtime/BuildProfileSecretsTest.java
@@ -1,0 +1,40 @@
+package de.tum.cit.aet.hephaestus.core.runtime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import de.tum.cit.aet.hephaestus.testconfig.BaseUnitTest;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.core.env.StandardEnvironment;
+
+class BuildProfileSecretsTest extends BaseUnitTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {"specs", "cds-training"})
+    void shouldNotProvideKnownWebhookOrOAuthSecrets(String profile) {
+        new ApplicationContextRunner()
+                .withInitializer(context -> context.getEnvironment()
+                        .getPropertySources()
+                        .remove(StandardEnvironment.SYSTEM_ENVIRONMENT_PROPERTY_SOURCE_NAME))
+                .withInitializer(new ConfigDataApplicationContextInitializer())
+                .withPropertyValues("spring.config.import=", "spring.profiles.active=" + profile, "WEBHOOK_SECRET=")
+                .run(context -> {
+                    assertThat(context).hasNotFailed();
+                    var environment = context.getEnvironment();
+                    assertThat(environment.getProperty("hephaestus.webhook.secret"))
+                            .isNullOrEmpty();
+                    assertThat(environment.getProperty("hephaestus.integration.oauth-state.secret"))
+                            .isNullOrEmpty();
+                    if (profile.equals("specs")) {
+                        assertThat(environment.getProperty("hephaestus.integration.slack.enabled", Boolean.class))
+                                .isTrue();
+                        assertThat(environment.getProperty("hephaestus.integration.slack.client-id"))
+                                .isEmpty();
+                        assertThat(environment.getProperty("hephaestus.integration.slack.client-secret"))
+                                .isEmpty();
+                    }
+                });
+    }
+}

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/security/EncryptedStringConverterIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/security/EncryptedStringConverterIntegrationTest.java
@@ -1,0 +1,53 @@
+package de.tum.cit.aet.hephaestus.core.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import de.tum.cit.aet.hephaestus.core.auth.provider.LoginProvider;
+import de.tum.cit.aet.hephaestus.core.auth.provider.LoginProviderRepository;
+import de.tum.cit.aet.hephaestus.testconfig.BaseIntegrationTest;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+class EncryptedStringConverterIntegrationTest extends BaseIntegrationTest {
+
+    @Autowired
+    private LoginProviderRepository repository;
+
+    @Autowired
+    private JdbcTemplate jdbc;
+
+    @Autowired
+    private EncryptedStringConverter springConverter;
+
+    @Autowired
+    private SystemEncryptionKey systemEncryptionKey;
+
+    @Test
+    void shouldEncryptThroughHibernateAndReadThroughTheSharedSpringConfiguration() {
+        var key = systemEncryptionKey.key();
+        assertThat(key).isNotNull();
+        assertThat(key.getEncoded()).hasSize(32);
+
+        var provider = new LoginProvider();
+        provider.setRegistrationId("encryption-" + UUID.randomUUID());
+        provider.setType(LoginProvider.ProviderType.GITLAB);
+        provider.setDisplayName("Encryption contract");
+        provider.setBaseUrl("https://encryption-contract.example.com");
+        provider.setClientId("test-client");
+        provider.setClientSecret("test-client-secret");
+        provider.setScopes("read_user");
+        var saved = repository.saveAndFlush(provider);
+        try {
+            String stored = jdbc.queryForObject(
+                    "SELECT client_secret FROM login_provider WHERE id = ?", String.class, saved.getId());
+            assertThat(stored).isNotNull().startsWith("ENC:").doesNotContain("test-client-secret");
+            assertThat(springConverter.convertToEntityAttribute(stored)).isEqualTo("test-client-secret");
+            assertThat(repository.findById(saved.getId()).orElseThrow().getClientSecret())
+                    .isEqualTo("test-client-secret");
+        } finally {
+            repository.deleteById(saved.getId());
+        }
+    }
+}

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/security/EncryptedStringConverterTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/security/EncryptedStringConverterTest.java
@@ -1,5 +1,6 @@
 package de.tum.cit.aet.hephaestus.core.security;
 
+import static de.tum.cit.aet.hephaestus.testconfig.TestSystemEncryptionKeys.systemKey;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -8,7 +9,7 @@ import java.util.Base64;
 import org.junit.jupiter.api.Test;
 
 /**
- * Unit-level guarantees for the AES-256-GCM at-rest converter via its canonical (key, profiles) seam:
+ * Unit-level guarantees for the AES-256-GCM at-rest converter with shared system-key configuration:
  * round-trip, IV uniqueness, prod fail-fast, legacy-plaintext passthrough, and tamper detection.
  */
 class EncryptedStringConverterTest extends BaseUnitTest {
@@ -16,7 +17,7 @@ class EncryptedStringConverterTest extends BaseUnitTest {
     private static final String KEY = "0123456789abcdef0123456789abcdef"; // 32 ASCII chars = 32 bytes
 
     private EncryptedStringConverter converter() {
-        return new EncryptedStringConverter(KEY, "test");
+        return new EncryptedStringConverter(systemKey(KEY, "test"));
     }
 
     @Test
@@ -58,42 +59,9 @@ class EncryptedStringConverterTest extends BaseUnitTest {
     }
 
     @Test
-    void failsFastInProdWhenKeyMissing() {
-        assertThatThrownBy(() -> new EncryptedStringConverter("", "prod")).isInstanceOf(IllegalStateException.class);
-    }
-
-    @Test
     void disabledWhenKeyMissingOutsideProd() {
         // No key + non-prod ⇒ encryption disabled, values pass through untouched.
-        EncryptedStringConverter disabled = new EncryptedStringConverter("", "test");
+        EncryptedStringConverter disabled = new EncryptedStringConverter(systemKey("", "test"));
         assertThat(disabled.convertToDatabaseColumn("x")).isEqualTo("x");
-    }
-
-    /**
-     * The operator this message has to serve counted 32 characters and still got rejected. Saying only
-     * "must be 32 bytes. Got: 64" sends them hunting for a length they already have, so the message
-     * must state both counts and say which one is wrong and why.
-     */
-    @Test
-    void rejectsKeyThatIsNot32BytesAndExplainsTheCharacterCountItGotInstead() {
-        // 32 CHARS but multibyte ⇒ >32 bytes ⇒ must fail fast at construction, not at first encrypt.
-        String multibyte = "ä".repeat(32); // 32 chars, 64 UTF-8 bytes
-        assertThatThrownBy(() -> new EncryptedStringConverter(multibyte, "test"))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("32-byte")
-                .hasMessageContaining("Got 64 bytes from 32 characters")
-                .hasMessageContaining("non-ASCII")
-                .hasMessageContaining("openssl rand -base64 24 | cut -c1-32")
-                .as("never echo the key material itself")
-                .hasMessageNotContaining(multibyte);
-    }
-
-    /** An ASCII key of the wrong length is the ordinary case, and "32 characters" is true for it. */
-    @Test
-    void tellsAnAsciiKeyOfTheWrongLengthTheCountInCharacters() {
-        assertThatThrownBy(() -> new EncryptedStringConverter("tooshort", "test"))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("Got 8 bytes from 8 characters")
-                .hasMessageContaining("that is 32 characters");
     }
 }

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/security/EncryptionProfileTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/security/EncryptionProfileTest.java
@@ -1,0 +1,56 @@
+package de.tum.cit.aet.hephaestus.core.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import de.tum.cit.aet.hephaestus.integration.core.connection.CredentialBundleConverter;
+import de.tum.cit.aet.hephaestus.testconfig.BaseUnitTest;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import tools.jackson.databind.ObjectMapper;
+
+class EncryptionProfileTest extends BaseUnitTest {
+
+    private final ApplicationContextRunner runner = new ApplicationContextRunner()
+            .withInitializer(new ConfigDataApplicationContextInitializer())
+            .withPropertyValues("spring.config.import=")
+            .withBean(SecurityProperties.class, () -> new SecurityProperties(null, null, 1, null, null, false, 100));
+
+    @ParameterizedTest
+    @ValueSource(strings = {"test", "nonprod"})
+    void shouldNotMistakeOtherProfileNamesForProduction(String profile) {
+        runner.withPropertyValues("spring.profiles.active=" + profile)
+                .withBean(ObjectMapper.class, ObjectMapper::new)
+                .withUserConfiguration(
+                        SystemEncryptionKey.class, EncryptedStringConverter.class, CredentialBundleConverter.class)
+                .run(context -> assertThat(context).hasNotFailed());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"prod", "worker-node", "webhook-server"})
+    void shouldRequireSystemEncryptionWhenProductionIsActivatedDirectlyOrThroughAGroup(String profile) {
+        runner.withPropertyValues("spring.profiles.active=" + profile)
+                .withUserConfiguration(SystemEncryptionKey.class, EncryptedStringConverter.class)
+                .run(context -> {
+                    assertThat(context).hasFailed();
+                    assertThat(context.getStartupFailure())
+                            .hasRootCauseMessage(
+                                    "Encryption key is required in production! Set hephaestus.security.encryption-key");
+                });
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"prod", "worker-node", "webhook-server"})
+    void shouldRequireCredentialEncryptionWhenProductionIsActivatedDirectlyOrThroughAGroup(String profile) {
+        runner.withPropertyValues("spring.profiles.active=" + profile)
+                .withBean(ObjectMapper.class, ObjectMapper::new)
+                .withUserConfiguration(CredentialBundleConverter.class)
+                .run(context -> {
+                    assertThat(context).hasFailed();
+                    assertThat(context.getStartupFailure())
+                            .hasRootCauseMessage(
+                                    "Credential encryption key is required in production! Set hephaestus.security.credential-encryption-key");
+                });
+    }
+}

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/security/SystemEncryptionKeyTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/security/SystemEncryptionKeyTest.java
@@ -1,0 +1,103 @@
+package de.tum.cit.aet.hephaestus.core.security;
+
+import static de.tum.cit.aet.hephaestus.testconfig.TestSystemEncryptionKeys.systemKey;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import de.tum.cit.aet.hephaestus.core.auth.jwt.JwtSigningKeySealer;
+import de.tum.cit.aet.hephaestus.testconfig.BaseUnitTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+
+@ExtendWith(OutputCaptureExtension.class)
+class SystemEncryptionKeyTest extends BaseUnitTest {
+
+    /**
+     * The operator this message has to serve counted 32 characters and still got rejected. Saying only
+     * "must be 32 bytes. Got: 64" sends them hunting for a length they already have, so the message
+     * must state both counts and say which one is wrong and why.
+     */
+    @Test
+    void rejectsKeyThatIsNot32BytesAndExplainsTheCharacterCountItGotInstead() {
+        // 32 CHARS but multibyte ⇒ >32 bytes ⇒ must fail fast at construction, not at first encrypt.
+        String multibyte = "ä".repeat(32); // 32 chars, 64 UTF-8 bytes
+        assertThatThrownBy(() -> systemKey(multibyte, "test"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("32-byte")
+                .hasMessageContaining("Got 64 bytes from 32 characters")
+                .hasMessageContaining("non-ASCII")
+                .hasMessageContaining("openssl rand -base64 24 | cut -c1-32")
+                .as("never echo the key material itself")
+                .hasMessageNotContaining(multibyte);
+    }
+
+    /** An ASCII key of the wrong length is the ordinary case, and "32 characters" is true for it. */
+    @Test
+    void tellsAnAsciiKeyOfTheWrongLengthTheCountInCharacters() {
+        assertThatThrownBy(() -> systemKey("tooshort", "test"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Got 8 bytes from 8 characters")
+                .hasMessageContaining("that is 32 characters");
+    }
+
+    @Test
+    void shouldUseTheSameByteLengthValidationForJwtSealing() {
+        var sealer = new JwtSigningKeySealer(systemKey("ä".repeat(16)));
+        byte[] secret = {1, 2, 3};
+        assertThat(sealer.unseal(sealer.seal(secret))).isEqualTo(secret);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"specs", "cds-training"})
+    void shouldTreatMissingArtifactKeysAsExpectedWithoutWeakeningProduction(String profile, CapturedOutput output) {
+        assertThat(systemKey(null, profile).key()).isNull();
+        assertThat(output.getAll()).doesNotContain("WARN");
+        assertThatThrownBy(() -> systemKey(null, profile, "prod"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("required in production");
+    }
+
+    @Test
+    void shouldStillWarnWhenRuntimeEncryptionIsUnavailable(CapturedOutput output) {
+        assertThat(systemKey(null, "dev").key()).isNull();
+        assertThat(output.getAll()).contains("Skipped encryption configuration: reason=missing_key");
+    }
+
+    @Test
+    void shouldShareValidatedStateWithHibernateCreatedConverters(CapturedOutput output) {
+        new ApplicationContextRunner()
+                .withBean(
+                        SecurityProperties.class,
+                        () -> new SecurityProperties(
+                                "0123456789abcdef0123456789abcdef", null, 1, null, null, false, 100))
+                .withUserConfiguration(
+                        SystemEncryptionKey.class, EncryptedStringConverter.class, JwtSigningKeySealer.class)
+                .run(context -> {
+                    assertThat(context).hasNotFailed();
+                    var springConverter = context.getBean(EncryptedStringConverter.class);
+                    // SpringBeanContainer's JPA-compliant path uses createBean rather than getBean.
+                    var hibernateConverter =
+                            context.getAutowireCapableBeanFactory().createBean(EncryptedStringConverter.class);
+                    assertThat(hibernateConverter).isNotSameAs(springConverter);
+                    assertThat(hibernateConverter.convertToEntityAttribute(
+                                    springConverter.convertToDatabaseColumn("secret")))
+                            .isEqualTo("secret");
+                    var sealer = context.getBean(JwtSigningKeySealer.class);
+                    byte[] secret = {1, 2, 3};
+                    assertThat(sealer.unseal(sealer.seal(secret))).isEqualTo(secret);
+                    assertThat(output.getAll().split("Enabled system encryption", -1))
+                            .hasSize(2);
+                });
+    }
+
+    @Test
+    void shouldKeepStandaloneSchemaInspectionUnencrypted() {
+        var converter = new EncryptedStringConverter();
+        assertThat(converter.convertToDatabaseColumn("schema-only")).isEqualTo("schema-only");
+    }
+}

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/core/connection/ConnectionPurgeContributorTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/core/connection/ConnectionPurgeContributorTest.java
@@ -60,7 +60,7 @@ class ConnectionPurgeContributorTest extends BaseUnitTest {
 
     @BeforeEach
     void setUp() {
-        credentialConverter = new CredentialBundleConverter("a".repeat(32), "dev");
+        credentialConverter = new CredentialBundleConverter("a".repeat(32), false);
         connectionService = new ConnectionService(
                 connectionRepository,
                 auditRepository,

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/core/connection/ConnectionServiceTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/core/connection/ConnectionServiceTest.java
@@ -76,7 +76,7 @@ class ConnectionServiceTest extends BaseUnitTest {
         MockitoAnnotations.openMocks(this);
         // Real converter so the credential-purge case operates on a genuine AES-GCM blob,
         // not a mock stand-in.
-        credentialConverter = new CredentialBundleConverter("a".repeat(32), "dev");
+        credentialConverter = new CredentialBundleConverter("a".repeat(32), false);
         // The revoke callback runs through a TransactionTemplate over this manager; a stub status is
         // enough to let the template execute, and it lets us assert the propagation it asked for.
         Mockito.lenient().when(transactionManager.getTransaction(any())).thenReturn(new SimpleTransactionStatus());

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/core/connection/ConnectionTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/core/connection/ConnectionTest.java
@@ -20,8 +20,8 @@ class ConnectionTest extends BaseUnitTest {
 
     @Test
     void shouldClearQuarantineWhenCredentialsAreReplaced() {
-        CredentialBundleConverter oldConverter = new CredentialBundleConverter(OLD_KEY, "dev");
-        CredentialBundleConverter rotatingConverter = new CredentialBundleConverter(NEW_KEY, 2, OLD_KEY, 1, "dev");
+        CredentialBundleConverter oldConverter = new CredentialBundleConverter(OLD_KEY, false);
+        CredentialBundleConverter rotatingConverter = new CredentialBundleConverter(NEW_KEY, 2, OLD_KEY, 1, false);
         Connection connection = connection();
         connection.setCredentials(TOKEN, oldConverter);
         connection.markCredentialRotationFailed(Instant.parse("2026-09-03T12:00:00Z"));
@@ -37,10 +37,10 @@ class ConnectionTest extends BaseUnitTest {
         Connection connection = connection();
         assertThat(connection.hasCredentials()).isFalse();
 
-        connection.setCredentials(TOKEN, new CredentialBundleConverter(OLD_KEY, "dev"));
+        connection.setCredentials(TOKEN, new CredentialBundleConverter(OLD_KEY, false));
 
         assertThat(connection.hasCredentials()).isTrue();
-        assertThatThrownBy(() -> connection.credentials(new CredentialBundleConverter(NEW_KEY, "dev")))
+        assertThatThrownBy(() -> connection.credentials(new CredentialBundleConverter(NEW_KEY, false)))
                 .isInstanceOf(EncryptionException.class);
     }
 

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/core/connection/CredentialBundleConverterTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/core/connection/CredentialBundleConverterTest.java
@@ -28,7 +28,7 @@ class CredentialBundleConverterTest extends BaseUnitTest {
             new EncryptionContext(42L, IntegrationKind.GITHUB, "installation-999", "connection.credentials_encrypted");
 
     private static CredentialBundleConverter enabled() {
-        return new CredentialBundleConverter(KEY, "dev");
+        return new CredentialBundleConverter(KEY, false);
     }
 
     @Nested
@@ -156,7 +156,7 @@ class CredentialBundleConverterTest extends BaseUnitTest {
         @Test
         void wrongKey_throws() {
             CredentialBundleConverter writer = enabled();
-            CredentialBundleConverter reader = new CredentialBundleConverter(OTHER_KEY, "dev");
+            CredentialBundleConverter reader = new CredentialBundleConverter(OTHER_KEY, false);
             byte[] ciphertext = writer.encrypt(new BearerToken("secret", null), CTX_A);
 
             assertThatThrownBy(() -> reader.decrypt(ciphertext, CTX_A)).isInstanceOf(EncryptionException.class);
@@ -223,9 +223,9 @@ class CredentialBundleConverterTest extends BaseUnitTest {
 
         @Test
         void keyVersionColumnSelectsPriorAndActiveKeysDuringRotation() {
-            CredentialBundleConverter old = new CredentialBundleConverter(KEY, 7, null, null, "dev");
+            CredentialBundleConverter old = new CredentialBundleConverter(KEY, 7, null, null, false);
             byte[] oldBlob = old.encrypt(new BearerToken("secret", null), CTX_A);
-            CredentialBundleConverter rotating = new CredentialBundleConverter(OTHER_KEY, 8, KEY, 7, "dev");
+            CredentialBundleConverter rotating = new CredentialBundleConverter(OTHER_KEY, 8, KEY, 7, false);
 
             assertThat(rotating.decrypt(oldBlob, CTX_A, 7)).isEqualTo(new BearerToken("secret", null));
             byte[] newBlob = rotating.encrypt(new BearerToken("new", null), CTX_A);
@@ -247,7 +247,7 @@ class CredentialBundleConverterTest extends BaseUnitTest {
 
         @Test
         void disabled_writeThrows() {
-            CredentialBundleConverter disabled = new CredentialBundleConverter("", "dev");
+            CredentialBundleConverter disabled = new CredentialBundleConverter("", false);
             assertThat(disabled.isEnabled()).isFalse();
 
             assertThatThrownBy(() -> disabled.encrypt(new BearerToken("x", null), CTX_A))
@@ -257,7 +257,7 @@ class CredentialBundleConverterTest extends BaseUnitTest {
 
         @Test
         void disabled_readThrows() {
-            CredentialBundleConverter disabled = new CredentialBundleConverter("", "dev");
+            CredentialBundleConverter disabled = new CredentialBundleConverter("", false);
             byte[] anyBytes = new byte[32];
             anyBytes[0] = CredentialBundleConverter.FORMAT_VERSION_V2;
 
@@ -266,14 +266,14 @@ class CredentialBundleConverterTest extends BaseUnitTest {
 
         @Test
         void prodProfile_missingKey_failsFast() {
-            assertThatThrownBy(() -> new CredentialBundleConverter("", "prod"))
+            assertThatThrownBy(() -> new CredentialBundleConverter("", true))
                     .isInstanceOf(IllegalStateException.class)
                     .hasMessageContaining("required in production");
         }
 
         @Test
         void wrongLengthKey_failsFast() {
-            assertThatThrownBy(() -> new CredentialBundleConverter("short", "dev"))
+            assertThatThrownBy(() -> new CredentialBundleConverter("short", false))
                     .isInstanceOf(IllegalArgumentException.class)
                     .hasMessageContaining("exactly 32");
         }

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/core/connection/CredentialReaderIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/core/connection/CredentialReaderIntegrationTest.java
@@ -115,7 +115,7 @@ class CredentialReaderIntegrationTest extends AbstractWorkspaceIntegrationTest {
                 IntegrationKind.GITHUB,
                 instanceKey,
                 new ConnectionConfig.GitHubAppConfig(100L, null, null, Set.of())));
-        connection.setCredentials(TOKEN, new CredentialBundleConverter(OTHER_KEY, "test"));
+        connection.setCredentials(TOKEN, new CredentialBundleConverter(OTHER_KEY, false));
         return connectionRepository.saveAndFlush(connection);
     }
 }

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/core/connection/CredentialReaderTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/core/connection/CredentialReaderTest.java
@@ -72,10 +72,10 @@ class CredentialReaderTest extends BaseUnitTest {
 
     @Test
     void shouldHandTheRecordToItsExecutorRatherThanRunItInline() {
-        connection.setCredentials(TOKEN, new CredentialBundleConverter(KEY_A, "dev"));
+        connection.setCredentials(TOKEN, new CredentialBundleConverter(KEY_A, false));
         List<Runnable> handedOver = new ArrayList<>();
 
-        assertThatThrownBy(() -> readerWith(new CredentialBundleConverter(KEY_B, "dev"), handedOver::add)
+        assertThatThrownBy(() -> readerWith(new CredentialBundleConverter(KEY_B, false), handedOver::add)
                         .credentialsOf(connection))
                 .isInstanceOf(CredentialUnreadableException.class);
 
@@ -97,7 +97,7 @@ class CredentialReaderTest extends BaseUnitTest {
     @Test
     @Timeout(10)
     void shouldStillAnswerAtOnceWhenTheRecorderIsStalledAndItsQueueIsFull() throws InterruptedException {
-        connection.setCredentials(TOKEN, new CredentialBundleConverter(KEY_A, "dev"));
+        connection.setCredentials(TOKEN, new CredentialBundleConverter(KEY_A, false));
         CountDownLatch recording = new CountDownLatch(1);
         CountDownLatch release = new CountDownLatch(1);
         doAnswer(invocation -> {
@@ -109,7 +109,7 @@ class CredentialReaderTest extends BaseUnitTest {
                 .markCredentialsUnreadable(any(), any(), any(), any());
         ThreadPoolTaskExecutor recorder = productionRecorder();
         try {
-            CredentialReader reader = readerWith(new CredentialBundleConverter(KEY_B, "dev"), recorder);
+            CredentialReader reader = readerWith(new CredentialBundleConverter(KEY_B, false), recorder);
             int queueCapacity = recorder.getQueueCapacity();
 
             // The first record occupies the only worker until released; the next fill the queue.
@@ -134,11 +134,11 @@ class CredentialReaderTest extends BaseUnitTest {
 
     @Test
     void shouldStillAnswerWithTheUnreadableCredentialWhenTheRecorderHasShutDown() {
-        connection.setCredentials(TOKEN, new CredentialBundleConverter(KEY_A, "dev"));
+        connection.setCredentials(TOKEN, new CredentialBundleConverter(KEY_A, false));
         ThreadPoolTaskExecutor recorder = productionRecorder();
         recorder.shutdown();
 
-        assertThatThrownBy(() -> readerWith(new CredentialBundleConverter(KEY_B, "dev"), recorder)
+        assertThatThrownBy(() -> readerWith(new CredentialBundleConverter(KEY_B, false), recorder)
                         .credentialsOf(connection))
                 .isExactlyInstanceOf(CredentialUnreadableException.class);
         // A record submitted after shutdown is discarded, not run and not thrown.
@@ -147,7 +147,7 @@ class CredentialReaderTest extends BaseUnitTest {
 
     @Test
     void shouldReturnTheCredentialWhenTheKeyReadsIt() {
-        CredentialBundleConverter converter = new CredentialBundleConverter(KEY_A, "dev");
+        CredentialBundleConverter converter = new CredentialBundleConverter(KEY_A, false);
         connection.setCredentials(TOKEN, converter);
 
         assertThat(readerWith(converter).credentialsOf(connection)).contains(TOKEN);
@@ -156,10 +156,10 @@ class CredentialReaderTest extends BaseUnitTest {
 
     @Test
     void shouldMarkTheConnectionAndNameItWhenTheKeyCannotReadTheCredential() {
-        connection.setCredentials(TOKEN, new CredentialBundleConverter(KEY_A, "dev"));
+        connection.setCredentials(TOKEN, new CredentialBundleConverter(KEY_A, false));
 
         assertThatThrownBy(() ->
-                        readerWith(new CredentialBundleConverter(KEY_B, "dev")).credentialsOf(connection))
+                        readerWith(new CredentialBundleConverter(KEY_B, false)).credentialsOf(connection))
                 .isInstanceOf(CredentialUnreadableException.class)
                 .satisfies(e -> {
                     CredentialUnreadableException unreadable = (CredentialUnreadableException) e;
@@ -175,7 +175,7 @@ class CredentialReaderTest extends BaseUnitTest {
 
     @Test
     void shouldClearTheRecordWhenAMarkedCredentialReadsAgain() {
-        CredentialBundleConverter converter = new CredentialBundleConverter(KEY_A, "dev");
+        CredentialBundleConverter converter = new CredentialBundleConverter(KEY_A, false);
         connection.setCredentials(TOKEN, converter);
         connection.markCredentialRotationFailed(NOW.minusSeconds(60));
 
@@ -187,10 +187,10 @@ class CredentialReaderTest extends BaseUnitTest {
     void shouldLetAMissingKeyVersionThroughWithoutMarking() {
         // Written under key version 2; a server that only holds version 1 has an instance fault,
         // not a credential to give up on.
-        connection.setCredentials(TOKEN, new CredentialBundleConverter(KEY_A, 2, null, null, "dev"));
+        connection.setCredentials(TOKEN, new CredentialBundleConverter(KEY_A, 2, null, null, false));
 
         assertThatThrownBy(() ->
-                        readerWith(new CredentialBundleConverter(KEY_A, "dev")).credentialsOf(connection))
+                        readerWith(new CredentialBundleConverter(KEY_A, false)).credentialsOf(connection))
                 .isInstanceOf(MissingCredentialKeyException.class);
         verify(connectionRepository, never()).markCredentialsUnreadable(any(), any(), any(), any());
     }

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/core/connection/CredentialRotationServiceIntegrationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/core/connection/CredentialRotationServiceIntegrationTest.java
@@ -39,8 +39,8 @@ class CredentialRotationServiceIntegrationTest extends AbstractWorkspaceIntegrat
         User owner = persistUser("rotation-owner-" + System.nanoTime());
         Workspace workspace = createWorkspace(
                 "rotation-ws-" + System.nanoTime(), "Rotation Test", "rotation-org", AccountType.ORG, owner);
-        CredentialBundleConverter oldConverter = new CredentialBundleConverter(OLD_KEY, "test");
-        CredentialBundleConverter rotatingConverter = new CredentialBundleConverter(NEW_KEY, 2, OLD_KEY, 1, "test");
+        CredentialBundleConverter oldConverter = new CredentialBundleConverter(OLD_KEY, false);
+        CredentialBundleConverter rotatingConverter = new CredentialBundleConverter(NEW_KEY, 2, OLD_KEY, 1, false);
 
         Connection corrupt = connectionRepository.save(connection(workspace, "corrupt"));
         corrupt.setCredentials(TOKEN, oldConverter);

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/core/connection/CredentialRotationServiceTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/core/connection/CredentialRotationServiceTest.java
@@ -53,8 +53,8 @@ class CredentialRotationServiceTest extends BaseUnitTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        oldConverter = new CredentialBundleConverter(OLD_KEY, "dev");
-        rotatingConverter = new CredentialBundleConverter(NEW_KEY, 2, OLD_KEY, 1, "dev");
+        oldConverter = new CredentialBundleConverter(OLD_KEY, false);
+        rotatingConverter = new CredentialBundleConverter(NEW_KEY, 2, OLD_KEY, 1, false);
         SecurityProperties properties = new SecurityProperties(null, NEW_KEY, 2, OLD_KEY, 1, true, 25);
         meterRegistry = new SimpleMeterRegistry();
         service = new CredentialRotationService(
@@ -77,7 +77,7 @@ class CredentialRotationServiceTest extends BaseUnitTest {
         assertThat(stale.getCredentialsEncrypted()).isNotEqualTo(staleBlob);
         assertThat(stale.credentials(rotatingConverter)).contains(TOKEN);
         // The rewritten blob must not need the prior key any more.
-        CredentialBundleConverter activeOnly = new CredentialBundleConverter(NEW_KEY, 2, null, null, "dev");
+        CredentialBundleConverter activeOnly = new CredentialBundleConverter(NEW_KEY, 2, null, null, false);
         assertThat(stale.credentials(activeOnly)).contains(TOKEN);
     }
 

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/core/connection/api/ConnectionAdminServiceTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/core/connection/api/ConnectionAdminServiceTest.java
@@ -62,7 +62,7 @@ class ConnectionAdminServiceTest extends BaseUnitTest {
     void setUp() {
         MockitoAnnotations.openMocks(this);
         // Real converter so the encrypt/round-trip behaviour is exercised end-to-end.
-        credentialConverter = new CredentialBundleConverter("a".repeat(32), "dev");
+        credentialConverter = new CredentialBundleConverter("a".repeat(32), false);
         service = new ConnectionAdminService(
                 connectionRepository,
                 auditRepository,

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/core/connection/migration/CredentialBundleCryptoCompatTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/core/connection/migration/CredentialBundleCryptoCompatTest.java
@@ -64,7 +64,7 @@ class CredentialBundleCryptoCompatTest extends BaseUnitTest {
 
         @Test
         void producesBlobsThatDecryptBackWithTheRealConverter() {
-            CredentialBundleConverter converter = new CredentialBundleConverter(KEY, "dev");
+            CredentialBundleConverter converter = new CredentialBundleConverter(KEY, false);
             EncryptionContext ctx =
                     new EncryptionContext(7L, IntegrationKind.GITHUB, "pat", "connection.credentials_encrypted");
 
@@ -100,7 +100,7 @@ class CredentialBundleCryptoCompatTest extends BaseUnitTest {
 
         @Test
         void aadIsBoundToTheRow_wrongContextFailsAuthentication() {
-            CredentialBundleConverter converter = new CredentialBundleConverter(KEY, "dev");
+            CredentialBundleConverter converter = new CredentialBundleConverter(KEY, false);
             EncryptionContext writeCtx =
                     new EncryptionContext(7L, IntegrationKind.GITHUB, "pat", "connection.credentials_encrypted");
             EncryptionContext readCtx = new EncryptionContext(

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/core/oauth/state/HmacOAuthStateServiceTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/core/oauth/state/HmacOAuthStateServiceTest.java
@@ -15,8 +15,15 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.springframework.core.env.Environment;
+import org.springframework.mock.env.MockEnvironment;
 
+@ExtendWith(OutputCaptureExtension.class)
 class HmacOAuthStateServiceTest extends BaseUnitTest {
 
     private static final String SECRET = "unit-test-secret-with-enough-entropy-32b";
@@ -34,6 +41,24 @@ class HmacOAuthStateServiceTest extends BaseUnitTest {
             }
         }
         return new HmacOAuthStateService(properties, webhookProperties, environment, null);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"specs", "cds-training"})
+    void shouldUseEphemeralArtifactSecretsInsteadOfKnownPlaceholders(String profile, CapturedOutput output) {
+        var environment = new MockEnvironment();
+        environment.setActiveProfiles(profile);
+        var properties = new OAuthStateProperties(null, Duration.ofMinutes(10), Duration.ofDays(7));
+        var webhook = mock(WebhookProperties.class);
+        var first = new HmacOAuthStateService(properties, webhook, environment, null);
+        var second = new HmacOAuthStateService(properties, webhook, environment, null);
+        String state = first.issue(42L, IntegrationKind.GITHUB);
+        assertThat(first.consume(state).workspaceId()).isEqualTo(42L);
+        assertThatThrownBy(() -> second.consume(state)).isInstanceOf(IllegalArgumentException.class);
+        assertThat(output.getAll()).doesNotContain("WARN");
+        environment.setActiveProfiles(profile, "prod");
+        assertThatThrownBy(() -> new HmacOAuthStateService(properties, webhook, environment, null))
+                .isInstanceOf(IllegalStateException.class);
     }
 
     @Test

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/scm/github/credentials/GithubCredentialProviderTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/scm/github/credentials/GithubCredentialProviderTest.java
@@ -45,7 +45,7 @@ class GithubCredentialProviderTest extends BaseUnitTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        converter = new CredentialBundleConverter("0123456789abcdef0123456789abcdef", "dev");
+        converter = new CredentialBundleConverter("0123456789abcdef0123456789abcdef", false);
         lenient().when(appTokenService.getConfiguredAppId()).thenReturn(42L);
         provider =
                 new GithubCredentialProvider(connectionService, CredentialReaders.forTests(converter), appTokenService);

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/scm/gitlab/credentials/GitlabCredentialProviderTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/scm/gitlab/credentials/GitlabCredentialProviderTest.java
@@ -34,7 +34,7 @@ class GitlabCredentialProviderTest extends BaseUnitTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        converter = new CredentialBundleConverter("0123456789abcdef0123456789abcdef", "dev");
+        converter = new CredentialBundleConverter("0123456789abcdef0123456789abcdef", false);
         provider = new GitlabCredentialProvider(connectionService, CredentialReaders.forTests(converter));
     }
 

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/slack/credentials/SlackCredentialProviderTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/slack/credentials/SlackCredentialProviderTest.java
@@ -33,7 +33,7 @@ class SlackCredentialProviderTest extends BaseUnitTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        converter = new CredentialBundleConverter("0123456789abcdef0123456789abcdef", "dev");
+        converter = new CredentialBundleConverter("0123456789abcdef0123456789abcdef", false);
         provider = new SlackCredentialProvider(connectionService, CredentialReaders.forTests(converter));
     }
 

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/slack/messaging/SlackMessageServiceLiveTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/integration/slack/messaging/SlackMessageServiceLiveTest.java
@@ -52,7 +52,7 @@ class SlackMessageServiceLiveTest {
         workspace.setId(workspaceId);
 
         // Real per-row AES-GCM encryption (same converter the app wires), AAD-bound to this row.
-        CredentialBundleConverter converter = new CredentialBundleConverter("a".repeat(32), "live");
+        CredentialBundleConverter converter = new CredentialBundleConverter("a".repeat(32), false);
         Connection connection = new Connection(
                 workspace,
                 IntegrationKind.SLACK,

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/testconfig/TestSystemEncryptionKeys.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/testconfig/TestSystemEncryptionKeys.java
@@ -1,0 +1,17 @@
+package de.tum.cit.aet.hephaestus.testconfig;
+
+import de.tum.cit.aet.hephaestus.core.security.SecurityProperties;
+import de.tum.cit.aet.hephaestus.core.security.SystemEncryptionKey;
+import org.jspecify.annotations.Nullable;
+import org.springframework.mock.env.MockEnvironment;
+
+public final class TestSystemEncryptionKeys {
+
+    private TestSystemEncryptionKeys() {}
+
+    public static SystemEncryptionKey systemKey(@Nullable String key, String... profiles) {
+        var environment = new MockEnvironment();
+        environment.setActiveProfiles(profiles);
+        return new SystemEncryptionKey(new SecurityProperties(key, null, 1, null, null, false, 100), environment);
+    }
+}

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/workspace/WorkspaceSettingsServiceTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/workspace/WorkspaceSettingsServiceTest.java
@@ -62,7 +62,7 @@ class WorkspaceSettingsServiceTest extends BaseUnitTest {
         Workspace workspace = TestEntities.workspace(7L);
         Connection connection = new Connection(
                 workspace, IntegrationKind.GITHUB, "acme", new ConnectionConfig.GitHubPatConfig("x", "x", Set.of()));
-        connection.setCredentials(new BearerToken("ghp-old", null), new CredentialBundleConverter(KEY, "test"));
+        connection.setCredentials(new BearerToken("ghp-old", null), new CredentialBundleConverter(KEY, false));
         when(workspaceRepository.findById(7L)).thenReturn(Optional.of(workspace));
         when(connectionService.findActiveProviderKind(7L)).thenReturn(Optional.of(IntegrationKind.GITHUB));
         when(connectionService.rotateBearerToken(eq(7L), eq(IntegrationKind.GITHUB), any(BearerToken.class)))


### PR DESCRIPTION
## What changed and why

Production activated through `worker-node` or `webhook-server` bypassed encryption fail-fast checks because those checks searched the raw profile string instead of Spring's expanded profiles. System-key validation also ran separately in Spring/Hibernate consumers and checked JWT key length in characters rather than bytes.

Use Spring's profile evaluation and one validated system-key component, while retaining the separate versioned credential keys and existing ciphertext formats. Resolve the state-cookie key once for its two consumers. Artifact profiles keep authentication types available without known placeholder secrets, skip runtime image validation/pulls, and refuse any combination with production.

## How to test

- Fail-before reproduction: both encryption checks reject direct `prod`, but four production-group cases wrongly started before the fix.
- `vp run test:server:unit`: 7,410 tests and the coverage gate pass. Full architecture (302), integration (1,563), and database suites also pass.
- The Hibernate integration test checks the raw encrypted database column, decrypts it through the Spring consumer, and reloads it through JPA.
- `vp run generate:api` and `vp run db:check-drift`: no API/client or schema changes. The isolated API scrape used `http://127.0.0.1:37217/v3/api-docs.yaml`; the generator stopped it afterward.
- A fresh packaged JAR completes offline CDS training with `-Dspring.context.exit=onRefresh`, empty deployment keys and an unreachable database: exit 0, a 164 MB archive, no application warnings/errors. JVM archive warnings remain visible.
- `vp run format`, `vp run check`, and `vp run docs:build` pass.

## Release impact

Patch changeset: `.changeset/build-security-bootstrap.md`. Production groups now enforce the existing required encryption configuration. No migration, wire-format change, new dependency, or operator configuration key.

## Notes for reviewers

The JPA no-argument constructor remains for standalone schema tooling. The Spring-wired path shares validation; credential bundles keep their independent keys, versions and AAD. Normal runtime missing-key warnings and production failures are preserved; only expected artifact initialization is classified separately.

CI still needs to verify the actual Paketo image training path.
