### PR TITLE
fix(ci): let preview comment links wrap naturally

### DIFF
--- a/scripts/lib/preview-comment.ts
+++ b/scripts/lib/preview-comment.ts
@@ -41,7 +41,8 @@ export function renderPreviewComments(
 		let block = heading;
 		for (const entry of entries) {
 			const link = `[${markdown(entry.title)}](<${entry.url.replaceAll("&", "&amp;")}>)`;
-			const separator = block === heading ? "" : " ·\n";
+			// GitHub comments turn soft newlines into hard breaks; let inline links wrap naturally.
+			const separator = block === heading ? "" : " · ";
 			if (heading.length + link.length > budget) {
 				throw new Error(`A preview link in ${group} exceeds GitHub's comment limit.`);
 			}

--- a/scripts/render-preview-comment.test.ts
+++ b/scripts/render-preview-comment.test.ts
@@ -282,9 +282,51 @@ void test("uses stable, disambiguated groups with complete headings and atomic l
 		assert.match(comment, /#### components\/(admin|workspace)\/Button \(\d+\)/);
 		assert.ok(comment.endsWith("Build provenance\n"));
 		assert.doesNotMatch(comment, /<details|<summary/);
+		assertInlineParagraphs(comment);
 	}
 	const combined = comments.join("\n");
 	for (const { url } of links) assert.equal(combined.split(`](<${url}>)`).length - 1, 1);
+});
+
+/** CommonMark leaves soft newlines in text nodes; GitHub comments render those as <br>. */
+function assertInlineParagraphs(comment: string): void {
+	for (const node of fromMarkdown(comment).children) {
+		if (node.type !== "paragraph") continue;
+		assert.equal(node.position?.start.line, node.position?.end.line);
+	}
+}
+
+void test("keeps links inline within groups and blank lines between blocks in GitHub comments", () => {
+	const [comment] = renderPreviewComments(
+		"## Preview\n\n[Open full preview](<https://preview.example/>)\n\n### Changed content (3)",
+		[
+			{ group: "First", title: "Default", url: "https://preview.example/default" },
+			{ group: "First", title: "Loading\r\nstate", url: "https://preview.example/loading" },
+			{ group: "Second", title: "Narrow\tview", url: "https://preview.example/narrow" },
+		],
+		"Empty",
+		"Build provenance",
+	);
+	assert.ok(comment);
+	assertInlineParagraphs(comment);
+	assert.deepEqual(
+		fromMarkdown(comment).children.map((node) => node.type),
+		[
+			"heading",
+			"paragraph",
+			"heading",
+			"heading",
+			"paragraph",
+			"heading",
+			"paragraph",
+			"paragraph",
+		],
+	);
+	assert.ok(
+		comment.includes(
+			"[Default](<https://preview.example/default>) · [Loading  state](<https://preview.example/loading>)\n\n#### Second (1)\n\n[Narrow view](<https://preview.example/narrow>)",
+		),
+	);
 });
 
 void test("renders metadata as literal text rather than Markdown or HTML", () => {


### PR DESCRIPTION
## What changed and why

Follow-up to [#2119](https://github.com/hephaestus-build/Hephaestus/pull/2119). The [Storybook comment on #2042](https://github.com/hephaestus-build/Hephaestus/pull/2042#issuecomment-5577472105) contains 41 links but forces a new line after almost every story, leaving separator dots stranded at line ends instead of producing the intended compact, wrapping groups.

GitHub [automatically renders single newlines as line breaks in pull request comments](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#line-breaks). This differs from Markdown files and the CommonMark parser used in the existing tests. Replace the newline in the shared link separator with a space: groups remain distinct paragraphs, while links wrap naturally to the available width. No tables, HTML layout, disclosure controls, truncation, or new dependencies.

Regression tests check single-source-line paragraphs, preserve blank lines between blocks, exercise metadata containing CR/LF and tabs, and enforce the same layout across oversized continuation comments. Both layout regression cases fail with the original separator.

## How to test

Verified:

- `vp run format` and `vp run check` (39 quality tasks).
- `node --test scripts/render-preview-comment.test.ts scripts/publish-preview-comments.test.ts scripts/ci-contract.test.ts` — 98 passing tests, including escaping, empty states, 106 stories, 1,200-link pagination, and publisher lifecycle behavior.
- Retrieved the actual comment HTML with GitHub's `application/vnd.github.full+json` API representation, then rendered the same content through the fixed renderer and `https://api.github.com/markdown` (`mode: gfm`, repository context). Storybook: 41 content links, six groups, **35 hard breaks → zero**. Documentation: eight content links, four groups, **four hard breaks → zero**. All link destinations, including the full preview and provenance links, are preserved.

Manual smoke test: compare the examples below on GitHub at wide and narrow window sizes. “After” should wrap only when space runs out, not after every link. On the next successful story/docs preview build using this renderer, the sticky comment should retain its headings, counts, complete links, and provenance with this inline layout. No local server or browser session was started for verification.

## Release impact

No changeset or operator action: this changes CI comment tooling only, not shipped application code. Both Storybook and documentation use the shared renderer. No product integration adapter, runtime role, wire contract, schema, feedback channel, admin console, or application UI state changes. Publication, shrinking lists, and teardown are unchanged and covered by the existing tests.

## Visual evidence

Native Markdown examples let GitHub itself demonstrate the rendering difference rather than relying on a local Markdown viewer. These use three destinations from the reported comment; preview availability remains tied to that pull request's lifecycle.

### Before — forced breaks and trailing dots

#### components/auth/ConsentPage (3)

[Both Answered](https://hephaestus-build-storybook-pr-2042.surge.sh/?path=/story/components-auth-consentpage--both-answered) ·
[Dark](https://hephaestus-build-storybook-pr-2042.surge.sh/?path=/story/components-auth-consentpage--dark) ·
[Default](https://hephaestus-build-storybook-pr-2042.surge.sh/?path=/story/components-auth-consentpage--default)

### After — inline links that wrap naturally

#### components/auth/ConsentPage (3)

[Both Answered](https://hephaestus-build-storybook-pr-2042.surge.sh/?path=/story/components-auth-consentpage--both-answered) · [Dark](https://hephaestus-build-storybook-pr-2042.surge.sh/?path=/story/components-auth-consentpage--dark) · [Default](https://hephaestus-build-storybook-pr-2042.surge.sh/?path=/story/components-auth-consentpage--default)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preview comment links now wrap naturally within groups instead of forcing line breaks.
  - Blank lines continue to separate distinct content blocks.
  - Improved handling of titles containing varied whitespace and line endings.

- **Tests**
  - Added coverage to verify inline link formatting and prevent unintended soft line breaks in rendered preview comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->