### PR TITLE
fix(ci): scan images against one advisory snapshot per run

### DIFF
--- a/.github/actions/download-trivy-db/action.yml
+++ b/.github/actions/download-trivy-db/action.yml
@@ -1,8 +1,12 @@
 name: Download the Trivy database
 description: >-
-  Fetches the Trivy vulnerability database once, with the retries and registry fallback a gate
-  needs, optionally asserts its freshness and records its metadata, and can prepare the Java index.
+  Downloads a new advisory database with retries and registry fallback, or restores this run's
+  immutable snapshot; validates freshness when requested and can prepare the separate Java index.
 inputs:
+  database-artifact:
+    description: Immutable artifact ID for this run, or registry to download a new database.
+    required: false
+    default: "registry"
   java-db:
     description: Prepare the Java index before concurrent Java image scans.
     required: false
@@ -18,12 +22,38 @@ inputs:
       Copy the database metadata to this path, creating parent directories. Empty skips the copy.
     required: false
     default: ""
+outputs:
+  database-directory:
+    description: Directory containing the advisory database and its metadata.
+    value: ${{ steps.cache.outputs.directory }}
 runs:
   using: composite
   steps:
+    - name: Locate the advisory database
+      id: cache
+      shell: bash
+      env:
+        DATABASE_ARTIFACT: ${{ inputs.database-artifact }}
+      run: |
+        set -euo pipefail
+        if [ "$DATABASE_ARTIFACT" != registry ] && ! [[ "$DATABASE_ARTIFACT" =~ ^[1-9][0-9]*$ ]]; then
+          echo "::error::database-artifact must be registry or a positive artifact ID"
+          exit 1
+        fi
+        echo "directory=${TRIVY_CACHE_DIR:-$HOME/.cache/trivy}/db" >> "$GITHUB_OUTPUT"
+
+    - name: Restore this run's advisory database
+      if: inputs.database-artifact != 'registry'
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        artifact-ids: ${{ inputs.database-artifact }}
+        path: ${{ steps.cache.outputs.directory }}
+        merge-multiple: true
+
     - name: Download the Trivy database
       shell: bash
       env:
+        DATABASE_ARTIFACT: ${{ inputs.database-artifact }}
         JAVA_DB: ${{ inputs.java-db }}
         MAX_AGE_HOURS: ${{ inputs.max-age-hours }}
         METADATA_PATH: ${{ inputs.metadata-path }}
@@ -42,14 +72,20 @@ runs:
           echo "::error::max-age-hours must be a whole number of hours"
           exit 1
         fi
-        for attempt in 1 2 3; do
-          trivy image --timeout 90s --download-db-only && break
-          if [ "$attempt" -eq 3 ]; then
-            echo "::error::Trivy database download failed after $attempt attempts"
-            exit 1
-          fi
-          sleep $((attempt * 5))
-        done
+        if [ "$DATABASE_ARTIFACT" = registry ]; then
+          for attempt in 1 2 3; do
+            trivy image --timeout 90s --download-db-only && break
+            if [ "$attempt" -eq 3 ]; then
+              echo "::error::Trivy database download failed after $attempt attempts"
+              exit 1
+            fi
+            sleep $((attempt * 5))
+          done
+        else
+          # A missing or incomplete snapshot must never fall back to a different advisory set.
+          test -s "${TRIVY_CACHE_DIR:-$HOME/.cache/trivy}/db/trivy.db"
+          test -s "${TRIVY_CACHE_DIR:-$HOME/.cache/trivy}/db/metadata.json"
+        fi
         if [ "$JAVA_DB" = true ]; then
           for attempt in 1 2 3; do
             trivy image --timeout 5m --download-java-db-only && break

--- a/.github/workflows/ci-docker-build.yml
+++ b/.github/workflows/ci-docker-build.yml
@@ -10,6 +10,10 @@ on:
       SENTRY_PROJECT:
         required: false
     inputs:
+      database-artifact:
+        description: "Immutable advisory database artifact ID selected by this CI run"
+        type: string
+        required: true
       scan-images:
         description: "Scan published images here unless the caller requires complete release evidence instead."
         type: boolean
@@ -72,6 +76,7 @@ jobs:
       SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
       SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
     with:
+      database-artifact: ${{ inputs.database-artifact }}
       image-name: "hephaestus-build/webapp"
       docker-file: "./webapp/Dockerfile"
       docker-context: "."
@@ -101,6 +106,7 @@ jobs:
       attestations: write
       artifact-metadata: write
     with:
+      database-artifact: ${{ inputs.database-artifact }}
       image-name: "hephaestus-build/agent-pi"
       docker-file: "./docker/agents/pi/Dockerfile"
       docker-context: "./docker/agents"
@@ -129,6 +135,7 @@ jobs:
       attestations: write
       artifact-metadata: write
     with:
+      database-artifact: ${{ inputs.database-artifact }}
       image-name: "hephaestus-build/postgres"
       docker-file: "./docker/postgres/Dockerfile"
       docker-context: "./docker/postgres"

--- a/.github/workflows/ci-security-scan.yml
+++ b/.github/workflows/ci-security-scan.yml
@@ -3,6 +3,10 @@ name: Security
 on:
   workflow_call:
     inputs:
+      database-artifact:
+        description: "Immutable advisory database artifact ID selected by this CI run"
+        type: string
+        required: true
       should_skip:
         description: "Whether to skip the workflow"
         required: false
@@ -45,6 +49,8 @@ jobs:
       # A blocking gate inherits Trivy's database availability as a hard dependency, so the
       # retries and the mirror fallback live in one action rather than in each caller.
       - uses: ./.github/actions/download-trivy-db
+        with:
+          database-artifact: ${{ inputs.database-artifact }}
 
       - name: Enforce the release vulnerability policy on the pinned digests
         run: node scripts/scan-upstream-images.ts reports

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -539,10 +539,53 @@ jobs:
           # A re-run of failed jobs keeps this artifact; a re-run of all jobs replaces it.
           overwrite: true
 
+  # Image policy has one advisory set per attempt. Failed-job reruns retain the producer's
+  # artifact ID; rerunning every job creates a new snapshot. Java identification is separate.
+  vulnerability-database:
+    name: "Image advisory database"
+    needs: [detect-changes]
+    if: |
+      needs.detect-changes.outputs.should_skip != 'true' && (
+        needs.detect-changes.outputs.release-preflight == 'true' ||
+        needs.detect-changes.outputs.release-images == 'true' ||
+        (needs.detect-changes.outputs.publishable == 'true' && (
+          needs.detect-changes.outputs.all-images == 'true' ||
+          needs.detect-changes.outputs.application-server-image == 'true' ||
+          needs.detect-changes.outputs.supported-host-smoke == 'true' ||
+          needs.detect-changes.outputs.webapp-image == 'true' ||
+          needs.detect-changes.outputs.agent-images == 'true' ||
+          needs.detect-changes.outputs.postgres-image == 'true' ||
+          needs.detect-changes.outputs.docker-config == 'true'
+        ))
+      )
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    outputs:
+      artifact-id: ${{ steps.snapshot.outputs.artifact-id }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+      - uses: ./.github/actions/setup-release-security-tools
+        with:
+          install-syft: "false"
+      - uses: ./.github/actions/download-trivy-db
+        id: database
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        id: snapshot
+        with:
+          name: trivy-db-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ steps.database.outputs.database-directory }}
+          if-no-files-found: error
+          retention-days: 1
+
   application-server-image:
     name: "App Server image"
-    needs: [detect-changes, server-package]
-    if: needs.detect-changes.outputs.application-server-image == 'true' || needs.detect-changes.outputs.supported-host-smoke == 'true' || needs.detect-changes.outputs.all-images == 'true'
+    needs: [detect-changes, server-package, vulnerability-database]
+    if: ${{ !cancelled() && needs.detect-changes.result == 'success' && (needs.vulnerability-database.result == 'success' || needs.vulnerability-database.result == 'skipped') && needs.server-package.result == 'success' && (needs.detect-changes.outputs.application-server-image == 'true' || needs.detect-changes.outputs.supported-host-smoke == 'true' || needs.detect-changes.outputs.all-images == 'true') }}
     uses: ./.github/workflows/reusable-docker-build.yml
     permissions:
       contents: read
@@ -551,6 +594,7 @@ jobs:
       attestations: write
       artifact-metadata: write
     with:
+      database-artifact: ${{ needs.vulnerability-database.outputs.artifact-id }}
       image-name: "hephaestus-build/application-server"
       use-buildpacks: true
       application-artifact: server-build-${{ github.run_id }}
@@ -577,8 +621,9 @@ jobs:
 
   Security:
     uses: ./.github/workflows/ci-security-scan.yml
-    needs: [detect-changes]
+    needs: [detect-changes, vulnerability-database]
     if: |
+      !cancelled() && needs.detect-changes.result == 'success' && (needs.vulnerability-database.result == 'success' || needs.vulnerability-database.result == 'skipped') &&
       (github.event_name != 'push' || needs.detect-changes.outputs.version-bump == 'true') &&
       needs.detect-changes.outputs.should_skip != 'true' && (
         needs.detect-changes.outputs.any-code == 'true' ||
@@ -590,6 +635,7 @@ jobs:
       contents: read
       security-events: write
     with:
+      database-artifact: ${{ needs.vulnerability-database.outputs.artifact-id }}
       should_skip: ${{ needs.detect-changes.outputs.should_skip }}
       release_images_changed: ${{ (needs.detect-changes.outputs.release-images == 'true' || needs.detect-changes.outputs.unfiltered == 'true') && 'true' || 'false' }}
 
@@ -629,11 +675,12 @@ jobs:
       SENTRY_AUTH_TOKEN: ${{ github.event_name == 'push' && secrets.SENTRY_AUTH_TOKEN || '' }}
       SENTRY_ORG: ${{ github.event_name == 'push' && secrets.SENTRY_ORG || '' }}
       SENTRY_PROJECT: ${{ github.event_name == 'push' && secrets.SENTRY_PROJECT || '' }}
-    needs: [detect-changes]
+    needs: [detect-changes, vulnerability-database]
     # Same-repository previews require every image at the PR head tag; unchanged images are aliased
     # here and the application image is built by Build. A fork and a merge group have no preview, so
     # their image builds stay path-filtered.
     if: |
+      !cancelled() && needs.detect-changes.result == 'success' && (needs.vulnerability-database.result == 'success' || needs.vulnerability-database.result == 'skipped') &&
       needs.detect-changes.outputs.should_skip != 'true' && (
         needs.detect-changes.outputs.unfiltered == 'true' ||
         needs.detect-changes.outputs.previews == 'true' ||
@@ -647,6 +694,7 @@ jobs:
       attestations: write
       artifact-metadata: write
     with:
+      database-artifact: ${{ needs.vulnerability-database.outputs.artifact-id }}
       should_skip: ${{ needs.detect-changes.outputs.should_skip }}
       publish: ${{ needs.detect-changes.outputs.publishable == 'true' }}
       single_arch: ${{ needs.detect-changes.outputs.single-arch }}
@@ -716,8 +764,8 @@ jobs:
   # release-management.mdx owns the evidence contract.
   Release-preflight:
     name: "Release evidence preflight"
-    needs: [detect-changes, application-server-image, Docker]
-    if: needs.detect-changes.outputs.release-preflight == 'true'
+    needs: [detect-changes, application-server-image, Docker, vulnerability-database]
+    if: ${{ !cancelled() && needs.detect-changes.result == 'success' && (needs.vulnerability-database.result == 'success' || needs.vulnerability-database.result == 'skipped') && needs.application-server-image.result == 'success' && needs.Docker.result == 'success' && (needs.detect-changes.outputs.release-preflight == 'true') }}
     timeout-minutes: 45
     runs-on: ubuntu-latest
     permissions:
@@ -739,6 +787,7 @@ jobs:
       - uses: ./.github/actions/download-trivy-db
         with:
           max-age-hours: "24"
+          database-artifact: ${{ needs.vulnerability-database.outputs.artifact-id }}
           java-db: "true"
 
       - uses: ./.github/actions/ghcr-login
@@ -793,7 +842,7 @@ jobs:
     permissions:
       actions: read
       statuses: write
-    needs: [detect-changes, gradle-wrapper, workflow-lint, zizmor, CodeQL, Quality, server-package, application-server-image, Build, Security, Test, Changesets, Compose, Docker, Supported-host-smoke, Release-preflight]
+    needs: [detect-changes, vulnerability-database, gradle-wrapper, workflow-lint, zizmor, CodeQL, Quality, server-package, application-server-image, Build, Security, Test, Changesets, Compose, Docker, Supported-host-smoke, Release-preflight]
     if: always()
     steps:
       - name: Generate workflow timeline

--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -10,6 +10,10 @@ on:
       SENTRY_PROJECT:
         required: false
     inputs:
+      database-artifact:
+        description: "Immutable advisory database artifact ID selected by this CI run"
+        type: string
+        required: true
       scan-images:
         description: "Scan published images here unless the caller requires complete release evidence instead."
         type: boolean
@@ -480,6 +484,8 @@ jobs:
       # A blocking gate inherits Trivy's database availability as a hard dependency, so the
       # retries and the mirror fallback live in one action rather than in each caller.
       - uses: ./.github/actions/download-trivy-db
+        with:
+          database-artifact: ${{ inputs.database-artifact }}
 
       - name: Enforce the release vulnerability policy
         env:

--- a/docs/contributor/ci-cd.mdx
+++ b/docs/contributor/ci-cd.mdx
@@ -557,7 +557,7 @@ credential is still `GITHUB_TOKEN`, so these commits start no further workflow r
 | `restore-server-build` | Downloads and validates the packaged JARs, compiled tests and resources; outputs the executable JAR path without recompiling or installing local artifacts |
 | `setup-browsers` | Restores the exact Playwright browser version and installs Chromium system dependencies |
 | `setup-release-security-tools` | Installs Cosign, Trivy, and optionally Syft for release-evidence jobs |
-| `download-trivy-db` | Fetches the vulnerability database with retries and a mirror fallback; optionally refuses one over `max-age-hours` old and records its metadata |
+| `download-trivy-db` | Downloads with retries and mirror fallback, or restores the CI run's immutable advisory artifact; checks freshness at consumption and records metadata as requested — [database identity](./vulnerability-remediation.mdx#advisory-database-identity) owns the rerun contract |
 | `ghcr-login` | Authenticates Docker to GHCR |
 
 Browser jobs install Playwright's system dependencies using the runner's Ubuntu package sources,

--- a/docs/contributor/vulnerability-remediation.mdx
+++ b/docs/contributor/vulnerability-remediation.mdx
@@ -37,6 +37,27 @@ All six evaluate `security/vulnerability-policy.json` through `scripts/check-rel
 The release, preflight and rescans use the same evaluator. The CI contract checks that scans before
 release cover the subject set derived from `security/release-images.json`.
 
+### Advisory database identity
+
+CI/CD image-policy jobs share one advisory database artifact produced before they scan. The producer
+uses the existing bounded download retries and registry fallback; consumers restore its immutable
+artifact ID instead of fetching the moving database tag again. This includes first-party image
+builds, pinned upstream image scans and release preflight. A new advisory published during the run
+cannot change a later image job's advisory set. A later run can still block on that advisory; no
+severity, fixability or exception policy changes.
+
+A failed-job rerun retains the successful producer's artifact ID. Rerunning all jobs creates a new
+snapshot named for that run attempt. Snapshots are retained for one day; a missing, expired or
+incomplete artifact fails rather than silently fetching another database. Rerun all jobs to obtain
+a new snapshot. Evidence consumers still enforce the 24-hour freshness bound **after restoration**,
+so retaining an artifact does not extend the lifetime of acceptable release evidence.
+
+This snapshot contains the advisory database, not the separate Java index that identifies JAR
+coordinates. Java preparation and scanning remain enabled where required. Filesystem dependency
+scans have their own dependency policy and are outside this image-policy snapshot. Release and
+scheduled-rescan workflows already prepare their advisory database once in a single job; they
+continue downloading a fresh database through the same action.
+
 The Version PR preflight verifies the complete evidence bundle, not just vulnerability policy —
 [Release management](release-management.mdx#nothing-may-fail-for-the-first-time-at-a-release).
 Scheduled rescans report newly disclosed

--- a/scripts/ci-contract.test.ts
+++ b/scripts/ci-contract.test.ts
@@ -697,7 +697,7 @@ void describe("CI contract", () => {
 		assert.match(e2e, /http:\/\/localhost:8080\/actuator\/health\/readiness/);
 		assert.doesNotMatch(e2e, /actuator\/health\/liveness/);
 		const image = job(orchestrator, "application-server-image");
-		assert.match(image, /needs: \[detect-changes, server-package\]/);
+		assert.match(image, /needs: \[detect-changes, server-package, vulnerability-database\]/);
 		assert.match(image, /use-buildpacks: true/);
 
 		// The long suites compile from source and never wait for the package job.
@@ -727,7 +727,11 @@ void describe("CI contract", () => {
 		for (const name of ["Build", "application-server-image"]) {
 			const dependencies = workflow.getIn(["jobs", name, "needs"]);
 			assert.ok(isSeq(dependencies));
-			assert.deepEqual(dependencies.toJSON(), ["detect-changes", "server-package"]);
+			assert.deepEqual(dependencies.toJSON(), [
+				"detect-changes",
+				"server-package",
+				...(name === "application-server-image" ? ["vulnerability-database"] : []),
+			]);
 		}
 		for (const name of ["Supported-host-smoke", "Release-preflight"]) {
 			const dependencies = workflow.getIn(["jobs", name, "needs"]);
@@ -736,6 +740,7 @@ void describe("CI contract", () => {
 				"detect-changes",
 				"application-server-image",
 				"Docker",
+				...(name === "Release-preflight" ? ["vulnerability-database"] : []),
 			]);
 		}
 		const gate = workflow.getIn(["jobs", "all-ci-passed", "needs"]);
@@ -853,7 +858,12 @@ void describe("CI contract", () => {
 			/version-bump: \${{ steps\.version_bump\.outputs\.changed }}/,
 		);
 		for (const name of ["workflow-lint", "zizmor", "Quality", "Security", "Test", "Compose"]) {
-			assert.match(job(source, name), /needs: \[detect-changes\]/);
+			assert.match(
+				job(source, name),
+				name === "Security"
+					? /needs: \[detect-changes, vulnerability-database\]/
+					: /needs: \[detect-changes\]/,
+			);
 			assert.match(
 				job(source, name),
 				/github\.event_name != 'push'.*needs\.detect-changes\.outputs\.version-bump == 'true'/s,
@@ -1510,7 +1520,7 @@ void describe("CI contract", () => {
 		// documents are re-derived and compared exactly as the release re-derives them.
 		assert.match(preflight, /node scripts\/verify-release-evidence\.ts evidence\n/);
 		assert.match(preflight, /max-age-hours: "24"/);
-		assert.match(preflight, /if: needs\.detect-changes\.outputs\.release-preflight == 'true'/);
+		assert.match(preflight, /if: .*needs\.detect-changes\.outputs\.release-preflight == 'true'/);
 		assert.match(cicd, /^ {6}release-preflight:$/m);
 		assert.match(job(cicd, "all-ci-passed"), /needs: \[[^\]]*Release-preflight\]/);
 

--- a/scripts/ci-image-database.test.ts
+++ b/scripts/ci-image-database.test.ts
@@ -1,0 +1,189 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { test } from "node:test";
+
+import { data, Evaluator, Lexer, Parser } from "@actions/expressions";
+import { isMap, isScalar, isSeq, parseDocument } from "yaml";
+
+const main = parseDocument(await readFile(".github/workflows/cicd.yml", "utf8"));
+
+function runs(
+	job: string,
+	outputs: Record<string, string>,
+	results: Record<string, string> = {},
+	cancelled = false,
+) {
+	const condition = main.getIn(["jobs", job, "if"]);
+	assert.ok(typeof condition === "string");
+	const functions = new Map([
+		[
+			"cancelled",
+			{ name: "cancelled", minArgs: 0, maxArgs: 0, call: () => new data.BooleanData(cancelled) },
+		],
+	]);
+	const expression = new Parser(
+		new Lexer(condition.replace(/^\$\{\{\s*|\s*}}$/g, "")).lex().tokens,
+		["needs", "github"],
+		[...functions.values()],
+	).parse();
+	const context: unknown = JSON.parse(
+		JSON.stringify({
+			github: { event_name: "pull_request" },
+			needs: {
+				...Object.fromEntries(
+					[
+						"detect-changes",
+						"server-package",
+						"vulnerability-database",
+						"application-server-image",
+						"Docker",
+					].map((name) => [name, { result: results[name] ?? "success" }]),
+				),
+				"detect-changes": { result: results["detect-changes"] ?? "success", outputs },
+			},
+		}),
+		data.reviver,
+	);
+	assert.ok(context instanceof data.Dictionary);
+	return new Evaluator(expression, context, functions).evaluate().coerceString() === "true";
+}
+
+void test("one advisory snapshot is selected for every image-policy consumer, not unpublished fork builds", () => {
+	for (const flag of [
+		"all-images",
+		"application-server-image",
+		"supported-host-smoke",
+		"webapp-image",
+		"agent-images",
+		"postgres-image",
+		"docker-config",
+	]) {
+		assert.ok(runs("vulnerability-database", { publishable: "true", [flag]: "true" }), flag);
+		assert.ok(
+			!runs("vulnerability-database", { publishable: "false", [flag]: "true" }),
+			`unpublished ${flag}`,
+		);
+	}
+	for (const flag of ["release-preflight", "release-images"]) {
+		assert.ok(runs("vulnerability-database", { publishable: "false", [flag]: "true" }), flag);
+		assert.ok(
+			!runs("vulnerability-database", { should_skip: "true", [flag]: "true" }),
+			`duplicate ${flag}`,
+		);
+	}
+	assert.ok(!runs("vulnerability-database", { publishable: "true", previews: "true" }));
+	const fork = { publishable: "false", "all-images": "true", "any-code": "true" };
+	for (const result of ["skipped", "failure", "cancelled"]) {
+		for (const job of ["Docker", "application-server-image", "Security"]) {
+			assert.equal(
+				runs(job, fork, { "vulnerability-database": result }),
+				result === "skipped",
+				`${job}: ${result}`,
+			);
+			assert.ok(
+				!runs(job, fork, { "vulnerability-database": result }, true),
+				`${job}: cancellation`,
+			);
+			assert.ok(!runs(job, fork, { "detect-changes": "failure" }), `${job}: no selection`);
+		}
+	}
+	assert.ok(runs("Docker", { previews: "true" }, { "vulnerability-database": "skipped" }));
+	assert.ok(!runs("application-server-image", fork, { "server-package": "failure" }));
+	assert.ok(!runs("application-server-image", fork, { "server-package": "skipped" }));
+	assert.ok(runs("Release-preflight", { "release-preflight": "true" }));
+	assert.ok(!runs("Release-preflight", { "release-preflight": "false" }));
+	assert.ok(
+		!runs(
+			"Release-preflight",
+			{ "release-preflight": "true" },
+			{ "vulnerability-database": "failure" },
+		),
+	);
+	for (const prerequisite of ["application-server-image", "Docker"]) {
+		assert.ok(
+			!runs("Release-preflight", { "release-preflight": "true" }, { [prerequisite]: "failure" }),
+		);
+		assert.ok(
+			!runs("Release-preflight", { "release-preflight": "true" }, { [prerequisite]: "skipped" }),
+		);
+	}
+});
+
+void test("every CI image scan receives the producer's immutable artifact ID across reusable workflows", async () => {
+	for (const job of ["application-server-image", "Docker", "Security"]) {
+		assert.equal(
+			main.getIn(["jobs", job, "with", "database-artifact"]),
+			`\${{ needs.vulnerability-database.outputs.artifact-id }}`,
+		);
+		const needs = main.getIn(["jobs", job, "needs"]);
+		assert.ok(isSeq(needs));
+		assert.ok(
+			needs.items.some((item) => isScalar(item) && item.value === "vulnerability-database"),
+		);
+	}
+	for (const name of ["ci-docker-build.yml", "reusable-docker-build.yml", "ci-security-scan.yml"]) {
+		const workflow = parseDocument(await readFile(`.github/workflows/${name}`, "utf8"));
+		assert.equal(
+			workflow.getIn(["on", "workflow_call", "inputs", "database-artifact", "required"]),
+			true,
+		);
+		assert.equal(
+			workflow.getIn(["on", "workflow_call", "inputs", "database-artifact", "default"]),
+			undefined,
+		);
+		if (name === "ci-docker-build.yml") {
+			for (const job of ["webapp-build", "agent-pi-build", "postgres-build"])
+				assert.equal(
+					workflow.getIn(["jobs", job, "with", "database-artifact"]),
+					`\${{ inputs.database-artifact }}`,
+				);
+		} else {
+			const job = name === "reusable-docker-build.yml" ? "scan" : "upstream-images";
+			const steps = workflow.getIn(["jobs", job, "steps"]);
+			assert.ok(isSeq(steps));
+			const restore = steps.items.find(
+				(step) => isMap(step) && step.get("uses") === "./.github/actions/download-trivy-db",
+			);
+			assert.ok(isMap(restore));
+			assert.equal(
+				restore.getIn(["with", "database-artifact"]),
+				`\${{ inputs.database-artifact }}`,
+			);
+		}
+	}
+	const preflight = main.getIn(["jobs", "Release-preflight", "steps"]);
+	assert.ok(isSeq(preflight));
+	const restore = preflight.items.find(
+		(step) => isMap(step) && step.get("uses") === "./.github/actions/download-trivy-db",
+	);
+	assert.ok(isMap(restore));
+	assert.equal(
+		restore.getIn(["with", "database-artifact"]),
+		`\${{ needs.vulnerability-database.outputs.artifact-id }}`,
+	);
+	assert.equal(restore.getIn(["with", "max-age-hours"]), "24");
+	assert.equal(restore.getIn(["with", "java-db"]), "true");
+});
+
+void test("snapshot identity comes from the producer, not the consumer attempt, and its verdict is required", () => {
+	const producer = main.getIn(["jobs", "vulnerability-database", "steps"]);
+	assert.ok(isSeq(producer));
+	const upload = producer.items.find((step) => isMap(step) && step.get("id") === "snapshot");
+	assert.ok(isMap(upload));
+	assert.match(String(upload.get("uses")), /^actions\/upload-artifact@[a-f0-9]{40}$/);
+	assert.equal(
+		upload.getIn(["with", "name"]),
+		`trivy-db-\${{ github.run_id }}-\${{ github.run_attempt }}`,
+	);
+	assert.equal(upload.getIn(["with", "overwrite"]), undefined);
+	assert.equal(upload.getIn(["with", "path"]), `\${{ steps.database.outputs.database-directory }}`);
+	assert.equal(upload.getIn(["with", "if-no-files-found"]), "error");
+	assert.equal(upload.getIn(["with", "retention-days"]), 1);
+	assert.equal(
+		main.getIn(["jobs", "vulnerability-database", "outputs", "artifact-id"]),
+		`\${{ steps.snapshot.outputs.artifact-id }}`,
+	);
+	const needs = main.getIn(["jobs", "all-ci-passed", "needs"]);
+	assert.ok(isSeq(needs));
+	assert.ok(needs.items.some((item) => isScalar(item) && item.value === "vulnerability-database"));
+});

--- a/scripts/download-trivy-db.test.ts
+++ b/scripts/download-trivy-db.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { spawnSync, type SpawnSyncReturns } from "node:child_process";
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { test } from "node:test";
@@ -16,7 +16,7 @@ void test(
 		const action = parseDocument(
 			await readFile(".github/actions/download-trivy-db/action.yml", "utf8"),
 		);
-		const script: unknown = action.getIn(["runs", "steps", 0, "run"]);
+		const script: unknown = action.getIn(["runs", "steps", 2, "run"]);
 		if (typeof script !== "string") throw new Error("Database action has no executable step");
 		const directory = await mkdtemp(path.join(tmpdir(), "trivy-download-"));
 		context.after(() => rm(directory, { recursive: true, force: true }));
@@ -40,6 +40,7 @@ case "$*" in *--download-java-db-only*) exit "$JAVA_EXIT" ;; esac
 			const env = {
 				...process.env,
 				PATH: `${directory}${path.delimiter}${process.env.PATH ?? ""}`,
+				DATABASE_ARTIFACT: "registry",
 				JAVA_DB: javaDb,
 				JAVA_EXIT: exit,
 				MAX_AGE_HOURS: "",
@@ -57,5 +58,93 @@ case "$*" in *--download-java-db-only*) exit "$JAVA_EXIT" ;; esac
 			if (expectedCalls > 0) assert.match(calls[0] ?? "", /--download-db-only$/);
 			for (const call of calls.slice(1)) assert.match(call, /--download-java-db-only$/);
 		}
+	},
+);
+
+void test(
+	"restored snapshots never fetch new advisories and still enforce freshness and Java preparation",
+	{ skip: process.platform === "win32" },
+	async (context) => {
+		const action = parseDocument(
+			await readFile(".github/actions/download-trivy-db/action.yml", "utf8"),
+		);
+		const validate: unknown = action.getIn(["runs", "steps", 0, "run"]);
+		const prepare: unknown = action.getIn(["runs", "steps", 2, "run"]);
+		assert.ok(typeof validate === "string");
+		assert.ok(typeof prepare === "string");
+		const directory = await mkdtemp(path.join(tmpdir(), "trivy-snapshot-"));
+		context.after(() => rm(directory, { recursive: true, force: true }));
+		const db = path.join(directory, "db");
+		await mkdir(db);
+		const log = path.join(directory, "calls");
+		await writeFile(
+			path.join(directory, "trivy"),
+			'#!/bin/sh\nprintf "%s\\n" "$*" >> "$SCAN_LOG"\n',
+			{ mode: 0o755 },
+		);
+		for (const scenario of [
+			{ id: "123", java: "false", age: 1, file: true, success: true },
+			{ id: "123", java: "true", age: 1, file: true, success: true },
+			{ id: "123", java: "false", age: 25, file: true, success: false },
+			{ id: "123", java: "false", age: -1, file: true, success: false },
+			{ id: "123", java: "false", age: 1, file: false, success: false },
+			{ id: "", java: "false", age: 1, file: true, success: false },
+			{ id: "0", java: "false", age: 1, file: true, success: false },
+			{ id: "123,456", java: "false", age: 1, file: true, success: false },
+		]) {
+			await writeFile(log, "");
+			const output = path.join(directory, "output");
+			await writeFile(output, "");
+			await writeFile(
+				path.join(db, "metadata.json"),
+				JSON.stringify({
+					UpdatedAt: new Date(Date.now() - scenario.age * 3_600_000).toISOString(),
+				}),
+			);
+			if (scenario.file) await writeFile(path.join(db, "trivy.db"), "the immutable database");
+			else await rm(path.join(db, "trivy.db"), { force: true });
+			const result: SpawnSyncReturns<string> = spawnSync(
+				"bash",
+				["-e", "-c", `${validate}\n${prepare}`],
+				{
+					encoding: "utf8",
+					env: {
+						...process.env,
+						PATH: `${directory}${path.delimiter}${process.env.PATH ?? ""}`,
+						TRIVY_CACHE_DIR: directory,
+						DATABASE_ARTIFACT: scenario.id,
+						JAVA_DB: scenario.java,
+						MAX_AGE_HOURS: "24",
+						METADATA_PATH: "",
+						GITHUB_OUTPUT: output,
+						SCAN_LOG: log,
+					},
+				},
+			);
+			assert.equal(
+				result.status === 0,
+				scenario.success,
+				`${JSON.stringify(scenario)}: ${result.stderr}`,
+			);
+			assert.equal(
+				await readFile(output, "utf8"),
+				scenario.id === "123" ? `directory=${db}\n` : "",
+			);
+			const calls = await readFile(log, "utf8");
+			assert.doesNotMatch(calls, /--download-db-only/);
+			assert.equal(calls.includes("--download-java-db-only"), scenario.java === "true");
+			if (scenario.file)
+				assert.equal(await readFile(path.join(db, "trivy.db"), "utf8"), "the immutable database");
+		}
+		assert.equal(
+			action.getIn(["runs", "steps", 1, "with", "artifact-ids"]),
+			`\${{ inputs.database-artifact }}`,
+		);
+		assert.equal(
+			action.getIn(["runs", "steps", 1, "with", "path"]),
+			`\${{ steps.cache.outputs.directory }}`,
+		);
+		assert.equal(action.getIn(["runs", "steps", 1, "with", "merge-multiple"]), true);
+		assert.equal(action.getIn(["runs", "steps", 1, "continue-on-error"]), undefined);
 	},
 );


### PR DESCRIPTION
## What changed and why

Image-policy jobs in the same CI run downloaded the moving Trivy database tag independently, so a newly published advisory could change the policy input between early and late scans. Produce one advisory database artifact per attempt and pass its immutable artifact ID to every first-party image scan, pinned-upstream scan and release preflight.

The producer retains the existing bounded download retries and mirror fallback. Consumers fail on an absent/incomplete snapshot instead of fetching a different database, and release preflight checks freshness after restoration. Failed-job reruns retain the successful producer's ID; rerunning all jobs creates a new attempt-scoped artifact. Fork builds and alias-only jobs still run when no image-policy snapshot is needed. Failed or cancelled snapshot preparation stops dependent work instead of producing misleading missing-artifact errors after expensive builds.

Related: https://github.com/hephaestus-build/Hephaestus/issues/1903. This implements the run-wide advisory-snapshot alternative, not a relaxation of vulnerability policy. The broader image-registry retry acceptance is separate.

## How to test

- `node --test scripts/download-trivy-db.test.ts scripts/ci-image-database.test.ts scripts/ci-contract.test.ts`: 85 tests pass.
- `vp run format` and `vp run check`: all 39 local quality gates pass.
- Negative controls reject advisory re-fetch during restore, bypassing the producer ID, and accepting a stale restored database.
- Inspect the CI producer's artifact ID and the IDs downloaded by all selected image-policy consumers. An expired snapshot must require a full rerun rather than a fresh per-consumer download.

## Release impact

CI/tooling only; no application behavior or operator configuration changes, so no changeset is required. HIGH/CRITICAL fixability policy, exceptions and release freshness checks are unchanged.

## Notes for reviewers

The snapshot is the advisory database, not Java's separate JAR-identification index or filesystem dependency scans' separate policy. Standalone release/rescan workflows continue preparing their advisory database once in their existing job.

The native artifact avoids assuming mirrors share an OCI manifest digest: actual GHCR and ECR downloads have different manifests but byte-identical database files. No new registry resolver, mutable snapshot-name lookup, cross-run cache or signing permission is added. Hosted verification on [CI run 34569808942](https://github.com/hephaestus-build/Hephaestus/actions/runs/34569808942) confirms all five selected image-policy jobs downloaded artifact `10187390650` with SHA-256 `0da5df64b99ab715b22f0d2b27d30eaf4d9ed1171e33f1f3b510435639a37967`; all five scans passed. The producer took 30 seconds (17-second upload, 117,380,242-byte artifact); consumer database preparation took 6–8 seconds. These are one-run observations, not a latency improvement claim. The separate [release-preflight job](https://github.com/hephaestus-build/Hephaestus/actions/runs/34570402023/job/103172102621) also passed: it restored that run's exact artifact ID `10187556610` and matching digest with the 24-hour freshness bound enabled. Downloaded evidence re-verifies locally, describes the exact PR head, and covers 16 image/platform subjects, including all four first-party images on amd64 and arm64. The dispatch's remaining Java CodeQL analysis is still pending; no release or deployment was performed.

CodeRabbit reported its included-review limit; no completed remote bot review is claimed. Independent read-only review was completed, with producer-failure handling and restore-path coverage addressed and the final review reporting no blockers.
