### PR TITLE
ci: report every workflow result without guessing skip causes

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -886,161 +886,51 @@ jobs:
 
           echo "status=success" >> $GITHUB_OUTPUT
 
+      # Keep this checkout-free: the job writes commit statuses and must not execute PR source.
       - name: Generate CI Summary
         if: always()
-        run: |
-          echo "## 🔍 CI Pipeline Summary" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-
-          if [[ "${{ steps.evaluate.outputs.status }}" == "success" ]]; then
-            echo "✅ **All checks passed!**" >> $GITHUB_STEP_SUMMARY
-          elif [[ "${{ steps.evaluate.outputs.status }}" == "failure" ]]; then
-            echo "❌ **Some checks failed.** See details below." >> $GITHUB_STEP_SUMMARY
-          else
-            echo "⚠️ **CI was cancelled or encountered an issue.**" >> $GITHUB_STEP_SUMMARY
-          fi
-          echo "" >> $GITHUB_STEP_SUMMARY
-
-          echo "### Workflow Results" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "| Workflow | Status |" >> $GITHUB_STEP_SUMMARY
-          echo "|----------|--------|" >> $GITHUB_STEP_SUMMARY
-          echo "| CodeQL | ${{ needs.CodeQL.result }} |" >> $GITHUB_STEP_SUMMARY
-
-          result_to_emoji() {
-            case "$1" in
-              success) echo "✅ Passed" ;;
-              failure) echo "❌ Failed" ;;
-              skipped) echo "⏭️ Skipped" ;;
-              cancelled) echo "🚫 Cancelled" ;;
-              *) echo "❓ Unknown" ;;
-            esac
-          }
-
-          echo "| Actionlint | $(result_to_emoji '${{ needs.workflow-lint.result }}') |" >> $GITHUB_STEP_SUMMARY
-          echo "| Zizmor | $(result_to_emoji '${{ needs.zizmor.result }}') |" >> $GITHUB_STEP_SUMMARY
-          echo "| Quality | $(result_to_emoji '${{ needs.Quality.result }}') |" >> $GITHUB_STEP_SUMMARY
-          echo "| Build | $(result_to_emoji '${{ needs.Build.result }}') |" >> $GITHUB_STEP_SUMMARY
-          echo "| Test | $(result_to_emoji '${{ needs.Test.result }}') |" >> $GITHUB_STEP_SUMMARY
-          echo "| Changesets | $(result_to_emoji '${{ needs.Changesets.result }}') |" >> $GITHUB_STEP_SUMMARY
-          echo "| Compose | $(result_to_emoji '${{ needs.Compose.result }}') |" >> $GITHUB_STEP_SUMMARY
-          echo "| Security | $(result_to_emoji '${{ needs.Security.result }}') |" >> $GITHUB_STEP_SUMMARY
-          echo "| Docker | $(result_to_emoji '${{ needs.Docker.result }}') |" >> $GITHUB_STEP_SUMMARY
-          echo "| Supported-host boot smoke | $(result_to_emoji '${{ needs.Supported-host-smoke.result }}') |" >> $GITHUB_STEP_SUMMARY
-          echo "| Release evidence preflight | $(result_to_emoji '${{ needs.Release-preflight.result }}') |" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-
-          echo "### 📁 Components Changed" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "| Component | Changed |" >> $GITHUB_STEP_SUMMARY
-          echo "|-----------|---------|" >> $GITHUB_STEP_SUMMARY
-          echo "| Webapp | ${{ needs.detect-changes.outputs.webapp == 'true' && '✅ Yes' || '➖ No' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Application Server | ${{ needs.detect-changes.outputs.application-server == 'true' && '✅ Yes' || '➖ No' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Agent Images | ${{ needs.detect-changes.outputs.agent-images == 'true' && '✅ Yes' || '➖ No' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| CI Config | ${{ needs.detect-changes.outputs.ci-config == 'true' && '⚙️ Yes' || '➖ No' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-
-          if [[ "${{ steps.evaluate.outputs.status }}" == "failure" ]]; then
-            echo "### 💡 Troubleshooting Guide" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-
-            if [[ "${{ needs.detect-changes.outputs.release-candidate == 'true' && needs.Release-preflight.result != 'success' }}" == "true" ]]; then
-              echo "❌ **The release evidence preflight did not pass.** Merging this pull request cuts a release, so its gate requires the preflight to succeed in this run; it was \`${{ needs.Release-preflight.result }}\`." >> $GITHUB_STEP_SUMMARY
-              echo "" >> $GITHUB_STEP_SUMMARY
-            fi
-
-            if [[ "${{ needs.Quality.result }}" == "failure" ]]; then
-              echo "<details><summary><b>❌ Quality Failed</b></summary>" >> $GITHUB_STEP_SUMMARY
-              echo "" >> $GITHUB_STEP_SUMMARY
-              echo "| Issue | Fix Command |" >> $GITHUB_STEP_SUMMARY
-              echo "|-------|-------------|" >> $GITHUB_STEP_SUMMARY
-              echo "| Formatting errors | \`vp run format\` |" >> $GITHUB_STEP_SUMMARY
-              echo "| TypeScript errors | \`vp run typecheck\` |" >> $GITHUB_STEP_SUMMARY
-              echo "| Lint errors (webapp) | \`vp run fix:webapp\` |" >> $GITHUB_STEP_SUMMARY
-              echo "| Lint errors (outside webapp) | \`vp run fix:agents\` |" >> $GITHUB_STEP_SUMMARY
-              echo "| Java formatting | \`vp run format:java\` |" >> $GITHUB_STEP_SUMMARY
-              echo "| Java lint (PMD) | \`vp run lint:java:report\` |" >> $GITHUB_STEP_SUMMARY
-              echo "| Storybook sidebar order | \`vp run gate:story-sort\` |" >> $GITHUB_STEP_SUMMARY
-              echo "| Mermaid diagram parse errors | \`vp run gate:diagrams\` |" >> $GITHUB_STEP_SUMMARY
-              echo "| Stale \`routeTree.gen.ts\` | \`vp run --filter webapp build\` |" >> $GITHUB_STEP_SUMMARY
-              echo "| OpenAPI out of sync | \`vp run generate:api\` |" >> $GITHUB_STEP_SUMMARY
-              echo "| Database schema drift | \`vp run db:draft-changelog\` |" >> $GITHUB_STEP_SUMMARY
-              echo "" >> $GITHUB_STEP_SUMMARY
-              echo "</details>" >> $GITHUB_STEP_SUMMARY
-              echo "" >> $GITHUB_STEP_SUMMARY
-            fi
-
-            if [[ "${{ needs.Test.result }}" == "failure" ]]; then
-              echo "<details><summary><b>❌ Tests Failed</b></summary>" >> $GITHUB_STEP_SUMMARY
-              echo "" >> $GITHUB_STEP_SUMMARY
-              echo "| Test Suite | Run Locally |" >> $GITHUB_STEP_SUMMARY
-              echo "|------------|-------------|" >> $GITHUB_STEP_SUMMARY
-              echo "| Webapp unit | \`vp run test:webapp\` |" >> $GITHUB_STEP_SUMMARY
-              echo "| Webapp Storybook | \`vp run --filter webapp test:storybook\` |" >> $GITHUB_STEP_SUMMARY
-              echo "| Application server | \`cd server && ./gradlew :application:test\` |" >> $GITHUB_STEP_SUMMARY
-              echo "" >> $GITHUB_STEP_SUMMARY
-              echo "**Tip:** Check the **Test Results** tab above for specific failures." >> $GITHUB_STEP_SUMMARY
-              echo "" >> $GITHUB_STEP_SUMMARY
-              echo "</details>" >> $GITHUB_STEP_SUMMARY
-              echo "" >> $GITHUB_STEP_SUMMARY
-            fi
-
-            if [[ "${{ needs.Changesets.result }}" == "failure" ]]; then
-              echo "<details><summary><b>❌ Changesets Failed</b></summary>" >> $GITHUB_STEP_SUMMARY
-              echo "" >> $GITHUB_STEP_SUMMARY
-              echo "Run \`vp run gate:changesets\` for policy-test failures; otherwise correct the changeset reported by the job." >> $GITHUB_STEP_SUMMARY
-              echo "" >> $GITHUB_STEP_SUMMARY
-              echo "</details>" >> $GITHUB_STEP_SUMMARY
-              echo "" >> $GITHUB_STEP_SUMMARY
-            fi
-
-            if [[ "${{ needs.Docker.result }}" == "failure" ]]; then
-              echo "<details><summary><b>❌ Docker Failed</b></summary>" >> $GITHUB_STEP_SUMMARY
-              echo "" >> $GITHUB_STEP_SUMMARY
-              echo "Common causes:" >> $GITHUB_STEP_SUMMARY
-              echo "- Build errors in the application code" >> $GITHUB_STEP_SUMMARY
-              echo "- Missing dependencies" >> $GITHUB_STEP_SUMMARY
-              echo "- Dockerfile syntax errors" >> $GITHUB_STEP_SUMMARY
-              echo "" >> $GITHUB_STEP_SUMMARY
-              echo "Test locally: \`docker build -f <component>/Dockerfile .\`" >> $GITHUB_STEP_SUMMARY
-              echo "" >> $GITHUB_STEP_SUMMARY
-              echo "</details>" >> $GITHUB_STEP_SUMMARY
-              echo "" >> $GITHUB_STEP_SUMMARY
-            fi
-
-            if [[ "${{ needs.Security.result }}" == "failure" ]]; then
-              echo "<details><summary><b>❌ Security Failed</b></summary>" >> $GITHUB_STEP_SUMMARY
-              echo "" >> $GITHUB_STEP_SUMMARY
-              echo "Check the **Security** tab for details on vulnerabilities." >> $GITHUB_STEP_SUMMARY
-              echo "" >> $GITHUB_STEP_SUMMARY
-              echo "</details>" >> $GITHUB_STEP_SUMMARY
-              echo "" >> $GITHUB_STEP_SUMMARY
-            fi
-
-            echo "---" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "**Quick fix:** Run \`vp run format && vp run check\` before pushing." >> $GITHUB_STEP_SUMMARY
-          fi
-
-          if [[ "${{ steps.evaluate.outputs.status }}" == "success" ]]; then
-            echo "### ⚡ Performance" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            SKIPPED_COUNT=0
-            [[ "${{ needs.Quality.result }}" == "skipped" ]] && SKIPPED_COUNT=$((SKIPPED_COUNT + 1)) || true
-            [[ "${{ needs.Build.result }}" == "skipped" ]] && SKIPPED_COUNT=$((SKIPPED_COUNT + 1)) || true
-            [[ "${{ needs.Test.result }}" == "skipped" ]] && SKIPPED_COUNT=$((SKIPPED_COUNT + 1)) || true
-            [[ "${{ needs.Security.result }}" == "skipped" ]] && SKIPPED_COUNT=$((SKIPPED_COUNT + 1)) || true
-            [[ "${{ needs.Docker.result }}" == "skipped" ]] && SKIPPED_COUNT=$((SKIPPED_COUNT + 1)) || true
-            if [[ $SKIPPED_COUNT -gt 0 ]]; then
-              echo "🚀 **Path-based filtering saved time!** $SKIPPED_COUNT workflow(s) skipped because no relevant files changed." >> $GITHUB_STEP_SUMMARY
-            else
-              echo "All workflows ran (CI config or main branch push)." >> $GITHUB_STEP_SUMMARY
-            fi
-          fi
-
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "---" >> $GITHUB_STEP_SUMMARY
-          echo "*Generated by CI Status Gate • [View workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})*" >> $GITHUB_STEP_SUMMARY
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          NEEDS: ${{ toJSON(needs) }}
+          VERDICT: ${{ steps.evaluate.outputs.status }}
+        with:
+          script: |
+            const needs = JSON.parse(process.env.NEEDS);
+            if (!needs || typeof needs !== 'object' || Array.isArray(needs)) {
+              throw new Error('Expected CI job results');
+            }
+            const statuses = new Set(['success', 'failure', 'skipped', 'cancelled']);
+            const jobs = Object.entries(needs);
+            for (const [name, job] of jobs) {
+              if (!job || typeof job !== 'object' || !statuses.has(job.result)) {
+                throw new Error(`Invalid CI result for ${name}`);
+              }
+            }
+            const verdict = process.env.VERDICT;
+            core.summary.addHeading('CI Pipeline Summary', 2)
+              .addRaw(verdict === 'success' ? '✅ All required checks passed.\n\n'
+                : verdict === 'failure' ? '❌ CI failed. Review the job results and logs.\n\n'
+                : verdict === 'cancelled' ? '🚫 CI was cancelled before it finished.\n\n'
+                : '⚠️ CI did not produce a verdict.\n\n')
+              .addHeading('Job results', 3)
+              .addTable([
+                [{data: 'Job', header: true}, {data: 'Result', header: true}],
+                ...jobs.map(([name, job]) => [name, job.result]),
+              ]);
+            const skipped = jobs.filter(([, job]) => job.result === 'skipped').length;
+            core.summary.addRaw(`${skipped} of ${jobs.length} jobs skipped. Job conditions determine why; a skip alone does not prove a path-filter saving.\n\n`);
+            const selection = needs['detect-changes']?.outputs;
+            const flags = selection && typeof selection === 'object' && !Array.isArray(selection)
+              ? Object.entries(selection).filter(([, value]) => value === 'true' || value === 'false') : [];
+            if (flags.length > 0) {
+              core.summary.addHeading('Selection flags', 3).addTable([
+                [{data: 'Flag', header: true}, {data: 'Value', header: true}],
+                ...flags,
+              ]);
+            }
+            core.summary.addLink('Local verification and troubleshooting',
+              `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/blob/main/docs/contributor/local-verification.mdx`);
+            await core.summary.write();
 
       - name: Create commit status
         if: ${{ !cancelled() }}

--- a/docs/contributor/ci-cd.mdx
+++ b/docs/contributor/ci-cd.mdx
@@ -718,8 +718,12 @@ reaches no such commit builds every image itself. `detect-changes` resolves that
 
 Use GitHub's organization-level [Actions metrics](https://docs.github.com/en/actions/concepts/metrics)
 for workflow and job run time, queue time, failure rate, and runner usage. Each `CI Status Gate` job
-also includes the current run's dependency-aware timeline and job summary, and JUnit results appear
-as `Test Results - …` check runs.
+also includes the current run's dependency-aware timeline, every direct prerequisite's result and
+the boolean selection flags from `Detect changes`. Selection is not a claim that a component's files
+changed: an unfiltered run or a preview can select unchanged inputs. The summary counts all skipped
+prerequisites without guessing their cause and links to the [local verification guide](./local-verification.mdx)
+for troubleshooting. It stays checkout-free because the same job writes commit statuses. JUnit
+results appear as `Test Results - …` check runs.
 
 ### Pull-request latency
 

--- a/scripts/ci-summary.test.ts
+++ b/scripts/ci-summary.test.ts
@@ -1,0 +1,122 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { test } from "node:test";
+import { runInNewContext } from "node:vm";
+
+import { isMap, isSeq, parseDocument } from "yaml";
+
+const workflow = parseDocument(await readFile(".github/workflows/cicd.yml", "utf8"));
+const steps = workflow.getIn(["jobs", "all-ci-passed", "steps"]);
+assert.ok(isSeq(steps));
+const summary = steps.items.find(
+	(item) => isMap(item) && item.get("name") === "Generate CI Summary",
+);
+assert.ok(isMap(summary));
+const script = summary.getIn(["with", "script"]);
+assert.equal(typeof script, "string");
+
+async function report(needs: unknown, verdict = "success") {
+	const rendered: unknown[] = [];
+	const output = {
+		addHeading: (text: string) => {
+			rendered.push(text);
+			return output;
+		},
+		addRaw: (text: string) => {
+			rendered.push(text);
+			return output;
+		},
+		addTable: (rows: unknown) => {
+			rendered.push(rows);
+			return output;
+		},
+		addLink: (label: string, url: string) => {
+			rendered.push([label, url]);
+			return output;
+		},
+		write: () => {
+			rendered.push("written");
+			return Promise.resolve();
+		},
+	};
+	const completed: unknown = runInNewContext(`(async () => { ${String(script)} })()`, {
+		process: { env: { NEEDS: JSON.stringify(needs), VERDICT: verdict } },
+		core: { summary: output },
+		context: {
+			serverUrl: "https://github.com",
+			repo: { owner: "hephaestus-build", repo: "Hephaestus" },
+		},
+	});
+	await completed;
+	return JSON.stringify(rendered);
+}
+
+void test("the status-writing summary remains checkout-free and uses native workflow data", () => {
+	assert.match(String(summary.get("uses")), /^actions\/github-script@/);
+	assert.equal(summary.getIn(["env", "NEEDS"]), `\${{ toJSON(needs) }}`);
+	assert.equal(summary.getIn(["env", "VERDICT"]), `\${{ steps.evaluate.outputs.status }}`);
+	assert.equal(summary.get("if"), "always()");
+	for (const item of steps.items)
+		if (isMap(item))
+			assert.doesNotMatch(String(item.get("uses")), /checkout|setup-toolchain|^\.\//);
+	assert.equal(workflow.getIn(["jobs", "all-ci-passed", "permissions", "contents"]), undefined);
+});
+
+void test("the summary includes every job and counts actual skips without inventing their reason", async () => {
+	const jobs = workflow.getIn(["jobs", "all-ci-passed", "needs"]);
+	assert.ok(isSeq(jobs));
+	const needs = Object.fromEntries(jobs.items.map((name) => [String(name), { result: "skipped" }]));
+	needs["future-job"] = { result: "success" };
+	const text = await report(needs);
+	for (const name of Object.keys(needs)) assert.ok(text.includes(name));
+	assert.ok(text.includes(`${jobs.items.length} of ${jobs.items.length + 1} jobs skipped`));
+	assert.ok(text.includes("Job conditions determine why"));
+	assert.ok(!text.includes("All workflows ran"));
+});
+
+void test("selection flags report PostgreSQL and false values without labelling selections as file changes", async () => {
+	const text = await report({
+		"detect-changes": {
+			result: "success",
+			outputs: {
+				"postgres-image": "true",
+				webapp: "false",
+				unfiltered: "true",
+				"alias-base": "private-commit-value",
+			},
+		},
+	});
+	for (const expected of ["postgres-image", "webapp", "false", "unfiltered", "Selection flags"])
+		assert.ok(text.includes(expected));
+	assert.ok(!text.includes("private-commit-value"));
+	assert.ok(!text.includes("Components Changed"));
+});
+
+void test("a missing verdict and a failure never render as success", async () => {
+	assert.ok((await report({ Build: { result: "failure" } }, "failure")).includes("CI failed"));
+	assert.ok(
+		(await report({ Build: { result: "cancelled" } }, "")).includes("did not produce a verdict"),
+	);
+	assert.ok(
+		(await report({ Build: { result: "success" } })).includes("All required checks passed"),
+	);
+});
+
+void test("malformed job data fails instead of rendering a misleading report", async () => {
+	for (const needs of [null, [], { Build: null }, { Build: { result: "unknown" } }])
+		await assert.rejects(report(needs));
+});
+
+void test("a cancellation verdict is distinct from a missing verdict", async () => {
+	const text = await report({ Build: { result: "cancelled" } }, "cancelled");
+	assert.ok(text.includes("CI was cancelled before it finished"));
+	assert.ok(!text.includes("did not produce a verdict"));
+});
+
+void test("missing selection data produces no empty flags table", async () => {
+	const text = await report(
+		{ "detect-changes": { result: "cancelled", outputs: {} } },
+		"cancelled",
+	);
+	assert.ok(!text.includes("Selection flags"));
+});


### PR DESCRIPTION
## What changed and why

The CI summary omitted several prerequisite jobs, showed only four selection flags and attributed skips to path filtering without evidence. It also maintained a second set of troubleshooting commands.

Render every actual `needs` result and boolean selection flag through the existing SHA-pinned `github-script` action. Count all skipped prerequisites without guessing why, distinguish cancellation from a missing verdict, and link to the owning local-verification guide. The status-writing job remains checkout-free; its evaluation logic, release-preflight requirement, permissions and commit-status publication are unchanged.

## How to test

- `node --test scripts/ci-summary.test.ts`: seven tests execute the actual workflow script, covering all declared prerequisites plus a future job, PostgreSQL/false selection flags, all verdict states, absent selection data and malformed inputs.
- Cancellation and empty-selection regressions each failed before their fixes. The old shell summary fails the new summary contract.
- `vp run format` and `vp run check`: all local gates passed on the final tree. A read-only review also checked the sibling CI-contract suites and native summary API.
- Hosted smoke: open this run's **CI Status Gate** summary. Every direct prerequisite should have a row, the skipped count should match those rows, and the troubleshooting link should open the contributor guide. Cancellation must read as cancellation, not as a missing verdict. No checkout step should appear in this job.

## Release impact

CI reporting, tests and contributor documentation only; no application/API/schema change, operator action or changeset.
