### PR TITLE
ci: reuse workflow setup and native image tags

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -201,6 +201,7 @@ jobs:
       - uses: ./.github/actions/setup-toolchain
         with:
           install: "frozen"
+      # This job runs the packaged JAR, never Gradle; it needs no wrapper validation or build cache.
       - uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:
           distribution: "temurin"

--- a/.github/workflows/openapi-autocommit.yml
+++ b/.github/workflows/openapi-autocommit.yml
@@ -31,11 +31,8 @@ jobs:
       - uses: ./.github/actions/setup-toolchain
         with:
           install: "frozen"
-      - name: Setup Java
-        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
-        with:
-          distribution: temurin
-          java-version-file: .java-version
+      - name: Set up Java build
+        uses: ./.github/actions/setup-caches
       - name: Generate OpenAPI spec and client
         run: vp run generate:api
       - name: Upload generated files

--- a/.github/workflows/rescan-main-images.yml
+++ b/.github/workflows/rescan-main-images.yml
@@ -38,9 +38,8 @@ jobs:
           install-syft: "false"
 
       - name: Log in to Container Registry
-        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        uses: ./.github/actions/ghcr-login
         with:
-          registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -83,11 +83,11 @@ env:
   # is the commit a push, dispatch or merge group built, and a pull request uses its head commit
   # because `github.sha` there is a merge commit no other run can name.
   STANDARD_IMAGE_TAGS: |
-    ${{ github.event_name == 'push' && github.ref_name || '' }}
-    ${{ github.event_name == 'push' && format('ci-{0}', github.run_number) || '' }}
-    ${{ github.event_name != 'pull_request' && github.sha || '' }}
-    ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}
-    ${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.number) || '' }}
+    type=raw,value=${{ github.ref_name }},enable=${{ github.event_name == 'push' }}
+    type=raw,value=${{ format('ci-{0}', github.run_number) }},enable=${{ github.event_name == 'push' }}
+    type=raw,value=${{ github.sha }},enable=${{ github.event_name != 'pull_request' }}
+    type=raw,value=${{ github.event.pull_request.head.sha }},enable=${{ github.event_name == 'pull_request' }}
+    type=raw,value=${{ format('pr-{0}', github.event.number) }},enable=${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:
@@ -125,34 +125,12 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Prepare tag configuration
-        id: tags
-        if: inputs.single-arch
-        run: |
-          {
-            echo "tags<<EOF"
-            while IFS= read -r line || [[ -n "$line" ]]; do
-              line=$(echo "$line" | xargs)
-              [ -z "$line" ] && continue
-              if [[ "$line" == *"type="* ]]; then
-                echo "$line"
-              else
-                IFS=',' read -ra values <<< "$line"
-                for value in "${values[@]}"; do
-                  value=$(echo "$value" | xargs)
-                  [ -n "$value" ] && echo "type=raw,value=$value"
-                done
-              fi
-            done <<< "$STANDARD_IMAGE_TAGS"
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
-
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ${{ inputs.registry }}/${{ inputs.image-name }}
-          tags: ${{ inputs.single-arch && steps.tags.outputs.tags || '' }}
+          tags: ${{ inputs.single-arch && env.STANDARD_IMAGE_TAGS || '' }}
           labels: ${{ inputs.labels }}
 
       - name: Prepare platform pair
@@ -387,38 +365,12 @@ jobs:
         with:
           driver: docker
 
-      - name: Prepare tag configuration
-        id: tags
-        run: |
-          {
-            echo "tags<<EOF"
-            if [ -n "${STANDARD_IMAGE_TAGS}" ]; then
-              echo "${STANDARD_IMAGE_TAGS}" | while IFS= read -r line || [[ -n "$line" ]]; do
-                line=$(echo "$line" | xargs)
-                if [ -n "$line" ]; then
-                  if [[ "$line" == *"type="* ]]; then
-                    echo "$line"
-                  else
-                    IFS=',' read -ra TAG_ARRAY <<< "$line"
-                    for tag in "${TAG_ARRAY[@]}"; do
-                      tag=$(echo "$tag" | xargs)
-                      if [ -n "$tag" ]; then
-                        echo "type=raw,value=${tag}"
-                      fi
-                    done
-                  fi
-                fi
-              done
-            fi
-            echo "EOF"
-          } >> $GITHUB_OUTPUT
-
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ${{ inputs.registry }}/${{ inputs.image-name }}
-          tags: ${{ steps.tags.outputs.tags }}
+          tags: ${{ env.STANDARD_IMAGE_TAGS }}
           labels: ${{ inputs.labels }}
 
       - name: Create manifest and push

--- a/docs/contributor/ci-cd.mdx
+++ b/docs/contributor/ci-cd.mdx
@@ -595,7 +595,10 @@ reuse remains within a job: no encryption key is configured, so the
 action does not persist configuration-cache entries across jobs.
 
 Repository-local actions require checkout first. Jobs without checkout use the external SHA-pinned
-action directly rather than checking out the repository only to reach a wrapper.
+action directly rather than checking out the repository only to reach a wrapper. The reusable
+image builder also uses the external login action because its registry is a caller input, whereas
+`ghcr-login` intentionally authenticates only to GHCR. Browser E2E boots the packaged JAR without
+Gradle, so it sets up Java directly; OpenAPI autocommit builds the JAR and uses `setup-caches`.
 
 ## Path filters
 

--- a/scripts/ci-contract.test.ts
+++ b/scripts/ci-contract.test.ts
@@ -437,6 +437,36 @@ void describe("CI contract", () => {
 		assert.match(source, /inputs.cache-write != 'true' \|\| github.ref != format/);
 	});
 
+	void test("OpenAPI generation uses the read-only Gradle setup but runtime-only E2E does not", async () => {
+		const api = parseDocument(await readFile(".github/workflows/openapi-autocommit.yml", "utf8"));
+		const setup = namedStep(api, ["jobs", "generate"], "Set up Java build");
+		assert.equal(setup.get("uses"), "./.github/actions/setup-caches");
+		assert.notEqual(setup.getIn(["with", "cache-write"]), "true");
+		assert.equal(api.getIn(["jobs", "generate", "permissions", "contents"]), "read");
+		assert.doesNotMatch(job(String(api), "generate"), /actions\/setup-java@/);
+		assert.doesNotMatch(job(String(api), "commit"), /setup-caches|gradlew|vp run/);
+		const build = await readFile(".github/workflows/ci-build.yml", "utf8");
+		assert.match(job(build, "webapp-e2e"), /actions\/setup-java@/);
+		assert.doesNotMatch(job(build, "webapp-e2e"), /setup-caches|gradlew/);
+	});
+
+	void test("GHCR-only rescans share login while the image builder keeps its registry input", async () => {
+		const rescan = parseDocument(
+			await readFile(".github/workflows/rescan-main-images.yml", "utf8"),
+		);
+		const login = namedStep(rescan, ["jobs", "rescan"], "Log in to Container Registry");
+		assert.equal(login.get("uses"), "./.github/actions/ghcr-login");
+		assert.equal(login.getIn(["with", "username"]), `\${{ github.actor }}`);
+		assert.equal(login.getIn(["with", "password"]), `\${{ secrets.GITHUB_TOKEN }}`);
+		const reusable = parseDocument(
+			await readFile(".github/workflows/reusable-docker-build.yml", "utf8"),
+		);
+		for (const name of ["build", "merge", "scan"]) {
+			const registry = step(reusable, ["jobs", name], "docker/login-action");
+			assert.equal(registry.get("registry"), `\${{ inputs.registry }}`);
+		}
+	});
+
 	void test("image scans are delegated only to required release preflight", async () => {
 		const workflow = parseDocument(await readFile(".github/workflows/cicd.yml", "utf8"));
 		assert.equal(
@@ -1177,11 +1207,10 @@ void describe("CI contract", () => {
 		);
 		const declared = reusable.getIn(["env", "STANDARD_IMAGE_TAGS"]);
 		assert.equal(typeof declared, "string");
-		// `${{ github.event_name <op> '<event>' && <expression> || '' }}`: every tag the build
-		// publishes is guarded on the event that started the run, so a consumer can derive from its
-		// own event which tags exist. A tag published under every event names the attempt rather than
-		// the artefact, and a re-run of a failed job would resolve nothing.
-		const guard = /^\$\{\{ github\.event_name (==|!=) '(\w+)' && (.+?) \|\| '' }}$/;
+		// Native metadata-action entries keep the event guard alongside the value. A tag names
+		// the artifact, not a run attempt that a re-run could never resolve.
+		const guard =
+			/^type=raw,value=\$\{\{ (.+?) }},enable=\$\{\{ github\.event_name (==|!=) '(\w+)' }}$/;
 		const lines = String(declared)
 			.split("\n")
 			.filter((line) => line.length > 0);
@@ -1189,8 +1218,30 @@ void describe("CI contract", () => {
 			lines.flatMap((line) => {
 				const parsed = guard.exec(line);
 				assert.ok(parsed, `image tag "${line}" is published under every event`);
-				return (parsed[1] === "==") === (parsed[2] === event) ? [String(parsed[3])] : [];
+				return (parsed[2] === "==") === (parsed[3] === event) ? [String(parsed[1])] : [];
 			});
+
+		assert.deepEqual(publishedOn("push"), [
+			"github.ref_name",
+			"format('ci-{0}', github.run_number)",
+			"github.sha",
+		]);
+		assert.deepEqual(publishedOn("pull_request"), [
+			"github.event.pull_request.head.sha",
+			"format('pr-{0}', github.event.number)",
+		]);
+		for (const event of ["merge_group", "workflow_dispatch"])
+			assert.deepEqual(publishedOn(event), ["github.sha"]);
+		for (const name of ["build", "merge"]) {
+			const metadata = step(reusable, ["jobs", name], "docker/metadata-action");
+			assert.equal(
+				metadata.get("tags"),
+				name === "build"
+					? `\${{ inputs.single-arch && env.STANDARD_IMAGE_TAGS || '' }}`
+					: `\${{ env.STANDARD_IMAGE_TAGS }}`,
+			);
+		}
+		assert.doesNotMatch(String(reusable), /steps\.tags\.outputs|Prepare tag configuration/);
 
 		const source = await readFile(".github/workflows/cicd.yml", "utf8");
 		const triggers = /^on:\n([\s\S]*?)^\S/m.exec(source)?.[1] ?? "";


### PR DESCRIPTION
## What changed and why

The reusable image workflow converted the same tag list to metadata-action syntax twice, while OpenAPI autocommit ran Gradle outside the shared Java setup. Use native event-guarded metadata entries directly and the existing read-only Gradle action for API generation. The GHCR-only image rescan now reuses the login action.

Keep intentionally different boundaries: browser E2E only boots a packaged JAR and needs no Gradle cache; the reusable image builder accepts a configurable registry, unlike the GHCR-specific wrapper; jobs without checkout remain checkout-free. Document those distinctions.

## How to test

- `node --test scripts/ci-contract.test.ts`: exact event tag sets, both metadata consumers, read-only API build setup, runtime-only E2E and configurable-registry behavior. All 78 tests passed. Restoring the three original workflows makes three regression contracts fail.
- `vp run format` and `vp run check`: passed all local quality gates.
- Executed the SHA-pinned `docker/metadata-action` bundle with both original and replacement tag inputs: push, pull request, merge group and manual dispatch produced identical published tags, including the disabled empty pull-request value on other events.
- Hosted check: all four published images (webapp, application-server, agent-pi and postgres) resolve the exact PR head SHA and `pr-2128` to the same digest. Their build and vulnerability-policy jobs passed. The default-branch push's multi-architecture commit-tag check remains pending; ordinary merge groups build only amd64. An `autocommit-openapi` label on an eligible same-repository PR should show shared Gradle setup before generation, with no cache writer in the generator.

## Release impact

Workflow, test and contributor-documentation changes only. No application/API/schema behavior, operator action or changeset.
