### PR TITLE
test(ci): protect image verification boundaries

### DIFF
--- a/.github/workflows/ci-docker-build.yml
+++ b/.github/workflows/ci-docker-build.yml
@@ -174,6 +174,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Verify each immutable subject before moving tags; see ci-cd.mdx § Shared setup actions.
       - name: Verify and tag unchanged images
         id: tag
         env:

--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -301,6 +301,7 @@ jobs:
         if: inputs.publish && inputs.single-arch
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
+      # Signing stays in this workflow; ci-cd.mdx § Shared setup actions owns its identity boundary.
       - name: Sign and verify image
         if: inputs.publish && inputs.single-arch
         env:
@@ -418,6 +419,7 @@ jobs:
         run: |
           cosign sign --yes --recursive "$IMAGE_REF"
 
+      # Intentionally inline in this checkout-free registry job; see ci-cd.mdx § Shared setup actions.
       - name: Verify signature + attestation
         env:
           IMAGE_REF: ${{ inputs.registry }}/${{ inputs.image-name }}@${{ steps.digest.outputs.manifest-digest }}

--- a/docs/contributor/ci-cd.mdx
+++ b/docs/contributor/ci-cd.mdx
@@ -565,6 +565,23 @@ with APT configuration scoped to that installation process. Unrelated vendor rep
 participate; repository signatures and package hashes remain enforced. The pinned Playwright CLI
 then installs Chromium as the runner user so the browser cache retains its normal ownership.
 
+Repository-local actions require checkout first. Jobs without checkout use the external SHA-pinned
+action directly rather than checking out the repository only to reach a wrapper. The reusable
+image builder also uses the external login action because its registry is a caller input, whereas
+`ghcr-login` intentionally authenticates only to GHCR. Browser E2E boots the packaged JAR without
+Gradle, so it sets up Java directly; OpenAPI autocommit builds the JAR and uses `setup-caches`.
+Preview controllers keep their trusted sparse bootstrap checkouts explicit: a repository-local
+action is unavailable before checkout. Their inventory job uses `github-script`'s bundled Node;
+controller jobs that invoke Node scripts use `setup-toolchain` without a package install.
+
+Image verification stays beside publishing. The single-platform step signs and verifies one image;
+the merge job signs recursively, then verifies the index; the alias job verifies each immutable
+subject before moving its tags. Merge and alias jobs need no checkout or repository toolchain just
+to verify registry evidence. `scripts/ci-provenance.test.ts` executes all three shell paths and pins
+the same repository/workflow signature identity, GitHub OIDC issuer and owner-constrained
+attestation verification, including rejection before alias publication. Signing remains in
+`reusable-docker-build.yml`, so a refactor cannot silently change the certificate identity.
+
 ### Caches
 
 A run restores caches from its own branch and from `main`, never from a sibling branch. Task-cache
@@ -607,19 +624,16 @@ exact-match cache cannot refresh build outputs after source-only changes. Config
 reuse remains within a job: no encryption key is configured, so the
 action does not persist configuration-cache entries across jobs.
 
-Repository-local actions require checkout first. Jobs without checkout use the external SHA-pinned
-action directly rather than checking out the repository only to reach a wrapper. The reusable
-image builder also uses the external login action because its registry is a caller input, whereas
-`ghcr-login` intentionally authenticates only to GHCR. Browser E2E boots the packaged JAR without
-Gradle, so it sets up Java directly; OpenAPI autocommit builds the JAR and uses `setup-caches`.
-
 ## Path filters
 
 `detect-changes` in `cicd.yml` selects legs from the changed paths on the two events that are a
 diff: a pull request against its base, and a merge group against `merge_group.base_sha..head_sha`. A
-push to `main` and a dispatch validate a whole commit and run every leg, which `detect-changes`
-publishes as `unfiltered`. Same-repository pull requests also run `Build` and `Docker` regardless of
-paths, because previews need every image at the head SHA; no other event has a preview.
+push to `main` and a dispatch publish `unfiltered` selection flags rather than filtering a diff.
+Selection does not override the outer event guards: ordinary main pushes omit Quality, Test,
+Security, Actionlint, Zizmor and Compose, and skip the API/schema/database/browser jobs inside
+`Build`; release-version pushes repeat those checks. Main still packages and publishes images and
+runs CodeQL. Same-repository pull requests also run `Build` and `Docker` regardless of paths, because
+previews need every image at the head SHA; no other event has a preview.
 
 | Selects | Paths |
 | --- | --- |
@@ -724,11 +738,17 @@ reaches no such commit builds every image itself. `detect-changes` resolves that
   validation. Either survivor must pass release preflight; the merge queue separately validates
   the final merge tree. Ordinary PRs, forks, main pushes and merge groups retain separate lanes.
 - A run on `main` that leaves a per-commit record — `codeql.yml`, `semgrep.yml`, `scorecard.yml`,
-  `scorecard-ratchet.yml` — is never cancelled, because it is the only run that commit will get and
-  its absence is what a later score reads as a gap. Those workflows write
+  `scorecard-ratchet.yml` — does not cancel an in-progress predecessor when another commit arrives;
+  a missing record can become a gap in a later score. Those workflows write
   `cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}`, and `scripts/ci-contract.test.ts`
   holds every `main` push to it; a workflow whose newest run simply replaces the last, such as the
-  docs deploy, is named there as the exception.
+  docs deploy, is named there as the exception. GitHub can still replace a **pending** run in the
+  same [concurrency group](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency):
+  `cancel-in-progress: false` protects running work, not every queued commit. Post-merge verification
+  must use the actual completed run for the converged main head, not infer success from this setting.
+  GitHub's native `queue: max` can retain more pending runs, but the required Actionlint parser
+  [does not yet support it](https://github.com/rhysd/actionlint/issues/657). Adopt it when a supported
+  validator release is available; do not suppress workflow syntax checks or add a custom queue.
 
 ## Monitoring CI
 

--- a/scripts/ci-provenance.test.ts
+++ b/scripts/ci-provenance.test.ts
@@ -1,5 +1,8 @@
 import assert from "node:assert/strict";
-import { readFile } from "node:fs/promises";
+import { spawnSync } from "node:child_process";
+import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { delimiter, join } from "node:path";
 import { test } from "node:test";
 
 import { isMap, isSeq, parseDocument } from "yaml";
@@ -48,4 +51,171 @@ void test("artifact checks have no registry publishing permissions", async () =>
 	const permissions = workflow.getIn(["jobs", "Build", "permissions"]);
 	assert.ok(isMap(permissions));
 	assert.deepEqual(permissions.toJSON(), { contents: "read", checks: "write" });
+});
+
+const repository = "hephaestus-build/Hephaestus";
+const owner = "hephaestus-build";
+const digest = `sha256:${"a".repeat(64)}`;
+const image = `ghcr.io/${owner}/webapp`;
+const immutable = `${image}@${digest}`;
+const verificationSites = [
+	{ file: "reusable-docker-build.yml", job: "build", step: "Sign and verify image" },
+	{ file: "reusable-docker-build.yml", job: "merge", step: "Verify signature + attestation" },
+	{
+		file: "ci-docker-build.yml",
+		job: "tag-unchanged-images",
+		step: "Verify and tag unchanged images",
+	},
+];
+
+// These are Linux publishing jobs. Execute their actual shell bodies with tool-boundary fixtures
+// so different quoting or function control flow cannot silently weaken one verification site.
+for (const site of verificationSites) {
+	for (const failure of ["none", "signature", "attestation"]) {
+		void test(
+			`${site.job}: ${failure === "none" ? "success" : `${failure} rejection`} preserves immutable-image verification`,
+			{ skip: process.platform === "win32" },
+			async (t) => {
+				const workflow = parseDocument(await readFile(`.github/workflows/${site.file}`, "utf8"));
+				const steps = workflow.getIn(["jobs", site.job, "steps"]);
+				assert.ok(isSeq(steps));
+				const step: unknown = steps.items.find(
+					(item) => isMap(item) && item.get("name") === site.step,
+				);
+				assert.ok(isMap(step));
+				if (site.job === "tag-unchanged-images") {
+					assert.equal(step.getIn(["env", "REPOSITORY"]), `\${{ github.repository }}`);
+					assert.equal(step.getIn(["env", "REPOSITORY_OWNER"]), `\${{ github.repository_owner }}`);
+					assert.equal(step.getIn(["env", "ALIAS_BASE"]), `\${{ inputs.alias_base }}`);
+				} else {
+					const source = site.job === "build" ? "single-digest" : "digest";
+					assert.equal(
+						step.getIn(["env", "IMAGE_REF"]),
+						`\${{ inputs.registry }}/\${{ inputs.image-name }}@\${{ steps.${source}.outputs.manifest-digest }}`,
+					);
+				}
+				const script = String(step.get("run"))
+					.replaceAll(`\${{ github.repository }}`, repository)
+					.replaceAll(`\${{ github.repository_owner }}`, owner);
+				assert.ok(!script.includes(`\${{`));
+				const directory = await mkdtemp(join(tmpdir(), "image-verification-"));
+				t.after(() => rm(directory, { recursive: true, force: true }));
+				const log = join(directory, "calls");
+				await writeFile(log, "");
+				for (const tool of ["cosign", "gh", "docker"]) {
+					const file = join(directory, tool);
+					await writeFile(
+						file,
+						`#!/usr/bin/env node
+const fs = require('node:fs');
+const tool = require('node:path').basename(process.argv[1]);
+const args = process.argv.slice(2);
+fs.appendFileSync(process.env.CALL_LOG, JSON.stringify([tool, ...args]) + '\\n');
+if (tool === 'cosign' && args[0] === 'verify' && process.env.FAILURE === 'signature') process.exit(7);
+if (tool === 'gh' && process.env.FAILURE === 'attestation') process.exit(9);
+if (tool === 'docker' && args.includes('inspect')) process.stdout.write(process.env.DIGEST);
+`,
+					);
+					await chmod(file, 0o755);
+				}
+				const result = spawnSync("bash", ["-e", "-c", script], {
+					encoding: "utf8",
+					env: {
+						...process.env,
+						PATH: `${directory}${delimiter}${process.env.PATH ?? ""}`,
+						CALL_LOG: log,
+						FAILURE: failure,
+						DIGEST: digest,
+						IMAGE_REF: immutable,
+						REPOSITORY: repository,
+						REPOSITORY_OWNER: owner,
+						ALIAS_BASE: "b".repeat(40),
+						HEAD_SHA: "c".repeat(40),
+						PR_NUMBER: "42",
+						WEBAPP_CHANGED: "false",
+						APPLICATION_SERVER_CHANGED: "true",
+						AGENT_IMAGES_CHANGED: "true",
+						POSTGRES_IMAGE_CHANGED: "true",
+					},
+				});
+				const calls = (await readFile(log, "utf8")).trim().split("\n");
+				const expected = [];
+				if (site.job === "build") expected.push(["cosign", "sign", "--yes", immutable]);
+				if (site.job === "tag-unchanged-images")
+					expected.push([
+						"docker",
+						"buildx",
+						"imagetools",
+						"inspect",
+						"--format",
+						"{{.Manifest.Digest}}",
+						`${image}:${"b".repeat(40)}`,
+					]);
+				expected.push([
+					"cosign",
+					"verify",
+					immutable,
+					"--certificate-identity-regexp",
+					`^https://github\\.com/${repository}/\\.github/workflows/reusable-docker-build\\.yml@`,
+					"--certificate-oidc-issuer",
+					"https://token.actions.githubusercontent.com",
+					"--certificate-github-workflow-repository",
+					repository,
+				]);
+				if (failure !== "signature")
+					expected.push(["gh", "attestation", "verify", `oci://${immutable}`, "--owner", owner]);
+				if (failure === "none" && site.job === "tag-unchanged-images")
+					expected.push([
+						"docker",
+						"buildx",
+						"imagetools",
+						"create",
+						"--tag",
+						`${image}:${"c".repeat(40)}`,
+						"--tag",
+						`${image}:pr-42`,
+						immutable,
+					]);
+				assert.deepEqual(
+					calls,
+					expected.map((args) => JSON.stringify(args)),
+				);
+				assert.equal(
+					result.status,
+					failure === "none" ? 0 : failure === "signature" ? 7 : 9,
+					result.stderr,
+				);
+			},
+		);
+	}
+}
+
+void test("registry-only merge and alias jobs remain checkout-free and signing keeps its workflow identity", async () => {
+	for (const site of verificationSites.filter((candidate) => candidate.job !== "build")) {
+		const workflow = parseDocument(await readFile(`.github/workflows/${site.file}`, "utf8"));
+		const steps = workflow.getIn(["jobs", site.job, "steps"]);
+		assert.ok(isSeq(steps));
+		for (const step of steps.items)
+			if (isMap(step)) {
+				assert.doesNotMatch(String(step.get("uses")), /actions\/checkout@|^\.\//);
+			}
+	}
+	const workflow = parseDocument(
+		await readFile(".github/workflows/reusable-docker-build.yml", "utf8"),
+	);
+	for (const job of ["build", "merge"]) {
+		const steps = workflow.getIn(["jobs", job, "steps"]);
+		assert.ok(isSeq(steps));
+		const sign: unknown = steps.items.find(
+			(item) =>
+				isMap(item) &&
+				item.get("name") === (job === "build" ? "Sign and verify image" : "Sign image with cosign"),
+		);
+		assert.ok(isMap(sign));
+		assert.match(
+			String(sign.get("run")),
+			job === "merge" ? /cosign sign --yes --recursive/ : /cosign sign --yes/,
+		);
+		if (job === "build") assert.doesNotMatch(String(sign.get("run")), /--recursive/);
+	}
 });


### PR DESCRIPTION
## What changed and why

The three image-verification paths intentionally run at different publishing boundaries, but their immutable subjects, certificate identity and failure behavior were not exercised together. Execute the actual workflow shell bodies in process fixtures for single-platform publishing, index verification and alias publication, including signature and attestation rejection. Keep registry-only jobs checkout-free and signing in its existing workflow.

Correct the CI guide's main-push selection and concurrency guarantees: selection flags do not override event guards, and protecting running work does not retain every pending run. Document the intentional setup/verification boundaries rather than introducing a checkout-dependent wrapper.

Related: https://github.com/hephaestus-build/Hephaestus/issues/1591

## How to test

- Run `node --test scripts/ci-provenance.test.ts` on Linux: all 12 tests pass, exercising real shell bodies with tool-boundary fixtures.
- Run `vp run format` and `vp run check`: the full local quality gate passes.
- Negative control: weakening the certificate workflow identity fails all three verification-site fixtures. Signature/attestation failures must stop before alias publication.

## Release impact

No shipped application or image behavior changes: tests, contributor documentation and workflow comments only. No changeset or operator action required.

## Notes for reviewers

No new checkout, signing action, certificate identity, permission, policy exception or custom queue. Native concurrency queuing remains dependent on supported Actionlint syntax: https://github.com/rhysd/actionlint/issues/657. The Linux publishing fixtures skip Windows; the YAML boundary checks remain cross-platform.
