### PR TITLE
ci: check generated drift without staging files

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -62,8 +62,7 @@ jobs:
           HEPHAESTUS_APPLICATION_JAR: ${{ steps.server.outputs.executable-jar }}
         run: |
           vp run generate:api
-          git add .
-          if ! git diff --cached --quiet; then
+          if ! node scripts/assert-generated-clean.ts server/openapi.yaml webapp/src/api; then
             echo "::error::OpenAPI out of sync. Run: vp run generate:api"
             echo "### OpenAPI Validation" >> $GITHUB_STEP_SUMMARY
             echo "| Check | Status | Fix |" >> $GITHUB_STEP_SUMMARY
@@ -95,8 +94,7 @@ jobs:
           vp run db:check-drift || ISSUES_FOUND+=("Schema drift or migration-chain apply failed. Run: vp run db:draft-changelog")
 
           vp run db:generate-erd-docs || ISSUES_FOUND+=("ERD generation failed. Run: vp run db:generate-erd-docs")
-          git add docs/contributor/erd/schema.mmd
-          if ! git diff --cached --quiet docs/contributor/erd/schema.mmd; then
+          if ! node scripts/assert-generated-clean.ts docs/contributor/erd/schema.mmd; then
             echo "::error::ERD outdated. Run: vp run db:generate-erd-docs"
             ISSUES_FOUND+=("ERD outdated")
           fi

--- a/docs/contributor/ci-cd.mdx
+++ b/docs/contributor/ci-cd.mdx
@@ -670,6 +670,11 @@ and database contract tests use the restored classes with `-PpackagedServer=true
 compilation. Unit, architecture and integration suites compile from source in `Test` without
 waiting for packaging; their outputs do not ship.
 
+API and ERD drift checks use `scripts/assert-generated-clean.ts` against their own generated paths.
+It includes added, modified, deleted and staged files without staging anything or refreshing the Git
+index. Unrelated changes cannot contaminate either verdict. The API and schema steps still report
+independently, and a failure in either fails the artifact gate.
+
 The application image and `Build` artifact gates depend on packaging independently. Host smoke
 and release preflight wait for the image producers, not the API, database or browser checks. The
 final CI gate still requires all of them; an early image verdict cannot approve a failed artifact gate.

--- a/scripts/assert-generated-clean.test.ts
+++ b/scripts/assert-generated-clean.test.ts
@@ -1,0 +1,160 @@
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { test } from "node:test";
+
+import { isMap, isSeq, parseDocument } from "yaml";
+
+import { environmentForGitFixture } from "./lib/git-environment.ts";
+
+const checker = join(import.meta.dirname, "assert-generated-clean.ts");
+const apiPaths = ["server/openapi.yaml", "webapp/src/api"];
+const erdPath = "docs/contributor/erd/schema.mmd";
+
+function fixture() {
+	const repo = mkdtempSync(join(tmpdir(), "generated-clean-"));
+	const env = environmentForGitFixture();
+	const git = (...args: string[]) =>
+		execFileSync("git", args, {
+			cwd: repo,
+			env,
+			encoding: "utf8",
+			stdio: ["ignore", "pipe", "pipe"],
+		});
+	git("init", "--quiet", "--initial-branch=main");
+	git("config", "user.name", "Test");
+	git("config", "user.email", "test@example.invalid");
+	for (const file of [
+		"server/openapi.yaml",
+		"webapp/src/api/client.ts",
+		erdPath,
+		"unrelated.txt",
+	]) {
+		mkdirSync(dirname(join(repo, file)), { recursive: true });
+		writeFileSync(join(repo, file), "original\n");
+	}
+	git("add", ".");
+	git("commit", "--quiet", "-m", "initial");
+	return {
+		repo,
+		git,
+		check: (paths: string[], subdirectory = ".") =>
+			spawnSync(process.execPath, [checker, ...paths], {
+				cwd: join(repo, subdirectory),
+				env,
+				encoding: "utf8",
+			}),
+		index: () => readFileSync(join(repo, ".git/index")),
+	};
+}
+
+for (const file of ["server/openapi.yaml", "webapp/src/api/client.ts", erdPath]) {
+	for (const change of ["modified", "deleted", "staged"]) {
+		void test(`rejects ${change} ${file} without changing the index`, (t) => {
+			const { repo, git, check, index } = fixture();
+			t.after(() => rmSync(repo, { recursive: true, force: true }));
+			if (change === "deleted") rmSync(join(repo, file));
+			else writeFileSync(join(repo, file), "generated change\n");
+			if (change === "staged") git("add", file);
+			const before = index();
+			const result = check(file === erdPath ? [erdPath] : apiPaths, "server");
+			assert.equal(result.status, 1, result.stderr);
+			assert.ok(result.stderr.includes(file.split("/").at(-1) ?? file));
+			assert.deepEqual(index(), before);
+		});
+	}
+}
+
+for (const change of ["added", "renamed"]) {
+	void test(`rejects a generated client file that is ${change} without staging it`, (t) => {
+		const { repo, check, index } = fixture();
+		t.after(() => rmSync(repo, { recursive: true, force: true }));
+		const added = join(repo, "webapp/src/api/new.ts");
+		if (change === "renamed") renameSync(join(repo, "webapp/src/api/client.ts"), added);
+		else writeFileSync(added, "new client\n");
+		const before = index();
+		assert.equal(check(apiPaths).status, 1);
+		assert.deepEqual(index(), before);
+	});
+}
+
+void test("API and ERD verdicts ignore unrelated drift and remain independent", (t) => {
+	const { repo, git, check, index } = fixture();
+	t.after(() => rmSync(repo, { recursive: true, force: true }));
+	writeFileSync(join(repo, "unrelated.txt"), "unrelated staged change\n");
+	git("add", "unrelated.txt");
+	writeFileSync(join(repo, "untracked.txt"), "unrelated new file\n");
+	const before = index();
+	assert.equal(check(apiPaths).status, 0);
+	assert.equal(check([erdPath]).status, 0);
+	writeFileSync(join(repo, "server/openapi.yaml"), "API drift\n");
+	assert.equal(check(apiPaths).status, 1);
+	assert.equal(check([erdPath]).status, 0);
+	writeFileSync(join(repo, erdPath), "ERD drift\n");
+	assert.equal(check(apiPaths).status, 1);
+	assert.equal(check([erdPath]).status, 1);
+	assert.deepEqual(index(), before);
+});
+
+void test("a missing path argument is an error rather than a whole-tree check", (t) => {
+	const { repo, check } = fixture();
+	t.after(() => rmSync(repo, { recursive: true, force: true }));
+	const result = check([]);
+	assert.notEqual(result.status, 0);
+	assert.match(result.stderr, /Name the generated paths/);
+});
+
+void test("both workflow checks are path-scoped and keep independent outcomes and the packaged JAR", () => {
+	const workflow = parseDocument(readFileSync(".github/workflows/ci-build.yml", "utf8"));
+	const steps = workflow.getIn(["jobs", "server-api", "steps"]);
+	assert.ok(isSeq(steps));
+	for (const [id, paths] of [
+		["openapi", apiPaths],
+		["schema", [erdPath]],
+	] as const) {
+		const step: unknown = steps.items.find((item) => isMap(item) && item.get("id") === id);
+		assert.ok(isMap(step));
+		assert.equal(step.get("continue-on-error"), true);
+		const run = String(step.get("run"));
+		assert.ok(run.includes(`node scripts/assert-generated-clean.ts ${paths.join(" ")}`));
+		assert.doesNotMatch(run, /git add|git diff --cached/);
+		if (id === "openapi") {
+			assert.equal(
+				step.getIn(["env", "HEPHAESTUS_APPLICATION_JAR"]),
+				`\${{ steps.server.outputs.executable-jar }}`,
+			);
+			assert.match(run, /vp run generate:api/);
+		} else {
+			assert.equal(step.get("if"), "always()");
+			assert.match(run, /vp run db:check-drift/);
+			assert.match(run, /vp run db:generate-erd-docs/);
+			assert.match(run, /trap 'docker stop postgres-db.*docker rm postgres-db/);
+		}
+	}
+	const verdict = steps.items.find(
+		(item) => isMap(item) && item.get("name") === "Evaluate generated artifacts",
+	);
+	assert.ok(isMap(verdict));
+	assert.equal(verdict.get("if"), "always()");
+	assert.equal(verdict.getIn(["env", "OPENAPI"]), `\${{ steps.openapi.outcome }}`);
+	assert.equal(verdict.getIn(["env", "SCHEMA"]), `\${{ steps.schema.outcome }}`);
+});
+
+void test("an unmatched generated path fails even when another path matches", (t) => {
+	const { repo, check, index } = fixture();
+	t.after(() => rmSync(repo, { recursive: true, force: true }));
+	const before = index();
+	assert.notEqual(check(["server/openapi.yaml", "docs/contributor/erd/missing.mmd"]).status, 0);
+	assert.deepEqual(index(), before);
+});
+
+void test("no-op regeneration passes without refreshing the index", (t) => {
+	const { repo, check, index } = fixture();
+	t.after(() => rmSync(repo, { recursive: true, force: true }));
+	const before = index();
+	writeFileSync(join(repo, "server/openapi.yaml"), "original\n");
+	assert.equal(check(apiPaths).status, 0);
+	assert.deepEqual(index(), before);
+});

--- a/scripts/assert-generated-clean.ts
+++ b/scripts/assert-generated-clean.ts
@@ -1,0 +1,23 @@
+import { output } from "./lib/process.ts";
+
+const paths = process.argv.slice(2);
+if (paths.length === 0) throw new Error("Name the generated paths to check");
+
+const pathspecs = paths.map((path) => `:(top)${path}`);
+// A stale or mistyped artifact path must not silently become an empty, successful comparison.
+await output("git", ["ls-files", "--error-unmatch", "--", ...pathspecs]);
+
+// Status includes staged edits, deletions and new files without changing the index. Top-level
+// pathspecs keep a caller in a subdirectory from accidentally checking an empty, unrelated path.
+const changed = await output("git", [
+	"--no-optional-locks",
+	"status",
+	"--porcelain=v1",
+	"--untracked-files=all",
+	"--",
+	...pathspecs,
+]);
+if (changed.trim()) {
+	console.error(changed.trimEnd());
+	process.exitCode = 1;
+}


### PR DESCRIPTION
## What changed and why

The API drift check staged the entire checkout before comparing it, so unrelated changes could contaminate the verdict and validation mutated the Git index. The ERD check used the same staging pattern for its own path.

Both now call one small Node script that checks only the named generated paths with porcelain Git status. It sees new, modified, deleted and staged artifacts without staging files or refreshing the index. Root-anchored pathspecs also prevent a nested working directory from turning the check into an empty comparison; unmatched paths fail rather than silently checking nothing.

API/schema outcomes, packaged-JAR reuse, migration replay, database cleanup and their existing failure reports remain independent and unchanged.

## How to test

- `node --test scripts/assert-generated-clean.test.ts`: 16 real-Git tests cover artifact changes, exact index-byte preservation, nested invocation, unrelated staged/untracked files, and independent API/ERD verdicts. The old stage-and-global-diff pattern fails the regression tests, and the unmatched-path test failed before its safeguard was added.
- `vp run format` and `vp run check`: all local gates passed.
- Manual smoke: modify or add a generated API client file and run `node scripts/assert-generated-clean.ts server/openapi.yaml webapp/src/api`; it should fail without staging it. A change only outside those paths should not fail that check. Check the ERD independently with `node scripts/assert-generated-clean.ts docs/contributor/erd/schema.mmd`.
- Hosted smoke: the two generated-artifact steps should still run/report independently and the final artifact verdict should reject either failure.

## Release impact

CI validation, tests and contributor documentation only. No application/API/schema change, operator action or changeset.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **CI/CD**
  - Improved validation of generated API and database schema artifacts during builds.
  - Checks now identify modified, added, deleted, or renamed generated files without altering the repository’s staging state.
  - API and schema validations report independently while both continue to gate artifact creation.

- **Documentation**
  - Updated contributor CI/CD guidance to explain the revised generated-file validation process.

- **Tests**
  - Added comprehensive coverage for generated-file drift detection and independent validation outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->