### PR TITLE
ci: share immutable platform scan resolution

### DIFF
--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -518,22 +518,7 @@ jobs:
         env:
           IMAGE_REF: ${{ inputs.registry }}/${{ inputs.image-name }}@${{ inputs.single-arch && needs.build.outputs.manifest-digest || needs.merge.outputs.manifest-digest }}
           INPUT_IMAGE_NAME: ${{ inputs.image-name }}
-        run: |
-          set -euo pipefail
-          echo "image=${INPUT_IMAGE_NAME##*/}" >> "$GITHUB_OUTPUT"
-          raw=$(docker buildx imagetools inspect "$IMAGE_REF" --raw)
-          if jq -e 'has("manifests")' <<< "$raw" > /dev/null; then
-            digest=$(jq -er 'first(.manifests[]
-              | select(.platform.os == "linux" and .platform.architecture == "amd64")
-              | .digest)' <<< "$raw")
-          else
-            digest=$(docker buildx imagetools inspect --format '{{.Manifest.Digest}}' "$IMAGE_REF")
-          fi
-          if [[ ! "$digest" =~ ^sha256:[a-f0-9]{64}$ ]]; then
-            echo "::error::No linux/amd64 digest for $IMAGE_REF (got: ${digest:-<empty>})"
-            exit 1
-          fi
-          echo "digest=$digest" >> "$GITHUB_OUTPUT"
+        run: node scripts/resolve-image-scan-subject.ts
 
       # A blocking gate inherits Trivy's database availability as a hard dependency, so the
       # retries and the mirror fallback live in one action rather than in each caller.

--- a/docs/contributor/ci-cd.mdx
+++ b/docs/contributor/ci-cd.mdx
@@ -656,6 +656,12 @@ When release preflight is required, it owns image vulnerability scanning for bot
 the image-build workflows omit their duplicate amd64 scans. Other published builds retain those
 scans. The final gate rejects a required preflight that is skipped, cancelled or unsuccessful.
 
+The build scan resolves its immutable image reference through
+`scripts/resolve-image-scan-subject.ts`, using the same platform resolver in `scripts/lib/image-scan.ts` as scheduled rescans. An index must
+contain the requested platform; a missing platform or malformed index fails instead of falling back
+to whichever architecture the scanner's host would choose. A single manifest is resolved through
+that same immutable reference.
+
 ## Image identity
 
 Every consumer resolves an image through the commit the run built it from, and

--- a/scripts/lib/image-scan.ts
+++ b/scripts/lib/image-scan.ts
@@ -6,7 +6,8 @@
  * `security/release-images.json`. Both hand the Trivy report to `check-release-vulnerabilities.ts`
  * — the same evaluator and the same policy file the build gate and the release use. A second copy
  * of either is precisely the failure this whole effort removes, so the policy is evaluated by
- * invoking that script rather than by reimplementing it.
+ * invoking that script rather than by reimplementing it. The blocking build scan shares only the
+ * platform-digest resolver through `resolve-image-scan-subject.ts`.
  */
 import { existsSync } from "node:fs";
 import { mkdir } from "node:fs/promises";
@@ -68,12 +69,15 @@ export function selectPlatformDigest(raw: unknown, platform: string): string | u
 
 /** Whether the inspected document is a multi-platform index rather than a single manifest. */
 export function isImageIndex(raw: unknown): boolean {
-	return Array.isArray(asRecord(raw, "imagetools manifest").manifests);
+	const document = asRecord(raw, "imagetools manifest");
+	if (Object.hasOwn(document, "manifests") && !Array.isArray(document.manifests))
+		throw new Error("imagetools index manifests must be an array");
+	return Array.isArray(document.manifests);
 }
 
-async function resolveDigest(subject: Subject, platform: string): Promise<string> {
+export async function resolvePlatformDigest(reference: string, platform: string): Promise<string> {
 	const raw: unknown = JSON.parse(
-		await output("docker", ["buildx", "imagetools", "inspect", subject.reference, "--raw"]),
+		await output("docker", ["buildx", "imagetools", "inspect", reference, "--raw"]),
 	);
 	const selected = selectPlatformDigest(raw, platform);
 	// An index that publishes no manifest for this platform must fail, never fall through. The
@@ -82,7 +86,7 @@ async function resolveDigest(subject: Subject, platform: string): Promise<string
 	// this platform's evidence, and the evaluator's ArtifactName check cannot catch it, because the
 	// reference Trivy reports is exactly the one it was handed.
 	if (selected === undefined && isImageIndex(raw))
-		throw new Error(`${subject.reference} publishes no ${platform} manifest`);
+		throw new Error(`${reference} publishes no ${platform} manifest`);
 	const digest =
 		selected ??
 		(
@@ -92,11 +96,11 @@ async function resolveDigest(subject: Subject, platform: string): Promise<string
 				"inspect",
 				"--format",
 				"{{.Manifest.Digest}}",
-				subject.reference,
+				reference,
 			])
 		).trim();
 	if (!DIGEST.test(digest))
-		throw new Error(`no ${platform} digest for ${subject.reference} (got: ${digest || "<empty>"})`);
+		throw new Error(`no ${platform} digest for ${reference} (got: ${digest || "<empty>"})`);
 	return digest;
 }
 
@@ -121,7 +125,7 @@ async function scan(
 	platform: string,
 	annotate: boolean,
 ): Promise<ScanOutcome> {
-	const digest = await resolveDigest(subject, platform);
+	const digest = await resolvePlatformDigest(subject.reference, platform);
 	const stem = reportStem(subject.image, platform);
 	const report = path.join(directory, `${stem}.json`);
 	await run("trivy", [

--- a/scripts/resolve-image-scan-subject.test.ts
+++ b/scripts/resolve-image-scan-subject.test.ts
@@ -1,0 +1,152 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { delimiter, join } from "node:path";
+import { test } from "node:test";
+
+import { isMap, isSeq, parseDocument } from "yaml";
+
+const amd64 = `sha256:${"a".repeat(64)}`;
+const arm64 = `sha256:${"b".repeat(64)}`;
+const index = `sha256:${"c".repeat(64)}`;
+const reference = `ghcr.io/example/webapp@${index}`;
+const checker = join(import.meta.dirname, "resolve-image-scan-subject.ts");
+
+// The CLI is used only by the Linux image-scan job. Its Docker process boundary uses a POSIX
+// executable fixture; pure manifest-selection tests also run on Windows in scan-main-images.test.ts.
+for (const scenario of [
+	{
+		name: "selects amd64 after arm64 and attestation entries",
+		raw: {
+			manifests: [
+				{ digest: index, platform: { os: "unknown", architecture: "unknown" } },
+				{ digest: arm64, platform: { os: "linux", architecture: "arm64" } },
+				{ digest: amd64, platform: { os: "linux", architecture: "amd64" } },
+			],
+		},
+		expected: amd64,
+	},
+	{
+		name: "resolves a single manifest through the original immutable reference",
+		raw: { config: {}, layers: [] },
+		expected: index,
+		formatLookup: true,
+	},
+	{
+		name: "rejects a missing platform instead of scanning the index",
+		raw: { manifests: [{ digest: arm64, platform: { os: "linux", architecture: "arm64" } }] },
+	},
+	{
+		name: "rejects an invalid selected digest",
+		raw: { manifests: [{ digest: "bad", platform: { os: "linux", architecture: "amd64" } }] },
+	},
+	{
+		name: "rejects an invalid single-manifest digest",
+		raw: { config: {}, layers: [] },
+		singleDigest: "bad",
+		formatLookup: true,
+	},
+	{ name: "rejects a malformed index declaration", raw: { manifests: null } },
+	{ name: "rejects malformed registry JSON", rawText: "{" },
+	{ name: "propagates registry failure", raw: { config: {}, layers: [] }, dockerExit: "7" },
+	{
+		name: "rejects mutable references before inspecting them",
+		raw: {},
+		imageRef: "ghcr.io/example/webapp:main",
+		noInspect: true,
+	},
+	{
+		name: "rejects output injection in the image name",
+		raw: {},
+		imageName: "webapp\ndigest=bad",
+		noInspect: true,
+	},
+	{
+		name: "rejects a trailing newline in the reference before inspection",
+		raw: {},
+		imageRef: `${reference}\n`,
+		noInspect: true,
+	},
+	{
+		name: "rejects a trailing newline in the image before inspection",
+		raw: {},
+		imageName: "webapp\n",
+		noInspect: true,
+	},
+] as const) {
+	void test(scenario.name, { skip: process.platform === "win32" }, (t) => {
+		const directory = mkdtempSync(join(tmpdir(), "image-scan-subject-"));
+		t.after(() => rmSync(directory, { recursive: true, force: true }));
+		const docker = join(directory, "docker");
+		writeFileSync(
+			docker,
+			`#!/usr/bin/env node
+const fs = require('node:fs');
+const args = process.argv.slice(2);
+fs.appendFileSync(process.env.CALL_LOG, JSON.stringify(args) + '\\n');
+if (process.env.DOCKER_EXIT) process.exit(Number(process.env.DOCKER_EXIT));
+process.stdout.write(args.includes('--raw') ? process.env.RAW : process.env.SINGLE_DIGEST);
+`,
+		);
+		chmodSync(docker, 0o755);
+		const output = join(directory, "output");
+		const callLog = join(directory, "calls");
+		writeFileSync(output, "");
+		writeFileSync(callLog, "");
+		const imageRef = "imageRef" in scenario ? scenario.imageRef : reference;
+		const result = spawnSync(process.execPath, [checker], {
+			encoding: "utf8",
+			env: {
+				...process.env,
+				PATH: `${directory}${delimiter}${process.env.PATH ?? ""}`,
+				IMAGE_REF: imageRef,
+				INPUT_IMAGE_NAME: "imageName" in scenario ? scenario.imageName : "example/webapp",
+				GITHUB_OUTPUT: output,
+				RAW: "rawText" in scenario ? scenario.rawText : JSON.stringify(scenario.raw),
+				SINGLE_DIGEST: "singleDigest" in scenario ? scenario.singleDigest : index,
+				DOCKER_EXIT: "dockerExit" in scenario ? scenario.dockerExit : "",
+				CALL_LOG: callLog,
+			},
+		});
+		const emitted = readFileSync(output, "utf8");
+		const calls = readFileSync(callLog, "utf8");
+		if ("expected" in scenario) {
+			assert.equal(result.status, 0, result.stderr);
+			assert.equal(emitted, `image=webapp\ndigest=${scenario.expected}\n`);
+		} else {
+			assert.notEqual(result.status, 0);
+			assert.equal(emitted, "", "failed resolution must publish no usable scan subject");
+		}
+		if ("noInspect" in scenario) assert.equal(calls, "");
+		else {
+			const expectedCalls = [["buildx", "imagetools", "inspect", imageRef, "--raw"]];
+			if ("formatLookup" in scenario)
+				expectedCalls.push([
+					"buildx",
+					"imagetools",
+					"inspect",
+					"--format",
+					"{{.Manifest.Digest}}",
+					imageRef,
+				]);
+			assert.equal(calls, expectedCalls.map((args) => `${JSON.stringify(args)}\n`).join(""));
+		}
+	});
+}
+
+void test("the image workflow shares the resolver and retains its immutable subject and platform", () => {
+	const workflow = parseDocument(
+		readFileSync(".github/workflows/reusable-docker-build.yml", "utf8"),
+	);
+	const steps = workflow.getIn(["jobs", "scan", "steps"]);
+	assert.ok(isSeq(steps));
+	const subject = steps.items.find((item) => isMap(item) && item.get("id") === "subject");
+	assert.ok(isMap(subject));
+	assert.equal(subject.get("run"), "node scripts/resolve-image-scan-subject.ts");
+	assert.equal(subject.getIn(["env", "INPUT_IMAGE_NAME"]), `\${{ inputs.image-name }}`);
+	assert.equal(
+		subject.getIn(["env", "IMAGE_REF"]),
+		`\${{ inputs.registry }}/\${{ inputs.image-name }}@\${{ inputs.single-arch && needs.build.outputs.manifest-digest || needs.merge.outputs.manifest-digest }}`,
+	);
+});

--- a/scripts/resolve-image-scan-subject.ts
+++ b/scripts/resolve-image-scan-subject.ts
@@ -1,0 +1,14 @@
+import { appendFile } from "node:fs/promises";
+
+import { requiredEnv } from "./lib/env.ts";
+import { PLATFORM, resolvePlatformDigest } from "./lib/image-scan.ts";
+
+const outputFile = requiredEnv(process.env, "GITHUB_OUTPUT");
+const reference = requiredEnv(process.env, "IMAGE_REF");
+if (!/^[^\s@]+@sha256:[a-f0-9]{64}$/.test(reference))
+	throw new Error("IMAGE_REF must be an immutable image digest reference");
+const image = requiredEnv(process.env, "INPUT_IMAGE_NAME").split("/").at(-1);
+if (!image || !/^[a-z0-9][a-z0-9._-]*$/.test(image))
+	throw new Error("INPUT_IMAGE_NAME must end in a valid image name");
+const digest = await resolvePlatformDigest(reference, PLATFORM);
+await appendFile(outputFile, `image=${image}\ndigest=${digest}\n`);

--- a/scripts/scan-main-images.test.ts
+++ b/scripts/scan-main-images.test.ts
@@ -104,6 +104,12 @@ void describe("selectPlatformDigest", () => {
 });
 
 void describe("isImageIndex", () => {
+	void test("malformed index declarations never become a single-manifest fallback", () => {
+		for (const manifests of [null, {}, "invalid", 42]) {
+			assert.throws(() => isImageIndex({ manifests }), /must be an array/);
+		}
+	});
+
 	// The two ways selectPlatformDigest returns undefined mean opposite things, and only this tells
 	// them apart: a single manifest is asked for its own digest, while an index missing the platform
 	// must fail. Falling back to the index digest there would hand Trivy a multi-platform reference,


### PR DESCRIPTION
## What changed and why

The build-image scan reimplemented platform-digest resolution in jq while scheduled scans already used the tested TypeScript resolver. Export that resolver and call it through a small build-scan CLI, preserving the immutable published reference, linux/amd64 selection and release-vulnerability policy.

An index with a missing platform still fails rather than falling back to the scanner host. The shared resolver now also rejects malformed index declarations (`manifests: null`, for example), preserving the old jq step's fail-closed behavior. The CLI validates its inputs and publishes no subject on failure.

## How to test

- `node --test scripts/resolve-image-scan-subject.test.ts scripts/scan-main-images.test.ts`: 26 tests cover platform selection, attestation entries, exact immutable-reference subprocess arguments, missing/malformed indexes, malformed JSON, invalid digests, registry failure and input/output boundaries. POSIX process fixtures run on Linux, where the image workflow runs; pure selection/guard tests remain cross-platform.
- Restoring the old malformed-index guard makes the pure guard and CLI regression fail. Trailing-newline inputs are also tested; those already failed safely and did not require a new workaround.
- Executed both the original jq step and the replacement CLI against actual published webapp/server indexes and a webapp single-manifest leaf: identical image/digest outputs in all three cases.
- `vp run format` and `vp run check`: all local gates passed. A read-only adversarial review found no blockers; its documentation/test-placement and early-output-path validation suggestions were adopted.
- Hosted smoke: check the image scan's resolved subject and successful vulnerability-policy step. The resolver must choose the amd64 manifest, not an attestation manifest or index fallback, and a resolution failure must prevent scanning.

## Release impact

CI scripts, workflow and contributor documentation only. No application/API/schema change, operator action or changeset. The vulnerability policy and published image identity are unchanged.
