### PR TITLE
ci(deps): seed trusted install caches on both runner platforms

### DIFF
--- a/.github/workflows/cache-toolchain.yml
+++ b/.github/workflows/cache-toolchain.yml
@@ -1,0 +1,38 @@
+name: Warm toolchain caches
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - package.json
+      - pnpm-lock.yaml
+      - pnpm-workspace.yaml
+      - .npmrc
+      - .github/actions/setup-toolchain/**
+      - .github/workflows/cache-toolchain.yml
+
+permissions: {}
+
+# Cache warming is independent of release validation; a cold cache remains a valid install.
+concurrency:
+  group: cache-toolchain-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  install:
+    name: Frozen install (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-toolchain
+        with:
+          install: "frozen"

--- a/docs/contributor/ci-cd.mdx
+++ b/docs/contributor/ci-cd.mdx
@@ -499,6 +499,7 @@ why the label is the authority, and which alternatives were priced and declined,
 | `pull-request.yml` | PR opened, edited, synchronized, reopened, ready for review | Validates the title against the policy `commitlint.config.ts` exports, without installing the workspace, checks that every commit resolves to the pull request's author, and assigns the author when the pull request opens |
 | `ci-quality-gates.yml` | Called by cicd.yml | Selects quality legs, clean-install verification and story tests |
 | `ci-quality-leg.yml` | Called by ci-quality-gates.yml | Shared formatting, lint, type-check and unit-test execution for each selected task-graph leg |
+| `cache-toolchain.yml` | Main push changing install inputs or setup | Seeds trusted Linux and Windows install caches without repeating quality gates |
 | `ci-build.yml` | Called by cicd.yml | Runs the OpenAPI, schema, database and browser E2E gates against the server artifact packaged by cicd.yml |
 | `ci-tests.yml` | Called by cicd.yml | The server unit, architecture and integration suites, compiled from source |
 | `ci-docker-build.yml` | Called by cicd.yml | Dockerfile image builds (webapp, agent, PostgreSQL) and aliases for unchanged images |
@@ -579,6 +580,13 @@ fallback. The action verifies the native cache file exists on each runner, inclu
 changed upstream cache contract must be reviewed rather than silently losing reuse. Registry
 metadata itself is not cached by this action. A dependency update is cold under its new key; only
 later runs with the same inputs can reuse the default branch's verdict.
+
+`cache-toolchain.yml` performs a frozen install on Linux and Windows after a main-branch push changes
+these inputs or the setup workflow/action. Ordinary main CI skips quality legs, so this dedicated
+producer keeps both platforms warm without duplicating their gates. It is separate from release
+validation: a failed or expired cache is a normal cold install, not a reason to block a release.
+Rerunning the original main-push cache workflow can replenish an expired entry; manual dispatch and
+pull requests cannot publish verification verdicts.
 
 Java quality verdicts are not stored in the Vite task cache: Gradle owns their task inputs and outputs.
 GraphQL generation opts into Gradle's build cache using the plugin's declared inputs and outputs.

--- a/scripts/ci-contract.test.ts
+++ b/scripts/ci-contract.test.ts
@@ -2739,3 +2739,44 @@ void test(
 			}
 	},
 );
+
+void test("toolchain cache producers cover Linux and Windows without repeating quality gates", async () => {
+	const workflow = parseDocument(await readFile(".github/workflows/cache-toolchain.yml", "utf8"));
+	const triggers = workflow.get("on");
+	assert.ok(isMap(triggers));
+	assert.deepEqual(triggers.toJSON(), {
+		push: {
+			branches: ["main"],
+			paths: [
+				"package.json",
+				"pnpm-lock.yaml",
+				"pnpm-workspace.yaml",
+				".npmrc",
+				".github/actions/setup-toolchain/**",
+				".github/workflows/cache-toolchain.yml",
+			],
+		},
+	});
+	const jobs = workflow.get("jobs");
+	assert.ok(isMap(jobs));
+	assert.equal(jobs.items.length, 1);
+	const install = jobs.get("install");
+	assert.ok(isMap(install));
+	assert.equal(install.get("runs-on"), `\${{ matrix.os }}`);
+	assert.equal(install.has("if"), false);
+	const platforms = install.getIn(["strategy", "matrix", "os"]);
+	assert.ok(isSeq(platforms));
+	assert.deepEqual(platforms.toJSON(), ["ubuntu-latest", "windows-latest"]);
+	assert.equal(install.getIn(["strategy", "fail-fast"]), false);
+	const steps = install.get("steps");
+	assert.ok(isSeq(steps));
+	assert.equal(steps.items.length, 2);
+	const checkout = steps.items[0];
+	const setup = steps.items[1];
+	assert.ok(isMap(checkout) && isMap(setup));
+	assert.match(String(checkout.get("uses")), /^actions\/checkout@/);
+	assert.equal(checkout.getIn(["with", "persist-credentials"]), false);
+	assert.equal(setup.get("uses"), "./.github/actions/setup-toolchain");
+	assert.equal(setup.getIn(["with", "install"]), "frozen");
+	assert.equal(setup.has("if"), false);
+});


### PR DESCRIPTION
## What changed and why

The native pnpm verification cache is restored on Linux and Windows, but ordinary main-branch CI skips quality installs. That leaves Windows without a reliable trusted cache producer.

Add a small, separate main-push workflow that performs the existing frozen install on both runner platforms when install policy inputs or the setup action/workflow change. It repeats no quality gates and does not couple cache warming to release validation. Cache publication remains restricted to successful default-branch push installs; misses and expired entries retain the normal online verification path.

Follow-up to #2123; refs #1591.

## How to test

- `node --test scripts/ci-contract.test.ts`: 77 contracts pass, including trigger inputs, both runner platforms, and the unchanged trusted-publication predicate. A negative control removing Windows fails.
- `vp run format`, `vp run check`, and `vp run docs:build` pass.
- After merge, inspect **Warm toolchain caches / Frozen install (windows-latest)**: verify the native ledger file and successful cache save, then confirm a later Windows quality install restores that exact key. Hosted producer/follower evidence is pending; this PR does not claim it already happened.

## Release impact

CI and contributor documentation only; no shipped-code changeset or operator action. A cache-warming failure is visible in its own workflow but does not change release policy.


## Post-merge Windows verification

The [trusted main producer](https://github.com/hephaestus-build/Hephaestus/actions/runs/34540724291/job/103082534212) succeeded after protected merge. It found no Windows verification verdict, completed the frozen install in 35.5 seconds, validated `C:\Users\runneradmin\AppData\Local\pnpm-cache\lockfile-verified.jsonl`, and saved key `pnpm-verification-v1-Windows-X64-12.3.4-112ad77b22a87da26a93b1970d5c9f7181fc302ce027387764ebef262e139cc3`.

The later [Windows quality job on PR #2130](https://github.com/hephaestus-build/Hephaestus/actions/runs/34540973088/job/103083804576) restored that exact key, validated the same native Windows path, completed its frozen install in 27.4 seconds, and passed all its gates. This was a naturally following PR job, not a special offline install or a relaxed check. The two times are individual observations, not a representative latency claim.
