### PR TITLE
perf(ci): avoid duplicate compiler analysis in CodeQL

### DIFF
--- a/.changeset/codeql-analysis-compilation.md
+++ b/.changeset/codeql-analysis-compilation.md
@@ -1,0 +1,4 @@
+---
+---
+
+CI-only compilation avoids repeating compiler analysis during CodeQL extraction. Normal build checks and released artifacts are unchanged.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -85,7 +85,7 @@ jobs:
         working-directory: server
         # Extraction observes javac: restored classes and a reused Gradle daemon bypass it.
         # This produces analysis inputs, never the packaged server that CI tests and ships.
-        run: ./gradlew --no-daemon --no-build-cache --no-configuration-cache clean :application:testClasses
+        run: ./gradlew --no-daemon --no-build-cache --no-configuration-cache -PcodeqlExtraction=true clean :application:testClasses
 
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9

--- a/docs/contributor/ci-cd.mdx
+++ b/docs/contributor/ci-cd.mdx
@@ -278,7 +278,10 @@ of no-build dependency and JDK guesses. The single-use Gradle process runs insid
 neither cached classes nor a pre-existing daemon can bypass project compilation. Gradle's own
 generated version-catalog helpers, outside the project source tree, need not be recompiled or
 extracted on a cache hit. This compilation produces analysis inputs only: the packaged server
-remains owned by the build-once job. Actions and JavaScript/TypeScript retain no-build analysis.
+remains owned by the build-once job. Its explicit `codeqlExtraction=true` Gradle property skips
+the duplicate ErrorProne/NullAway pass only for analysis compilation. Normal builds and tests keep
+NullAway enabled by default; javac warnings, annotation processing and CodeQL queries are unchanged.
+Actions and JavaScript/TypeScript retain no-build analysis.
 
 `.github/workflows/codeql.yml` runs CodeQL under advanced setup: only advanced setup reads a
 committed config file, and `.github/codeql/codeql-config.yml` excludes `security/semgrep/**`,

--- a/scripts/ci-contract.test.ts
+++ b/scripts/ci-contract.test.ts
@@ -2674,7 +2674,7 @@ void test("CodeQL runs advanced setup and excludes the Semgrep fixtures it would
 	assert.equal(compile.get("working-directory"), "server");
 	assert.equal(
 		compile.get("run"),
-		"./gradlew --no-daemon --no-build-cache --no-configuration-cache clean :application:testClasses",
+		"./gradlew --no-daemon --no-build-cache --no-configuration-cache -PcodeqlExtraction=true clean :application:testClasses",
 	);
 	const ci = parseDocument(await readFile(".github/workflows/cicd.yml", "utf8"));
 	assert.equal(ci.getIn(["jobs", "CodeQL", "uses"]), "./.github/workflows/codeql.yml");
@@ -2699,6 +2699,23 @@ void test("CodeQL runs advanced setup and excludes the Semgrep fixtures it would
 		"codeql-config.yml",
 	);
 	assert.deepEqual(config["paths-ignore"], ["security/semgrep/**"]);
+});
+
+void test("only CodeQL extraction opts out of duplicate compiler analysis", async () => {
+	const build = await readFile("server/application/build.gradle.kts", "utf8");
+	assert.match(
+		build,
+		/enabled\.set\(providers\.gradleProperty\("codeqlExtraction"\)\.map \{ it != "true" \}\.orElse\(true\)\)/,
+		"ordinary compilation must keep ErrorProne enabled unless extraction explicitly opts out",
+	);
+	assert.match(build, /error\("NullAway", "RequireExplicitNullMarking"\)/);
+	assert.match(build, /"-Werror"/);
+	const callers: string[] = [];
+	for (const file of await posixGlob(".github/**/*.yml")) {
+		if ((await readFile(file, "utf8")).includes("codeqlExtraction")) callers.push(file);
+	}
+	assert.deepEqual(callers, [".github/workflows/codeql.yml"]);
+	assert.doesNotMatch(await readFile("vite.config.ts", "utf8"), /codeqlExtraction/);
 });
 
 void test("every Semgrep rule ships a positive and a negative fixture", async () => {

--- a/server/application/build.gradle.kts
+++ b/server/application/build.gradle.kts
@@ -116,6 +116,8 @@ tasks.withType<JavaCompile>().configureEach {
         listOf("-Werror", "-Xlint:all,-processing", "-XDaddTypeAnnotationsToSymbol=true")
     )
     options.errorprone {
+        // CodeQL recompiles analysis inputs; normal builds own NullAway enforcement.
+        enabled.set(providers.gradleProperty("codeqlExtraction").map { it != "true" }.orElse(true))
         disableAllChecks.set(true)
         error("NullAway", "RequireExplicitNullMarking")
         option("NullAway:AnnotatedPackages", "de.tum.cit.aet.hephaestus")


### PR DESCRIPTION
## What changed and why

CodeQL's clean Java compilation repeats the ErrorProne/NullAway pass already enforced by ordinary builds. An explicit extraction-only Gradle property avoids that duplicate work while retaining javac warnings, annotation processing, generated clients, test sources and the full CodeQL query suite. Normal compilation keeps ErrorProne enabled by default.

## How to test

- `vp run format` and `vp run check`: passed all 39 quality gates; pre-push check also passed.
- `vp run test:server:unit`: 7,410 tests passed, zero failures/errors/skips; coverage verification passed.
- Actual Gradle configuration checks cover absent, false, true and misspelled property values for production and test compilation. Only exact `true` disables the duplicate pass; `-Werror` remains enabled.
- A temporary injected null return is rejected by the ordinary compiler with a NullAway error.
- Same-source local CodeQL 2.27.0 / java-queries 1.11.10 comparison: identical 15,500 extracted Java files, byte-identical source archives, 76 rule definitions, seven existing alerts and 549 telemetry metrics. This is parity evidence, not a clean-security claim.

## Release impact

CI-only empty changeset; no operator action, API or runtime behavior change. The packaged server remains owned by the normal build-once job.

## Notes for reviewers

Hosted runtime verification is pending. Local extraction timing was noisy even in unchanged generated compilation and does not establish a speedup. Do not merge solely on local parity; evaluate the hosted CodeQL critical path before landing. No debug database upload or security-query suppression is added.
