### PR TITLE
fix(ci): give a preview's application server room to start

### DIFF
--- a/.changeset/preview-appserver-heap.md
+++ b/.changeset/preview-appserver-heap.md
@@ -1,0 +1,4 @@
+---
+---
+
+No user-facing effect: this raises the memory ceiling of the application server in `docker/preview/`, which only the project's own preview deployments run.

--- a/docker/preview/compose.app.yaml
+++ b/docker/preview/compose.app.yaml
@@ -352,8 +352,13 @@ services:
     deploy:
       resources:
         limits:
+          # The buildpack derives the heap from this ceiling, and reserves metaspace, code cache and
+          # 250 thread stacks out of it first. At 2G that left ~1.14G of heap with no headroom, and
+          # the application exits on the first OutOfMemoryError, so the container restarted forever
+          # and the stack never came up. Startup peaks above what it then settles at: staging holds
+          # ~1.26G for the whole process once warm.
           cpus: "1.0"
-          memory: 2G
+          memory: 3G
           pids: 512
   webapp:
     image: ghcr.io/hephaestus-build/webapp:${SOURCE_COMMIT:?Coolify supplies the deployed commit}


### PR DESCRIPTION
## What changed and why

#2042's preview has failed four times running. GitHub only reports *"Coolify reported a failed preview deployment"*; the cause is on the host:

```
Terminating due to java.lang.OutOfMemoryError: Java heap space
Calculated JVM Memory Configuration: -Xmx1194224K -XX:MaxMetaspaceSize=270095K
  -XX:ReservedCodeCacheSize=240M -Xss1M (Total Memory: 2G, Thread Count: 250, Headroom: 0%)
```

The application server exhausts its heap during startup — before Liquibase logs anything — and it runs with `-XX:+ExitOnOutOfMemoryError`, so it exits and `restart: unless-stopped` brings it straight back. The container had **835 restarts**. The webapp `depends_on` it and was never created, so the stack could never come up.

The buildpack derives the heap from the container ceiling, taking metaspace, code cache and 250 thread stacks out of it first. At 2G that leaves ~1.14G of heap with **0% headroom**. Startup peaks above what the process settles at: staging holds ~1.26G for the whole process once warm, which is already more than that heap.

Raising the ceiling to 3G gives the heap ~2.1G and room for the peak.

## Why this is a sizing problem and not a regression in the branch

The branch under preview adds nothing that would explain it, which I checked before reaching for a bigger number:

- **No new startup work** — no `@PostConstruct`, `ApplicationRunner`, `CommandLineRunner` or `ApplicationReadyEvent` listener anywhere in its diff.
- **Fewer JPA objects than `main`**, not more — 104 repositories and 106 entities against main's 105 and 107.
- **A 70-line migration** with one `addColumn`, one `dropColumn` and one `sql`, and the process dies before Liquibase produces any output at all.

The same preview came up yesterday on an earlier commit of the same branch, so 2G was already marginal and is now simply under the line.

## Capacity

The limit is a ceiling, not a reservation. The host has ~10G available, an idle preview application server holds ~321MiB, and the admission controller caps concurrent previews at three. Staging's own application server is configured at 5G for comparison.

## How to test

```sh
node scripts/check-preview-stack.ts     # stack renders and stays sandboxed
```

The effect itself is only observable on a real deployment, and by design not on this pull request: the admission controller refuses to deploy a PR that changes `docker/preview/`. It applies to previews created from commits that carry it.

Afterwards the check is that the application server reaches `Started Application` instead of looping:

```sh
docker inspect <appserver> --format '{{.RestartCount}}'
```

## Release impact

Empty changeset: `docker/preview/` is run only by this project's own previews, so no released instance is affected.

## Notes for reviewers

Worth considering instead of, or alongside, a larger ceiling: the buildpack sizes for 250 threads, which reserves ~250M of stack out of the same budget, and a preview serves one or two reviewers. Lowering `BPL_JVM_THREAD_COUNT` would move some of that into the heap without raising the ceiling. I did not do it here because it buys ~150M where the shortfall is larger, and two knobs are harder to reason about than one — but it is the lever to reach for if preview density on the host ever matters more than headroom.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the memory allocation for preview application servers to reduce unexpected restarts during builds and runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->