### PR TITLE
fix(ci): bound a preview application server's crash retries

### DIFF
--- a/.changeset/preview-appserver-restart-cap.md
+++ b/.changeset/preview-appserver-restart-cap.md
@@ -1,0 +1,4 @@
+---
+---
+
+No user-facing effect: this caps how often the application server restarts in `docker/preview/`, which only the project's own preview deployments run.

--- a/docker/preview/compose.app.yaml
+++ b/docker/preview/compose.app.yaml
@@ -247,7 +247,16 @@ services:
 
   appserver:
     image: ghcr.io/hephaestus-build/application-server:${SOURCE_COMMIT:?Coolify supplies the deployed commit}
-    restart: unless-stopped
+    # Bounded automatic retries, unlike the reference stack, because restarting this image is not
+    # free: the buildpack adds the container's CA certificates to the JRE truststore on every start,
+    # that truststore is in the container's writable layer, and the additions accumulate, so each
+    # restart enlarges the file the next one parses. A container that keeps failing therefore
+    # becomes unable to start for a reason unrelated to why it first did, and it does so on a host
+    # shared with staging. Stopping bounds both.
+    #
+    # Uptime resets the retry delay, not the count, so five is a budget for the container's whole
+    # life rather than per incident; a preview is re-created on the next push, which clears it.
+    restart: on-failure:5
     expose:
       - "8080"
     environment:


### PR DESCRIPTION
## What changed and why

#2042's preview failed four deployments running, and memory was not the problem. I raised the live container's ceiling and restarted it:

| Container limit | Heap derived | Result |
|---|---|---|
| 2G | `-Xmx1194224K` | OOM |
| 3G | `-Xmx2242800K` | OOM |
| 5G | `-Xmx4339952K` | OOM |

Identical failure every time. Something was growing faster than the ceiling.

**The container was restarting every ~25 seconds and had done so 867 times in six hours.** The buildpack adds the container's CA certificates to the JRE truststore on every start — *"Adding 121 container CA certificates to JVM truststore"* — that truststore lives in the container's writable layer, and the additions accumulate:

| | `…/jre/lib/security/cacerts` |
|---|---|
| Staging application server (started once) | **516,808 bytes** |
| This preview (867 restarts) | **140,780,322 bytes** |

Parsing a 134MB PKCS12 store allocates far more than its size in `byte[]`, so it exhausted the heap, exited on `-XX:+ExitOnOutOfMemoryError`, restarted, appended another 121 certificates, and was strictly worse each time. The first failure was incidental; the restart policy made it permanent and unrecoverable.

How the evidence came together, since none of it is visible from GitHub:

- A class histogram across the startup window showed `byte[]` going from 74MB to 340MB while the instance count barely moved — a few very large arrays, not many small ones.
- A thread dump caught `main` inside `PKCS12KeyStore.engineLoad → DerValue.<init> → IOUtils.readExactlyNBytes`.
- `docker diff` showed `cacerts` in the writable layer, and the size comparison above named the mechanism.

Capping the restarts is the fix. A JVM that cannot start does not recover by being started again, and here each attempt damages the next one. A preview that stops reports a failed deployment, which is the answer its author needs, and stops thrashing a host it shares with staging.

## How to test

```sh
node scripts/check-preview-stack.ts        # stack renders and stays sandboxed
docker compose -f docker/preview/compose.app.yaml config   # renders `restart: on-failure:5`
```

Recreating the stack proved the diagnosis: the **same commit**, on the **unchanged 2G ceiling**, now starts and serves — `restarts=0`, all three containers healthy, app `200`, API `401`, and a `516,808`-byte truststore identical to staging's.

## Release impact

Empty changeset: `docker/preview/` is run only by this project's own previews.

## Notes for reviewers

**The same bomb exists in the reference stack.** `docker/compose.app.yaml` runs the application server with `restart: unless-stopped`, on the same buildpack, so a production or staging server that ever enters a crash loop accumulates the same truststore and becomes unable to start for a reason that has nothing to do with why it first fell over. I have not changed it here: restarting indefinitely is defensible for production, where a transient dependency failure should heal itself, and the right answer there may be alerting on restart count rather than a cap. It deserves its own decision rather than being carried along by a preview fix.

The underlying non-idempotent append is a buildpack behaviour, not ours, and worth reporting upstream. This change defends against it either way, which is why it is worth having even if that is fixed.

I also opened and closed #2134, which raised the memory ceiling. It would not have worked; the measurements above are why.

### After adversarial review

It blocked the first version for presenting containment as a root fix, and it was right on every count that mattered. Three corrections:

- **This is crash-loop containment, not a truststore fix.** The accumulation is a buildpack behaviour and survives this change; a manual start resets the retry budget without discarding the writable layer. Re-creating the stack is what recovers a container that has already bloated. The title, the commit and the comment now say that.
- **"The first failure was incidental" was unsupported.** My measurements implicate accumulated state in the *later* loop; they never identified the first exit. One clean start cannot exclude an intermittent original trigger. It now says the initial trigger is not established — which does not invalidate containment, but does invalidate any claim that preview startup is now fixed.
- **The retry budget is not per incident.** Docker's ten seconds of uptime resets the restart *delay*, not the count, so five is a budget for the container's whole life. That is acceptable here because a preview is re-created on the next push, but it is a fact worth stating rather than discovering.

Two things the review established that I had wrong or unverified, in this change's favour:

- **Coolify preserves an explicit `restart` policy** — its Compose parser applies its own default only when the service omits one, so this takes effect rather than being overwritten.
- **A naked tmpfs over the JRE security directory would be wrong**, since it would hide `cacerts` rather than bound its growth. That was the obvious-looking alternative and it does not work.

One gap it found that is outside this change: an application server that dies *after* the webapp starts leaves nginx serving, and the deployment controller probes only the web page — so a preview can report success with a dead API. Worth a follow-up.
