### PR TITLE
docs(ci): explain registry login boundaries at call sites

### DIFF
--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -117,6 +117,7 @@ jobs:
         with:
           driver: ${{ inputs.use-buildpacks && 'docker' || 'docker-container' }}
 
+      # Caller-selected registry, not GHCR-only; see ci-cd.mdx § Shared setup actions.
       - name: Log in to Container Registry
         if: inputs.publish
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
@@ -354,6 +355,7 @@ jobs:
           pattern: digests-${{ steps.prep.outputs.image_name }}-*
           merge-multiple: true
 
+      # Caller-selected registry, not GHCR-only; see ci-cd.mdx § Shared setup actions.
       - name: Log in to Container Registry
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
@@ -460,6 +462,7 @@ jobs:
         with:
           install-syft: "false"
 
+      # Caller-selected registry, not GHCR-only; see ci-cd.mdx § Shared setup actions.
       - name: Log in to Container Registry
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:


### PR DESCRIPTION
## What changed and why

The reusable builder intentionally accepts a caller-selected registry, whereas the shared login action is GHCR-only. Its guide already explains this boundary, but the three direct login call sites had no pointer to that explanation. Add those pointers so a future consolidation does not silently narrow the supported registry input.

Completes the call-site documentation identified in the closure audit for https://github.com/hephaestus-build/Hephaestus/issues/1591.

## How to test

- `vp run format` and `vp run check` pass.
- The parsed workflow is deeply equal before and after: only three comments changed, with no permissions, inputs, steps or commands affected.

## Release impact

Comments only; no application behavior or operator action changes, so no changeset is required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added workflow comments clarifying that build, merge, and scan operations use the registry selected by the caller, rather than being limited to GHCR.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->