### PR TITLE
perf(ci): reuse generated Java sources during CodeQL extraction

### DIFF
--- a/.changeset/codeql-generation-cache.md
+++ b/.changeset/codeql-generation-cache.md
@@ -1,0 +1,4 @@
+---
+---
+
+CI-only build optimization: reuse generated sources during security analysis without reusing compiled classes. No shipped behavior changes.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -88,9 +88,9 @@ jobs:
       - name: Compile Java for analysis
         if: matrix.language == 'java-kotlin'
         working-directory: server
-        # Extraction observes javac: restored classes and a reused Gradle daemon bypass it.
+        # Clean plus uncached JavaCompile tasks force javac; source generation can use the cache.
         # This produces analysis inputs, never the packaged server that CI tests and ships.
-        run: ./gradlew --no-daemon --no-build-cache --no-configuration-cache -PcodeqlExtraction=true clean :application:testClasses
+        run: ./gradlew --no-daemon --build-cache --no-configuration-cache -PcodeqlExtraction=true clean :application:testClasses
 
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9

--- a/docs/contributor/ci-cd.mdx
+++ b/docs/contributor/ci-cd.mdx
@@ -270,7 +270,8 @@ SARIF upload. A merge group therefore cannot pass the gate and lose its temporar
 is still publishing results. The weekly scan also runs directly from the same workflow.
 
 Java uses manual extraction with the JDK pinned in `.java-version` and a clean
-`:application:testClasses` compilation with Java compilation caching and the configuration cache disabled.
+`:application:testClasses` compilation with the Gradle build cache enabled, `JavaCompile` output
+caching disabled, and the configuration cache disabled.
 Source-generation tasks can restore their outputs from the build cache; every `JavaCompile` task
 still executes so the extractor sees both handwritten and generated Java. The shared
 `setup-caches` action restores Gradle dependencies read-only from the default-branch package

--- a/docs/contributor/ci-cd.mdx
+++ b/docs/contributor/ci-cd.mdx
@@ -270,7 +270,9 @@ SARIF upload. A merge group therefore cannot pass the gate and lose its temporar
 is still publishing results. The weekly scan also runs directly from the same workflow.
 
 Java uses manual extraction with the JDK pinned in `.java-version` and a clean
-`:application:testClasses` compilation with build and configuration caches disabled. The shared
+`:application:testClasses` compilation with Java compilation caching and the configuration cache disabled.
+Source-generation tasks can restore their outputs from the build cache; every `JavaCompile` task
+still executes so the extractor sees both handwritten and generated Java. The shared
 `setup-caches` action restores Gradle dependencies read-only from the default-branch package
 producer through the Gradle action's OS-wide fallback; analysis never publishes a cache. The
 package job is the only writer, and a missing or expired entry falls back to a cold build.

--- a/scripts/ci-contract.test.ts
+++ b/scripts/ci-contract.test.ts
@@ -2674,7 +2674,7 @@ void test("CodeQL runs advanced setup and excludes the Semgrep fixtures it would
 	assert.equal(compile.get("working-directory"), "server");
 	assert.equal(
 		compile.get("run"),
-		"./gradlew --no-daemon --no-build-cache --no-configuration-cache -PcodeqlExtraction=true clean :application:testClasses",
+		"./gradlew --no-daemon --build-cache --no-configuration-cache -PcodeqlExtraction=true clean :application:testClasses",
 	);
 	const ci = parseDocument(await readFile(".github/workflows/cicd.yml", "utf8"));
 	assert.equal(ci.getIn(["jobs", "CodeQL", "uses"]), "./.github/workflows/codeql.yml");
@@ -2699,6 +2699,15 @@ void test("CodeQL runs advanced setup and excludes the Semgrep fixtures it would
 		"codeql-config.yml",
 	);
 	assert.deepEqual(config["paths-ignore"], ["security/semgrep/**"]);
+});
+
+void test("CodeQL caches generation but never Java compilation", async () => {
+	const build = await readFile("server/build.gradle.kts", "utf8");
+	assert.match(
+		build,
+		/tasks\.withType<JavaCompile>\(\)\.configureEach \{\s*\/\/[^\n]*\n\s*if \(providers\.gradleProperty\("codeqlExtraction"\)\.orNull == "true"\) \{\s*outputs\.cacheIf \{ false \}/,
+		"disable compilation cache only for explicit extraction; generation remains cacheable",
+	);
 });
 
 void test("only CodeQL extraction opts out of duplicate compiler analysis", async () => {

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -60,6 +60,10 @@ subprojects {
         }
     }
     tasks.withType<JavaCompile>().configureEach {
+        // Extraction must observe javac, but generated source outputs remain safe to restore.
+        if (providers.gradleProperty("codeqlExtraction").orNull == "true") {
+            outputs.cacheIf { false }
+        }
         options.encoding = "UTF-8"
         options.isFork = true
         options.forkOptions.memoryMaximumSize = "4g"


### PR DESCRIPTION
## What changed and why

CodeQL disabled the entire Gradle build cache to force javac execution, unnecessarily regenerating the GitHub, GitLab and Outline clients too. Enable build caching while disabling it specifically for JavaCompile tasks under the existing explicit extraction property. Keep clean, a single-use Gradle daemon and disabled configuration caching so neither restored classes nor an existing process can bypass extraction.

Normal compilation caching, NullAway enforcement, the packaged server, query suite and mandatory security gate are unchanged. Update the workflow contract and contributor documentation.

## How to test

- `vp run format` and `vp run check`: all 39 quality gates pass.
- `vp run test:server:unit`: 7,434 tests, no failures, errors or skips.
- `./server/gradlew -p server --no-daemon --build-cache --no-configuration-cache -PcodeqlExtraction=true clean :application:testClasses`: all four generation tasks restore from cache, all three JavaCompile tasks execute.
- Native CodeQL 2.27.0 extraction with this cache policy succeeded. Its source archive contains all 15,499 expected Java source files. All 12,010 cached generated Java files are byte-identical to an independent regeneration with build caching disabled.

## Release impact

Empty changeset: CI-only build configuration, no shipped behavior changes or operator action.

## Notes for reviewers

This removes redundant generation, not the requirement for traced compilation. It does not establish a significant end-to-end runtime improvement; hosted timings must determine the benefit. Cache misses safely regenerate sources. No new shared cache writer is introduced.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved security-analysis builds by reusing generated source outputs where safe, while ensuring Java compilation remains available for complete analysis.
  - No changes to shipped application behavior or public APIs.

- **Documentation**
  - Clarified the CI/CD process and caching behavior used during security analysis.

- **Tests**
  - Added coverage to verify that caching settings preserve accurate CodeQL results while improving build efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->