### PR TITLE
perf(ci): select affected CodeQL languages on main pushes

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,8 +28,13 @@ jobs:
           persist-credentials: false
       - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: filter
-        if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+        if: >-
+          github.event_name == 'pull_request' || github.event_name == 'merge_group' ||
+          (github.event_name == 'push' && github.event.before != '' &&
+            github.event.before != '0000000000000000000000000000000000000000')
         with:
+          # Use the complete pushed range, not just its last commit. Scheduled/manual runs stay full.
+          base: ${{ github.event_name == 'push' && github.event.before || '' }}
           filters: |
             actions:
               - '.github/**'

--- a/docs/contributor/ci-cd.mdx
+++ b/docs/contributor/ci-cd.mdx
@@ -260,9 +260,10 @@ because GitHub caps a fork token's `security-events` access at read.
 
 ### CodeQL configuration
 
-PR and merge-group diffs select analysis languages, not individual files: each selected language
-scans its configured source tree. Main and scheduled runs select all languages, as do changes to
-the CodeQL workflow or configuration. The language filters live in `.github/workflows/codeql.yml`.
+PR, merge-group and main-push diffs select analysis languages, not individual files: each selected
+language scans its configured source tree. Main compares the full pushed range against the event's
+previous commit, including multi-commit pushes and deletions. Scheduled and manual runs select all
+languages, as do pushes without a previous commit and changes to the CodeQL workflow or configuration. The language filters live in `.github/workflows/codeql.yml`.
 
 CI calls that reusable workflow, and `CI Status Gate` waits for its successful completion, including
 SARIF upload. A merge group therefore cannot pass the gate and lose its temporary ref while CodeQL

--- a/scripts/ci-contract.test.ts
+++ b/scripts/ci-contract.test.ts
@@ -2759,11 +2759,36 @@ void test("CodeQL selects languages with native change detection", async () => {
 	assert.ok(isSeq(steps));
 	const selection = steps.items.find((item) => isMap(item) && item.get("id") === "filter");
 	assert.ok(isMap(selection));
-	assert.equal(
-		selection.get("if"),
-		"github.event_name == 'pull_request' || github.event_name == 'merge_group'",
-	);
+	const parsed = new Parser(
+		new Lexer(String(selection.get("if"))).lex().tokens,
+		["github"],
+		[],
+	).parse();
+	for (const [event, before, expected] of [
+		["pull_request", "", true],
+		["merge_group", "", true],
+		["push", "a".repeat(40), true],
+		["push", "", false],
+		["push", "0".repeat(40), false],
+		["schedule", "a".repeat(40), false],
+		["workflow_dispatch", "a".repeat(40), false],
+	] as const) {
+		const context: unknown = JSON.parse(
+			JSON.stringify({ github: { event_name: event, event: { before } } }),
+			data.reviver,
+		);
+		assert.ok(context instanceof data.Dictionary);
+		assert.equal(
+			new Evaluator(parsed, context).evaluate().coerceString(),
+			String(expected),
+			`${event} ${before}`,
+		);
+	}
 	const filter = step(workflow, ["jobs", "changes"], "dorny/paths-filter");
+	assert.equal(
+		filter.get("base"),
+		`\${{ github.event_name == 'push' && github.event.before || '' }}`,
+	);
 	const filters = asRecord(parseDocument(String(filter.get("filters"))).toJSON(), "CodeQL filters");
 	assert.deepEqual(Object.keys(filters), ["actions", "java-kotlin", "javascript-typescript"]);
 	for (const [language, patterns] of Object.entries(filters)) {


### PR DESCRIPTION
## What changed and why

CodeQL already selects affected languages for pull requests and merge groups, but every main push currently scans every language. Apply the same selection to ordinary pushes using the event's complete before-to-head range, avoiding unrelated Java extraction without removing any query or narrowing selected-language analysis.

Scheduled/manual scans, missing/zero previous commits and CodeQL configuration changes still select all languages. PR and merge-group native range handling remains unchanged; the explicit base is empty for those events.

## How to test

- Actual GitHub expression evaluation covers PR, merge-group, ordinary push, missing/zero base, schedule and manual dispatch.
- The exact pinned paths-filter action was executed against temporary Git repositories: docs-only selects no languages; Java and TS select their language; Java deletion and earlier Java changes in a multi-commit push retain Java; workflow changes select all three languages.
- `vp run format` and all 39 `vp run check` gates passed.
- CI must keep all three CodeQL analyses for this workflow change. A later unrelated main push should skip Java while the required CI gate succeeds only after valid selection.

## Release impact

Workflow/tests/contributor docs only; no shipped-code changes or operator action. No security query, ordinary compiler check, merge protection or release validation is disabled.

## Notes for reviewers

This saves unrelated work, not the cost of Java analysis when Java inputs change. Weekly scans retain updated-query coverage for unchanged source. Native range resolution failures fail the workflow rather than approving an unknown diff.
