### PR TITLE
perf(ci): reuse validated ordinary merge-queue server builds

### DIFF
--- a/docs/contributor/ci-cd.mdx
+++ b/docs/contributor/ci-cd.mdx
@@ -713,9 +713,12 @@ The application image and `Build` artifact gates depend on packaging independent
 and release preflight wait for the image producers, not the API, database or browser checks. The
 final CI gate still requires all of them; an early image verdict cannot approve a failed artifact gate.
 
-A default-branch push reuses the packaged server when a successful release-candidate merge group
+A default-branch push reuses the packaged server when a successful merge group
 validated the exact same commit. The source must be this repository's `cicd.yml` run, with successful
-artifact gates, tests, security checks, dual-platform server builds, release preflight and final gate.
+artifact gates, tests, security checks, the AMD64 server build and final gate. ARM64 image builds
+and release preflight do not change the packaged Java artifact, so their absence in ordinary merge
+groups does not force a rebuild. Main still validates both image platforms; release candidates
+still require release preflight.
 The immutable artifact ID and its SHA-256 digest bind the download to that run. Missing, expired or
 unavailable source evidence falls back to packaging; a corrupt download fails rather than being used.
 Main still runs its own validation and publishes its images, including main-only tags and source maps.

--- a/scripts/resolve-server-build.test.ts
+++ b/scripts/resolve-server-build.test.ts
@@ -14,12 +14,10 @@ const requiredJobs = [
 	"Build / App Server: Database",
 	"Build / Webapp: E2E",
 	"App Server image / Build linux/amd64 Docker Image",
-	"App Server image / Build linux/arm64 Docker Image",
 	"Test / App Server: Unit and architecture",
 	"Test / App Server: Integration (application)",
 	"Test / App Server: Integration (providers-and-startup)",
 	"Security / Dependencies, secrets, and policy",
-	"Release evidence preflight",
 	"CI Status Gate",
 ];
 function fixture() {
@@ -35,7 +33,11 @@ function fixture() {
 			repository: { id: 7, full_name: repository },
 			head_repository: { id: 7, full_name: repository },
 		},
-		jobs: requiredJobs.map((name) => ({ name, conclusion: "success" })),
+		jobs: [
+			...requiredJobs,
+			"App Server image / Build linux/arm64 Docker Image",
+			"Release evidence preflight",
+		].map((name) => ({ name, conclusion: "success" })),
 		artifact: {
 			id: 202,
 			name: "server-build-101",
@@ -60,6 +62,16 @@ await test("selects the immutable artifact of an exact-commit successful release
 	assert.deepEqual(await resolve(), { runId: 101, artifactId: 202 });
 });
 
+await test("reuses an ordinary merge group without release-only image and evidence jobs", async () => {
+	const data = fixture();
+	data.jobs = data.jobs
+		.filter((job) => job.name !== "App Server image / Build linux/arm64 Docker Image")
+		.map((job) =>
+			job.name === "Release evidence preflight" ? { ...job, conclusion: "skipped" } : job,
+		);
+	assert.deepEqual(await resolve(data), { runId: 101, artifactId: 202 });
+});
+
 await test("rejects a different commit, repository, event, workflow, branch or incomplete run", async () => {
 	for (const patch of [
 		{ head_sha: "c".repeat(40) },
@@ -78,7 +90,7 @@ await test("rejects a different commit, repository, event, workflow, branch or i
 	}
 });
 
-await test("every artifact gate, test, security, architecture and release verdict must succeed", async () => {
+await test("every required artifact, test, security and final verdict must succeed", async () => {
 	for (const missing of requiredJobs) {
 		for (const conclusion of ["skipped", "failure", "cancelled", ""]) {
 			const data = fixture();

--- a/scripts/resolve-server-build.ts
+++ b/scripts/resolve-server-build.ts
@@ -10,12 +10,10 @@ const requiredJobs = [
 	"Build / App Server: Database",
 	"Build / Webapp: E2E",
 	"App Server image / Build linux/amd64 Docker Image",
-	"App Server image / Build linux/arm64 Docker Image",
 	"Test / App Server: Unit and architecture",
 	"Test / App Server: Integration (application)",
 	"Test / App Server: Integration (providers-and-startup)",
 	"Security / Dependencies, secrets, and policy",
-	"Release evidence preflight",
 	"CI Status Gate",
 ];
 


### PR DESCRIPTION
## What changed and why

Main rebuilds the exact server commit already validated by an ordinary merge group because artifact reuse requires release-only ARM64 and release-preflight jobs. Those jobs do not change the packaged Java artifact. Accept ordinary successful merge groups while retaining all existing server artifact, database, browser, unit/architecture, integration, security, AMD64 image and final-gate checks.

Exact commit/repository/workflow identity, immutable artifact ID, digest verification, expiration checks and packaging fallback are unchanged. Main still executes its validation and platform publication; release candidates still require release preflight.

## How to test

- New ordinary-group regression fails on the previous resolver; all seven resolver tests pass after the change.
- Actual GitHub lookup now selects artifact `10195213918` from successful ordinary merge-group run https://github.com/hephaestus-build/Hephaestus/actions/runs/34589808646 for exact commit `00017d398907df63e8d180c12e5bf69bf8732ca5`.
- `vp run format` and all 39 `vp run check` gates passed. Existing negative tests retain failed/missing gates, wrong-source and corrupt/expired artifact rejection.
- Post-merge verification must observe main downloading the exact queue artifact and skipping packaging while retaining downstream checks.

## Release impact

Repository tooling and contributor documentation only; no shipped-code change or changeset required. No operator action.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved packaged server build reuse for default-branch pushes when the same commit has passed merge-group validation.
  - ARM64 image builds and release evidence checks are no longer required for reuse when not applicable; required validation checks must still pass.

- **Documentation**
  - Updated CI/CD guidance to reflect the revised packaged server build reuse requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->